### PR TITLE
Add Elasticsearch post-deploy regression test case

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/217_elasticsearch_deploy_regression/generate_data.py
+++ b/tests/llm/fixtures/test_ask_holmes/217_elasticsearch_deploy_regression/generate_data.py
@@ -1,0 +1,135 @@
+"""Generate API gateway log data for deploy regression test.
+
+Creates a realistic dataset showing a post-deploy regression where organization-linked
+accounts get 403 errors on the billing endpoint, while solo accounts are unaffected.
+
+Data layout:
+  Pre-deploy (v2.13.2, 08:00-09:40): All requests succeed (200)
+    - 15 solo user requests across 3 endpoints
+    - 15 org user requests across 3 endpoints
+
+  Deploy event (09:45): Version v2.14.0-rc3 rollout marker
+
+  Post-deploy (v2.14.0-rc3, 09:50-10:40): Regression appears
+    - 15 solo user requests across 3 endpoints → 200
+    - 5 solo user requests on billing endpoint → 200 (billing works for solo)
+    - 10 org user requests on non-billing endpoints → 200
+    - 15 org user requests on billing endpoint → 403 (AUTHZ-4821)
+
+Total: 76 documents
+"""
+
+import json
+import random
+
+random.seed(217)
+
+INDEX_ACTION = json.dumps({"index": {}})
+
+SOLO_USERS = ["usr-4821", "usr-7293", "usr-1054", "usr-8367", "usr-5940"]
+ORG_USERS = [
+    ("usr-2186", "org-8f4k2m7p"),
+    ("usr-6734", "org-8f4k2m7p"),
+    ("usr-9012", "org-3nq9v2xd"),
+    ("usr-3457", "org-3nq9v2xd"),
+    ("usr-7801", "org-kw5j7r1t"),
+]
+ENDPOINTS = ["/api/v3/billing/invoices", "/api/v3/users/profile", "/api/v3/projects/list"]
+NON_BILLING = ["/api/v3/users/profile", "/api/v3/projects/list"]
+
+minute_counter = 0
+
+
+def next_timestamp():
+    global minute_counter
+    h = 8 + minute_counter // 60
+    m = minute_counter % 60
+    minute_counter += 2
+    return f"2025-03-15T{h:02d}:{m:02d}:00Z"
+
+
+def emit(doc):
+    print(INDEX_ACTION)
+    print(json.dumps(doc))
+
+
+def success_request(ts, method, endpoint, user_id, version, org_id=None):
+    doc = {
+        "@timestamp": ts,
+        "method": method,
+        "endpoint": endpoint,
+        "status_code": 200,
+        "user_id": user_id,
+        "deploy_version": version,
+        "response_time_ms": random.randint(25, 120),
+        "request_id": f"req-{random.randint(100000, 999999)}",
+    }
+    if org_id:
+        doc["org_id"] = org_id
+    emit(doc)
+
+
+def forbidden_request(ts, method, endpoint, user_id, version, org_id):
+    emit({
+        "@timestamp": ts,
+        "method": method,
+        "endpoint": endpoint,
+        "status_code": 403,
+        "user_id": user_id,
+        "org_id": org_id,
+        "deploy_version": version,
+        "response_time_ms": random.randint(3, 12),
+        "error_code": "AUTHZ-4821",
+        "error_message": f"Authorization failed: required scope 'org:billing:read' not present in token for organization {org_id}",
+        "request_id": f"req-{random.randint(100000, 999999)}",
+    })
+
+
+# === Pre-deploy traffic (v2.13.2) — all succeed ===
+
+# Solo users hit all endpoints
+for user in SOLO_USERS:
+    for ep in ENDPOINTS:
+        success_request(next_timestamp(), "GET", ep, user, "v2.13.2")
+
+# Org users hit all endpoints (including billing — works pre-deploy)
+for user_id, org_id in ORG_USERS:
+    for ep in ENDPOINTS:
+        success_request(next_timestamp(), "GET", ep, user_id, "v2.13.2", org_id)
+
+
+# === Deploy event ===
+
+minute_counter = 105  # 09:45
+emit({
+    "@timestamp": next_timestamp(),
+    "event_type": "deployment",
+    "deploy_version": "v2.14.0-rc3",
+    "message": "Deployment v2.14.0-rc3 rolled out to all API gateway instances",
+    "deployed_by": "ci-pipeline",
+    "changelog": "Updated authorization middleware, billing API rate limits, user profile caching",
+})
+
+
+# === Post-deploy traffic (v2.14.0-rc3) — regression appears ===
+
+minute_counter = 110  # 09:50
+
+# Solo users hit all endpoints — still all succeed
+for user in SOLO_USERS:
+    for ep in ENDPOINTS:
+        success_request(next_timestamp(), "GET", ep, user, "v2.14.0-rc3")
+
+# Extra solo user billing requests to emphasize billing works for solo accounts
+for user in SOLO_USERS:
+    success_request(next_timestamp(), "GET", "/api/v3/billing/invoices", user, "v2.14.0-rc3")
+
+# Org users on non-billing endpoints — still succeed
+for user_id, org_id in ORG_USERS:
+    for ep in NON_BILLING:
+        success_request(next_timestamp(), "GET", ep, user_id, "v2.14.0-rc3", org_id)
+
+# Org users on billing endpoint — 403 AUTHZ-4821 (3 attempts each, simulating retries)
+for user_id, org_id in ORG_USERS:
+    for _ in range(3):
+        forbidden_request(next_timestamp(), "GET", "/api/v3/billing/invoices", user_id, "v2.14.0-rc3", org_id)

