### PR TITLE
Document CERTIFICATE environment variable for custom CA support

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -93,6 +93,31 @@ export HOLMES_LOG_LEVEL="DEBUG"
 ### HOLMES_CACHE_DIR
 Directory for caching HolmesGPT data and temporary files.
 
+### CERTIFICATE
+
+Base64-encoded custom CA certificate for outbound HTTPS requests. When set, the certificate is appended to the default CA bundle so that HolmesGPT trusts your private CA for all connections (LLM APIs, Elasticsearch, Prometheus, etc.).
+
+=== "Holmes CLI"
+
+    ```bash
+    export CERTIFICATE="$(base64 -w0 /path/to/ca.crt)"
+    ```
+
+=== "Holmes Helm Chart"
+
+    ```yaml
+    # values.yaml
+    certificate: "<base64-encoded CA cert>"
+    ```
+
+=== "Robusta Helm Chart"
+
+    ```yaml
+    # generated_values.yaml
+    holmes:
+      certificate: "<base64-encoded CA cert>"
+    ```
+
 ## Data Source Configuration
 
 ### Prometheus


### PR DESCRIPTION
## Summary
Added documentation for the `CERTIFICATE` environment variable that enables HolmesGPT to trust custom CA certificates for outbound HTTPS requests.

## Changes
- Added new `CERTIFICATE` section to the environment variables reference documentation
- Documented the purpose: appending base64-encoded custom CA certificates to the default CA bundle for all connections (LLM APIs, Elasticsearch, Prometheus, etc.)
- Provided configuration examples for three deployment methods:
  - Holmes CLI (using `export` with base64 encoding)
  - Holmes Helm Chart (direct values.yaml configuration)
  - Robusta Helm Chart (nested under `holmes` key in generated_values.yaml)

## Details
The documentation clarifies that the certificate is appended to the existing CA bundle rather than replacing it, ensuring HolmesGPT can validate both standard and private CAs. The examples show the proper base64 encoding format required for the variable across different deployment scenarios.

https://claude.ai/code/session_0184sJoA6va92t6Zkmx6x1k5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented a new CERTIFICATE environment variable for configuring custom Base64-encoded HTTPS CA certificates for all outbound connections.
  * Added detailed usage and deployment examples for Holmes CLI, Holmes Helm Chart configurations, and Robusta Helm Chart integrations.
  * Configuration applies to all service connections including LLM APIs, Elasticsearch, Prometheus, and other data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->