### PR TITLE
Add Kubernetes service discovery and API proxy support for Prometheus

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -37,7 +37,12 @@ from holmes.plugins.toolsets.logging_utils.logging_api import (
     DEFAULT_GRAPH_TIME_SPAN_SECONDS,
 )
 from holmes.plugins.toolsets.prometheus.utils import parse_duration_to_seconds
-from holmes.plugins.toolsets.service_discovery import PrometheusDiscovery
+from holmes.plugins.toolsets.service_discovery import (
+    PrometheusDiscovery,
+    build_service_url,
+    is_running_in_cluster,
+    resolve_kubernetes_service,
+)
 from holmes.plugins.toolsets.utils import (
     get_param_or_raise,
     process_timestamps_to_rfc3339,
@@ -99,6 +104,21 @@ class PrometheusConfig(ToolsetConfig):
             "http://prometheus.monitoring.svc:9090",
         ],
     )
+
+    kubernetes_service: Optional[str] = Field(
+        default=None,
+        title="Kubernetes Service",
+        description=(
+            "Kubernetes service to use as Prometheus in 'namespace/service_name' format. "
+            "When set, HolmesGPT resolves this service and connects to it directly "
+            "(via cluster DNS in-cluster or via the K8s API proxy when running locally). "
+            "Takes precedence over auto-detection but not over prometheus_url."
+        ),
+        examples=["monitoring/prometheus-server", "observability/thanos-query"],
+    )
+
+    # Whether this config uses K8s API proxy URLs (set during discovery, not by users)
+    _uses_kube_proxy: bool = False
 
     discover_metrics_from_last_hours: int = Field(
         default=DEFAULT_METADATA_TIME_WINDOW_HRS,
@@ -174,7 +194,6 @@ class PrometheusConfig(ToolsetConfig):
 
     @model_validator(mode="after")
     def validate_prom_config(self):
-
         # If openshift is enabled, and the user didn't configure auth headers, we will try to load the token from the service account.
         if IS_OPENSHIFT:
             if self.headers.get("Authorization"):
@@ -436,6 +455,18 @@ def do_request(
             verify=verify,
         )
 
+    # When using K8s API proxy, use the kubernetes client's authenticated session
+    if getattr(config, "_uses_kube_proxy", False):
+        return _do_kube_proxy_request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+            timeout=timeout,
+            verify=verify,
+        )
+
     # Non-AMP, Non-Azure: plain HTTP
     return requests.request(
         method=method,
@@ -445,6 +476,77 @@ def do_request(
         data=data,
         timeout=timeout,
         verify=verify,
+    )
+
+
+def _get_kube_proxy_session() -> requests.Session:
+    """
+    Build a requests.Session pre-configured with kubeconfig authentication.
+
+    Extracts auth (bearer token, client certs, CA bundle) from the active
+    kubeconfig and applies it to a session so that requests through the
+    K8s API proxy are properly authenticated.
+    """
+    from kubernetes import client as k8s_client  # type: ignore
+
+    api_client = k8s_client.ApiClient()
+    cfg = api_client.configuration
+
+    session = requests.Session()
+
+    # Bearer token auth
+    if cfg.api_key and cfg.api_key.get("authorization"):
+        session.headers["Authorization"] = cfg.api_key["authorization"]
+    elif cfg.api_key and cfg.api_key.get("BearerToken"):
+        session.headers["Authorization"] = f"Bearer {cfg.api_key['BearerToken']}"
+
+    # Client certificate auth
+    if cfg.cert_file and cfg.key_file:
+        session.cert = (cfg.cert_file, cfg.key_file)
+
+    # CA bundle for verifying the API server's TLS certificate
+    if cfg.ssl_ca_cert:
+        session.verify = cfg.ssl_ca_cert
+
+    return session
+
+
+# Module-level cached session (created on first use)
+_kube_proxy_session: Optional[requests.Session] = None
+
+
+def _do_kube_proxy_request(
+    method: str,
+    url: str,
+    headers: Optional[Dict] = None,
+    params: Optional[Dict] = None,
+    data: Optional[Dict] = None,
+    timeout: int = 60,
+    verify: Optional[bool] = None,
+) -> requests.Response:
+    """
+    Route a request through the Kubernetes API server proxy, with kubeconfig auth.
+    """
+    global _kube_proxy_session  # noqa: PLW0603
+    if _kube_proxy_session is None:
+        _kube_proxy_session = _get_kube_proxy_session()
+
+    # Merge per-request headers on top of session headers
+    merged_headers = dict(_kube_proxy_session.headers)
+    if headers:
+        merged_headers.update(headers)
+
+    # If verify is explicitly provided, use it; otherwise use the session default
+    req_verify = verify if verify is not None else _kube_proxy_session.verify
+
+    return _kube_proxy_session.request(
+        method=method,
+        url=url,
+        headers=merged_headers,
+        params=params,
+        data=data,
+        timeout=timeout,
+        verify=req_verify,
     )
 
 
@@ -1823,31 +1925,53 @@ class PrometheusToolset(Toolset):
         self.tools = [t for t in self.tools if t.name not in incompatible]
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
+        # Path 1: Explicit config provided by the user
         try:
             if config:
                 config_cls = self.determine_prometheus_class(config)
                 self.config = config_cls(**config)  # type: ignore
                 if isinstance(self.config, AzurePrometheusConfig):
                     self._disable_azure_incompatible_tools()
+
+                # If kubernetes_service is set but prometheus_url is not, resolve it
+                if not self.config.prometheus_url and self.config.kubernetes_service:
+                    url, uses_proxy = self._resolve_kubernetes_service(
+                        self.config.kubernetes_service
+                    )
+                    if not url:
+                        return (
+                            False,
+                            f"Failed to resolve kubernetes_service '{self.config.kubernetes_service}'. "
+                            "Check that the namespace/service exists and is accessible.",
+                        )
+                    self.config.prometheus_url = url
+                    self.config._uses_kube_proxy = uses_proxy
+
                 self._reload_llm_instructions()
                 return self._is_healthy()
         except Exception:
             logging.exception("Failed to create prometheus config")
             return False, "Failed to create prometheus config"
+
+        # Path 2: No explicit config — try env var, then auto-detect
         try:
             prometheus_url = os.environ.get("PROMETHEUS_URL")
+            uses_kube_proxy = False
+
             if not prometheus_url:
-                prometheus_url = self.auto_detect_prometheus_url()
+                prometheus_url, uses_kube_proxy = self._auto_detect_prometheus()
                 if not prometheus_url:
                     return (
                         False,
-                        "Unable to auto-detect prometheus. Define prometheus_url in the configuration for tool prometheus/metrics",
+                        "Unable to auto-detect prometheus. Define prometheus_url or "
+                        "kubernetes_service in the configuration for tool prometheus/metrics",
                     )
 
             self.config = PrometheusConfig(
                 prometheus_url=prometheus_url,
                 headers=add_prometheus_auth(os.environ.get("PROMETHEUS_AUTH_HEADER")),
             )
+            self.config._uses_kube_proxy = uses_kube_proxy
             logging.info(f"Prometheus auto discovered at url {prometheus_url}")
             self._reload_llm_instructions()
             return self._is_healthy()
@@ -1855,12 +1979,39 @@ class PrometheusToolset(Toolset):
             logging.exception("Failed to set up prometheus")
             return False, str(e)
 
-    def auto_detect_prometheus_url(self) -> Optional[str]:
+    def _resolve_kubernetes_service(
+        self, kubernetes_service: str
+    ) -> Tuple[Optional[str], bool]:
+        """
+        Resolve a 'namespace/service_name' to a reachable URL.
+
+        Returns (url, uses_kube_proxy) tuple. uses_kube_proxy is True when the
+        URL routes through the K8s API server proxy (i.e. running locally).
+        """
+        service = resolve_kubernetes_service(kubernetes_service)
+        if service is None:
+            return None, False
+        url = build_service_url(service)
+        uses_proxy = not is_running_in_cluster()
+        logging.info(
+            f"Resolved kubernetes_service '{kubernetes_service}' to {url} "
+            f"(kube_proxy={'yes' if uses_proxy else 'no'})"
+        )
+        return url, uses_proxy
+
+    def _auto_detect_prometheus(self) -> Tuple[Optional[str], bool]:
+        """
+        Auto-detect Prometheus or VictoriaMetrics in the cluster.
+
+        Returns (url, uses_kube_proxy) tuple.
+        """
         url: Optional[str] = PrometheusDiscovery.find_prometheus_url()
         if not url:
             url = PrometheusDiscovery.find_vm_url()
-
-        return url
+        if url is None:
+            return None, False
+        uses_proxy = not is_running_in_cluster()
+        return url, uses_proxy
 
     def _is_healthy(self) -> Tuple[bool, str]:
         if (

--- a/holmes/plugins/toolsets/service_discovery.py
+++ b/holmes/plugins/toolsets/service_discovery.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from dataclasses import dataclass
 from typing import List, Optional
 
 from kubernetes import client  # type: ignore
@@ -9,8 +10,10 @@ from kubernetes.client.models.v1_service import V1Service  # type: ignore
 
 CLUSTER_DOMAIN = os.environ.get("CLUSTER_DOMAIN", "cluster.local")
 
+_is_running_in_cluster = bool(os.getenv("KUBERNETES_SERVICE_HOST"))
+
 try:
-    if os.getenv("KUBERNETES_SERVICE_HOST"):
+    if _is_running_in_cluster:
         config.load_incluster_config()
     else:
         config.load_kube_config()
@@ -18,11 +21,46 @@ except config.config_exception.ConfigException as e:
     logging.warning(f"Running without kube-config! e={e}")
 
 
-def find_service_url(label_selector):
+@dataclass
+class DiscoveredService:
+    """Structured representation of a discovered Kubernetes service."""
+
+    name: str
+    namespace: str
+    port: int
+
+
+def is_running_in_cluster() -> bool:
+    """Check whether HolmesGPT is running inside a Kubernetes cluster."""
+    return _is_running_in_cluster
+
+
+def build_service_url(service: DiscoveredService) -> str:
     """
-    Get the url of an in-cluster service with a specific label
+    Build a reachable URL for a discovered Kubernetes service.
+
+    When running in-cluster, returns the standard cluster DNS URL.
+    When running locally (outside the cluster), returns a K8s API proxy URL
+    that routes through the API server using kubeconfig auth.
     """
-    # we do it this way because there is a weird issue with hikaru's ServiceList.listServiceForAllNamespaces()
+    if is_running_in_cluster():
+        return f"http://{service.name}.{service.namespace}.svc.{CLUSTER_DOMAIN}:{service.port}"
+
+    # Running locally — use the K8s API server proxy to reach the service.
+    # The kubernetes python client's Configuration already has the api server host
+    # from the loaded kubeconfig.
+    api_client = client.ApiClient()
+    api_host = api_client.configuration.host.rstrip("/")
+    return f"{api_host}/api/v1/namespaces/{service.namespace}/services/{service.name}:{service.port}/proxy/"
+
+
+def find_service(label_selector: str) -> Optional[DiscoveredService]:
+    """
+    Find a Kubernetes service matching a label selector.
+
+    Returns a DiscoveredService with name, namespace, and port,
+    or None if no matching service is found.
+    """
     try:
         v1 = client.CoreV1Api()
         svc_list: V1ServiceList = v1.list_service_for_all_namespaces(  # type: ignore
@@ -34,13 +72,67 @@ def find_service_url(label_selector):
         name = svc.metadata.name
         namespace = svc.metadata.namespace
         port = svc.spec.ports[0].port
-        url = f"http://{name}.{namespace}.svc.{CLUSTER_DOMAIN}:{port}"
         logging.info(
-            f"Discovered service with label-selector: `{label_selector}` at url: `{url}`"
+            f"Discovered service with label-selector: `{label_selector}` at {namespace}/{name}:{port}"
         )
-        return url
+        return DiscoveredService(name=name, namespace=namespace, port=port)
     except Exception:
-        logging.warning("Error finding url")
+        logging.warning("Error finding service", exc_info=True)
+        return None
+
+
+def find_service_url(label_selector: str) -> Optional[str]:
+    """
+    Get the url of a Kubernetes service with a specific label.
+
+    When running in-cluster, returns the standard cluster DNS URL.
+    When running locally, returns a K8s API proxy URL.
+    """
+    service = find_service(label_selector)
+    if service is None:
+        return None
+    url = build_service_url(service)
+    logging.info(
+        f"Discovered service with label-selector: `{label_selector}` at url: `{url}`"
+    )
+    return url
+
+
+def resolve_kubernetes_service(kubernetes_service: str) -> Optional[DiscoveredService]:
+    """
+    Resolve a 'namespace/service_name' string to a DiscoveredService by looking up the
+    service in the Kubernetes API to determine the port.
+
+    Args:
+        kubernetes_service: Service reference in 'namespace/service_name' format.
+
+    Returns:
+        DiscoveredService if found, None otherwise.
+    """
+    parts = kubernetes_service.split("/", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        logging.error(
+            f"Invalid kubernetes_service format: '{kubernetes_service}'. "
+            "Expected 'namespace/service_name' (e.g. 'monitoring/prometheus-server')"
+        )
+        return None
+
+    namespace, service_name = parts
+    try:
+        v1 = client.CoreV1Api()
+        svc: V1Service = v1.read_namespaced_service(
+            name=service_name, namespace=namespace
+        )  # type: ignore
+        port = svc.spec.ports[0].port
+        logging.info(
+            f"Resolved kubernetes_service '{kubernetes_service}' with port {port}"
+        )
+        return DiscoveredService(name=service_name, namespace=namespace, port=port)
+    except Exception:
+        logging.warning(
+            f"Failed to resolve kubernetes_service '{kubernetes_service}'",
+            exc_info=True,
+        )
         return None
 
 

--- a/tests/plugins/toolsets/prometheus/test_kube_proxy.py
+++ b/tests/plugins/toolsets/prometheus/test_kube_proxy.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from holmes.plugins.toolsets.prometheus.prometheus import (
+    PrometheusConfig,
+    _do_kube_proxy_request,
+    do_request,
+)
+
+
+class TestDoRequestKubeProxy:
+    """Test that do_request routes through kube proxy when _uses_kube_proxy is set."""
+
+    @patch("holmes.plugins.toolsets.prometheus.prometheus._do_kube_proxy_request")
+    def test_routes_through_kube_proxy_when_flag_set(self, mock_kube_request):
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_kube_request.return_value = mock_response
+
+        config = PrometheusConfig(
+            prometheus_url="https://k8s-api:6443/api/v1/namespaces/monitoring/services/prom:9090/proxy/"
+        )
+        config._uses_kube_proxy = True
+
+        response = do_request(
+            config=config,
+            url="https://k8s-api:6443/api/v1/namespaces/monitoring/services/prom:9090/proxy/api/v1/query",
+        )
+        assert response.status_code == 200
+        mock_kube_request.assert_called_once()
+
+    @patch("holmes.plugins.toolsets.prometheus.prometheus.requests.request")
+    def test_plain_http_when_flag_not_set(self, mock_request):
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
+
+        config = PrometheusConfig(prometheus_url="http://prometheus:9090/")
+        # _uses_kube_proxy is False by default
+
+        response = do_request(config=config, url="http://prometheus:9090/api/v1/query")
+        assert response.status_code == 200
+        mock_request.assert_called_once()
+
+
+class TestKubeProxySession:
+    @patch("holmes.plugins.toolsets.prometheus.prometheus._kube_proxy_session", None)
+    @patch("holmes.plugins.toolsets.prometheus.prometheus._get_kube_proxy_session")
+    def test_creates_session_on_first_use(self, mock_get_session):
+        mock_session = MagicMock(spec=requests.Session)
+        mock_session.headers = {}
+        mock_session.verify = True
+        mock_response = MagicMock(spec=requests.Response)
+        mock_session.request.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        result = _do_kube_proxy_request(method="GET", url="https://k8s:6443/proxy/test")
+        mock_get_session.assert_called_once()
+        assert result == mock_response
+
+
+class TestPrometheusConfigKubernetesService:
+    def test_kubernetes_service_field_default_none(self):
+        config = PrometheusConfig(prometheus_url="http://localhost:9090")
+        assert config.kubernetes_service is None
+
+    def test_kubernetes_service_field_set(self):
+        config = PrometheusConfig(kubernetes_service="monitoring/prometheus-server")
+        assert config.kubernetes_service == "monitoring/prometheus-server"
+        assert config.prometheus_url is None  # not resolved yet
+
+    def test_uses_kube_proxy_default_false(self):
+        config = PrometheusConfig(prometheus_url="http://localhost:9090")
+        assert config._uses_kube_proxy is False

--- a/tests/plugins/toolsets/test_service_discovery.py
+++ b/tests/plugins/toolsets/test_service_discovery.py
@@ -1,0 +1,166 @@
+from unittest.mock import MagicMock, patch
+
+from holmes.plugins.toolsets.service_discovery import (
+    DiscoveredService,
+    build_service_url,
+    find_service,
+    find_service_url,
+    resolve_kubernetes_service,
+)
+
+
+class TestDiscoveredService:
+    def test_dataclass_fields(self):
+        svc = DiscoveredService(name="prometheus", namespace="monitoring", port=9090)
+        assert svc.name == "prometheus"
+        assert svc.namespace == "monitoring"
+        assert svc.port == 9090
+
+
+class TestBuildServiceUrl:
+    @patch(
+        "holmes.plugins.toolsets.service_discovery.is_running_in_cluster",
+        return_value=True,
+    )
+    def test_in_cluster_url(self, _mock_in_cluster):
+        svc = DiscoveredService(
+            name="prometheus-server", namespace="monitoring", port=9090
+        )
+        url = build_service_url(svc)
+        assert url == "http://prometheus-server.monitoring.svc.cluster.local:9090"
+
+    @patch(
+        "holmes.plugins.toolsets.service_discovery.is_running_in_cluster",
+        return_value=False,
+    )
+    @patch("holmes.plugins.toolsets.service_discovery.client.ApiClient")
+    def test_local_kube_proxy_url(self, mock_api_client_cls, _mock_in_cluster):
+        mock_cfg = MagicMock()
+        mock_cfg.host = "https://127.0.0.1:6443"
+        mock_api_client = MagicMock()
+        mock_api_client.configuration = mock_cfg
+        mock_api_client_cls.return_value = mock_api_client
+
+        svc = DiscoveredService(
+            name="prometheus-server", namespace="monitoring", port=9090
+        )
+        url = build_service_url(svc)
+        assert (
+            url
+            == "https://127.0.0.1:6443/api/v1/namespaces/monitoring/services/prometheus-server:9090/proxy/"
+        )
+
+    @patch(
+        "holmes.plugins.toolsets.service_discovery.is_running_in_cluster",
+        return_value=False,
+    )
+    @patch("holmes.plugins.toolsets.service_discovery.client.ApiClient")
+    def test_local_url_strips_trailing_slash(
+        self, mock_api_client_cls, _mock_in_cluster
+    ):
+        mock_cfg = MagicMock()
+        mock_cfg.host = "https://k8s.example.com:6443/"
+        mock_api_client = MagicMock()
+        mock_api_client.configuration = mock_cfg
+        mock_api_client_cls.return_value = mock_api_client
+
+        svc = DiscoveredService(name="prom", namespace="ns", port=8080)
+        url = build_service_url(svc)
+        assert (
+            url
+            == "https://k8s.example.com:6443/api/v1/namespaces/ns/services/prom:8080/proxy/"
+        )
+
+
+class TestFindService:
+    @patch("holmes.plugins.toolsets.service_discovery.client.CoreV1Api")
+    def test_returns_discovered_service(self, mock_core_api_cls):
+        mock_svc = MagicMock()
+        mock_svc.metadata.name = "prometheus-server"
+        mock_svc.metadata.namespace = "monitoring"
+        mock_svc.spec.ports = [MagicMock(port=9090)]
+
+        mock_api = MagicMock()
+        mock_api.list_service_for_all_namespaces.return_value = MagicMock(
+            items=[mock_svc]
+        )
+        mock_core_api_cls.return_value = mock_api
+
+        result = find_service("app=prometheus-server")
+        assert result is not None
+        assert result.name == "prometheus-server"
+        assert result.namespace == "monitoring"
+        assert result.port == 9090
+
+    @patch("holmes.plugins.toolsets.service_discovery.client.CoreV1Api")
+    def test_returns_none_when_no_services(self, mock_core_api_cls):
+        mock_api = MagicMock()
+        mock_api.list_service_for_all_namespaces.return_value = MagicMock(items=[])
+        mock_core_api_cls.return_value = mock_api
+
+        result = find_service("app=nonexistent")
+        assert result is None
+
+    @patch("holmes.plugins.toolsets.service_discovery.client.CoreV1Api")
+    def test_returns_none_on_exception(self, mock_core_api_cls):
+        mock_core_api_cls.side_effect = Exception("API error")
+        result = find_service("app=broken")
+        assert result is None
+
+
+class TestFindServiceUrl:
+    @patch(
+        "holmes.plugins.toolsets.service_discovery.build_service_url",
+        return_value="http://prom.monitoring.svc.cluster.local:9090",
+    )
+    @patch("holmes.plugins.toolsets.service_discovery.find_service")
+    def test_returns_url(self, mock_find, mock_build):
+        mock_find.return_value = DiscoveredService(
+            name="prom", namespace="monitoring", port=9090
+        )
+        url = find_service_url("app=prometheus")
+        assert url == "http://prom.monitoring.svc.cluster.local:9090"
+
+    @patch("holmes.plugins.toolsets.service_discovery.find_service", return_value=None)
+    def test_returns_none_when_not_found(self, _mock_find):
+        url = find_service_url("app=nonexistent")
+        assert url is None
+
+
+class TestResolveKubernetesService:
+    @patch("holmes.plugins.toolsets.service_discovery.client.CoreV1Api")
+    def test_resolves_valid_service(self, mock_core_api_cls):
+        mock_svc = MagicMock()
+        mock_svc.spec.ports = [MagicMock(port=9090)]
+
+        mock_api = MagicMock()
+        mock_api.read_namespaced_service.return_value = mock_svc
+        mock_core_api_cls.return_value = mock_api
+
+        result = resolve_kubernetes_service("monitoring/prometheus-server")
+        assert result is not None
+        assert result.name == "prometheus-server"
+        assert result.namespace == "monitoring"
+        assert result.port == 9090
+        mock_api.read_namespaced_service.assert_called_once_with(
+            name="prometheus-server", namespace="monitoring"
+        )
+
+    def test_rejects_invalid_format_no_slash(self):
+        result = resolve_kubernetes_service("prometheus-server")
+        assert result is None
+
+    def test_rejects_invalid_format_empty_parts(self):
+        result = resolve_kubernetes_service("/prometheus-server")
+        assert result is None
+        result = resolve_kubernetes_service("monitoring/")
+        assert result is None
+
+    @patch("holmes.plugins.toolsets.service_discovery.client.CoreV1Api")
+    def test_returns_none_on_api_error(self, mock_core_api_cls):
+        mock_api = MagicMock()
+        mock_api.read_namespaced_service.side_effect = Exception("not found")
+        mock_core_api_cls.return_value = mock_api
+
+        result = resolve_kubernetes_service("monitoring/nonexistent")
+        assert result is None


### PR DESCRIPTION
## Summary
This PR adds support for discovering and connecting to Prometheus via Kubernetes services, with automatic routing through the K8s API server proxy when running locally outside the cluster.

## Key Changes

### Service Discovery Enhancements (`service_discovery.py`)
- Introduced `DiscoveredService` dataclass to represent Kubernetes services with name, namespace, and port
- Added `is_running_in_cluster()` function to detect if HolmesGPT is running inside a cluster
- Added `build_service_url()` to generate appropriate URLs:
  - In-cluster: standard cluster DNS URLs (`http://service.namespace.svc.cluster.local:port`)
  - Local: K8s API proxy URLs (`https://api-server/api/v1/namespaces/.../services/.../proxy/`)
- Added `resolve_kubernetes_service()` to resolve `namespace/service_name` format strings to actual services
- Refactored `find_service()` to return structured `DiscoveredService` objects instead of URLs
- Updated `find_service_url()` to use the new helper functions

### Prometheus Configuration (`prometheus.py`)
- Added `kubernetes_service` field to `PrometheusConfig` for explicit service specification
- Added `_uses_kube_proxy` internal flag to track when K8s API proxy routing is needed
- Implemented `_resolve_kubernetes_service()` method to resolve user-provided service references
- Refactored `_auto_detect_prometheus()` to return both URL and proxy flag
- Updated `prerequisites_callable()` to support three configuration paths:
  1. Explicit `kubernetes_service` config (takes precedence over auto-detection)
  2. Environment variable `PROMETHEUS_URL`
  3. Auto-detection via label selectors

### K8s API Proxy Support (`prometheus.py`)
- Added `_get_kube_proxy_session()` to create authenticated requests.Session from kubeconfig
- Added `_do_kube_proxy_request()` to route requests through the K8s API server proxy
- Updated `do_request()` to conditionally route through proxy when `_uses_kube_proxy` is set
- Implemented module-level session caching to avoid recreating authentication on each request

## Implementation Details

- **Authentication**: When using K8s API proxy, authentication is extracted from the active kubeconfig (bearer tokens, client certificates, CA bundles)
- **Backward Compatibility**: Existing configurations continue to work unchanged; new features are opt-in
- **Error Handling**: Clear error messages guide users when service resolution fails
- **Logging**: Added informative logging for service discovery and proxy routing decisions

## Tests
Added comprehensive test coverage for:
- K8s API proxy request routing
- Service URL building for both in-cluster and local scenarios
- Service discovery and resolution
- Configuration validation

https://claude.ai/code/session_019eMJZ2cHATWuAAf7ePGqhv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes service integration for Prometheus monitoring with automatic service discovery and proxy support
  * Enhanced service discovery to support both in-cluster and out-of-cluster Kubernetes environments

* **Tests**
  * Added comprehensive test coverage for Kubernetes service discovery and Prometheus Kubernetes proxy functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->