### PR TITLE
Handle Prometheus toolset import failure gracefully on Python 3.14+

### DIFF
--- a/holmes/plugins/toolsets/__init__.py
+++ b/holmes/plugins/toolsets/__init__.py
@@ -123,15 +123,15 @@ def load_python_toolsets(
     if not DISABLE_PROMETHEUS_TOOLSET:
         try:
             from holmes.plugins.toolsets.prometheus.prometheus import PrometheusToolset
-
-            toolsets.append(PrometheusToolset())
-        except Exception as e:
+        except (ImportError, ModuleNotFoundError) as e:
             logging.warning(
                 "Skipping Prometheus toolset (import failed). "
                 "This can happen on Python 3.14+ due to prometrix/pydantic-v1 compatibility. "
                 "Use Python 3.12 or 3.13 for full toolset support, or set DISABLE_PROMETHEUS_TOOLSET=true to silence. Error: %s",
                 e,
             )
+        else:
+            toolsets.append(PrometheusToolset())
 
     if not USE_LEGACY_KUBERNETES_LOGS:
         toolsets.append(KubernetesLogsToolset())


### PR DESCRIPTION
   ## Summary
   - Wrap Prometheus toolset import in try/except to handle Python 3.14+ compatibility issues gracefully
   - Log a warning with actionable guidance instead of crashing the application

   ## Test plan
   - [ ] Verify HolmesGPT starts without errors on Python 3.12/3.13
   - [ ] Verify HolmesGPT starts with a warning (not crash) on Python 3.14+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when optional integrations fail to load so the app logs a warning and continues rather than crashing.
* **Chores**
  * No user-facing API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->