--- a/tests/llm/fixtures/test_ask_holmes/217_elasticsearch_deploy_regression/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/217_elasticsearch_deploy_regression/test_case.yaml
@@ -1,0 +1,135 @@
+# Test: Elasticsearch Post-Deploy Regression (Organization Permission Scope)
+#
+# Simulates a subtle post-deploy regression where a new authorization middleware version
+# breaks billing API access for organization-linked accounts only. Solo accounts (no org_id)
+# are unaffected, and org accounts can still access other endpoints — making this hard to
+# detect with broad monitoring.
+#
+# Pattern:
+#   Pre-deploy (v2.13.2):  All users, all endpoints → 200
+#   Post-deploy (v2.14.0-rc3):
+#     - Solo users, any endpoint → 200
+#     - Org users, non-billing endpoints → 200
+#     - Org users, /api/v3/billing/invoices → 403 (AUTHZ-4821)
+#
+# Anti-hallucination:
+#   - Error code AUTHZ-4821 cannot be guessed
+#   - Deploy version v2.14.0-rc3 cannot be guessed
+#   - The correlation (org_id + billing endpoint + post-deploy = 403) requires querying
+#
+# Requirements:
+# - ELASTICSEARCH_URL: URL to Elasticsearch cluster
+# - ELASTICSEARCH_API_KEY: API key for authentication
+
+user_prompt: "Several customers are reporting they get authorization errors when trying to view billing invoices since our last platform deploy, but most customers aren't affected. Can you investigate the app-217-api-logs index to figure out what's different about the failing requests and what caused this regression?"
+
+expected_output:
+  - "Must identify error code AUTHZ-4821 as the authorization failure code"
+  - "Must identify that the failures only affect requests that have an org_id field (organization-linked accounts), while requests without org_id (solo accounts) succeed"
+  - "Must identify /api/v3/billing/invoices as the only affected endpoint (other endpoints work fine even for org accounts)"
+  - "Must connect the regression to the deployment of version v2.14.0-rc3 (failures only appear after this deploy)"
+
+tags:
+  - elasticsearch
+  - logs
+  - hard
+  - regression
+
+allow_toolset_failures: true
+setup_timeout: 300
+
+before_test: |
+  source ../../shared/es_test_utils.sh
+  es_setup
+  set -e
+
+  INDEX="app-217-api-logs"
+  BULK_FILE="/tmp/es_bulk_217_$$.ndjson"
+
+  # Clean up any existing test index
+  echo "Cleaning up any existing test index..."
+  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${INDEX}" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+
+  # Create the index with mapping
+  echo "Creating test index with API gateway log mapping..."
+  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${INDEX}?wait_for_active_shards=1" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{
+      "settings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0
+      },
+      "mappings": {
+        "properties": {
+          "@timestamp": {"type": "date"},
+          "method": {"type": "keyword"},
+          "endpoint": {"type": "keyword"},
+          "status_code": {"type": "integer"},
+          "user_id": {"type": "keyword"},
+          "org_id": {"type": "keyword"},
+          "deploy_version": {"type": "keyword"},
+          "response_time_ms": {"type": "integer"},
+          "error_code": {"type": "keyword"},
+          "error_message": {"type": "text"},
+          "request_id": {"type": "keyword"},
+          "event_type": {"type": "keyword"},
+          "message": {"type": "text"}
+        }
+      }
+    }')
+
+  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+    echo "Failed to create index: $CREATE_RESPONSE"
+    exit 1
+  fi
+
+  sleep 2
+
+  # Generate test data using Python script
+  echo "Generating API gateway log data..."
+  python3 generate_data.py > "$BULK_FILE"
+
+  DOC_COUNT=$(grep -c '"index"' "$BULK_FILE")
+  echo "Generated $DOC_COUNT log entries"
+
+  # Bulk insert
+  BULK_RESPONSE=$(curl -sf -X POST "${ELASTICSEARCH_URL}/${INDEX}/_bulk" \
+    -H "Content-Type: application/x-ndjson" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    --data-binary @"$BULK_FILE")
+
+  if echo "$BULK_RESPONSE" | grep -q '"errors":true'; then
+    echo "Bulk insert had errors: $BULK_RESPONSE"
+    rm -f "$BULK_FILE"
+    exit 1
+  fi
+
+  # Refresh the index
+  curl -sf -X POST "${ELASTICSEARCH_URL}/${INDEX}/_refresh" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" > /dev/null
+
+  rm -f "$BULK_FILE"
+
+  # Verify the needle: count 403 errors with AUTHZ-4821
+  ERROR_COUNT=$(curl -sf -X POST "${ELASTICSEARCH_URL}/${INDEX}/_count" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"term":{"error_code":"AUTHZ-4821"}}}' | grep -o '"count":[0-9]*' | cut -d':' -f2)
+
+  if [ "$ERROR_COUNT" = "15" ]; then
+    echo "Verified: $ERROR_COUNT requests with error code AUTHZ-4821"
+  else
+    echo "Expected 15 AUTHZ-4821 errors but found: $ERROR_COUNT"
+    exit 1
+  fi
+
+  echo "Setup complete!"
+
+after_test: |
+  echo "Cleaning up test index: app-217-api-logs"
+  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-217-api-logs" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  rm -f /tmp/es_bulk_217_*.ndjson
+  echo "Cleanup complete"

