### PR TITLE
Use hardcoded kubectl version to improve setup reliability

### DIFF
--- a/.github/actions/setup-holmes-env/action.yml
+++ b/.github/actions/setup-holmes-env/action.yml
@@ -47,7 +47,9 @@ runs:
       if: inputs.install-kubectl == 'true'
       shell: bash
       run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        # Using hardcoded version to avoid failures when dl.k8s.io/release/stable.txt is unreachable
+        KUBECTL_VERSION="v1.35.0"
+        curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
         kubectl version --client


### PR DESCRIPTION
## Summary
Updated the kubectl installation step in the Holmes environment setup action to use a hardcoded version instead of dynamically fetching the latest stable version. This improves reliability by eliminating a dependency on the external `dl.k8s.io/release/stable.txt` endpoint.

## Changes
- Replaced dynamic version lookup (`curl -L -s https://dl.k8s.io/release/stable.txt`) with hardcoded version `v1.35.0`
- Added explanatory comment documenting the rationale for this approach
- Simplified the curl command by removing the nested subshell

## Details
The previous implementation relied on fetching the stable version from an external endpoint, which could fail if that service was unreachable or experiencing issues. By pinning to a specific version, we ensure more predictable and reliable CI/CD pipeline execution. The version can be easily updated in the future by modifying the `KUBECTL_VERSION` variable.

https://claude.ai/code/session_01Ey6pp1kmk6YptLwBkXrsTq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build environment setup stability by using a fixed version for a critical dependency, reducing the risk of unexpected changes affecting deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->