### PR TITLE
Add secrets to GitHub Actions for confluence evals

### DIFF
--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -92,7 +92,7 @@ jobs:
           echo "benchmark_type=$BENCHMARK_TYPE" >> $GITHUB_OUTPUT
 
       - name: Run evaluation benchmarks
-        env:  
+        env:
           AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
           AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
@@ -101,6 +101,8 @@ jobs:
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
+          CONFLUENCE_API_KEY: ${{ secrets.CONFLUENCE_API_KEY }}
           EXPERIMENT_ID: "ci-benchmark-${{ github.run_id }}"
         run: |
           echo "Running: ${{ steps.build-command.outputs.command }}"

--- a/.github/workflows/eval-regression.yaml
+++ b/.github/workflows/eval-regression.yaml
@@ -779,6 +779,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ELASTICSEARCH_URL: ${{ secrets.ELASTICSEARCH_URL }}
           ELASTICSEARCH_API_KEY: ${{ secrets.ELASTICSEARCH_API_KEY }}
+          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
+          CONFLUENCE_API_KEY: ${{ secrets.CONFLUENCE_API_KEY }}
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           UPLOAD_DATASET: "true"
           EXPERIMENT_ID: github-${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}


### PR DESCRIPTION
Add CONFLUENCE_BASE_URL and CONFLUENCE_API_KEY environment variables to both eval-regression.yaml and eval-benchmarks.yaml workflows to enable Confluence integration tests.