### PR TITLE
Simplify MCP header rendering by delegating to base Toolset

### DIFF
--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -24,7 +24,6 @@ from holmes.core.tools import (
     ToolParameter,
     Toolset,
 )
-from holmes.utils.header_rendering import render_template_headers
 from holmes.utils.pydantic_utils import ToolsetConfig
 
 logger = logging.getLogger(__name__)
@@ -339,28 +338,11 @@ class RemoteMCPToolset(Toolset):
 
         Process:
         1. Start with 'headers' field (backward compatibility, passed as-is)
-        2. Render config-level 'extra_headers' templates (from MCPConfig)
+        2. Render config-level 'extra_headers' via base Toolset.render_extra_headers()
         3. Merge them (later layers take precedence)
-
-        Template sources for extra_headers:
-        - {{ request_context.headers['foo'] }}: Pass-through from client request
-        - {{ env.CORALOGIX_API_KEY }}: From environment variables
-        - "hardcoded value": Static hardcoded values
 
         Returns:
             Merged headers dictionary or None
-
-        Example of mcp_config:
-            mcp_servers:
-                my_mcp_server:
-                    config:
-                        ...
-                        headers:
-                            Header-Name: "hardcoded value"
-                        extra_headers:
-                            Header-Name-1: "hardcoded value"
-                            Header-Name-2: "{{ request_context.headers['foo'] }}"
-                            Header-Name-3: "{{ env.CORALOGIX_API_KEY }}"
         """
         if not isinstance(self._mcp_config, MCPConfig):
             return None
@@ -371,22 +353,11 @@ class RemoteMCPToolset(Toolset):
             final_headers.update(self._mcp_config.headers)
 
         # Render and merge config-level extra_headers
-        if self._mcp_config.extra_headers:
-            config_extra = render_template_headers(
-                extra_headers=self._mcp_config.extra_headers,
-                request_context=request_context,
-                source_name=f"MCP:{self.name}",
-            )
-            final_headers.update(config_extra)
+        rendered = super().render_extra_headers(request_context)
+        if rendered:
+            final_headers.update(rendered)
 
         return final_headers if final_headers else None
-
-    def render_extra_headers(
-        self, request_context: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, str]:
-        """MCP toolsets handle header rendering at connection time via _render_headers(),
-        not per-tool-call.  Return empty to avoid duplicate rendering in tool_calling_llm."""
-        return {}
 
     def model_post_init(self, __context: Any) -> None:
         self.prerequisites = [

--- a/holmes/utils/header_rendering.py
+++ b/holmes/utils/header_rendering.py
@@ -9,37 +9,9 @@ import os
 from typing import Any, Dict, Optional
 
 from jinja2 import Template
+from requests.structures import CaseInsensitiveDict
 
 logger = logging.getLogger(__name__)
-
-
-class CaseInsensitiveDict(dict):
-    """Dictionary with case-insensitive key lookup for HTTP headers."""
-
-    def _find_key(self, key: str) -> Optional[str]:
-        if isinstance(key, str):
-            key_lower = key.lower()
-            for k in dict.keys(self):
-                if k.lower() == key_lower:
-                    return k
-        return None
-
-    def __getitem__(self, key: str) -> Any:
-        found = self._find_key(key)
-        if found is not None:
-            return dict.__getitem__(self, found)
-        raise KeyError(key)
-
-    def __contains__(self, key: object) -> bool:
-        if isinstance(key, str):
-            return self._find_key(key) is not None
-        return False
-
-    def get(self, key: str, default: Any = None) -> Any:
-        found = self._find_key(key)
-        if found is not None:
-            return dict.__getitem__(self, found)
-        return default
 
 
 def render_template_headers(

--- a/tests/test_header_propagation.py
+++ b/tests/test_header_propagation.py
@@ -26,10 +26,9 @@ from holmes.core.tools import (
     YAMLTool,
     YAMLToolset,
 )
-from holmes.utils.header_rendering import (
-    CaseInsensitiveDict,
-    render_template_headers,
-)
+from requests.structures import CaseInsensitiveDict
+
+from holmes.utils.header_rendering import render_template_headers
 
 
 # ---------------------------------------------------------------------------
@@ -482,9 +481,10 @@ class TestMCPConfigExtraHeaders:
         assert rendered["X-Static"] == "static-value"
         assert rendered["X-Dynamic"] == "dynamic-value"
 
-    def test_render_extra_headers_returns_empty(self):
-        """MCP toolsets handle headers at connection time, not per-tool-call.
-        The base render_extra_headers() should return empty to avoid duplicate rendering."""
+    def test_render_extra_headers_falls_through_to_base(self):
+        """MCP toolsets no longer override render_extra_headers — the base Toolset
+        implementation renders extra_headers from config normally.  The actual
+        merging with static 'headers' happens in _render_headers() at connection time."""
         from holmes.plugins.toolsets.mcp.toolset_mcp import RemoteMCPToolset
 
         mcp_toolset = RemoteMCPToolset(
@@ -492,11 +492,12 @@ class TestMCPConfigExtraHeaders:
             description="Test toolset",
             config={
                 "url": "http://localhost:1234",
-                "extra_headers": {"X-Should-Not-Render": "value"},
+                "extra_headers": {"X-Dynamic": "value"},
             },
         )
-        # Base class method should return empty for MCP
-        assert mcp_toolset.render_extra_headers({"headers": {"X-Foo": "bar"}}) == {}
+        # Base class renders extra_headers normally (no override blocking it)
+        result = mcp_toolset.render_extra_headers({"headers": {"X-Foo": "bar"}})
+        assert result == {"X-Dynamic": "value"}
 
     def test_extra_headers_override_static_headers(self):
         """extra_headers should take precedence over static headers."""


### PR DESCRIPTION
## Summary
Refactored MCP toolset header rendering to eliminate custom logic and delegate to the base `Toolset.render_extra_headers()` method. This reduces code duplication and simplifies the header handling pipeline.

## Key Changes
- **Removed custom `render_extra_headers()` override** from `RemoteMCPToolset` that was returning an empty dict. The base class implementation now handles extra_headers rendering normally.
- **Simplified `_render_headers()` method** to call `super().render_extra_headers()` instead of directly invoking `render_template_headers()` with manual template rendering logic.
- **Removed unused import** of `render_template_headers` from the MCP toolset module (still used elsewhere).
- **Removed custom `CaseInsensitiveDict` implementation** from `holmes/utils/header_rendering.py` and replaced with the standard `requests.structures.CaseInsensitiveDict` from the requests library.
- **Updated test expectations** to reflect that MCP toolsets now use the standard header rendering flow rather than a special case.

## Implementation Details
- The `_render_headers()` method still handles the merging of static `headers` with `extra_headers` at MCP connection time, maintaining backward compatibility.
- By delegating to the base class `render_extra_headers()`, MCP toolsets now benefit from any future improvements to header template rendering without requiring updates.
- The removal of the custom `CaseInsensitiveDict` reduces maintenance burden by using a well-tested standard library implementation.

https://claude.ai/code/session_01TjsbvuR731LPWcXy2Zg3if

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal header rendering by consolidating duplicate logic and removing unnecessary code
  * Updated imports to use standard library components where applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->