### PR TITLE
mute logging toolset status for console

### DIFF
--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -207,7 +207,7 @@ class ShowCommandCompleter(Completer):
                         )
 
 
-WELCOME_BANNER = f"[bold {HELP_COLOR}]Welcome to {agent_name}:[/bold {HELP_COLOR}] Type '{SlashCommands.EXIT.command}' to exit, '{SlashCommands.HELP.command}' for commands."
+WELCOME_BANNER = f"[bold {HELP_COLOR}]Welcome to {agent_name}:[/bold {HELP_COLOR}] Type '{SlashCommands.EXIT.command}' to exit, Type '{SlashCommands.TOOLS_CONFIG.command}' for tools, '{SlashCommands.HELP.command}' for commands."
 
 
 def format_tool_call_output(

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -207,7 +207,7 @@ class ShowCommandCompleter(Completer):
                         )
 
 
-WELCOME_BANNER = f"[bold {HELP_COLOR}]Welcome to {agent_name}:[/bold {HELP_COLOR}] Type '{SlashCommands.EXIT.command}' to exit, Type '{SlashCommands.TOOLS_CONFIG.command}' for tools, '{SlashCommands.HELP.command}' for commands."
+WELCOME_BANNER = f"[bold {HELP_COLOR}]Welcome to {agent_name}:[/bold {HELP_COLOR}] Type '{SlashCommands.EXIT.command}' to exit, '{SlashCommands.HELP.command}' for commands."
 
 
 def format_tool_call_output(
@@ -1169,12 +1169,12 @@ def run_interactive_loop(
                     continue
                 elif command.startswith(SlashCommands.SHOW.command):
                     # Parse the command to extract tool index or name
-                    show_arg = original_input[len(SlashCommands.SHOW.command) :].strip()
+                    show_arg = original_input[len(SlashCommands.SHOW.command):].strip()
                     handle_show_command(show_arg, all_tool_calls_history, console)
                     continue
                 elif command.startswith(SlashCommands.RUN.command):
                     bash_command = original_input[
-                        len(SlashCommands.RUN.command) :
+                        len(SlashCommands.RUN.command):
                     ].strip()
                     shared_input = handle_run_command(
                         bash_command, session, style, console

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -1169,12 +1169,12 @@ def run_interactive_loop(
                     continue
                 elif command.startswith(SlashCommands.SHOW.command):
                     # Parse the command to extract tool index or name
-                    show_arg = original_input[len(SlashCommands.SHOW.command):].strip()
+                    show_arg = original_input[len(SlashCommands.SHOW.command) :].strip()
                     handle_show_command(show_arg, all_tool_calls_history, console)
                     continue
                 elif command.startswith(SlashCommands.RUN.command):
                     bash_command = original_input[
-                        len(SlashCommands.RUN.command):
+                        len(SlashCommands.RUN.command) :
                     ].strip()
                     shared_input = handle_run_command(
                         bash_command, session, style, console

--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -2,28 +2,34 @@ import json
 import logging
 import os
 import time
-import dateutil.parser
 from typing import Any, Dict, Optional, Tuple, Type, Union
 from urllib.parse import urljoin
 
+import dateutil.parser
 import requests  # type: ignore
-from pydantic import BaseModel, field_validator, Field, model_validator
-from requests import RequestException
 from prometrix.connect.aws_connect import AWSPrometheusConnect
 from prometrix.models.prometheus_config import PrometheusConfig as BasePrometheusConfig
+from pydantic import BaseModel, Field, field_validator, model_validator
+from requests import RequestException
+
+from holmes.common.env_vars import IS_OPENSHIFT, MAX_GRAPH_POINTS
+from holmes.common.openshift import load_openshift_token
 from holmes.core.tools import (
     CallablePrerequisite,
     StructuredToolResult,
+    StructuredToolResultStatus,
     Tool,
     ToolInvokeContext,
     ToolParameter,
-    StructuredToolResultStatus,
     Toolset,
     ToolsetTag,
 )
 from holmes.core.tools_utils.token_counting import count_tool_response_tokens
 from holmes.core.tools_utils.tool_context_window_limiter import get_pct_token_count
 from holmes.plugins.toolsets.consts import STANDARD_END_DATETIME_TOOL_PARAM_DESCRIPTION
+from holmes.plugins.toolsets.logging_utils.logging_api import (
+    DEFAULT_GRAPH_TIME_SPAN_SECONDS,
+)
 from holmes.plugins.toolsets.prometheus.utils import parse_duration_to_seconds
 from holmes.plugins.toolsets.service_discovery import PrometheusDiscovery
 from holmes.plugins.toolsets.utils import (
@@ -33,15 +39,11 @@ from holmes.plugins.toolsets.utils import (
     toolset_name_for_one_liner,
 )
 from holmes.utils.cache import TTLCache
-from holmes.common.env_vars import IS_OPENSHIFT, MAX_GRAPH_POINTS
-from holmes.common.openshift import load_openshift_token
-from holmes.plugins.toolsets.logging_utils.logging_api import (
-    DEFAULT_GRAPH_TIME_SPAN_SECONDS,
-)
 from holmes.utils.keygen_utils import generate_random_key
 
 PROMETHEUS_RULES_CACHE_KEY = "cached_prometheus_rules"
-PROMETHEUS_METADATA_API_LIMIT = 100  # Default limit for Prometheus metadata APIs (series, labels, metadata) to prevent overwhelming responses
+# Default limit for Prometheus metadata APIs (series, labels, metadata) to prevent overwhelming responses
+PROMETHEUS_METADATA_API_LIMIT = 100
 # Default timeout values for PromQL queries
 DEFAULT_QUERY_TIMEOUT_SECONDS = 20
 MAX_QUERY_TIMEOUT_SECONDS = 180
@@ -58,7 +60,8 @@ class PrometheusConfig(BaseModel):
     healthcheck: str = "-/healthy"
 
     # New config for default time window for metadata APIs
-    default_metadata_time_window_hrs: int = DEFAULT_METADATA_TIME_WINDOW_HRS  # Default: only show metrics active in the last hour
+    # Default: only show metrics active in the last hour
+    default_metadata_time_window_hrs: int = DEFAULT_METADATA_TIME_WINDOW_HRS
 
     # Query timeout configuration
     default_query_timeout_seconds: int = (
@@ -1546,7 +1549,7 @@ class PrometheusToolset(Toolset):
                 prometheus_url=prometheus_url,
                 headers=add_prometheus_auth(os.environ.get("PROMETHEUS_AUTH_HEADER")),
             )
-            logging.info(f"Prometheus auto discovered at url {prometheus_url}")
+            logging.debug(f"Prometheus auto discovered at url {prometheus_url}")
             self._reload_llm_instructions()
             return self._is_healthy()
         except Exception as e:

--- a/holmes/plugins/toolsets/service_discovery.py
+++ b/holmes/plugins/toolsets/service_discovery.py
@@ -35,7 +35,7 @@ def find_service_url(label_selector):
         namespace = svc.metadata.namespace
         port = svc.spec.ports[0].port
         url = f"http://{name}.{namespace}.svc.{CLUSTER_DOMAIN}:{port}"
-        logging.info(
+        logging.debug(
             f"Discovered service with label-selector: `{label_selector}` at url: `{url}`"
         )
         return url

--- a/tests/core/test_toolset_manager.py
+++ b/tests/core/test_toolset_manager.py
@@ -124,7 +124,9 @@ def test_refresh_toolset_status_creates_file(mock_list_all_toolsets, toolset_man
 
 
 @patch("holmes.core.toolset_manager.ToolsetManager._list_all_toolsets")
-def test_load_toolset_with_status_reads_cache(mock_list_all_toolsets, toolset_manager):
+def test_load_console_toolset_with_status_reads_cache(
+    mock_list_all_toolsets, toolset_manager
+):
     toolset = MagicMock(spec=Toolset)
     toolset.name = "test"
     toolset.tags = [ToolsetTag.CORE]
@@ -149,17 +151,17 @@ def test_load_toolset_with_status_reads_cache(mock_list_all_toolsets, toolset_ma
         with open(cache_path, "w") as f:
             json.dump(cache_data, f)
         toolset_manager.toolset_status_location = cache_path
-        result = toolset_manager.load_toolset_with_status()
+        result = toolset_manager.load_console_toolset_with_status()
         assert result[0].name == "test"
         assert result[0].enabled is True
 
 
-@patch("holmes.core.toolset_manager.ToolsetManager.load_toolset_with_status")
-def test_list_console_toolsets(mock_load_toolset_with_status, toolset_manager):
+@patch("holmes.core.toolset_manager.ToolsetManager.load_console_toolset_with_status")
+def test_list_console_toolsets(mock_load_console_toolset_with_status, toolset_manager):
     toolset = MagicMock(spec=Toolset)
     toolset.tags = [ToolsetTag.CORE, ToolsetTag.CLI]
     toolset.enabled = True
-    mock_load_toolset_with_status.return_value = [toolset]
+    mock_load_console_toolset_with_status.return_value = [toolset]
     result = toolset_manager.list_console_toolsets()
     assert toolset in result
 


### PR DESCRIPTION
To avoid printing the lengthy toolset status, we mute the status for console, since we have /tools to print the toolset status.
Also, we unform the output for both using and not using toolset.

With cache
```
Loaded models: ['azure/gpt-5-mini']
Loading toolsets...
Refreshing available datasources (toolsets)
Toolset statuses are cached to /home/azureuser/.holmes/toolsets_status.json
Using 44 datasources (toolsets). To view all available toolsets: run '/tools'. To refresh: use flag `--refresh-toolsets`
Using model: azure/gpt-5-mini (272,000 total tokens, 54,400 output tokens)
Welcome to HolmesGPT: Type '/exit' to exit, '/help' for commands.
```
Without cache
```
Loaded models: ['azure/gpt-5-mini']
Loading toolsets...
Using 44 datasources (toolsets). To view all available toolsets: run '/tools'. To refresh: use flag `--refresh-toolsets`
Using model: azure/gpt-5-mini (272,000 total tokens, 54,400 output tokens)
Welcome to HolmesGPT: Type '/exit' to exit, '/help' for commands.
```