### PR TITLE
chore: remove extra missing_keys check for azure

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -232,21 +232,8 @@ class DefaultLLM(LLM):
                 )
         else:
             model_requirements = litellm.validate_environment(
-                model=model, api_key=api_key, api_base=api_base
+                model=model, api_key=api_key, api_base=api_base, api_version=api_version
             )
-            # validate_environment does not accept api_version, and as a special case for Azure OpenAI Service,
-            # when all the other AZURE environments are set expect AZURE_API_VERSION, validate_environment complains
-            # the missing of it even after the api_version is set.
-            # TODO: There's an open PR in litellm to accept api_version in validate_environment, we can leverage this
-            # change if accepted to ignore the following check.
-            # https://github.com/BerriAI/litellm/pull/13808
-            if (
-                provider == "azure"
-                and ["AZURE_API_VERSION"] == model_requirements["missing_keys"]
-                and api_version is not None
-            ):
-                model_requirements["missing_keys"] = []
-                model_requirements["keys_in_environment"] = True
 
         if not model_requirements["keys_in_environment"]:
             raise Exception(

--- a/tests/core/test_check_llm.py
+++ b/tests/core/test_check_llm.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from holmes.core.llm import DefaultLLM
+
+
+def _make_llm(model, api_key=None, api_base=None, api_version=None, args=None, is_robusta_model=False):
+    """Helper to construct a DefaultLLM with check_llm un-mocked so we actually test it."""
+    with patch.object(DefaultLLM, "update_custom_args"):
+        llm = object.__new__(DefaultLLM)
+        llm.model = model
+        llm.api_key = api_key
+        llm.api_base = api_base
+        llm.api_version = api_version
+        llm.args = args or {}
+        llm.is_robusta_model = is_robusta_model
+        return llm
+
+
+class TestCheckLLMAzureOpenAI:
+    """Tests for Azure OpenAI model validation in check_llm."""
+
+    def test_azure_model_with_all_env_vars(self, monkeypatch):
+        """Azure model passes when all required env vars are set."""
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
+        monkeypatch.setenv("AZURE_API_BASE", "https://myresource.openai.azure.com")
+        monkeypatch.setenv("AZURE_API_VERSION", "2024-02-01")
+        llm = _make_llm("azure/gpt-4o")
+        llm.check_llm("azure/gpt-4o", None, None, None)
+
+    def test_azure_model_with_all_config(self, monkeypatch):
+        """Azure model passes when api_key and api_base are provided directly."""
+        monkeypatch.delenv("AZURE_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_API_BASE", raising=False)
+        monkeypatch.delenv("AZURE_API_VERSION", raising=False)
+        llm = _make_llm("azure/gpt-4o")
+        llm.check_llm(
+            "azure/gpt-4o", "test-key", "https://myresource.openai.azure.com", "2024-02-01"
+        )


### PR DESCRIPTION
We don't have to add extra missing key check for azure openai since api_version variable is added by https://github.com/BerriAI/litellm/pull/13808 to litellm to filter out the AZURE_API_VERSION from missing key

## Manual test

- when  llm configure are specified by environment variables
```
poetry run holmes ask "how may pods are running in my cluster?" --model azure/gpt-5 -n
Loaded models: ['azure/gpt-5']
User: how may pods are running in my cluster?
Config hash changed for datasource: /home/azureuser/.holmes/config.yaml
Datasource config file(s) changed, refreshing toolsets
Refreshing available datasources (toolsets)
```

- when llm configure are specified by configure.yaml

```
Loaded models: ['azure/gpt-5']                                                                                                                                                                    
User: how may pods are running in my cluster?
Toolset aks-mcp: 'url' field has been migrated to config. Please move 'url' to the config section.                                                                                                
✅ Toolset aks-mcp                                                                                                                                                                                
Using 50 datasources (toolsets). To refresh: use flag `--refresh-toolsets`                                                                                                                        
Using selected model: azure/gpt-5   
Using model: azure/gpt-5 (272,000 total tokens, 54,400 output tokens)                                                                                                                             
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved validation behavior for non-watsonx/non-bedrock providers by ensuring API version is considered and removed a legacy Azure-specific workaround that altered validation outcomes.

* **Tests**
  * Added tests covering Azure OpenAI validation scenarios using environment variables and direct configuration to ensure correct validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->