### PR TITLE
fix: cache llm windows size

### DIFF
--- a/examples/custom_llm.py
+++ b/examples/custom_llm.py
@@ -1,20 +1,24 @@
 from typing import Any, Dict, List, Optional, Type, Union
-from holmes.core.llm import LLM, TokenCountMetadata
+
 from litellm.types.utils import ModelResponse
+from pydantic import BaseModel
+
+from holmes.core.llm import LLM, TokenCountMetadata
+from holmes.core.prompt import generate_user_prompt
 from holmes.core.tool_calling_llm import ToolCallingLLM
 from holmes.core.tools import Tool
-from holmes.plugins.toolsets import load_builtin_toolsets
-from pydantic import BaseModel
-from holmes.plugins.prompts import load_and_render_prompt
 from holmes.core.tools_utils.tool_executor import ToolExecutor
-from holmes.core.prompt import generate_user_prompt
+from holmes.plugins.prompts import load_and_render_prompt
+from holmes.plugins.toolsets import load_builtin_toolsets
 
 
 class MyCustomLLM(LLM):
-    def get_context_window_size(self) -> int:
+    @property
+    def context_window_size(self) -> int:
         return 128000
 
-    def get_maximum_output_token(self) -> int:
+    @property
+    def maximum_output_token(self) -> int:
         return 4096
 
     def count_tokens(

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -515,7 +515,7 @@ class Config(RobustaBaseConfig):
             is_robusta_model=is_robusta_model,
         )  # type: ignore
         logging.info(
-            f"Using model: {model_name} ({llm.get_context_window_size():,} total tokens, {llm.get_maximum_output_token():,} output tokens)"
+            f"Using model: {model_name} ({llm.context_window_size:,} total tokens, {llm.maximum_output_token:,} output tokens)"
         )
         return llm
 

--- a/holmes/core/conversations.py
+++ b/holmes/core/conversations.py
@@ -1,20 +1,18 @@
 from typing import Dict, List, Optional
 
 import sentry_sdk
+
 from holmes.config import Config
 from holmes.core.models import (
-    ToolCallConversationResult,
     IssueChatRequest,
+    ToolCallConversationResult,
     WorkloadHealthChatRequest,
 )
-from holmes.plugins.prompts import load_and_render_prompt
-from holmes.core.tool_calling_llm import ToolCallingLLM
-from holmes.plugins.runbooks import RunbookCatalog
-from holmes.utils.global_instructions import (
-    Instructions,
-    generate_runbooks_args,
-)
 from holmes.core.prompt import generate_user_prompt
+from holmes.core.tool_calling_llm import ToolCallingLLM
+from holmes.plugins.prompts import load_and_render_prompt
+from holmes.plugins.runbooks import RunbookCatalog
+from holmes.utils.global_instructions import Instructions, generate_runbooks_args
 
 DEFAULT_TOOL_SIZE = 10000
 
