### PR TITLE
Rename New Relic config fields for consistency

### DIFF
--- a/docs/data-sources/builtin-toolsets/newrelic.md
+++ b/docs/data-sources/builtin-toolsets/newrelic.md
@@ -20,8 +20,8 @@ You can find these in your New Relic account under Administration > API keys and
       newrelic:
         enabled: true
         config:
-          nr_api_key: "<your New Relic API key>"
-          nr_account_id: "<your New Relic account ID>"
+          api_key: "<your New Relic API key>"
+          account_id: "<your New Relic account ID>"
           is_eu_datacenter: false  # Set to true if using New Relic EU region
     ```
 
@@ -35,8 +35,8 @@ You can find these in your New Relic account under Administration > API keys and
         newrelic:
           enabled: true
           config:
-            nr_api_key: "<your New Relic API key>"
-            nr_account_id: "<your New Relic account ID>"
+            api_key: "<your New Relic API key>"
+            account_id: "<your New Relic account ID>"
             is_eu_datacenter: false  # Set to true if using New Relic EU region
     ```
 

--- a/tests/llm/fixtures/test_ask_holmes/117_new_relic_tracing/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/117_new_relic_tracing/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/117b_new_relic_block_embed/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/117b_new_relic_block_embed/toolsets.yaml
@@ -2,6 +2,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/118_new_relic_logs/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/118_new_relic_logs/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/119_new_relic_metrics/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/119_new_relic_metrics/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/120_new_relic_traces2/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/120_new_relic_traces2/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/121_new_relic_checkout_errors_tracing/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/121_new_relic_checkout_errors_tracing/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/122_new_relic_checkout_latency_tracing_rebuild/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/122_new_relic_checkout_latency_tracing_rebuild/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/123_new_relic_checkout_errors_tracing/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/123_new_relic_checkout_errors_tracing/toolsets.yaml
@@ -8,6 +8,6 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu

--- a/tests/llm/fixtures/test_ask_holmes/124a_new_relic_multi_account_account_name/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/124a_new_relic_multi_account_account_name/toolsets.yaml
@@ -8,7 +8,7 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu
       enable_multi_account: true

--- a/tests/llm/fixtures/test_ask_holmes/124b_new_relic_multi_account_alert_prompt/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/124b_new_relic_multi_account_alert_prompt/toolsets.yaml
@@ -8,7 +8,7 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu
       enable_multi_account: true

--- a/tests/llm/fixtures/test_ask_holmes/124c_new_relic_multi_account_default/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/124c_new_relic_multi_account_default/toolsets.yaml
@@ -8,7 +8,7 @@ toolsets:
   newrelic:
     enabled: true
     config:
-      nr_account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
-      nr_api_key: "{{env.NEW_RELIC_API_KEY}}"
+      account_id: "{{env.NEW_RELIC_ACCOUNT_ID}}"
+      api_key: "{{env.NEW_RELIC_API_KEY}}"
       is_eu_datacenter: false # set "{{env.NEW_RELIC_IS_EU}}" with true to use eu
       enable_multi_account: true

--- a/tests/plugins/toolsets/test_verify_tool_urls.py
+++ b/tests/plugins/toolsets/test_verify_tool_urls.py
@@ -668,16 +668,16 @@ class TestNewRelicURLs:
     @pytest.fixture
     def toolset_us(self):
         toolset = NewRelicToolset()
-        toolset.nr_api_key = "test-key"
-        toolset.nr_account_id = self.ACCOUNT_ID
+        toolset.api_key = "test-key"
+        toolset.account_id = self.ACCOUNT_ID
         toolset.is_eu_datacenter = False
         return toolset
 
     @pytest.fixture
     def toolset_eu(self):
         toolset = NewRelicToolset()
-        toolset.nr_api_key = "test-key"
-        toolset.nr_account_id = self.ACCOUNT_ID
+        toolset.api_key = "test-key"
+        toolset.account_id = self.ACCOUNT_ID
         toolset.is_eu_datacenter = True
         return toolset
 


### PR DESCRIPTION
## Summary
Rename New Relic toolset configuration fields from `nr_api_key` and `nr_account_id` to `api_key` and `account_id` for improved naming consistency. The old field names are maintained as deprecated aliases with automatic migration to ensure backward compatibility.

## Key Changes
- **Configuration Fields**: Renamed `nr_api_key` → `api_key` and `nr_account_id` → `account_id` in `NewrelicConfig` class
- **Toolset Properties**: Updated corresponding properties in `NewRelicToolset` class
- **Parameter Naming**: Renamed `account_id` parameter to `override_account_id` in multi-account mode to avoid confusion with the config field
- **Backward Compatibility**: Added `_deprecated_mappings` to `NewrelicConfig` to automatically migrate old field names with deprecation warnings
- **Documentation**: Updated all examples in docs and test fixtures to use new field names
- **Variable Naming**: Improved clarity by renaming `account_id` to `effective_account_id` in method implementations to distinguish between override and default values

## Implementation Details
- The `ToolsetConfig` base class handles automatic field migration via `_deprecated_mappings`, logging warnings when deprecated fields are used
- All test fixtures across 13 test files have been updated to use the new field names
- The `create_api_client()` method now uses `override_account_id` parameter to clearly indicate it's overriding the default account ID
- Added comprehensive test coverage for backward compatibility in `test_toolset_config.py`

https://claude.ai/code/session_01JbMgQXpJtUqJMp3Ntgg1pf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account override support for New Relic queries

* **Documentation**
  * Clarified New Relic configuration field names

* **Chores**
  * Renamed New Relic config keys to clearer names with backward-compatibility mappings and deprecation handling
  * Updated test fixtures and sample configs to use new keys

* **Tests**
  * Added tests validating New Relic config backward compatibility and deprecation warnings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->