### PR TITLE
Add Datadog API keys to eval regression workflow

### DIFF
--- a/.github/workflows/eval-regression.yaml
+++ b/.github/workflows/eval-regression.yaml
@@ -794,6 +794,8 @@ jobs:
           CONFLUENCE_USER_NAME: ${{ secrets.CONFLUENCE_USER_NAME }}
           CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
           CORALOGIX_SEND_API_KEY: ${{ secrets.CORALOGIX_SEND_API_KEY }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           MODEL_LIST_FILE_LOCATION: /tmp/model_list.yaml
           UPLOAD_DATASET: "true"


### PR DESCRIPTION
Add DATADOG_API_KEY and DATADOG_APP_KEY environment variables to the
"Run tests" step for Datadog integration evals.

https://claude.ai/code/session_01WzLxLvmEovB7Kb9rYtau6w
Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluation regression workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->