@@ -26,10 +24,10 @@ def calculate_tool_size(
     if number_of_tools == 0:
         return DEFAULT_TOOL_SIZE
 
-    context_window = ai.llm.get_context_window_size()
+    context_window = ai.llm.context_window_size
     tokens = ai.llm.count_tokens(messages_without_tools)
     message_size_without_tools = tokens.total_tokens
-    maximum_output_token = ai.llm.get_maximum_output_token()
+    maximum_output_token = ai.llm.maximum_output_token
 
     tool_size = min(
         DEFAULT_TOOL_SIZE,

--- a/holmes/core/feedback.py
+++ b/holmes/core/feedback.py
@@ -28,7 +28,7 @@ class FeedbackLLM(FeedbackInfoBase):
 
     def update_from_llm(self, llm: LLM):
         self.model = llm.model
-        self.max_context_size = llm.get_context_window_size()
+        self.max_context_size = llm.context_window_size
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -173,7 +173,7 @@ class DefaultLLM(LLM):
         )
         self._max_output_tokens = self.args.get("custom_args", {}).get(
             "max_output_tokens"
-        )  # TODO: add doc for max_output_tokens?
+        )
         self.args.pop("custom_args", None)
 
     def check_llm(
@@ -276,7 +276,7 @@ class DefaultLLM(LLM):
 
     @property
     def context_window_size(self) -> int:
-        if self._max_context_size:
+        if self._max_context_size is not None:
             return self._max_context_size
 
         if OVERRIDE_MAX_CONTENT_SIZE:

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -7,9 +7,9 @@ from math import floor
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 import litellm
+import sentry_sdk
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.types.utils import ModelResponse, TextCompletionResponse
-import sentry_sdk
 from pydantic import BaseModel, ConfigDict, SecretStr
 from typing_extensions import Self
 
@@ -18,15 +18,14 @@ from holmes.clients.robusta_client import (
     RobustaModelsResponse,
     fetch_robusta_models,
 )
-
 from holmes.common.env_vars import (
+    EXTRA_HEADERS,
     FALLBACK_CONTEXT_WINDOW_SIZE,
     LOAD_ALL_ROBUSTA_MODELS,
     REASONING_EFFORT,
     ROBUSTA_AI,
     ROBUSTA_API_ENDPOINT,
     THINKING,
-    EXTRA_HEADERS,
     TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_PCT,
     TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_TOKENS,
 )
@@ -93,12 +92,14 @@ class LLM:
     def __init__(self):
         self.model: str  # type: ignore
 
+    @property
     @abstractmethod
-    def get_context_window_size(self) -> int:
+    def context_window_size(self) -> int:
         pass
 
+    @property
     @abstractmethod
-    def get_maximum_output_token(self) -> int:
+    def maximum_output_token(self) -> int:
         pass
 
     def get_max_token_count_for_single_tool(self) -> int:
@@ -106,7 +107,7 @@ class LLM:
             0 < TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_PCT
             and TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_PCT <= 100
         ):
-            context_window_size = self.get_context_window_size()
+            context_window_size = self.context_window_size
             calculated_max_tokens = int(
                 context_window_size * TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_PCT // 100
             )
@@ -167,7 +168,12 @@ class DefaultLLM(LLM):
         )
 
     def update_custom_args(self):
-        self.max_context_size = self.args.get("custom_args", {}).get("max_context_size")
+        self._max_context_size = self.args.get("custom_args", {}).get(
+            "max_context_size"
+        )
+        self._max_output_tokens = self.args.get("custom_args", {}).get(
+            "max_output_tokens"
+        )  # TODO: add doc for max_output_tokens?
         self.args.pop("custom_args", None)
 
     def check_llm(
@@ -268,20 +274,23 @@ class DefaultLLM(LLM):
         # Remove duplicates while preserving order (dict.fromkeys maintains insertion order in Python 3.7+)
         return list(dict.fromkeys(names_to_try))
 
-    def get_context_window_size(self) -> int:
-        if self.max_context_size:
-            return self.max_context_size
+    @property
+    def context_window_size(self) -> int:
+        if self._max_context_size:
+            return self._max_context_size
 
         if OVERRIDE_MAX_CONTENT_SIZE:
-            logging.debug(
+            logging.info(
                 f"Using override OVERRIDE_MAX_CONTENT_SIZE {OVERRIDE_MAX_CONTENT_SIZE}"
             )
-            return OVERRIDE_MAX_CONTENT_SIZE
+            self._max_context_size = OVERRIDE_MAX_CONTENT_SIZE
+            return self._max_context_size
 
         # Try each name variant
         for name in self._get_model_name_variants_for_lookup():
             try:
-                return litellm.model_cost[name]["max_input_tokens"]
+                self._max_context_size = litellm.model_cost[name]["max_input_tokens"]
+                return self._max_context_size
             except Exception:
                 continue
 
@@ -291,7 +300,8 @@ class DefaultLLM(LLM):
             f"using default {FALLBACK_CONTEXT_WINDOW_SIZE} tokens for max_input_tokens. "
             f"To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to the correct value for your model."
         )
-        return FALLBACK_CONTEXT_WINDOW_SIZE
+        self._max_context_size = FALLBACK_CONTEXT_WINDOW_SIZE
+        return self._max_context_size
 
     @sentry_sdk.trace
     def count_tokens(
@@ -432,14 +442,16 @@ class DefaultLLM(LLM):
         else:
             raise Exception(f"Unexpected type returned by the LLM {type(result)}")
 
-    def get_maximum_output_token(self) -> int:
-        max_output_tokens = floor(min(64000, self.get_context_window_size() / 5))
+    @property
+    def maximum_output_token(self) -> int:
+        if self._max_output_tokens:
+            return self._max_output_tokens
+        max_output_tokens = floor(min(64000, self.context_window_size / 5))
 
         if OVERRIDE_MAX_OUTPUT_TOKEN:
-            logging.debug(
-                f"Using OVERRIDE_MAX_OUTPUT_TOKEN {OVERRIDE_MAX_OUTPUT_TOKEN}"
-            )
-            return OVERRIDE_MAX_OUTPUT_TOKEN
+            logging.info(f"Using OVERRIDE_MAX_OUTPUT_TOKEN {OVERRIDE_MAX_OUTPUT_TOKEN}")
+            self._max_output_tokens = OVERRIDE_MAX_OUTPUT_TOKEN
+            return self._max_output_tokens
 
         # Try each name variant
         for name in self._get_model_name_variants_for_lookup():
@@ -449,7 +461,9 @@ class DefaultLLM(LLM):
                 ]
                 if litellm_max_output_tokens < max_output_tokens:
                     max_output_tokens = litellm_max_output_tokens
-                return max_output_tokens
+
+                self._max_output_tokens = max_output_tokens
+                return self._max_output_tokens
             except Exception:
                 continue
 
@@ -459,7 +473,8 @@ class DefaultLLM(LLM):
             f"using {max_output_tokens} tokens for max_output_tokens. "
             f"To override, set OVERRIDE_MAX_OUTPUT_TOKEN environment variable to the correct value for your model."
         )
