### PR TITLE
Simplify litellm.modify_params handling

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -397,8 +397,7 @@ class DefaultLLM(LLM):
         if EXTRA_HEADERS:
             self.args.setdefault("extra_headers", json.loads(EXTRA_HEADERS))
 
-        if self.args.get("thinking", None):
-            litellm.modify_params = True
+        litellm.modify_params = True
 
         if REASONING_EFFORT:
             self.args.setdefault("reasoning_effort", REASONING_EFFORT)

--- a/holmes/core/truncation/compaction.py
+++ b/holmes/core/truncation/compaction.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-import litellm
 from litellm.types.utils import ModelResponse
 from pydantic import BaseModel
 
@@ -76,16 +75,9 @@ def compact_conversation_history(
     )
     conversation_history.append({"role": "user", "content": compaction_instructions})
 
-    # Set modify_params to handle providers like Anthropic that require tools
-    # when conversation history contains tool calls
-    original_modify_params = litellm.modify_params
-    try:
-        litellm.modify_params = True  # necessary when using anthropic
-        response: ModelResponse = llm.completion(
-            messages=conversation_history, drop_params=True
-        )  # type: ignore
-    finally:
-        litellm.modify_params = original_modify_params
+    response: ModelResponse = llm.completion(
+        messages=conversation_history, drop_params=True
+    )  # type: ignore
     compaction_usage = _extract_compaction_usage(response)
 
     response_message = None


### PR DESCRIPTION
## Summary
Simplified the handling of `litellm.modify_params` by removing conditional logic and always setting it to `True` during LLM completion calls.

## Key Changes
- **holmes/core/truncation/compaction.py**: Removed try-finally block that conditionally set `litellm.modify_params` only when processing conversation history with tool calls. The parameter is now always enabled during completion.
- **holmes/core/llm.py**: Changed `litellm.modify_params` to always be set to `True` instead of only when the "thinking" parameter is present in args.

## Implementation Details
Previously, `litellm.modify_params` was conditionally enabled based on specific conditions (presence of tool calls or thinking parameter). This change unconditionally enables it for all completion calls, which:
- Ensures consistent behavior across different provider types (e.g., Anthropic)
- Reduces code complexity by eliminating conditional branches
- Allows litellm to properly handle parameter modifications for all scenarios

https://claude.ai/code/session_01EUu69MzhDFEUhfK82b2t5Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified LLM parameter handling to consistently apply modifications across all completion requests.
  * Simplified completion workflow by removing provider-specific workarounds, reducing code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->