### PR TITLE
.github: README: Add OpenSSF scorecard badge

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -53,7 +53,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
+        uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: results.sarif
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 HolmesGPT is an AI agent for investigating problems in your cloud, finding the root cause, and suggesting remediations. It has dozens of built-in integrations for cloud providers, observability tools, and on-call systems.
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11586/badge)](https://www.bestpractices.dev/projects/11586)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/HolmesGPT/holmesgpt/badge)](https://scorecard.dev/viewer/?uri=github.com/HolmesGPT/holmesgpt)
 
 >🎉 **HolmesGPT is now a CNCF Sandbox Project!**  
 HolmesGPT was originally created by [Robusta.Dev](https://home.robusta.dev/) and is a CNCF sandbox project.


### PR DESCRIPTION
# Add OpenSSF scorecard badge

- CI: scorecard-analysis: Add config for OpenSSF scorecard
- README: Add OpenSSF scorecard badge

This is required by CNCF projects to move to incubated stage.

Additionally, once merged it gives more code scanning results in the Security tab -> Code Scanning section on github.
https://github.com/HolmesGPT/holmesgpt/security/code-scanning

## How to use

Once merged click on the badge in the README.

Note, `HolmesGPT/holmesgpt` isn't already scanned by OpenSSF, so it does not have data for it yet. To get the data, a merge will have to happen, OR wait for the badge results to be updated once daily. The action is run daily via github action cron.


## Testing done

We use it in the headlamp and inspektor-gadget repos, and it uses the OpenSSF template for the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated security analysis workflow to run periodic and push-triggered scorecard checks and publish results.

* **Documentation**
  * Added an OpenSSF Scorecard badge to the README to display current project score.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->