### PR TITLE
Add Connectivity Check toolset to helm chart and update name

### DIFF
--- a/docs/data-sources/builtin-toolsets/connectivity-check.md
+++ b/docs/data-sources/builtin-toolsets/connectivity-check.md
@@ -12,7 +12,7 @@ This toolset is useful for troubleshooting network connectivity issues, verifyin
 ```yaml
 holmes:
     toolsets:
-        connectivity_check:
+        "Connectivity Check":
             enabled: true
 ```
 

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -60,6 +60,8 @@ toolsets:
     enabled: true
   internet:
     enabled: true
+  "Connectivity Check":
+    enabled: true
   prometheus/metrics:
     enabled: true
   runbook:

--- a/holmes/plugins/toolsets/connectivity_check.py
+++ b/holmes/plugins/toolsets/connectivity_check.py
@@ -106,7 +106,7 @@ class TcpCheckTool(Tool):
 class ConnectivityCheckToolset(Toolset):
     def __init__(self):
         super().__init__(
-            name="connectivity_check",
+            name="Connectivity Check",
             description="Check TCP connectivity to endpoints",
             icon_url="https://platform.robusta.dev/demos/internet-access.svg",
             tools=[

--- a/tests/llm/utils/default_toolsets.yaml
+++ b/tests/llm/utils/default_toolsets.yaml
@@ -18,5 +18,5 @@ toolsets:
     enabled: true
   robusta:
     enabled: true
-  connectivity_check:
+  "Connectivity Check":
     enabled: true


### PR DESCRIPTION
- Add Connectivity Check toolset to helm/holmes/values.yaml to enable it by default
- Update toolset name from 'connectivity_check' to 'Connectivity Check' for better user-facing display
- Update documentation and test files to use the new name with proper YAML quoting
- All YAML files validated successfully

This change makes the toolset enabled by default in helm deployments and improves the display name to follow proper capitalization conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated example configurations to reflect the standardized Connectivity Check toolset naming format.

* **Chores**
  * Standardized the Connectivity Check toolset identifier naming across all configuration files for improved consistency and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->