### PR TITLE
Fix prompt caching when routing through LiteLLM proxy to Bedrock/Anth…

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -365,6 +365,21 @@ class DefaultLLM(LLM):
         else:
             return self.model
 
+    @staticmethod
+    def _is_openai_proxy_to_anthropic(model_name: str) -> bool:
+        """
+        Detect if the model is routing through an OpenAI-compatible proxy to an Anthropic model.
+
+        When using 'openai/claude-*' with a custom base URL (e.g., a LiteLLM proxy),
+        litellm's OpenAI provider strips cache_control from messages before sending.
+        In these cases we need to forward cache_control_injection_points via extra_body
+        so the proxy can apply caching when forwarding to the actual provider (e.g., Bedrock).
+        """
+        if not model_name.startswith("openai/"):
+            return False
+        model_suffix = model_name.split("/", 1)[1].lower()
+        return "claude" in model_suffix or "anthropic" in model_suffix
+
     def completion(
         self,
         messages: List[Dict[str, Any]],
@@ -409,6 +424,23 @@ class DefaultLLM(LLM):
         litellm_to_use = self.tracer.wrap_llm(litellm) if self.tracer else litellm
 
         litellm_model_name = self.get_litellm_corrected_name_for_robusta_ai()
+
+        cache_control_points = [
+            {
+                "location": "message",
+                "index": -1,  # -1 targets the last message.
+            }
+        ]
+
+        # When routing through an OpenAI-compatible proxy (e.g., LiteLLM proxy) to an
+        # Anthropic model, litellm's OpenAI provider strips cache_control from messages
+        # in transform_request(). Forward cache_control_injection_points via extra_body
+        # so the proxy can process it and enable caching when forwarding to Bedrock/Anthropic.
+        if self._is_openai_proxy_to_anthropic(litellm_model_name):
+            extra_body = self.args.get("extra_body", {})
+            extra_body["cache_control_injection_points"] = cache_control_points
+            self.args["extra_body"] = extra_body
+
         result = litellm_to_use.completion(
             model=litellm_model_name,
             api_key=self.api_key,
@@ -422,12 +454,7 @@ class DefaultLLM(LLM):
             timeout=LLM_REQUEST_TIMEOUT,
             **tools_args,
             **self.args,
-            cache_control_injection_points=[
-                {
-                    "location": "message",
-                    "index": -1,  # -1 targets the last message.
-                }
-            ],
+            cache_control_injection_points=cache_control_points,
         )
 
         if isinstance(result, ModelResponse):

--- a/tests/core/test_llm_api_base_version.py
+++ b/tests/core/test_llm_api_base_version.py
@@ -211,3 +211,91 @@ class TestDefaultLLMCheckLLM:
             "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
             args={"aws_access_key_id": "test", "aws_secret_access_key": "test"},
         )
