### PR TITLE
Add markdown table-focused eval cases

### DIFF
--- a/docs/development/markdown-table-evals.md
+++ b/docs/development/markdown-table-evals.md
@@ -1,0 +1,20 @@
+# Markdown table eval ideas
+
+## 10 candidate scenarios
+
+1. **Pod health snapshot** – summarize pod phase and restart counts across two namespaces into a single markdown table and highlight pods that need attention.
+2. **HTTP SLO comparison** – present p99 latency and error rate per service endpoint in a table, sorted by risk, and call out which endpoints are violating targets.
+3. **Capacity headroom** – turn node and mount utilization readings into a table with projected days to 95% usage where growth data is provided.
+4. **Deployment rollout matrix** – list deployment names, current replicas, and rollout status across namespaces, emphasizing ones stuck in progress.
+5. **Config drift audit** – compare desired vs. actual replicas and image tags for services in a table and flag mismatches.
+6. **Certificate expirations** – tabulate certificates with their service owner, expiration date, and days until expiry, prioritizing ones expiring soon.
+7. **Alert volume by team** – show alert counts per team with on-call rotation notes in a table and surface the highest-volume team.
+8. **DB query hotspots** – table of slowest queries with average duration, p99 duration, and affected tables, highlighting the worst offender.
+9. **Kafka partition skew** – table of topics with partition count, leader distribution, and skew percentage, identifying topics needing rebalancing.
+10. **Backup compliance** – table of services with last backup time, retention target, and gaps, flagging any missing their RPO.
+
+## Top 3 selected
+
+1. **Pod health snapshot** – clear, action-focused table that tests formatting and prioritization from structured operational data.
+2. **HTTP SLO comparison** – exercises numerical reporting in table form and requires highlighting the riskiest endpoint.
+3. **Capacity headroom** – validates tabular presentation plus a small calculation (projecting time to threshold) to justify table usage.

--- a/tests/llm/fixtures/test_ask_holmes/200_pod_health_snapshot/pod_status_report.md
+++ b/tests/llm/fixtures/test_ask_holmes/200_pod_health_snapshot/pod_status_report.md
@@ -1,0 +1,11 @@
+Daily cluster check:
+
+- Namespace `payments`:
+  - checkout-0 — Running, 0 restarts
+  - checkout-1 — CrashLoopBackOff, 5 restarts (failing during startup probe)
+  - payments-worker-0 — Running, 2 restarts (cleared after transient throttling)
+
+- Namespace `support`:
+  - chat-0 — Running, 0 restarts
+  - chat-1 — Running, 0 restarts
+  - notifier-0 — Pending, 0 restarts (waiting for a node with the required gpu=true label)

--- a/tests/llm/fixtures/test_ask_holmes/200_pod_health_snapshot/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/200_pod_health_snapshot/test_case.yaml
@@ -1,0 +1,17 @@
+user_prompt: |
+  Summarize the pod status report below into a markdown table with columns Namespace, Pod, Phase, and Restarts. Then call out which pods need immediate attention and why.
+
+include_files:
+  - pod_status_report.md
+
+expected_output:
+  - The response includes a markdown table with headers for Namespace, Pod, Phase (or Status), and Restarts.
+  - The table rows include checkout-0, checkout-1, payments-worker-0, chat-0, chat-1, and notifier-0 with their phases and restart counts from the report.
+  - The answer highlights that checkout-1 is in CrashLoopBackOff with five restarts and needs investigation.
+  - The answer notes payments-worker-0 has two restarts and notifier-0 is Pending because it is waiting for a gpu=true node.
+
+tags:
+  - kubernetes
+  - question-answer
+  - numerical
+  - medium

--- a/tests/llm/fixtures/test_ask_holmes/201_http_slo_comparison/service_metrics.md
+++ b/tests/llm/fixtures/test_ask_holmes/201_http_slo_comparison/service_metrics.md
@@ -1,0 +1,7 @@
+Latest SLO snapshot:
+
+- orders-api: p99 latency 1420 ms, error rate 3.8% with timeouts reaching inventory.
+- payments-api: p99 latency 880 ms, error rate 0.6% with occasional retry spikes.
+- catalog-api: p99 latency 620 ms, error rate 0.2% after cache warmup.
+
+Targets: p99 latency under 900 ms and error rate under 1%.

--- a/tests/llm/fixtures/test_ask_holmes/201_http_slo_comparison/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/201_http_slo_comparison/test_case.yaml
@@ -1,0 +1,17 @@
+user_prompt: |
+  Turn the SLO snapshot below into a markdown table with columns Service, P99 latency (ms), Error rate (%), and Notes. Sort by highest risk and state which endpoint is furthest from targets.
+
+include_files:
+  - service_metrics.md
+
+expected_output:
+  - The response contains a markdown table with columns for Service, P99 latency, Error rate, and Notes.
+  - The table rows include orders-api (1420 ms, 3.8%), payments-api (880 ms, 0.6%), and catalog-api (620 ms, 0.2%).
+  - The answer explicitly identifies orders-api as the riskiest endpoint because it exceeds both latency and error-rate targets.
+  - The response calls out that catalog-api is within targets and payments-api is close to latency limits but under the thresholds.
+
+tags:
+  - metrics
+  - numerical
+  - question-answer
+  - medium

--- a/tests/llm/fixtures/test_ask_holmes/202_capacity_headroom/capacity_snapshot.md
+++ b/tests/llm/fixtures/test_ask_holmes/202_capacity_headroom/capacity_snapshot.md
@@ -1,0 +1,7 @@
+Node and mount utilization:
+
+- worker-a: /var/lib/docker at 82% disk, 71% inodes. Growth flat after image prune.
+- worker-b: /var/lib/docker at 65% disk, 55% inodes. Stable.
+- db-node-0: /var/lib/postgresql at 91% disk, 88% inodes with ~3% daily growth.
+
+Threshold to watch: 95% disk usage.

--- a/tests/llm/fixtures/test_ask_holmes/202_capacity_headroom/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/202_capacity_headroom/test_case.yaml
@@ -1,0 +1,17 @@
+user_prompt: |
+  Convert the capacity snapshot into a markdown table with columns Node, Mount, Disk used %, Inodes %, and Notes. Include a short callout on how soon each mount will hit 95% if growth is mentioned.
+
+include_files:
+  - capacity_snapshot.md
+
+expected_output:
+  - The response includes a markdown table with columns for Node, Mount, Disk used %, Inodes %, and Notes.
+  - The table covers worker-a (/var/lib/docker 82% disk, 71% inodes), worker-b (/var/lib/docker 65% disk, 55% inodes), and db-node-0 (/var/lib/postgresql 91% disk, 88% inodes with ~3% daily growth).
+  - The answer highlights db-node-0 as the biggest risk and notes it will cross 95% in about two days at the current growth rate.
+  - The response notes that worker-a and worker-b are stable but should be watched for image growth on worker-a.
+
+tags:
+  - storage
+  - numerical
+  - question-answer
+  - medium


### PR DESCRIPTION
## Summary
- document 10 markdown-table eval ideas and select the top three candidates
- add ask-holmes eval for pod health snapshots that require tabular output
- add SLO comparison and capacity headroom evals that enforce markdown tables with key risk callouts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949376a50848327a97539458f2932d2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added evaluation documentation for operational dashboard scenarios.

* **Tests**
  * Added comprehensive test fixtures for pod health snapshots, HTTP SLO comparisons, and capacity headroom assessments, enhancing coverage for critical operational dashboard use cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->