### PR TITLE
Only run evals etc when relevant

### DIFF
--- a/.github/workflows/cli-performance.yaml
+++ b/.github/workflows/cli-performance.yaml
@@ -6,6 +6,8 @@ name: CLI Performance Benchmark
 on:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   check-changes:

--- a/.github/workflows/docker-dev-images.yaml
+++ b/.github/workflows/docker-dev-images.yaml
@@ -3,6 +3,8 @@ name: Docker Build on PR
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '.github/**'
 
 # Cancel in-progress runs for the same PR
 concurrency:

--- a/.github/workflows/eval-regression.yaml
+++ b/.github/workflows/eval-regression.yaml
@@ -3,6 +3,8 @@ name: Run eval regression tests
 on:
   pull_request:
     branches: ["*"]
+    paths-ignore:
+      - '.github/**'
   push:
     branches: [master]
   workflow_dispatch:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI adds a pre-check that detects docs-only or non-code PRs and exposes a code-change flag.
  * Builds, benchmarks, evaluations, and comparison steps are gated by that flag and will skip when only non-code files changed, reducing unnecessary runs and improving PR turnaround.
  * Benchmark artifacts are now surfaced when runs occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->