### PR TITLE
verify setup success in eval 64_keda_vs_hpa_confusio and change to hard

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/64_keda_vs_hpa_confusion/manifest.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/64_keda_vs_hpa_confusion/manifest.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: invoices-64
+  name: app-64
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: invoice-generator
-  namespace: invoices-64
+  namespace: app-64
   labels:
     app: invoice-generator
     version: v1.2.0
@@ -46,7 +46,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: invoice-generator
-  namespace: invoices-64
+  namespace: app-64
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/tests/llm/fixtures/test_ask_holmes/64_keda_vs_hpa_confusion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/64_keda_vs_hpa_confusion/test_case.yaml
@@ -4,8 +4,26 @@ expected_output: |
   - KEDA is not installed in your cluster OR you have no KEDA scaler defined for this resource (either answer is fine)
   - But I found an HPA attached to the invoice-generator deployment
 #  - Current CPU usage is 9%, which is below the 60% threshold configured in the HPA. That's why it isn't scaling up
-generate_mocks: False
+
 tags:
-  - medium
-before_test: 'kubectl apply -f ./manifest.yaml'
+  - hard
+before_test: |
+  kubectl apply -f ./manifest.yaml
+  # Wait for invoice-generator pod with logs (60s total) - MUST succeed or test fails
+  LOG_READY=false
+  for i in {1..20}; do
+    if kubectl wait --for=condition=ready pod -l app=invoice-generator -n app-64 --timeout=1s 2>/dev/null && kubectl logs -l app=invoice-generator -n app-64 --tail=10 2>/dev/null | grep -q "Generating invoice"; then
+      echo "✅ invoice-generator pod ready with logs!"
+      LOG_READY=true
+      break
+    else
+      echo "⏳ Attempt $i/20: pod/logs not ready, waiting 3s..."
+      sleep 3
+    fi
+  done
+  if [ "$LOG_READY" = false ]; then
+    echo "❌ Pod/logs failed after 60s"
+    kubectl get pods -l app=invoice-generator -n app-64
+    exit 1
+  fi
 after_test: 'kubectl delete -f ./manifest.yaml'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture namespace configuration across resources
  * Enhanced test initialization with improved pod readiness validation and log monitoring
  * Adjusted test difficulty classification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->