### PR TITLE
Improve ServiceNow health check to distinguish auth failure vs missing permissions

### DIFF
--- a/holmes/plugins/toolsets/servicenow_tables/servicenow_tables.py
+++ b/holmes/plugins/toolsets/servicenow_tables/servicenow_tables.py
@@ -84,15 +84,33 @@ class ServiceNowTablesToolset(Toolset):
             return False, f"Failed to validate ServiceNow configuration: {str(e)}"
 
     def _perform_health_check(self) -> Tuple[bool, str]:
-        """Perform a health check by making a minimal API call."""
+        """Perform a two-tier health check.
+
+        First verifies authentication using a low-privilege table (sys_user),
+        then checks access to the sys_db_object table used for table discovery.
+        This distinguishes between an invalid API key and missing permissions.
+        """
+        # Step 1: Verify authentication with a low-privilege API call
+        auth_ok, auth_message = self._check_authentication()
+        if not auth_ok:
+            return False, auth_message
+
+        # Step 2: Check sys_db_object access (used for table discovery)
+        return self._check_table_discovery_access()
+
+    def _check_authentication(self) -> Tuple[bool, str]:
+        """Verify that the API key is valid by querying the sys_user table.
+
+        The sys_user table is accessible to most ServiceNow API keys and serves
+        as a reliable low-privilege endpoint for authentication verification.
+        """
         try:
-            # Query sys_db_object table with minimal data
-            data, headers = self._make_api_request(
-                endpoint="api/now/v2/table/sys_db_object",
+            self._make_api_request(
+                endpoint="api/now/v2/table/sys_user",
                 query_params={"sysparm_limit": 1, "sysparm_fields": "sys_id"},
                 timeout=10,
             )
-            return True, "ServiceNow configuration is valid and API is accessible."
+            return True, "ServiceNow authentication successful."
 
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 401:
@@ -103,7 +121,9 @@ class ServiceNowTablesToolset(Toolset):
             elif e.response.status_code == 403:
                 return (
                     False,
-                    "ServiceNow access denied. Please ensure your user has Table API access.",
+                    "ServiceNow authentication failed. The API key was rejected. "
+                    "Please verify the API key and the api_key_header setting "
+                    f"(currently: '{self.servicenow_config.api_key_header}').",
                 )
             else:
                 return (
@@ -113,12 +133,50 @@ class ServiceNowTablesToolset(Toolset):
         except requests.exceptions.ConnectionError:
             return (
                 False,
-                f"Failed to connect to ServiceNow instance at {self.config.api_url if self.config else 'unknown'}",
+                f"Failed to connect to ServiceNow instance at {self.servicenow_config.api_url}",
             )
         except requests.exceptions.Timeout:
-            return False, "ServiceNow health check timed out"
+            return False, "ServiceNow health check timed out."
         except Exception as e:
             return False, f"ServiceNow health check failed: {str(e)}"
+
+    def _check_table_discovery_access(self) -> Tuple[bool, str]:
+        """Check access to the sys_db_object table used for table discovery.
+
+        If this fails due to permissions, the toolset is still enabled since the
+        user may have access to other tables they need. A warning is returned
+        to inform them that table discovery won't work.
+        """
+        try:
+            self._make_api_request(
+                endpoint="api/now/v2/table/sys_db_object",
+                query_params={"sysparm_limit": 1, "sysparm_fields": "sys_id"},
+                timeout=10,
+            )
+            return True, "ServiceNow configuration is valid and API is accessible."
+
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code in (401, 403):
+                return (
+                    True,
+                    "ServiceNow authentication is valid, but the API key does not have "
+                    "permission to access the sys_db_object table. Table discovery will "
+                    "not work, but you can still query tables you have access to.",
+                )
+            else:
+                return (
+                    True,
+                    f"ServiceNow authentication is valid, but the sys_db_object table "
+                    f"returned an error ({e.response.status_code}). Table discovery may "
+                    f"not work, but you can still query tables you have access to.",
+                )
+        except Exception:
+            # Auth succeeded, so don't block the toolset for secondary check failures
+            return (
+                True,
+                "ServiceNow authentication is valid. Could not verify sys_db_object "
+                "table access, but the toolset is enabled.",
+            )
 
     @property
     def servicenow_config(self) -> ServiceNowTablesConfig:

--- a/tests/plugins/toolsets/test_servicenow_health_check.py
+++ b/tests/plugins/toolsets/test_servicenow_health_check.py
@@ -1,0 +1,237 @@
+"""Tests for ServiceNow toolset two-tier health check.
+
+Verifies that the health check distinguishes between:
+1. Invalid API key (authentication failure)
+2. Valid API key but missing permissions for sys_db_object table
+3. Both checks passing (full access)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from holmes.plugins.toolsets.servicenow_tables.servicenow_tables import (
+    ServiceNowTablesConfig,
+    ServiceNowTablesToolset,
+)
+
+
+@pytest.fixture
+def toolset():
+    ts = ServiceNowTablesToolset()
+    ts.config = ServiceNowTablesConfig(
+        api_key="test-key",
+        api_url="https://test.service-now.com",
+    )
+    return ts
+
+
+def _make_http_error(status_code: int, text: str = "") -> requests.exceptions.HTTPError:
+    """Create an HTTPError with a mock response."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    error = requests.exceptions.HTTPError(response=response)
+    return error
+
+
+class TestAuthenticationCheck:
+    """Tests for the first tier: authentication verification via sys_user."""
+
+    def test_auth_success(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.return_value = ({"result": [{"sys_id": "abc"}]}, {})
+            ok, msg = toolset._check_authentication()
+
+        assert ok is True
+        assert "authentication successful" in msg.lower()
+        mock_req.assert_called_once_with(
+            endpoint="api/now/v2/table/sys_user",
+            query_params={"sysparm_limit": 1, "sysparm_fields": "sys_id"},
+            timeout=10,
+        )
+
+    def test_auth_401_invalid_key(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(401)
+            ok, msg = toolset._check_authentication()
+
+        assert ok is False
+        assert "authentication failed" in msg.lower()
+        assert "check your API key" in msg
+
+    def test_auth_403_rejected_key(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(403)
+            ok, msg = toolset._check_authentication()
+
+        assert ok is False
+        assert "authentication failed" in msg.lower()
+        assert "api_key_header" in msg
+        assert "x-sn-apikey" in msg
+
+    def test_auth_403_custom_header_shown(self):
+        ts = ServiceNowTablesToolset()
+        ts.config = ServiceNowTablesConfig(
+            api_key="test-key",
+            api_url="https://test.service-now.com",
+            api_key_header="Authorization",
+        )
+        with patch.object(ts, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(403)
+            ok, msg = ts._check_authentication()
+
+        assert ok is False
+        assert "Authorization" in msg
+
+    def test_auth_500_server_error(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(500, "Internal Server Error")
+            ok, msg = toolset._check_authentication()
+
+        assert ok is False
+        assert "500" in msg
+
+    def test_auth_connection_error(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = requests.exceptions.ConnectionError("Connection refused")
+            ok, msg = toolset._check_authentication()
+
+        assert ok is False
+        assert "Failed to connect" in msg
+        assert "test.service-now.com" in msg
+
+    def test_auth_timeout(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = requests.exceptions.Timeout("Request timed out")
+            ok, msg = toolset._check_authentication()
+
+        assert ok is False
+        assert "timed out" in msg.lower()
+
+
+class TestTableDiscoveryAccessCheck:
+    """Tests for the second tier: sys_db_object table access verification."""
+
+    def test_sys_db_object_accessible(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.return_value = ({"result": [{"sys_id": "abc"}]}, {})
+            ok, msg = toolset._check_table_discovery_access()
+
+        assert ok is True
+        assert "valid and API is accessible" in msg
+        mock_req.assert_called_once_with(
+            endpoint="api/now/v2/table/sys_db_object",
+            query_params={"sysparm_limit": 1, "sysparm_fields": "sys_id"},
+            timeout=10,
+        )
+
+    def test_sys_db_object_403_still_enabled(self, toolset):
+        """Toolset should still be enabled when sys_db_object returns 403."""
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(403)
+            ok, msg = toolset._check_table_discovery_access()
+
+        assert ok is True
+        assert "authentication is valid" in msg.lower()
+        assert "does not have permission" in msg
+        assert "sys_db_object" in msg
+        assert "still query tables" in msg
+
+    def test_sys_db_object_401_still_enabled(self, toolset):
+        """Toolset should still be enabled when sys_db_object returns 401."""
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(401)
+            ok, msg = toolset._check_table_discovery_access()
+
+        assert ok is True
+        assert "authentication is valid" in msg.lower()
+        assert "still query tables" in msg
+
+    def test_sys_db_object_500_still_enabled(self, toolset):
+        """Toolset should still be enabled even on 500 errors for sys_db_object."""
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(500, "Server Error")
+            ok, msg = toolset._check_table_discovery_access()
+
+        assert ok is True
+        assert "authentication is valid" in msg.lower()
+        assert "500" in msg
+
+    def test_sys_db_object_exception_still_enabled(self, toolset):
+        """Toolset should still be enabled even on unexpected exceptions."""
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = Exception("Unexpected error")
+            ok, msg = toolset._check_table_discovery_access()
+
+        assert ok is True
+        assert "authentication is valid" in msg.lower()
+        assert "toolset is enabled" in msg
+
+
+class TestHealthCheckIntegration:
+    """Tests for the combined two-tier health check flow."""
+
+    def test_both_checks_pass(self, toolset):
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.return_value = ({"result": [{"sys_id": "abc"}]}, {})
+            ok, msg = toolset._perform_health_check()
+
+        assert ok is True
+        assert "valid and API is accessible" in msg
+        assert mock_req.call_count == 2
+
+    def test_auth_fails_skips_second_check(self, toolset):
+        """When auth fails, sys_db_object should not be checked."""
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.side_effect = _make_http_error(401)
+            ok, msg = toolset._perform_health_check()
+
+        assert ok is False
+        assert "authentication failed" in msg.lower()
+        # Only one call should be made (sys_user), not two
+        assert mock_req.call_count == 1
+
+    def test_auth_passes_but_sys_db_object_forbidden(self, toolset):
+        """Auth passes, sys_db_object forbidden -> toolset still enabled."""
+        call_count = 0
+
+        def side_effect(endpoint, query_params=None, timeout=30):
+            nonlocal call_count
+            call_count += 1
+            if "sys_user" in endpoint:
+                return ({"result": [{"sys_id": "abc"}]}, {})
+            elif "sys_db_object" in endpoint:
+                raise _make_http_error(403)
+            raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+        with patch.object(toolset, "_make_api_request", side_effect=side_effect):
+            ok, msg = toolset._perform_health_check()
+
+        assert ok is True
+        assert "does not have permission" in msg
+        assert "still query tables" in msg
+        assert call_count == 2
+
+    def test_prerequisites_callable_full_flow(self, toolset):
+        """Test the full prerequisites_callable entry point."""
+        config = {
+            "api_key": "test-key",
+            "api_url": "https://test.service-now.com",
+        }
+
+        with patch.object(toolset, "_make_api_request") as mock_req:
+            mock_req.return_value = ({"result": [{"sys_id": "abc"}]}, {})
+            ok, msg = toolset.prerequisites_callable(config)
+
+        assert ok is True
+
+    def test_prerequisites_callable_invalid_config(self, toolset):
+        """Test that missing required fields are caught."""
+        config = {"api_key": "test-key"}  # missing api_url
+
+        ok, msg = toolset.prerequisites_callable(config)
+
+        assert ok is False
+        assert "Failed to validate" in msg


### PR DESCRIPTION
The previous health check only queried sys_db_object, giving a generic
"authentication failed" error even when the API key was valid but lacked
permission to that specific table. This implements a two-tier check:

1. First queries sys_user (low-privilege) to verify the API key is valid
2. Then queries sys_db_object to check table discovery permissions

If auth passes but sys_db_object is forbidden, the toolset is still
enabled with a warning that table discovery won't work.

https://claude.ai/code/session_013cE4FrWYBnbYm2VaQx5Mcf
Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for authentication failures with clearer guidance on configuration.
  * Improved handling of permission restrictions—toolset now gracefully degrades instead of failing entirely.

* **Refactor**
  * Redesigned health check to include two-tier verification for more robust connection validation.

* **Tests**
  * Added comprehensive test coverage for authentication, access verification, and health check workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->