### PR TITLE
Update welcome banner to mention CONFIG command

### DIFF
--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -233,7 +233,7 @@ class ShowCommandCompleter(Completer):
                         )
 
 
-WELCOME_BANNER = f"[bold {HELP_COLOR}]Welcome to {agent_name}:[/bold {HELP_COLOR}] Type '{SlashCommands.EXIT.command}' to exit, '{SlashCommands.HELP.command}' for commands."
+WELCOME_BANNER = f"[bold {HELP_COLOR}]Welcome to {agent_name}:[/bold {HELP_COLOR}] Type '{SlashCommands.EXIT.command}' to exit, '{SlashCommands.CONFIG.command}' to set up Holmes, or '{SlashCommands.HELP.command}' for all commands."
 
 
 def format_tool_call_output(


### PR DESCRIPTION

<img width="794" height="104" alt="image" src="https://github.com/user-attachments/assets/5981c68d-12cb-4507-9596-14351de41c6c" />


## Summary
Updated the welcome banner message in the interactive CLI to inform users about the CONFIG command for setting up Holmes, in addition to the existing EXIT and HELP commands.

## Changes
- Modified `WELCOME_BANNER` text to include reference to `SlashCommands.CONFIG.command`
- Updated message to guide users that they can use the CONFIG command to set up Holmes
- Reorganized command mentions for better clarity: EXIT → CONFIG → HELP

## Details
The welcome banner now provides more comprehensive guidance to new users by explicitly mentioning the configuration setup option alongside the existing help and exit commands. This improves discoverability of the configuration feature for users starting the interactive session.

https://claude.ai/code/session_0141sURkHoWBMgP9W4AvLVuk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the welcome banner to include the /config command option for configuring Holmes settings, alongside the existing /exit and /help commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->