### PR TITLE
Support multiple clusters and external filtering in issues metadata

### DIFF
--- a/tests/llm/utils/mock_dal.py
+++ b/tests/llm/utils/mock_dal.py
@@ -141,7 +141,8 @@ class MockSupabaseDal(SupabaseDal):
         name_pattern: Optional[str] = None,
         kind: Optional[str] = None,
         container: Optional[str] = None,
-    ) -> list:
+        clusters: Optional[List[str]] = None,
+    ) -> Optional[List[Dict]]:
         return []
 
     def get_issues_metadata(


### PR DESCRIPTION
## Summary
Updated the `get_issues_metadata` method signature and filtering logic to support querying multiple clusters and controlling whether external cluster items are included in results.

## Key Changes
- Changed `cluster` parameter to `clusters` accepting `Optional[List[str]]` instead of a single string
- Added `include_external` boolean parameter (defaults to `True`) to control filtering of external cluster items
- Updated filtering logic to handle:
  - Wildcard cluster selection (`["*"]`) with optional external filtering
  - Multiple specific clusters with optional inclusion of external items
  - Backward compatibility by defaulting to the instance's cluster when no clusters specified
- Updated the parent class method call to pass the new parameters

## Implementation Details
The new filtering logic distinguishes between two modes:
1. **Wildcard mode** (`clusters == ["*"]`): Returns all items, optionally excluding external cluster items based on `include_external`
2. **Specific clusters mode**: Returns items matching the specified clusters, optionally including external items if `include_external` is True

This provides more flexible cluster filtering while maintaining the ability to exclude external cluster data when needed.

https://claude.ai/code/session_01T9bZy1MwDZtXu5bHQ4aVrM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test utilities to support multi-cluster queries (including wildcard matching) instead of single-cluster only.
  * Added an option to include or exclude external items when filtering results.
  * Adjusted mocks and downstream test flows so generated test data and metadata lookups respect multi-cluster and external-item settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->