### PR TITLE
Fix test comment placement in HTTP API documentation

### DIFF
--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -130,8 +130,8 @@ curl -X POST http://<HOLMES-URL>/api/chat \
 
 **Example without Structured Output:**
 
-```bash
 <!-- test: status=200, has_fields=analysis|conversation_history, id=chat_basic -->
+```bash
 curl -X POST http://<HOLMES-URL>/api/chat \
   -H "Content-Type: application/json" \
   -d '{
@@ -362,8 +362,8 @@ data: {"sections": {"Alert Explanation": ...}}
 - `tools` (list, optional): Tools used/results
 
 **Example**
-```bash
 <!-- test: status=200, has_fields=analysis|conversation_history, id=issue_chat_basic -->
+```bash
 curl -X POST http://<HOLMES-URL>/api/issue_chat \
   -H "Content-Type: application/json" \
   -d '{
@@ -399,8 +399,8 @@ curl -X POST http://<HOLMES-URL>/api/issue_chat \
 **Description:** Returns a list of available AI models that can be used for investigations and chat.
 
 **Example**
-```bash
 <!-- test: status=200, has_fields=model_name, id=model_list -->
+```bash
 curl http://<HOLMES-URL>/api/model
 ```
 


### PR DESCRIPTION
## Summary
Corrected the placement of test annotation comments in the HTTP API reference documentation to appear before their corresponding code blocks rather than after.

## Key Changes
- Moved `<!-- test: ... -->` comments to appear immediately before the opening ` ```bash ` fence in three API endpoint examples:
  - `/api/chat` endpoint (chat_basic test)
  - `/api/issue_chat` endpoint (issue_chat_basic test)
  - `/api/model` endpoint (model_list test)

## Details
The test annotation comments are documentation metadata used by the testing framework to validate examples. By placing them before the code block fence, they are properly associated with the code examples they describe, improving the clarity and correctness of the documentation structure.

https://claude.ai/code/session_013pBC2yfQSoMz9oNnmiH9H6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation with clearer, executable examples for chat, issue chat, and model endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->