### PR TITLE
Add webhook configuration permissions to HolmesGPT service account

### DIFF
--- a/helm/holmes/templates/holmesgpt-service-account.yaml
+++ b/helm/holmes/templates/holmesgpt-service-account.yaml
@@ -139,6 +139,16 @@ rules:
       - "get"
 
   - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
       - networking.k8s.io
     resources:
     - ingresses


### PR DESCRIPTION
## Summary
This change grants the HolmesGPT service account permissions to read and monitor webhook configurations in the Kubernetes cluster.

## Key Changes
- Added RBAC rules to allow `get`, `list`, and `watch` operations on:
  - `mutatingwebhookconfigurations`
  - `validatingwebhookconfigurations`
- Permissions are scoped to the `admissionregistration.k8s.io` API group

## Implementation Details
These permissions enable HolmesGPT to inspect webhook configurations that may be relevant for diagnostics and troubleshooting. The `watch` verb allows the service account to monitor changes to webhook configurations in real-time, which may be useful for detecting configuration issues or tracking admission controller behavior.

https://claude.ai/code/session_01MTAfUQokvgCmCG4xedZc4J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Kubernetes cluster permissions to enable webhook configuration monitoring and management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->