### PR TITLE
Remove path filters from build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,12 +4,6 @@ name: Build and test HolmesGPT
 
 on:
   pull_request:
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!**/*.md'
-      - '!mkdocs.yml'
-      - 'docs/reference/http-api.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
Simplified the pull request trigger configuration for the build-and-test workflow by removing path-based filtering logic.

## Changes
- Removed the `paths` filter from the `pull_request` trigger that was excluding documentation files (`docs/**`, `**/*.md`, `mkdocs.yml`) with an exception for `docs/reference/http-api.md`
- The workflow will now run on all pull requests without path-based conditions

## Rationale
This change ensures the build and test workflow runs consistently on all pull requests, eliminating the complexity of maintaining path exclusion rules. This provides more reliable CI/CD execution and prevents edge cases where relevant changes might be skipped due to path filtering logic.

https://claude.ai/code/session_014U4VUp67Ww8B1bdJgf2Rpw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflow configuration to run on all pull requests instead of only when specific files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->