-        return max_output_tokens
+        self._max_output_tokens = max_output_tokens
+        return self._max_output_tokens
 
     def _add_cache_control_to_last_message(
         self, messages: List[Dict[str, Any]]

--- a/holmes/core/tools_utils/tool_context_window_limiter.py
+++ b/holmes/core/tools_utils/tool_context_window_limiter.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
+
 from holmes.core.llm import LLM
-from holmes.core.tools import StructuredToolResultStatus
 from holmes.core.models import ToolCallResult
+from holmes.core.tools import StructuredToolResultStatus
 from holmes.utils import sentry_helper
 
 
@@ -11,7 +12,7 @@ class ToolCallSizeMetadata(BaseModel):
 
 
 def get_pct_token_count(percent_of_total_context_window: float, llm: LLM) -> int:
-    context_window_size = llm.get_context_window_size()
+    context_window_size = llm.context_window_size
 
     if 0 < percent_of_total_context_window and percent_of_total_context_window <= 100:
         return int(context_window_size * percent_of_total_context_window // 100)

--- a/holmes/core/truncation/input_context_window_limiter.py
+++ b/holmes/core/truncation/input_context_window_limiter.py
@@ -1,7 +1,9 @@
 import logging
 from typing import Any, Optional
-from pydantic import BaseModel
+
 import sentry_sdk
+from pydantic import BaseModel
+
 from holmes.common.env_vars import (
     ENABLE_CONVERSATION_HISTORY_COMPACTION,
     MAX_OUTPUT_TOKEN_RESERVATION,
@@ -15,7 +17,6 @@ from holmes.core.models import TruncationMetadata, TruncationResult
 from holmes.core.truncation.compaction import compact_conversation_history
 from holmes.utils import sentry_helper
 from holmes.utils.stream import StreamEvents, StreamMessage
-
 
 TRUNCATION_NOTICE = "\n\n[TRUNCATED]"
 
@@ -149,8 +150,8 @@ def limit_input_context_window(
     events = []
     metadata = {}
     initial_tokens = llm.count_tokens(messages=messages, tools=tools)  # type: ignore
-    max_context_size = llm.get_context_window_size()
-    maximum_output_token = llm.get_maximum_output_token()
+    max_context_size = llm.context_window_size
+    maximum_output_token = llm.maximum_output_token
     conversation_history_compacted = False
     if ENABLE_CONVERSATION_HISTORY_COMPACTION and (
         initial_tokens.total_tokens + maximum_output_token

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import threading
@@ -51,7 +52,6 @@ from holmes.utils.colors import (
 )
 from holmes.utils.console.consts import agent_name
 from holmes.version import check_version_async
-import re
 
 
 class SlashCommands(Enum):
@@ -493,8 +493,8 @@ def handle_context_command(messages, ai: ToolCallingLLM, console: Console) -> No
     tokens_metadata = ai.llm.count_tokens(
         messages
     )  # TODO: pass tools to also count tokens used by input tools
-    max_context_size = ai.llm.get_context_window_size()
-    max_output_tokens = ai.llm.get_maximum_output_token()
+    max_context_size = ai.llm.context_window_size
+    max_output_tokens = ai.llm.maximum_output_token
     available_tokens = (
         max_context_size - tokens_metadata.total_tokens - max_output_tokens
     )

--- a/holmes/utils/console/logging.py
+++ b/holmes/utils/console/logging.py
@@ -39,6 +39,9 @@ def suppress_noisy_logs():
     logging.getLogger("markdown_it").setLevel(logging.INFO)
     # suppress UserWarnings from the slack_sdk module
     warnings.filterwarnings("ignore", category=UserWarning, module="slack_sdk.*")
+    # disable litellm's internal noisy logs suppression
+    import litellm
+    litellm.suppress_debug_info = True
 
 
 def init_logging(verbose_flags: Optional[List[bool]] = None, log_costs: bool = False):

--- a/tests/config_class/test_config_api_base_version.py
+++ b/tests/config_class/test_config_api_base_version.py
@@ -1,7 +1,8 @@
 from unittest.mock import MagicMock, patch
 
-from pydantic import SecretStr
 import yaml
+from pydantic import SecretStr
+
 from holmes.config import Config
 
 
@@ -44,8 +45,8 @@ def test_config_get_llm_with_api_base_version(monkeypatch):
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         result = config._get_llm()
@@ -73,8 +74,8 @@ def test_config_get_llm_with_azure_openai_parameters(monkeypatch):
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         result = config._get_llm()
@@ -110,8 +111,8 @@ def test_config_get_llm_with_model_list_api_base_version(monkeypatch, tmp_path):
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
         result = config._get_llm("test-model")
 
@@ -148,8 +149,8 @@ def test_config_get_llm_model_list_overrides_config_values(monkeypatch, tmp_path
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         config._get_llm("test-model")
@@ -186,8 +187,8 @@ def test_config_get_llm_model_list_defaults_to_config_values(monkeypatch, tmp_pa
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         config._get_llm("test-model")
@@ -237,8 +238,8 @@ def test_config_get_llm_with_non_none_model_list_first_model_fallback(
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         # Call _get_llm without model_key - should use first model in dict
@@ -296,8 +297,8 @@ def test_config_get_llm_with_specific_model_from_model_list(monkeypatch, tmp_pat
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         # Call _get_llm with specific model_key - should use that model's config
@@ -336,8 +337,8 @@ def test_config_get_llm_with_base_url_only(monkeypatch, tmp_path):
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         config._get_llm("test-model")
@@ -376,8 +377,8 @@ def test_config_get_llm_api_base_overrides_base_url(monkeypatch, tmp_path):
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         config._get_llm("test-model")
@@ -417,8 +418,8 @@ def test_config_get_llm_neither_api_base_nor_base_url_uses_config(
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         config._get_llm("test-model")
@@ -458,8 +459,8 @@ def test_config_get_llm_both_params_popped_from_model_params(monkeypatch, tmp_pa
 
     with patch("holmes.config.DefaultLLM") as mock_default_llm:
         mock_llm_instance = MagicMock()
-        mock_llm_instance.get_context_window_size.return_value = 128000
-        mock_llm_instance.get_maximum_output_token.return_value = 4096
+        mock_llm_instance.context_window_size = 128000
+        mock_llm_instance.maximum_output_token = 4096
         mock_default_llm.return_value = mock_llm_instance
 
         config._get_llm("test-model")

--- a/tests/config_class/test_config_load_model_list.py
+++ b/tests/config_class/test_config_load_model_list.py
@@ -57,8 +57,8 @@ def _setup_model_list_file(monkeypatch, tmp_path, data=None):
 def _get_mock_llm():
     """Helper to create a mock LLM instance."""
     mock_llm_instance = MagicMock()
-    mock_llm_instance.get_context_window_size.return_value = 128000
-    mock_llm_instance.get_maximum_output_token.return_value = 4096
+    mock_llm_instance.context_window_size = 128000
+    mock_llm_instance.maximum_output_token = 4096
     return mock_llm_instance
 
 

--- a/tests/config_class/test_config_load_robusta_ai.py
+++ b/tests/config_class/test_config_load_robusta_ai.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
-from holmes.config import Config
-from holmes.clients.robusta_client import RobustaModelsResponse, RobustaModel
 
+from holmes.clients.robusta_client import RobustaModel, RobustaModelsResponse
+from holmes.config import Config
 
 ROBUSTA_TEST_MODELS = RobustaModelsResponse(
     models={
@@ -147,5 +147,5 @@ def test_robusta_ai_config_get_llm_context_override(
     Also makes sure the args are poped before getting to completion call llm"""
     config = Config.load_from_env()
     llm = config._get_llm("Robusta/sonnet-1m")
-    assert llm.get_context_window_size() == 1000000
+    assert llm.context_window_size == 1000000
     assert llm.args.get("custom_args") is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any, Optional
+
 import pytest
 import yaml
 import logging
@@ -93,10 +94,12 @@ class MockLLM(LLM):
     def __init__(self, model: str = "mock-model"):
         self.model = model
 
-    def get_context_window_size(self) -> int:
+    @property
+    def context_window_size(self) -> int:
         return 8192
 
-    def get_maximum_output_token(self) -> int:
+    @property
+    def maximum_output_token(self) -> int:
         return 2048
 
     def count_tokens(

--- a/tests/core/test_feedback.py
+++ b/tests/core/test_feedback.py
@@ -19,10 +19,12 @@ class MockLLM(LLM):
         self.model = model
         self._context_size = context_size
 
-    def get_context_window_size(self) -> int:
+    @property
+    def context_window_size(self) -> int:
         return self._context_size
 
-    def get_maximum_output_token(self) -> int:
+    @property
+    def maximum_output_token(self) -> int:
         return 1024
 
     def count_tokens(

--- a/tests/core/tools_utils/test_tool_context_window_limiter.py
+++ b/tests/core/tools_utils/test_tool_context_window_limiter.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from holmes.core.llm import LLM, TokenCountMetadata
-from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
 from holmes.core.models import ToolCallResult
+from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
 from holmes.core.tools_utils.tool_context_window_limiter import (
     prevent_overly_big_tool_response,
 )
@@ -15,7 +15,7 @@ class TestPreventOverlyBigToolResponse:
     def mock_llm(self):
         """Create a mock LLM instance."""
         llm = Mock(spec=LLM)
-        llm.get_context_window_size.return_value = 4096
+        llm.context_window_size = 4096
         llm.get_max_token_count_for_single_tool.return_value = (
             2048  # Default to 50% of context window
         )
@@ -116,7 +116,7 @@ class TestPreventOverlyBigToolResponse:
         ):
             # Context window: 4096, 25% = 1024 tokens allowed
             # Token count: 2000 (exceeds limit)
-            mock_llm.get_context_window_size.return_value = 4096
+            mock_llm.context_window_size = 4096
             mock_llm.get_max_token_count_for_single_tool.return_value = 1024
             mock_llm.count_tokens.return_value = TokenCountMetadata(
                 total_tokens=2000,
@@ -169,7 +169,7 @@ class TestPreventOverlyBigToolResponse:
             40,
         ):
             # Test with smaller context window
-            mock_llm.get_context_window_size.return_value = 2048
+            mock_llm.context_window_size = 2048
             mock_llm.get_max_token_count_for_single_tool.return_value = (
                 819  # 40% of 2048
             )
@@ -198,7 +198,7 @@ class TestPreventOverlyBigToolResponse:
             "holmes.common.env_vars.TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_PCT",
             50,
         ):
-            mock_llm.get_context_window_size.return_value = 4096
+            mock_llm.context_window_size = 4096
             mock_llm.get_max_token_count_for_single_tool.return_value = 2048
             mock_llm.count_tokens.return_value = TokenCountMetadata(
                 total_tokens=2048,  # Exactly 50% of 4096
@@ -225,7 +225,7 @@ class TestPreventOverlyBigToolResponse:
             "holmes.common.env_vars.TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_PCT",
             20,
         ):
-            mock_llm.get_context_window_size.return_value = 5000
+            mock_llm.context_window_size = 5000
             mock_llm.get_max_token_count_for_single_tool.return_value = (
                 1000  # 20% of 5000
             )

--- a/tests/test_approval_workflow.py
+++ b/tests/test_approval_workflow.py
@@ -1,14 +1,16 @@
-from typing import Optional
-import pytest
 import json
-from unittest.mock import patch, MagicMock
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
 from fastapi.testclient import TestClient
-from server import app
-from holmes.core.models import StructuredToolResult, StructuredToolResultStatus
-from holmes.utils.stream import StreamEvents
-from holmes.core.tool_calling_llm import ToolCallingLLM
+
 from holmes.core.llm import LLM, TokenCountMetadata
+from holmes.core.models import StructuredToolResult, StructuredToolResultStatus
+from holmes.core.tool_calling_llm import ToolCallingLLM
 from holmes.core.tools_utils.tool_executor import ToolExecutor
+from holmes.utils.stream import StreamEvents
+from server import app
 
 
 @pytest.fixture
@@ -95,8 +97,8 @@ def test_streaming_chat_approval_workflow_requires_approval(
         assistant_tokens=0,
         other_tokens=0,
     )
-    mock_llm.get_context_window_size.return_value = 128000
-    mock_llm.get_maximum_output_token.return_value = 4096
+    mock_llm.context_window_size = 128000
+    mock_llm.maximum_output_token = 4096
     mock_llm.model = "gpt-4o"
 
     # Mock the LLM completion to return a tool call
@@ -229,8 +231,8 @@ def test_streaming_chat_approval_workflow_approve_and_execute(
         assistant_tokens=0,
         other_tokens=0,
     )
-    mock_llm.get_context_window_size.return_value = 128000
-    mock_llm.get_maximum_output_token.return_value = 4096
+    mock_llm.context_window_size = 128000
+    mock_llm.maximum_output_token = 4096
     mock_llm.model = "gpt-4o"
 
     mock_llm_response = create_mock_llm_response(
@@ -376,8 +378,8 @@ def test_streaming_chat_approval_workflow_reject_command(
         assistant_tokens=0,
         other_tokens=0,
     )
-    mock_llm.get_context_window_size.return_value = 128000
-    mock_llm.get_maximum_output_token.return_value = 4096
+    mock_llm.context_window_size = 128000
+    mock_llm.maximum_output_token = 4096
     mock_llm.model = "gpt-4o"
 
     mock_llm_response = create_mock_llm_response(

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -298,7 +298,7 @@ class TestRunInteractiveLoop(unittest.TestCase):
         self.mock_ai = Mock(spec=ToolCallingLLM)
         self.mock_ai.llm = Mock()
         self.mock_ai.llm.model = "test-model"
-        self.mock_ai.llm.get_context_window_size.return_value = 4096
+        self.mock_ai.llm.context_window_size = 4096
         self.mock_ai.tool_executor = Mock()
         self.mock_ai.tool_executor.toolsets = [SampleToolset()]
 


### PR DESCRIPTION
Holmesgpt tries to calculate the max context and output size from the https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json per the model name, but for azure openai service, the deployment not the model name is used for locating a azure openai service, and the deployment by default has the same with the model name, but it cannot be promised. In case the deployment name does not match model name, homlesgpt will print annoying warning log like below every time there's any llm call. This is not necessary considering we don't change the windows size on time.

```
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
```
Also, we need to suppress the litellm debug info when verbose logging is not enabled.

```
Provider List: https://docs.litellm.ai/docs/providers
```
## Tests

Before the change, running holmes prints annoying warning log 
```
Using 5 datasources (toolsets). To refresh: use flag `--refresh-toolsets`
NO ENABLED LOGGING TOOLSET
Using selected model: azure/gpt-5.1-qinhao
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using 40000 tokens for max_output_tokens. To override, set OVERRIDE_MAX_OUTPUT_TOKEN environment variable to the
correct value for your model.
Using model: azure/gpt-5.1-qinhao (200,000 total tokens, 40,000 output tokens)
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Welcome to HolmesGPT: Type '/exit' to exit, '/help' for commands.
User: how may pods are running fine in my cluster?

Thinking...

Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using 40000 tokens for max_output_tokens. To override, set OVERRIDE_MAX_OUTPUT_TOKEN environment variable to the
correct value for your model.

Provider List: https://docs.litellm.ai/docs/providers


Provider List: https://docs.litellm.ai/docs/providers

The AI requested 1 tool call(s).
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Running tool #1 fetch_runbook: Runbook: Fetch Runbook networking/dns_troubleshooting_instructions.md
  Finished #1 in 0.00s, output length: 7,933 characters (99 lines) - /show 1 to view contents
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.

Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using 40000 tokens for max_output_tokens. To override, set OVERRIDE_MAX_OUTPUT_TOKEN environment variable to the
correct value for your model.

Provider List: https://docs.litellm.ai/docs/providers


Provider List: https://docs.litellm.ai/docs/providers

The AI requested 1 tool call(s).
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Running tool #2 TodoWrite: Update investigation tasks
Task List:
+----+---------------------------------------------+-----------------+
| ID | Content                                     | Status          |
+----+---------------------------------------------+-----------------+
| 1  | Check overall pod status in all namespaces  | [~] in_progress |
| 2  | Count pods in Running phase and ready state | [ ] pending     |
| 3  | Final review against user question          | [ ] pending     |
+----+---------------------------------------------+-----------------+
  Finished #2 in 0.00s, output length: 490 characters (11 lines) - /show 2 to view contents
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.

Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using 40000 tokens for max_output_tokens. To override, set OVERRIDE_MAX_OUTPUT_TOKEN environment variable to the
correct value for your model.

Provider List: https://docs.litellm.ai/docs/providers


Provider List: https://docs.litellm.ai/docs/providers

```

After the change, it prints the warning log that the model name is found once.
```
 poetry run holmes ask "how may pods are running fine in my cluster?" --model azure/gpt-5.1-qinhao
Loaded models: ['azure/gpt-5.1-qinhao']
Toolset aks-mcp: 'url' field has been migrated to config. Please move 'url' to the config section.
✅ Toolset core_investigation
✅ Toolset internet
✅ Toolset runbook
✅ Toolset aks-mcp
Using 5 datasources (toolsets). To refresh: use flag `--refresh-toolsets`
NO ENABLED LOGGING TOOLSET
Using selected model: azure/gpt-5.1-qinhao
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using default 200000 tokens for max_input_tokens. To override, set OVERRIDE_MAX_CONTENT_SIZE environment variable to
the correct value for your model.
Couldn't find model azure/gpt-5.1-qinhao in litellm's model list (tried: azure/gpt-5.1-qinhao, gpt-5.1-qinhao), using 40000 tokens for max_output_tokens. To override, set OVERRIDE_MAX_OUTPUT_TOKEN environment variable to the
correct value for your model.
Using model: azure/gpt-5.1-qinhao (200,000 total tokens, 40,000 output tokens)
Welcome to HolmesGPT: Type '/exit' to exit, '/help' for commands.
User: how may pods are running fine in my cluster?

Thinking...

The AI requested 1 tool call(s).
Running tool #1 fetch_runbook: Runbook: Fetch Runbook networking/dns_troubleshooting_instructions.md
  Finished #1 in 0.00s, output length: 7,933 characters (99 lines) - /show 1 to view contents

The AI requested 1 tool call(s).
Running tool #2 TodoWrite: Update investigation tasks

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * LLM configuration values (context window size and maximum output tokens) are now exposed as read-only properties instead of callable methods. Custom LLM implementations should be updated to use the new property-based interface.

* **Tests**
  * Test mocks and fixtures updated to use the new property-style LLM interface so tests reflect attribute-based access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->