### PR TITLE
Add images field to chat API documentation

### DIFF
--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -54,6 +54,7 @@ For complete setup instructions with `modelList` configuration, see the [Kuberne
 | conversation_history    | No       |         | list      | Conversation history (first message must be system)|
 | model                   | No       |         | string    | Model name from your `modelList` configuration  |
 | response_format         | No       |         | object    | JSON schema for structured output (see below)   |
+| images                  | No       |         | array     | Image URLs, base64 data URIs, or objects with `url` (required), `detail` (low/high/auto), and `format` (MIME type). Requires vision-enabled model. See [Image Analysis](#image-analysis) |
 | stream                  | No       | false   | boolean   | Enable streaming response (SSE)                 |
 | enable_tool_approval    | No       | false   | boolean   | Require approval for certain tool executions    |
 | additional_system_prompt| No       |         | string    | Additional instructions appended to system prompt|


### PR DESCRIPTION
Document the images parameter in the API reference table with a concise description referencing the existing Image Analysis section for detailed examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to include support for images in chat requests. Users can now reference images via URLs, base64 data URIs, or structured objects with format and detail options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->