### PR TITLE
docs: standardize OpenRouter example model

### DIFF
--- a/docs/ai-providers/openai-compatible.md
+++ b/docs/ai-providers/openai-compatible.md
@@ -121,6 +121,13 @@ holmes ask "what pods are failing?" --model="openai/<your-model>"
 
 ## Setup Examples
 
+### OpenRouter
+
+```bash
+export OPENROUTER_API_KEY="your-api-key"
+holmes ask "what pods are failing?" --model="openrouter/anthropic/claude-opus-4.5"
+```
+
 ### LocalAI
 
 ```bash

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -10,6 +10,9 @@ This page documents all environment variables that can be used to configure Holm
 ### Anthropic
 - `ANTHROPIC_API_KEY` - API key for Anthropic Claude models
 
+### OpenRouter
+- `OPENROUTER_API_KEY` - API key for OpenRouter models
+
 ### Google
 - `GEMINI_API_KEY` - API key for Google Gemini models
 - `GOOGLE_API_KEY` - Alternative API key for Google services


### PR DESCRIPTION
### Motivation

- Ensure documentation consistently shows the OpenRouter example using `openrouter/anthropic/claude-opus-4.5`.
- Make OpenRouter usage discoverable in the OpenAI-compatible provider docs.
- Surface the `OPENROUTER_API_KEY` environment variable alongside other provider keys for clarity.

### Description

- Added an `OpenRouter` setup example to `docs/ai-providers/openai-compatible.md` demonstrating `holmes ask "what pods are failing?" --model="openrouter/anthropic/claude-opus-4.5"`.
- Added `OPENROUTER_API_KEY` to `docs/reference/environment-variables.md`.
- This is a documentation-only change and does not modify runtime code or tests.

### Testing

- No automated tests were run because this is a docs-only change.
- The most relevant automated eval for the `ask` flow is `tests/llm/test_ask_holmes.py`, which was not executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a928f322c8327b65a75358654799b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenRouter provider setup guides demonstrating configuration and usage with the Holmes CLI tool, including environment variable setup for the OpenRouter API key.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->