### PR TITLE
AWS_BEARER_TOKEN_BEDROCK for bedrock model

### DIFF
--- a/docs/ai-providers/aws-bedrock.md
+++ b/docs/ai-providers/aws-bedrock.md
@@ -173,6 +173,24 @@ This tells HolmesGPT the actual context window size (1M tokens) so it can proper
 !!! warning "Both Parameters Required"
     You must include **both** `extra_headers` and `custom_args` to use the 1M context window. The `extra_headers` enables the feature, while `custom_args.max_context_size` ensures HolmesGPT knows the correct window size.
 
+### Using Bearer Token Authentication (IAM Identity Center)
+
+If you're using AWS IAM Identity Center (SSO) with Bedrock, you can authenticate via bearer token instead of access/secret keys.
+
+Set the environment variable:
+```bash
+export AWS_BEARER_TOKEN_BEDROCK="your-bearer-token"
+```
+
+Or use `api_key` in the `modelList` config:
+```yaml
+modelList:
+  bedrock-claude-sonnet-4:
+    api_key: "{{ env.AWS_BEARER_TOKEN_BEDROCK }}"
+    aws_region_name: us-east-1
+    model: bedrock/anthropic.claude-sonnet-4-20250514-v1:0
+```
+
 ### Finding Your AWS Credentials
 
 If the AWS CLI is already configured on your machine, you may be able to find the above values with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Bearer Token Authentication documentation for AWS Bedrock, including setup instructions for the AWS_BEARER_TOKEN_BEDROCK environment variable and example configurations for IAM Identity Center integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->