### PR TITLE
fix typo

### DIFF
--- a/holmes/plugins/prompts/_global_instructions.jinja2
+++ b/holmes/plugins/prompts/_global_instructions.jinja2
@@ -1,6 +1,6 @@
 # Global Instructions
 
-You may receive a set of “Global Instructions” that describe how to perform certain tasks, handle certain situations, or apply certain best practices. They are not mandatory for every request, but serve as a reference resource and must be used if the current scenario or user prmopt aligns with one of the described methods or conditions.
+You may receive a set of "Global Instructions" that describe how to perform certain tasks, handle certain situations, or apply certain best practices. They are not mandatory for every request, but serve as a reference resource and must be used if the current scenario or user prompt aligns with one of the described methods or conditions.
 Use these rules when deciding how to apply them:
 
 * If the user prompt includes Global Instructions, treat them as a reference resource.


### PR DESCRIPTION
Fixed a typo in the global instructions template where "user prmopt" should have been "user prompt".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance on applying Global Instructions when multiple instructions are relevant or when specific prompts reference tasks.
  * Enhanced clarity on following applicable Global Instructions for both task-specific and general conditions.

* **Style**
  * Updated formatting in Global Instructions presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->