### PR TITLE
Improve Prometheus rules endpoint documentation

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -660,7 +660,9 @@ class ListPrometheusRules(JsonFilterMixin, BasePrometheusTool):
             description=(
                 "List Prometheus rules (api/v1/rules). Returns rule names, expressions, and annotations. "
                 "Use filtering parameters to reduce response size. "
-                "Without filters, returns ALL rules which may be very large."
+                "Without filters, returns ALL rules which may be very large. "
+                "The returned JSON has the structure {groups: [{name, file, rules: [{name, query, state, labels, annotations, ...}]}]}. "
+                "When using jq, note the root object is 'data' already extracted, so use '.groups[]' not '.data.groups[]'."
             ),
             parameters=self.extend_parameters(
                 {


### PR DESCRIPTION
## Summary
Enhanced the documentation for the Prometheus rules API endpoint to provide clearer guidance on the response structure and usage with JSON query tools.

## Key Changes
- Added detailed description of the returned JSON structure showing the nested hierarchy of groups and rules
- Included a helpful note about using `jq` with the endpoint, clarifying that the root object is already extracted as 'data' so users should use `.groups[]` instead of `.data.groups[]`
- Improved overall clarity of the endpoint's behavior and expected output format

## Implementation Details
The changes are purely documentation improvements to the tool description, making it easier for users to understand and work with the Prometheus rules API response without trial and error.

https://claude.ai/code/session_016frqnakvhiwFGyWDdC1b9K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for Prometheus rules listing to clarify the returned JSON structure and provide guidance on data reference when using jq.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->