### PR TITLE
Add OpenRouter to AI providers documentation

### DIFF
--- a/docs/ai-providers/.nav.yml
+++ b/docs/ai-providers/.nav.yml
@@ -6,6 +6,7 @@ nav:
   - Gemini: gemini.md
   - Google Vertex AI: google-vertex-ai.md
   - Ollama: ollama.md
+  - OpenRouter: openrouter.md
   - OpenAI: openai.md
   - OpenAI-Compatible: openai-compatible.md
   - Other: other.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
           - Gemini: ai-providers/gemini.md
           - "Google Vertex AI": ai-providers/google-vertex-ai.md
           - Ollama: ai-providers/ollama.md
+          - OpenRouter: ai-providers/openrouter.md
           - OpenAI: ai-providers/openai.md
           - "OpenAI-Compatible": ai-providers/openai-compatible.md
           - Other: ai-providers/other.md


### PR DESCRIPTION
## Summary
This PR adds OpenRouter to the AI providers documentation by updating the navigation configuration files to include the new provider in the documentation structure.

## Changes
- Added OpenRouter navigation entry to `docs/ai-providers/.nav.yml`
- Added OpenRouter navigation entry to `mkdocs.yml` under the AI providers section
- Entries are positioned alphabetically between Ollama and OpenAI providers

## Notes
This change updates the documentation navigation structure to include OpenRouter as an available AI provider option. The actual OpenRouter provider documentation file (`openrouter.md`) is referenced but not included in this diff.

https://claude.ai/code/session_012S1rzyS7tmrGvdDAiKomNW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenRouter to the AI provider documentation and navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->