### PR TITLE
Change kubernetes_jq_query to return JSON output instead of raw text

### DIFF
--- a/holmes/plugins/toolsets/kubernetes.yaml
+++ b/holmes/plugins/toolsets/kubernetes.yaml
@@ -99,10 +99,6 @@ toolsets:
         script: |
           #!/bin/bash
 
-          echo "Executing paginated query for {{ kind }} resources..." >&2
-          echo "Expression: {{ jq_expr }}" >&2
-          echo "---" >&2
-
           # Get the API path for the resource kind using kubectl
           API_INFO=$(kubectl api-resources --no-headers | grep "^{{ kind }} " | head -1)
 
@@ -198,7 +194,6 @@ toolsets:
 
               PROCESSED=$((PROCESSED + ITEMS_COUNT))
 
-              echo "Processed $PROCESSED items, found $TOTAL_MATCHES matches so far..." >&2
             fi
 
             CONTINUE=$(echo "$OUTPUT" | jq -r '.metadata.continue // empty')


### PR DESCRIPTION
- Switch jq from raw mode (-r) to compact mode (-c)
- Collect all paginated results and output as a JSON array via jq -s
- Move informational headers to stderr so stdout is clean JSON
- Output empty array [] when no matches found

https://claude.ai/code/session_01N8F1S8jQXernTtWhmym3DG
Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Query tool now returns a single structured JSON object with total_items_processed, matches_found, and results array instead of plain text
  * Per-page matches are emitted in compact JSON and aggregated across pages for consolidated output
  * Progress/diagnostic echoes removed from primary output for cleaner results
  * Increased transformer input threshold to reduce premature summarization and adjusted transformer prompt for JSON output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->