### PR TITLE
helm: Use dynamic imagePullPolicy from values

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: holmes
         image: "{{ .Values.registry }}/{{ .Values.image }}"
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["python3", "-u", "server.py"]
         ports:
         - containerPort: 5050

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -7,6 +7,7 @@ imagePullSecrets: []
 podAnnotations: {}
 
 replicas: 1
+imagePullPolicy: IfNotPresent
 
 autoscaling:
   enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment image pull policy is now configurable via chart values instead of being hard-coded. It defaults to "IfNotPresent", allowing operators to change the pull behavior at deploy/upgrade time without code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->