### PR TITLE
Fix Datadog API endpoint patterns and add missing descriptions

### DIFF
--- a/holmes/plugins/toolsets/datadog/toolset_datadog_general.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_general.py
@@ -43,7 +43,7 @@ WHITELISTED_ENDPOINTS = [
     # Monitors
     (r"^/api/v\d+/monitor(/search)?$", ""),
     (r"^/api/v\d+/monitor/\d+$", "Get a specific monitor by ID"),
-    (r"^/api/v\d+/monitor/groups/search$", "Search monitor groups"),
+    (r"^/api/v1/monitor/groups/search$", "Search monitor groups (v1 only, no v2 equivalent)"),
     # Dashboards
     (r"^/api/v\d+/dashboard(/lists)?$", ""),
     (r"^/api/v\d+/dashboard/[^/]+$", ""),
@@ -57,7 +57,7 @@ WHITELISTED_ENDPOINTS = [
         r"^/api/v\d+/events$",
         "Use time range parameters 'start' and 'end' as Unix timestamps",
     ),
-    (r"^/api/v\d+/events/\d+$", ""),
+    (r"^/api/v\d+/events/[^/]+$", "Get specific event by ID"),
     # Incidents
     (r"^/api/v\d+/incidents(/search)?$", ""),
     (r"^/api/v\d+/incidents/[^/]+$", ""),
@@ -99,7 +99,8 @@ WHITELISTED_ENDPOINTS = [
     (r"^/api/v2/container_images$", "List container images"),
     # Downtimes
     (r"^/api/v\d+/downtime$", "List scheduled downtimes"),
-    (r"^/api/v\d+/downtime/\d+$", "Get specific downtime"),
+    (r"^/api/v\d+/downtime/[^/]+$", "Get specific downtime by ID"),
+    (r"^/api/v2/monitor/\d+/downtime_matches$", "Get active downtimes for a specific monitor"),
     # Tags
     (r"^/api/v\d+/tags/hosts(/[^/]+)?$", ""),
     # Notebooks
@@ -186,7 +187,7 @@ WHITELISTED_POST_ENDPOINTS = [
     r"^/api/v\d+/monitor/search$",
     r"^/api/v\d+/dashboard/lists$",
     r"^/api/v\d+/slo/search$",
-    r"^/api/v\d+/events/search$",
+    r"^/api/v2/events/search$",  # v1 events/search does not exist, only v2
     r"^/api/v\d+/incidents/search$",
     r"^/api/v\d+/synthetics/tests/search$",
     r"^/api/v\d+/security_monitoring/rules/search$",


### PR DESCRIPTION
## Summary
Updated Datadog API endpoint patterns in the toolset to improve accuracy and add missing endpoint descriptions. These changes correct version-specific endpoints and fix regex patterns to properly match API resource identifiers.

## Key Changes
- **Monitor groups search**: Changed from `\d+` wildcard pattern to explicit `v1` version, as this endpoint only exists in v1 API
- **Events endpoint**: Updated pattern from `\d+` to `[^/]+` to properly match event IDs (which may contain non-numeric characters), and added descriptive text
- **Downtime endpoints**: 
  - Changed pattern from `\d+` to `[^/]+` for better ID matching
  - Added new endpoint for retrieving active downtimes for a specific monitor (`/api/v2/monitor/{id}/downtime_matches`)
- **Events search**: Restricted to `v2` only with clarifying comment, as v1 equivalent does not exist

## Implementation Details
- Regex pattern changes from `\d+` to `[^/]+` allow matching alphanumeric and special characters in resource IDs, improving compatibility with Datadog's actual API behavior
- Added clarifying comments for version-specific endpoints to prevent confusion during API integration
- Enhanced endpoint descriptions for better documentation and discoverability

https://claude.ai/code/session_01YT7RFQCdVCjb2ZLiWR3qps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Datadog API endpoint version handling for monitor groups, events, and downtime operations
  * Enhanced API compatibility by aligning endpoint patterns with correct API versions (v1 vs v2)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->