### PR TITLE
Reorder CONFIG command in SlashCommands enum

### DIFF
--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -78,6 +78,7 @@ from holmes.version import check_version_async
 
 
 class SlashCommands(Enum):
+    CONFIG = ("/config", "Open interactive toolset configuration editor")
     EXIT = ("/exit", "Exit interactive mode")
     HELP = ("/help", "Show help message with all commands")
     CLEAR = ("/clear", "Clear screen and reset conversation context")
@@ -95,7 +96,6 @@ class SlashCommands(Enum):
     CONTEXT = ("/context", "Show conversation context size and token count")
     SHOW = ("/show", "Show specific tool output in scrollable view")
     FEEDBACK = ("/feedback", "Provide feedback on the agent's response")
-    CONFIG = ("/config", "Open interactive toolset configuration editor")
 
     def __init__(self, command, description):
         self.command = command


### PR DESCRIPTION
## Summary
Reordered the `CONFIG` enum member in the `SlashCommands` class to appear at the beginning of the enumeration, before the `EXIT` command.

## Changes
- Moved `CONFIG = ("/config", "Open interactive toolset configuration editor")` from the end of the enum (after `FEEDBACK`) to the beginning (before `EXIT`)
- This change affects only the declaration order and does not impact functionality

## Details
This reordering likely improves the logical organization of slash commands by grouping configuration-related commands at the top of the enum, making the command list more intuitive for users and maintainers.

https://claude.ai/code/session_01DPunFwoi8dtM5zkEbJuto7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The /config slash command has been added, allowing users to quickly access and open the interactive toolset configuration editor from the command interface.

* **Chores**
  * Removed a duplicate command declaration within the slash command system to reduce redundancy and prevent potential command recognition conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->