### PR TITLE
Cohere support

### DIFF
--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -80,13 +80,15 @@ class ToolCallingLLM:
         if api_key:
             os.environ[api_key_env_var] = api_key
         model_requirements = litellm.validate_environment(model=model)
-        if not model_requirements["keys_in_environment"]:
+        if not model_requirements["keys_in_environment"] and "cohere" not in model:
             raise Exception(f"model {model} requires the following environment variables: {model_requirements['missing_keys']}")
 
         # this unfortunately does not seem to work for azure if the deployment name is not a well-known model name 
         #if not litellm.supports_function_calling(model=model):
         #    raise Exception(f"model {model} does not support function calling. You must use HolmesGPT with a model that supports function calling.")
     def get_context_window_size(self) -> int:
+        if "cohere" in self.model:
+            return 16000
         return litellm.model_cost[self.model]['max_input_tokens'] 
 
     def count_tokens_for_message(self, messages: list[dict]) -> int:
@@ -94,7 +96,9 @@ class ToolCallingLLM:
                                      messages=messages)
     
     def get_maximum_output_token(self) -> int:
-         return litellm.model_cost[self.model]['max_output_tokens'] 
+        if "cohere" in self.model:
+            return 16000
+        return litellm.model_cost[self.model]['max_output_tokens'] 
     
     def call(self, system_prompt, user_prompt, post_process_prompt: Optional[str] = None, response_format: dict = None) -> LLMResult:
         messages = [
@@ -254,12 +258,13 @@ class ToolCallingLLM:
 
         tool_call_messages = [message for message in messages if message["role"] == "tool"]
         
-        if message_size_without_tools >= (max_context_size - maximum_output_token):
+        if "cohere" not in self.model and message_size_without_tools >= (max_context_size - maximum_output_token):
             logging.error(f"The combined size of system_prompt and user_prompt ({message_size_without_tools} tokens) exceeds the model's context window for input.")
             raise Exception(f"The combined size of system_prompt and user_prompt ({message_size_without_tools} tokens) exceeds the model's context window for input.")
-
-        tool_size = min(10000, int((max_context_size - message_size_without_tools - maximum_output_token) / len(tool_call_messages)))
-
+        if len(tool_call_messages) > 0: 
+            tool_size = min(10000, int((max_context_size - message_size_without_tools - maximum_output_token) / len(tool_call_messages)))
+        else:
+            tool_size = min(10000, (max_context_size - message_size_without_tools - maximum_output_token))
         for message in messages:
             if message["role"] == "tool":
                 message["content"] = message["content"][:tool_size]


### PR DESCRIPTION
To run:
```
export COHERE_API_KEY=...
poetry run python3 holmes.py ask "what issues does my kubernetes cluster pods have?." --model="cohere/command-r-plus"
```
It looks like there are some internal issues with some of litellms functions with cohere
right now this just supports model `cohere/command-r-plus` but other models can be included in the future by updating 
`get_context_window_size`
`get_maximum_output_token`