+
+
+class TestIsOpenaiProxyToAnthropic:
+    """Test DefaultLLM._is_openai_proxy_to_anthropic detection."""
+
+    def test_openai_claude_model(self):
+        """openai/claude-* should be detected as proxy to Anthropic."""
+        assert DefaultLLM._is_openai_proxy_to_anthropic("openai/claude-sonnet-4.5") is True
+
+    def test_openai_claude_haiku_model(self):
+        assert DefaultLLM._is_openai_proxy_to_anthropic("openai/claude-haiku-4.5") is True
+
+    def test_openai_anthropic_prefix_model(self):
+        """openai/anthropic.claude-* (Robusta-style) should be detected."""
+        assert DefaultLLM._is_openai_proxy_to_anthropic("openai/anthropic.claude-3-5-sonnet") is True
+
+    def test_openai_gpt_model(self):
+        """openai/gpt-4 should NOT be detected as proxy to Anthropic."""
+        assert DefaultLLM._is_openai_proxy_to_anthropic("openai/gpt-4") is False
+
+    def test_direct_anthropic_model(self):
+        """anthropic/claude-* (direct) should NOT match."""
+        assert DefaultLLM._is_openai_proxy_to_anthropic("anthropic/claude-sonnet-4.5") is False
+
+    def test_direct_bedrock_model(self):
+        """bedrock/anthropic.claude-* (direct) should NOT match."""
+        assert DefaultLLM._is_openai_proxy_to_anthropic("bedrock/anthropic.claude-3-5-sonnet") is False
+
+    def test_model_without_prefix(self):
+        assert DefaultLLM._is_openai_proxy_to_anthropic("claude-sonnet-4.5") is False
+
+    def test_case_insensitive(self):
+        assert DefaultLLM._is_openai_proxy_to_anthropic("openai/Claude-Sonnet-4.5") is True
+
+
+class TestCacheControlExtraBody:
+    """Test that cache_control_injection_points is forwarded via extra_body for proxy scenarios."""
+
+    @patch("litellm.completion")
+    @patch.object(DefaultLLM, "check_llm")
+    def test_extra_body_set_for_openai_claude(self, mock_check, mock_completion):
+        """When model is openai/claude-*, extra_body should include cache_control_injection_points."""
+        mock_completion.return_value = type("MockResponse", (), {
+            "choices": [type("Choice", (), {"message": type("Msg", (), {"content": "test"})()})()],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        })()
+        mock_completion.return_value.__class__ = type("ModelResponse", (), {})
+        # Use a real ModelResponse mock
+        from litellm.types.utils import ModelResponse
+        mock_response = ModelResponse()
+        mock_completion.return_value = mock_response
+
+        llm = DefaultLLM(model="openai/claude-sonnet-4.5", api_key="test-key")
+        llm.completion(messages=[{"role": "user", "content": "hello"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert "cache_control_injection_points" in call_kwargs["extra_body"]
+        # Also still passed as direct kwarg for client-side processing
+        assert "cache_control_injection_points" in call_kwargs
+
+    @patch("litellm.completion")
+    @patch.object(DefaultLLM, "check_llm")
+    def test_no_extra_body_for_direct_anthropic(self, mock_check, mock_completion):
+        """When model is anthropic/claude-*, extra_body should NOT include cache_control_injection_points."""
+        from litellm.types.utils import ModelResponse
+        mock_completion.return_value = ModelResponse()
+
+        llm = DefaultLLM(model="anthropic/claude-sonnet-4.5", api_key="test-key")
+        llm.completion(messages=[{"role": "user", "content": "hello"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        extra_body = call_kwargs.get("extra_body", {})
+        assert "cache_control_injection_points" not in extra_body
+
+    @patch("litellm.completion")
+    @patch.object(DefaultLLM, "check_llm")
+    def test_no_extra_body_for_openai_gpt(self, mock_check, mock_completion):
+        """When model is openai/gpt-4, extra_body should NOT include cache_control_injection_points."""
+        from litellm.types.utils import ModelResponse
+        mock_completion.return_value = ModelResponse()
+
+        llm = DefaultLLM(model="openai/gpt-4", api_key="test-key")
+        llm.completion(messages=[{"role": "user", "content": "hello"}])
+
+        call_kwargs = mock_completion.call_args[1]
+        extra_body = call_kwargs.get("extra_body", {})
+        assert "cache_control_injection_points" not in extra_body


### PR DESCRIPTION
…ropic

When using model "openai/claude-*" with a LiteLLM proxy (e.g., OPENAI_BASE_URL pointing to a LiteLLM server that routes to AWS Bedrock), prompt caching did not work. The root cause is that litellm's OpenAI provider transformation (OpenAIGPTConfig.transform_request) recursively strips all cache_control fields from messages and tools before sending the request. This means the cache_control_injection_points parameter was effectively a no-op for openai/ prefixed models.

The fix forwards cache_control_injection_points via extra_body when the model name indicates it's routing through an OpenAI-compatible proxy to an Anthropic model (openai/claude-* or openai/anthropic.*). The proxy receives this in the request body and passes it as kwargs to its own litellm.acompletion() call, where the AnthropicCacheControlHook processes it and applies caching when forwarding to the actual provider.

https://claude.ai/code/session_01HRDw5THx6iKtSoz9PQzbbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced compatibility for OpenAI-compatible proxies routing to Anthropic models, with automatic detection and improved cache control injection support for seamless model endpoint interoperability.

* **Tests**
  * Comprehensive test coverage added for proxy detection logic and cache control behavior validation across OpenAI GPT models, Anthropic Claude models, and various proxy endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->