### PR TITLE
Log /api/chat streaming output

### DIFF
--- a/holmes/utils/stream.py
+++ b/holmes/utils/stream.py
@@ -90,6 +90,7 @@ def stream_chat_formatter(
 ):
     try:
         for message in call_stream:
+            sse_message = None
             if message.event == StreamEvents.ANSWER_END:
                 response_data = {
                     "analysis": message.data.get("content"),
@@ -98,7 +99,9 @@ def stream_chat_formatter(
                     "metadata": message.data.get("metadata") or {},
                 }
 
-                yield create_sse_message(StreamEvents.ANSWER_END.value, response_data)
+                sse_message = create_sse_message(
+                    StreamEvents.ANSWER_END.value, response_data
+                )
             elif message.event == StreamEvents.APPROVAL_REQUIRED:
                 response_data = {
                     "analysis": message.data.get("content"),
@@ -111,19 +114,40 @@ def stream_chat_formatter(
                     "pending_approvals", []
                 )
 
-                yield create_sse_message(
+                sse_message = create_sse_message(
                     StreamEvents.APPROVAL_REQUIRED.value, response_data
                 )
             else:
-                yield create_sse_message(message.event.value, message.data)
+                sse_message = create_sse_message(message.event.value, message.data)
+
+            logging.info(
+                "Streaming /api/chat event %s: %s",
+                message.event.value,
+                sse_message.strip(),
+            )
+            yield sse_message
     except litellm.exceptions.RateLimitError as e:
-        yield create_rate_limit_error_message(str(e))
+        sse_message = create_rate_limit_error_message(str(e))
+        logging.info(
+            "Streaming /api/chat event %s: %s",
+            StreamEvents.ERROR.value,
+            sse_message.strip(),
+        )
+        yield sse_message
     except Exception as e:
         logging.error(e)
         if "Model is getting throttled" in str(e):  # happens for bedrock
-            yield create_rate_limit_error_message(str(e))
+            sse_message = create_rate_limit_error_message(str(e))
         else:
-            yield create_sse_error_message(description=str(e), error_code=1, msg=str(e))
+            sse_message = create_sse_error_message(
+                description=str(e), error_code=1, msg=str(e)
+            )
+        logging.info(
+            "Streaming /api/chat event %s: %s",
+            StreamEvents.ERROR.value,
+            sse_message.strip(),
+        )
+        yield sse_message
 
 
 def add_token_count_to_metadata(

--- a/server.py
+++ b/server.py
@@ -400,13 +400,15 @@ def chat(chat_request: ChatRequest):
             # For non-streaming, we need to handle approvals differently
             # This is a simplified version - in practice, non-streaming with approvals
             # would require a different approach or conversion to streaming
-            return ChatResponse(
+            response = ChatResponse(
                 analysis=llm_call.result,
                 tool_calls=llm_call.tool_calls,
                 conversation_history=llm_call.messages,
                 follow_up_actions=follow_up_actions,
                 metadata=llm_call.metadata,
             )
+            logging.info("Completed /api/chat response: %s", response.model_dump())
+            return response
     except AuthenticationError as e:
         raise HTTPException(status_code=401, detail=e.message)
     except litellm.exceptions.RateLimitError as e:


### PR DESCRIPTION
## Summary
- log /api/chat SSE responses to stdout while streaming, including intermediate events
- log final non-streaming /api/chat responses for better observability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694d597b5e508327b6d6aff00e410cff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated streaming event handling to use a unified message accumulation and yield pattern.
  * Improved error handling for rate limit scenarios with dedicated error message construction.
  
* **Chores**
  * Enhanced logging of streamed chat events for better monitoring.
  * Added explicit logging of API response data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->