### PR TITLE
Suppress stderr output from ulimit commands

### DIFF
--- a/holmes/utils/memory_limit.py
+++ b/holmes/utils/memory_limit.py
@@ -17,7 +17,7 @@ def get_ulimit_prefix() -> str:
     The '|| true' ensures we continue even if ulimit is not supported.
     """
     memory_limit_kb = TOOL_MEMORY_LIMIT_MB * 1024
-    return f"ulimit -v {memory_limit_kb} || true; "
+    return f"ulimit -v {memory_limit_kb} 2>/dev/null || true; "
 
 
 def check_oom_and_append_hint(output: str, return_code: int) -> str:

--- a/tests/core/test_tool_memory_limit.py
+++ b/tests/core/test_tool_memory_limit.py
@@ -14,7 +14,7 @@ class TestGetUlimitPrefix:
         """Test ulimit prefix format with default value."""
         result = get_ulimit_prefix()
         expected_kb = 1024 * TOOL_MEMORY_LIMIT_MB
-        assert result == f"ulimit -v {expected_kb} || true; "
+        assert result == f"ulimit -v {expected_kb} 2>/dev/null || true; "
 
 
 class TestCheckOomAndAppendHint:

--- a/tests/integration/test_tool_execution_pipeline.py
+++ b/tests/integration/test_tool_execution_pipeline.py
@@ -37,7 +37,7 @@ def _ulimit_produces_clean_output() -> bool:
     """Check if ulimit commands run without producing stderr output."""
     # Test the same command pattern used in get_ulimit_prefix()
     result = subprocess.run(
-        "ulimit -v 1048576 || true",
+        "ulimit -v 1048576 2>/dev/null || true",
         shell=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
This change suppresses stderr output from `ulimit` commands by redirecting it to `/dev/null`. This prevents unnecessary error messages from appearing in logs when `ulimit` is not supported on certain systems.

## Key Changes
- Updated `get_ulimit_prefix()` in `holmes/utils/memory_limit.py` to redirect stderr (`2>/dev/null`) in the ulimit command
- Updated the corresponding unit test in `tests/core/test_tool_memory_limit.py` to match the new expected output format
- Updated the integration test in `tests/integration/test_tool_execution_pipeline.py` to use the same stderr suppression pattern

## Implementation Details
The change adds `2>/dev/null` to the ulimit command, which redirects standard error to `/dev/null`. This ensures that if `ulimit` is not available or produces warnings on a system, those messages won't clutter the output. The `|| true` fallback remains in place to ensure the command chain continues regardless of whether ulimit succeeds or fails.

https://claude.ai/code/session_01CiE6XavBr9D9EFWszJdiCs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated spurious error output from system utilities on certain platforms, resulting in cleaner console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->