### PR TITLE
fix: incompatible test script on wsl

### DIFF
--- a/scripts/run_eval_setup.py
+++ b/scripts/run_eval_setup.py
@@ -40,7 +40,7 @@ for eval_name in args.eval_names:
             data = yaml.safe_load(f)
 
         if section in data:
-            result = subprocess.run(data[section], shell=True)
+            result = subprocess.run(data[section], shell=True, executable="/bin/bash")
             if result.returncode != 0:
                 print(f"⚠️  {section} failed with exit code {result.returncode}")
         else:

--- a/tests/llm/utils/commands.py
+++ b/tests/llm/utils/commands.py
@@ -157,6 +157,7 @@ def _invoke_command(
             command,
             shell=True,
             capture_output=True,
+            executable="/bin/bash",
             text=True,
             check=True,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
bash grammer {1..60} is not supported in wsl default shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal scripts and test utilities to explicitly use Bash for command execution, ensuring consistent behavior across different system environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->