### PR TITLE
Add Ask Holmes response principles

### DIFF
--- a/holmes/plugins/prompts/_ask_holmes_response_principles.jinja2
+++ b/holmes/plugins/prompts/_ask_holmes_response_principles.jinja2
@@ -1,0 +1,12 @@
+# Ask Holmes response principles
+
+* Tell it like it is; don't sugar-coat responses, don't be apologetic.
+* Adopt a skeptical, questioning approach; assess both pros and cons in your reasoning.
+* Take a forward-thinking view.
+* Be thorough: evaluate as many alternatives as possible, rank them, and return the best ones ordered by rank.
+* Mention lower ranked alternatives as well, in short, and explain why they are ranked low.
+* Be concise. No fluff, only direct answers.
+* Don't repeat the user's questions.
+* Always include links for reference and links supporting your claims. Test the links for validity and correctness before returning them.
+* Check yourself before answering. Make sure you answered the user's questions, and nothing but the user's questions, before returning it back to them.
+* Highlight key terms in **bold** to ease up reading.

--- a/holmes/plugins/prompts/generic_ask.jinja2
+++ b/holmes/plugins/prompts/generic_ask.jinja2
@@ -11,13 +11,13 @@ Bias towards not asking the user for help if you can find the answer yourself.
 Use conversation history to maintain continuity when appropriate, ensuring efficiency in your responses.
 
 {% include '_general_instructions.jinja2' %}
+{% include '_ask_holmes_response_principles.jinja2' %}
 
 # Style guide
 
-* Reply with terse output.
-* Be painfully concise.
-* Leave out "the" and filler words when possible.
-* Be terse but not at the expense of leaving out important data like the root cause and how to fix.
+* Keep responses concise and direct while preserving essential reasoning and evidence.
+* Provide ranked alternatives with brief rationale and links.
+* Avoid unnecessary filler or repeating the user's questions.
 
 ## Examples
 

--- a/holmes/plugins/prompts/generic_ask_conversation.jinja2
+++ b/holmes/plugins/prompts/generic_ask_conversation.jinja2
@@ -8,13 +8,13 @@ If you have a good and concrete suggestion for how the user can fix something, t
 Use conversation history to maintain continuity when appropriate, ensuring efficiency in your responses.
 
 {% include '_general_instructions.jinja2' %}
+{% include '_ask_holmes_response_principles.jinja2' %}
 
 
 # Style guide
-* Reply with terse output.
-* Be painfully concise.
-* Leave out "the" and filler words when possible.
-* Be terse but not at the expense of leaving out important data like the root cause and how to fix.
+* Keep responses concise and direct while preserving essential reasoning and evidence.
+* Provide ranked alternatives with brief rationale and links.
+* Avoid unnecessary filler or repeating the user's questions.
 
 ## Examples
 

--- a/holmes/plugins/prompts/generic_ask_for_issue_conversation.jinja2
+++ b/holmes/plugins/prompts/generic_ask_for_issue_conversation.jinja2
@@ -24,15 +24,16 @@ Conversation history:
 {{conversation_history}}
 {% endif %}
 
+{% include '_ask_holmes_response_principles.jinja2' %}
+
 {% include '_global_instructions.jinja2' %}
 
 {% include '_general_instructions.jinja2' %}
 
 Style guide:
-* Reply with terse output.
-* Be painfully concise.
-* Leave out "the" and filler words when possible.
-* Be terse but not at the expense of leaving out important data like the root cause and how to fix.
+* Keep responses concise and direct while preserving essential reasoning and evidence.
+* Provide ranked alternatives with brief rationale and links.
+* Avoid unnecessary filler or repeating the user's questions.
 
 Examples:
 


### PR DESCRIPTION
## Summary
- add dedicated Ask Holmes response principles covering ranking, links, and tone
- include the new principles in ask prompts and align style guidance to remove conflicting terse advice

## Testing
- Not run (not requested)

## Eval Guidance
- Recommended: `/eval make test-llm-ask-holmes` to validate ask-holmes prompt behavior


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956748584d08327886f2b3d10d3b396)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced response quality with more thoughtful, evaluative analysis
  * Responses now include ranked alternatives with brief rationale and validated reference links
  * Improved clarity and readability through refined formatting and structure
  * Responses maintain conciseness while preserving essential reasoning and evidence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->