### PR TITLE
Less server errors when not connected to saas

### DIFF
--- a/server.py
+++ b/server.py
@@ -93,7 +93,9 @@ def sync_before_server_start():
         except Exception:
             logging.error("Failed to synchronise holmes toolsets", exc_info=True)
     else:
-        logging.debug("Skipping Robusta platform sync - no token or cluster name configured")
+        logging.debug(
+            "Skipping Robusta platform sync - no token or cluster name configured"
+        )
 
 
 if ENABLE_TELEMETRY and SENTRY_DSN:


### PR DESCRIPTION
I've tested in the case where SaaS is not available (i.e. no token) - please also test on happy path where it is available and verify everything still works.