### PR TITLE
[ROB-0000] docs mcp grafana fix

### DIFF
--- a/docs/data-sources/builtin-toolsets/grafana-mcp.md
+++ b/docs/data-sources/builtin-toolsets/grafana-mcp.md
@@ -120,7 +120,7 @@ The Grafana MCP server provides comprehensive access to your Grafana instance an
               X-Grafana-API-Key: "{{ env.GRAFANA_API_KEY }}"
           icon_url: "https://cdn.simpleicons.org/grafana/F46800"
           # These instructions were tested and produce improved results
-          llm_instr uctions: |
+          llm_instructions: |
               Always use Grafana tools (e.g. query_prometheus) for metrics/PromQL. Do not use kubectl top or prometheus/metrics toolset.
               NEVER answer based on truncated data. Retry with topk/bottomk or more filters until the query succeeds.
               For high-cardinality metrics (>10 series), ALWAYS use topk(5, <query>). Check cardinality first with count() if unsure.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the Grafana MCP configuration documentation, correcting the configuration key name from `llm_instr uctions` to `llm_instructions` for accurate setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->