--- a/tests/llm/fixtures/test_ask_holmes/217_elasticsearch_deploy_regression/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/217_elasticsearch_deploy_regression/toolsets.yaml
@@ -1,0 +1,13 @@
+toolsets:
+  elasticsearch/data:
+    enabled: true
+    config:
+      api_url: "{{ env.ELASTICSEARCH_URL }}"
+      api_key: "{{ env.ELASTICSEARCH_API_KEY }}"
+      verify_ssl: true
+  elasticsearch/cluster:
+    enabled: true
+    config:
+      api_url: "{{ env.ELASTICSEARCH_URL }}"
+      api_key: "{{ env.ELASTICSEARCH_API_KEY }}"
+      verify_ssl: true


### PR DESCRIPTION
## Summary
Add a new test case for detecting post-deploy regressions in Elasticsearch logs, specifically targeting authorization failures that affect only organization-linked accounts on specific endpoints.

## Key Changes
- **generate_data.py**: Python script that generates realistic API gateway log data simulating a deployment regression where:
  - Pre-deploy (v2.13.2): All requests succeed across all user types and endpoints
  - Post-deploy (v2.14.0-rc3): Organization-linked accounts receive 403 AUTHZ-4821 errors on the billing endpoint only, while solo accounts remain unaffected
  - Total of 76 documents with proper timestamps, request IDs, and error details

- **test_case.yaml**: Test configuration that:
  - Sets up an Elasticsearch index with appropriate mappings for API gateway logs
  - Generates test data via the Python script
  - Validates the test data contains exactly 15 AUTHZ-4821 errors
  - Defines expected outputs requiring identification of the error code, affected user type (org_id presence), specific endpoint, and deployment version
  - Includes cleanup procedures

- **toolsets.yaml**: Enables Elasticsearch data and cluster toolsets for the test

## Notable Implementation Details
- The regression is intentionally subtle: it only affects organization-linked accounts on one endpoint, making it harder to detect with broad monitoring
- Anti-hallucination measures: error code AUTHZ-4821 and version v2.14.0-rc3 cannot be guessed and must be discovered through querying
- Test data includes realistic details like response times, request IDs, and detailed error messages
- Uses fixed random seed (217) for reproducible data generation

https://claude.ai/code/session_01RY2pCUdZQGSSiDkRGM4MeP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Elasticsearch post-deploy regression test with synthetic API gateway log dataset to verify authorization behavior during version deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->