### PR TITLE
Enable connectivity_check toolset by default in helm chart

### DIFF
--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -64,6 +64,8 @@ toolsets:
     enabled: true
   runbook:
     enabled: true
+  connectivity_check:
+    enabled: true
 mcp_servers: {}
 
 resources:


### PR DESCRIPTION
The connectivity_check toolset was defined with enabled=True in the code but was missing from the helm chart values.yaml, causing it to not be enabled by default in helm deployments.