### PR TITLE
Add MCP startup retry mechanism for concurrent server initialization

### DIFF
--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -157,6 +157,11 @@ TOOLSET_STATUS_REFRESH_INTERVAL_SECONDS = int(
 # Backoff schedule (seconds) for retrying failed MCP servers before falling
 # back to TOOLSET_STATUS_REFRESH_INTERVAL_SECONDS.
 MCP_RETRY_BACKOFF_SCHEDULE = [30, 60, 120]
+# Startup retry schedule (seconds) for MCP servers that aren't ready yet.
+# Uses shorter intervals than the background retry since startup is blocking.
+MCP_STARTUP_RETRY_SCHEDULE = [int(x) for x in os.environ.get(
+    "MCP_STARTUP_RETRY_SCHEDULE", "5,10,20"
+).split(",")]
 
 # Filesystem storage for large tool results
 HOLMES_TOOL_RESULT_STORAGE_PATH = os.environ.get(

--- a/server.py
+++ b/server.py
@@ -34,6 +34,7 @@ from holmes.common.env_vars import (
     HOLMES_PORT,
     LOG_PERFORMANCE,
     MCP_RETRY_BACKOFF_SCHEDULE,
+    MCP_STARTUP_RETRY_SCHEDULE,
     SENTRY_DSN,
     SENTRY_TRACES_SAMPLE_RATE,
     TOOLSET_STATUS_REFRESH_INTERVAL_SECONDS,
@@ -120,6 +121,49 @@ def init_config():
 config, dal = init_config()
 
 
+def _retry_failed_mcp_toolsets_at_startup():
+    """Retry failed MCP toolsets at startup with short intervals.
+
+    When Holmes and MCP servers start simultaneously (e.g. in Kubernetes),
+    the initial prerequisite check may fail because MCP servers aren't ready yet.
+    This retries with short intervals so tools are available before the server
+    starts accepting requests, rather than waiting for the background refresh
+    loop whose first retry is 30+ seconds later.
+    """
+    if not _has_failed_mcp_toolsets():
+        return
+
+    for i, wait_seconds in enumerate(MCP_STARTUP_RETRY_SCHEDULE):
+        logging.info(
+            f"MCP server(s) not ready at startup, retry {i + 1}/{len(MCP_STARTUP_RETRY_SCHEDULE)} in {wait_seconds}s"
+        )
+        time.sleep(wait_seconds)
+        try:
+            changes = config.refresh_server_tool_executor(dal)
+            if changes:
+                for toolset_name, old_status, new_status in changes:
+                    logging.info(
+                        f"Toolset '{toolset_name}' status changed: {old_status} -> {new_status}"
+                    )
+                holmes_sync_toolsets_status(dal, config)
+        except Exception:
+            logging.error("Error retrying MCP toolsets at startup", exc_info=True)
+
+        if not _has_failed_mcp_toolsets():
+            logging.info("All MCP servers connected successfully at startup")
+            return
+
+    failed_names = [
+        t.name
+        for t in (config._server_tool_executor.toolsets if config._server_tool_executor else [])
+        if t.type == ToolsetType.MCP and t.status == ToolsetStatusEnum.FAILED
+    ]
+    logging.warning(
+        f"MCP server(s) still not ready after startup retries: {failed_names}. "
+        "Background refresh will continue retrying."
+    )
+
+
 def sync_before_server_start():
     if not dal.enabled:
         logging.info(
@@ -134,6 +178,9 @@ def sync_before_server_start():
         holmes_sync_toolsets_status(dal, config)
     except Exception:
         logging.error("Failed to synchronise holmes toolsets", exc_info=True)
+
+    _retry_failed_mcp_toolsets_at_startup()
+
     if not ENABLED_SCHEDULED_PROMPTS:
         return
     # No need to check if dal is enabled again, done at the start of this function

--- a/tests/test_mcp_startup_retry.py
+++ b/tests/test_mcp_startup_retry.py
@@ -1,0 +1,162 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.core.tools import ToolsetStatusEnum, ToolsetType
+
+
+def _make_toolset(name: str, toolset_type: ToolsetType, status: ToolsetStatusEnum):
+    ts = MagicMock()
+    ts.name = name
+    ts.type = toolset_type
+    ts.status = status
+    return ts
+
+
+class TestMCPStartupRetry:
+    """Tests for _retry_failed_mcp_toolsets_at_startup in server.py."""
+
+    @patch("server.time.sleep")
+    @patch("server.config")
+    @patch("server.holmes_sync_toolsets_status")
+    @patch("server.MCP_STARTUP_RETRY_SCHEDULE", [5, 10])
+    def test_no_retry_when_all_mcp_healthy(self, mock_sync, mock_config, mock_sleep):
+        """If no MCP toolsets are failed, no retries happen."""
+        healthy_toolset = _make_toolset("mcp-ok", ToolsetType.MCP, ToolsetStatusEnum.ENABLED)
+        executor = MagicMock()
+        executor.toolsets = [healthy_toolset]
+        mock_config._server_tool_executor = executor
+
+        from server import _retry_failed_mcp_toolsets_at_startup
+
+        _retry_failed_mcp_toolsets_at_startup()
+
+        mock_sleep.assert_not_called()
+        mock_config.refresh_server_tool_executor.assert_not_called()
+
+    @patch("server.time.sleep")
+    @patch("server.dal")
+    @patch("server.config")
+    @patch("server.holmes_sync_toolsets_status")
+    @patch("server.MCP_STARTUP_RETRY_SCHEDULE", [5, 10])
+    def test_retries_until_mcp_recovers(self, mock_sync, mock_config, mock_dal, mock_sleep):
+        """Retries and stops once the MCP toolset recovers."""
+        mcp_toolset = _make_toolset("mcp-aws", ToolsetType.MCP, ToolsetStatusEnum.FAILED)
+        executor = MagicMock()
+        executor.toolsets = [mcp_toolset]
+        mock_config._server_tool_executor = executor
+
+        # After first refresh call, mark toolset as recovered
+        def recover_on_refresh(dal):
+            mcp_toolset.status = ToolsetStatusEnum.ENABLED
+            return [("mcp-aws", "failed", "enabled")]
+
+        mock_config.refresh_server_tool_executor.side_effect = recover_on_refresh
+
+        from server import _retry_failed_mcp_toolsets_at_startup
+
+        _retry_failed_mcp_toolsets_at_startup()
+
+        # Should sleep once (5s), then succeed
+        mock_sleep.assert_called_once_with(5)
+        mock_config.refresh_server_tool_executor.assert_called_once()
+        mock_sync.assert_called_once()
+
+    @patch("server.time.sleep")
+    @patch("server.dal")
+    @patch("server.config")
+    @patch("server.holmes_sync_toolsets_status")
+    @patch("server.MCP_STARTUP_RETRY_SCHEDULE", [5, 10])
+    def test_exhausts_all_retries_when_mcp_stays_failed(
+        self, mock_sync, mock_config, mock_dal, mock_sleep
+    ):
+        """Goes through all retries when MCP never recovers."""
+        mcp_toolset = _make_toolset("mcp-aws", ToolsetType.MCP, ToolsetStatusEnum.FAILED)
+        executor = MagicMock()
+        executor.toolsets = [mcp_toolset]
+        mock_config._server_tool_executor = executor
+
+        # Return no changes (still failed)
+        mock_config.refresh_server_tool_executor.return_value = []
+
+        from server import _retry_failed_mcp_toolsets_at_startup
+
+        _retry_failed_mcp_toolsets_at_startup()
+
+        # Should sleep for each entry in the schedule
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(5)
+        mock_sleep.assert_any_call(10)
+        assert mock_config.refresh_server_tool_executor.call_count == 2
+
+    @patch("server.time.sleep")
+    @patch("server.dal")
+    @patch("server.config")
+    @patch("server.holmes_sync_toolsets_status")
+    @patch("server.MCP_STARTUP_RETRY_SCHEDULE", [5, 10, 20])
+    def test_recovers_on_second_retry(self, mock_sync, mock_config, mock_dal, mock_sleep):
+        """MCP recovers on the second retry attempt."""
+        mcp_toolset = _make_toolset("mcp-aws", ToolsetType.MCP, ToolsetStatusEnum.FAILED)
+        executor = MagicMock()
+        executor.toolsets = [mcp_toolset]
+        mock_config._server_tool_executor = executor
+
+        call_count = 0
+
+        def recover_on_second_call(dal):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                mcp_toolset.status = ToolsetStatusEnum.ENABLED
+                return [("mcp-aws", "failed", "enabled")]
+            return []
+
+        mock_config.refresh_server_tool_executor.side_effect = recover_on_second_call
+
+        from server import _retry_failed_mcp_toolsets_at_startup
+
+        _retry_failed_mcp_toolsets_at_startup()
+
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(5)
+        mock_sleep.assert_any_call(10)
+        assert mock_config.refresh_server_tool_executor.call_count == 2
+
+    @patch("server.time.sleep")
+    @patch("server.dal")
+    @patch("server.config")
+    @patch("server.holmes_sync_toolsets_status")
+    @patch("server.MCP_STARTUP_RETRY_SCHEDULE", [5])
+    def test_handles_refresh_exception(self, mock_sync, mock_config, mock_dal, mock_sleep):
+        """Continues retrying even if refresh raises an exception."""
+        mcp_toolset = _make_toolset("mcp-aws", ToolsetType.MCP, ToolsetStatusEnum.FAILED)
+        executor = MagicMock()
+        executor.toolsets = [mcp_toolset]
+        mock_config._server_tool_executor = executor
+
+        mock_config.refresh_server_tool_executor.side_effect = Exception("connection refused")
+
+        from server import _retry_failed_mcp_toolsets_at_startup
+
+        # Should not raise
+        _retry_failed_mcp_toolsets_at_startup()
+
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("server.time.sleep")
+    @patch("server.config")
+    @patch("server.holmes_sync_toolsets_status")
+    @patch("server.MCP_STARTUP_RETRY_SCHEDULE", [5])
+    def test_skips_non_mcp_failed_toolsets(self, mock_sync, mock_config, mock_sleep):
+        """Only MCP toolsets trigger the startup retry."""
+        non_mcp_toolset = _make_toolset("kubernetes", ToolsetType.BUILTIN, ToolsetStatusEnum.FAILED)
+        executor = MagicMock()
+        executor.toolsets = [non_mcp_toolset]
+        mock_config._server_tool_executor = executor
+
+        from server import _retry_failed_mcp_toolsets_at_startup
+
+        _retry_failed_mcp_toolsets_at_startup()
+
+        mock_sleep.assert_not_called()
+        mock_config.refresh_server_tool_executor.assert_not_called()


### PR DESCRIPTION
## Summary
Adds a startup retry mechanism for MCP (Model Context Protocol) toolsets that fail their initial prerequisite checks. This addresses the race condition that occurs when Holmes and MCP servers start simultaneously (e.g., in Kubernetes), where MCP servers may not be ready during the initial health check.

## Key Changes
- **New function `_retry_failed_mcp_toolsets_at_startup()`**: Implements a configurable retry loop with short intervals (default: 5s, 10s, 20s) that runs before the server starts accepting requests
- **Integration with startup flow**: Called from `sync_before_server_start()` to ensure MCP toolsets are ready before the server becomes operational
- **Configuration**: Added `MCP_STARTUP_RETRY_SCHEDULE` environment variable to allow customization of retry intervals
- **Error handling**: Gracefully handles exceptions during refresh attempts and logs detailed status changes
- **Comprehensive test coverage**: Added 6 test cases covering success paths, exhausted retries, partial recovery, exception handling, and filtering of non-MCP toolsets

## Implementation Details
- Uses a helper function `_has_failed_mcp_toolsets()` to check if any MCP toolsets are in FAILED status
- Only retries MCP-type toolsets; other toolset types are ignored
- Logs informative messages at each retry attempt and final status
- Falls back to the background refresh loop if startup retries are exhausted
- Exceptions during refresh are caught and logged but don't interrupt the retry sequence

https://claude.ai/code/session_01QRme4pNfuQvfYH7LyJuZXt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server now automatically retries failed MCP toolsets during startup using configurable retry intervals (default: 5, 10, 20 seconds).

* **Tests**
  * Added comprehensive test coverage for MCP toolset startup retry logic across multiple failure and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->