### PR TITLE
Fix bug: LLM-as-judge expected <any port> in the output 2% of the time

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/03_what_is_the_command_to_port_forward/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/03_what_is_the_command_to_port_forward/test_case.yaml
@@ -1,6 +1,6 @@
 user_prompt: 'what is the command to port-forward to << { "type": "pod", "name": "my_grafana_4j981" } >>'
 #user_prompt: "what is the command to port-forward to my grafana service?"
 expected_output:
-  - kubectl port-forward pod/my_grafana_4j981 <any port>:3000 -n default
+  - Includes the following port-forwarding command with <any port> replaced by a valid for number -> kubectl port-forward pod/my_grafana_4j981 <any port>:3000 -n default
 evaluation:
   correctness: 1


### PR DESCRIPTION
Before fix: https://www.braintrust.dev/app/Arkhaios%20AB/p/HolmesGPT/experiments/ask_holmes%3Aport-fw-judge?c=ask_holmes:trucate-namespace3&tg=false&search={%22sort%22:[{%22text%22:%22%2522scores%2522.%2522correctness%2522%2520ASC%22,%22spec%22:{%22col%22:{%22id%22:%22scores.correctness%22},%22path%22:{%22path%22:[%22scores%22,%22correctness%22]}}}]}.

after fix : https://www.braintrust.dev/app/Arkhaios%20AB/p/HolmesGPT/experiments/ask_holmes%3Aport-fw-judge-with-fix?c=ask_holmes:port-fw-judge&tg=false&search={%22sort%22:[{%22text%22:%22%2522scores%2522.%2522correctness%2522%2520ASC%22,%22spec%22:{%22col%22:{%22id%22:%22scores.correctness%22},%22path%22:{%22path%22:[%22scores%22,%22correctness%22]}}}]}