### PR TITLE
Remove custom runbooks example file

### DIFF
--- a/examples/custom_runbooks.yaml
+++ b/examples/custom_runbooks.yaml
@@ -1,7 +1,0 @@
-runbooks:
-  - match:
-      issue_name: "(MyAppIsDown)|(MyAppUnhealthy)"
-    instructions: >
-      Analyze pod logs for errors and also read the monogodb logs
-      Correlate between the two logs and try to find the root cause of the issue.
-      Based on the logs, report the session ids of impacted transactions


### PR DESCRIPTION
## Summary
Removed the `examples/custom_runbooks.yaml` example file that demonstrated custom runbook configuration for issue matching and remediation instructions.

## Changes
- Deleted `examples/custom_runbooks.yaml` - This file contained an example configuration showing how to define custom runbooks with pattern matching on issue names and associated remediation instructions for MyApp-related incidents.

## Rationale
This example file is no longer needed in the repository, likely due to documentation updates, API changes, or consolidation of example materials.

https://claude.ai/code/session_0168LM4M1Ye54tZf9tiHcYJ5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated example runbook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->