### PR TITLE
Prevent agents from running pre-commit/ruff/mypy unless explicitly asked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,6 @@ HolmesGPT is an AI-powered troubleshooting agent that connects to observability 
 ```bash
 # Install dependencies with Poetry
 poetry install
-
-# Install pre-commit hooks
-poetry run pre-commit install
 ```
 
 ### Testing
@@ -35,11 +32,12 @@ make test-llm-investigate         # Test AlertManager investigations
 poetry run pytest tests/llm/ -n 6 -vv  # Run all LLM tests in parallel
 
 # Run pre-commit checks (includes ruff, mypy, poetry validation)
+# NOTE: Only run these when the user explicitly asks. They run in CI automatically.
 make check
 poetry run pre-commit run -a
 ```
 
-### Code Quality
+### Code Quality (only run when explicitly asked)
 ```bash
 # Format code with ruff
 poetry run ruff format


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md to explicitly instruct agents to **never run `pre-commit`, `ruff`, or `mypy`** unless the user explicitly asks
- Changed commit instructions to use `git commit -s --no-verify` to skip local pre-commit hooks
- Clarified that pre-commit hooks are checked in CI, not locally

Previously, the instructions implicitly encouraged running these tools ("Pre-commit hooks must pass"), which caused agents to make widespread formatting/type changes to files unrelated to their task — since hooks aren't installed consistently across machines.

## Test plan
- [ ] Verify future agent sessions respect the new instructions and don't run linting tools unprompted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that code quality checks (pre-commit, ruff, mypy) are enforced in CI and should not be run locally unless explicitly requested.
  * Removed local pre-commit setup instructions and added CI-centric workflow guidance.
  * Renamed and reworded the Code Quality section to “Code Quality (only run when explicitly asked)” and updated Pull Request and Development guidelines to include how to skip local checks.
  * Minor formatting and wording improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->