### PR TITLE
Update HolmesGPT documentation link to new URL

### DIFF
--- a/docs/development/transformers.md
+++ b/docs/development/transformers.md
@@ -275,4 +275,4 @@ MyTool(
 )
 ```
 
-For more information, see the [HolmesGPT documentation](https://docs.robusta.dev/master/configuration/holmesgpt/toolsets/).
+For more information, see the [HolmesGPT documentation](https://holmesgpt.dev/data-sources/custom-toolsets/).


### PR DESCRIPTION
## Summary
Updated the HolmesGPT documentation reference link in the transformers development guide to point to the new documentation URL.

## Changes
- Updated the HolmesGPT documentation link from `https://docs.robusta.dev/master/configuration/holmesgpt/toolsets/` to `https://holmesgpt.dev/data-sources/custom-toolsets/`

## Details
This change reflects the migration of HolmesGPT documentation to a new domain and updated URL structure. The new link points to the custom toolsets documentation on the official HolmesGPT documentation site.

https://claude.ai/code/session_01D7DmBsJaqcF1WfMQ5NgtPY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development documentation hyperlink to reference current HolmesGPT resource location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->