### PR TITLE
github action bug fix: wait for calico CRD to be established

### DIFF
--- a/.github/actions/setup-kind-cluster/action.yml
+++ b/.github/actions/setup-kind-cluster/action.yml
@@ -130,6 +130,14 @@ runs:
           exit 1
         fi
         
+        # Wait for the CRD to be fully established
+        echo "Waiting for Installation CRD to be established..."
+        if ! kubectl wait --for=condition=Established --timeout=60s crd/installations.operator.tigera.io; then
+          echo "❌ Installation CRD failed to become established"
+          kubectl get crd installations.operator.tigera.io -o yaml
+          exit 1
+        fi
+        
         # Create custom resource for Calico installation optimized for KIND
         echo "Creating Calico installation resource..."
         if ! cat <<EOF | kubectl create -f -


### PR DESCRIPTION
Signed-off-by: Tomer Keshet <tomer@robusta.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster setup reliability by adding verification for Calico resource definitions with improved error handling and diagnostics on initialization failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->