### PR TITLE
add resourcequotas role to holmes default service account

### DIFF
--- a/helm/holmes/templates/holmesgpt-service-account.yaml
+++ b/helm/holmes/templates/holmesgpt-service-account.yaml
@@ -42,6 +42,7 @@ rules:
       - services
       - serviceaccounts
       - endpoints
+      - resourcequotas
     verbs:
       - get
       - list


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes service account permissions configuration to enable resource monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->