### PR TITLE
Refactor agent loop to unified event-driven architecture

### DIFF
--- a/holmes/core/agent_events.py
+++ b/holmes/core/agent_events.py
@@ -1,7 +1,11 @@
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from __future__ import annotations
 
-from holmes.core.models import ToolCallResult
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from holmes.core.models import PendingToolApproval, ToolCallResult
+    from holmes.utils.stream import StreamMessage
 
 
 @dataclass
@@ -18,7 +22,7 @@ class CompactionEvent:
 
     metadata: Dict[str, Any]
     # The StreamMessage events from the limiter (for backwards compat with call_stream)
-    stream_events: list = field(default_factory=list)
+    stream_events: List[StreamMessage] = field(default_factory=list)
 
 
 @dataclass
@@ -69,8 +73,8 @@ class CompletionEvent:
 class ApprovalRequiredEvent:
     """Emitted when tools require user approval (streaming mode)."""
 
-    pending_approvals: list  # list[PendingToolApproval]
-    approval_required_tools: list  # list[ToolCallResult]
+    pending_approvals: List[PendingToolApproval]
+    approval_required_tools: List[ToolCallResult]
     messages: List[Dict]
     metadata: Dict[str, Any]
     tool_number_offset: int = 0

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -378,7 +378,7 @@ class ToolCallingLLM:
         system_prompt: str,
         user_prompt: str,
         response_format: Optional[Union[dict, Type[BaseModel]]] = None,
-        trace_span=DummySpan(),
+        trace_span: Optional[Any] = None,
         request_context: Optional[Dict[str, Any]] = None,
     ) -> LLMResult:
         messages = [
@@ -388,7 +388,6 @@ class ToolCallingLLM:
         return self.call(
             messages,
             response_format=response_format,
-            user_prompt=user_prompt,
             trace_span=trace_span,
             request_context=request_context,
         )
@@ -397,7 +396,7 @@ class ToolCallingLLM:
         self,
         messages: List[Dict[str, str]],
         response_format: Optional[Union[dict, Type[BaseModel]]] = None,
-        trace_span=DummySpan(),
+        trace_span: Optional[Any] = None,
         request_context: Optional[Dict[str, Any]] = None,
     ) -> LLMResult:
         return self.call(
@@ -708,7 +707,6 @@ class ToolCallingLLM:
         self,
         messages: List[Dict[str, str]],
         response_format: Optional[Union[dict, Type[BaseModel]]] = None,
-        user_prompt: Optional[str] = None,
         trace_span: Optional[Any] = None,
         tool_number_offset: int = 0,
         request_context: Optional[Dict[str, Any]] = None,

--- a/tests/core/test_agent_events.py
+++ b/tests/core/test_agent_events.py
@@ -143,12 +143,12 @@ class TestRunLoopSimpleQA:
         assert CompletionEvent in event_types
 
         # Check completion event
-        completion = [e for e in events if isinstance(e, CompletionEvent)][0]
+        completion = next(e for e in events if isinstance(e, CompletionEvent))
         assert completion.result == "The answer is 42"
         assert completion.num_llm_calls == 1
 
         # LLMResponseEvent should have has_tool_calls=False
-        llm_response = [e for e in events if isinstance(e, LLMResponseEvent)][0]
+        llm_response = next(e for e in events if isinstance(e, LLMResponseEvent))
         assert llm_response.has_tool_calls is False
         assert llm_response.content == "The answer is 42"
 
@@ -197,12 +197,12 @@ class TestRunLoopWithToolCalls:
         assert ToolResultEvent in event_types
 
         # Check tool start event
-        tool_start = [e for e in events if isinstance(e, ToolStartEvent)][0]
+        tool_start = next(e for e in events if isinstance(e, ToolStartEvent))
         assert tool_start.tool_name == "my_tool"
         assert tool_start.tool_call_id == "tool_1"
 
         # Check tool result event
-        tool_result = [e for e in events if isinstance(e, ToolResultEvent)][0]
+        tool_result = next(e for e in events if isinstance(e, ToolResultEvent))
         assert tool_result.tool_call_result.tool_name == "my_tool"
         assert (
             tool_result.tool_call_result.result.status
@@ -210,7 +210,7 @@ class TestRunLoopWithToolCalls:
         )
 
         # Should end with completion
-        completion = [e for e in events if isinstance(e, CompletionEvent)][0]
+        completion = next(e for e in events if isinstance(e, CompletionEvent))
         assert completion.result == "The result is X"
         assert completion.num_llm_calls == 2
 
@@ -270,9 +270,9 @@ class TestRunLoopApprovalRequired:
         # Should NOT have CompletionEvent (loop paused)
         assert CompletionEvent not in event_types
 
-        approval_event = [
+        approval_event = next(
             e for e in events if isinstance(e, ApprovalRequiredEvent)
-        ][0]
+        )
         assert len(approval_event.pending_approvals) == 1
         assert approval_event.pending_approvals[0].tool_name == "dangerous_tool"
 
@@ -339,7 +339,7 @@ class TestRunLoopApprovalRequired:
         # Should complete normally
         assert CompletionEvent in event_types
 
-        completion = [e for e in events if isinstance(e, CompletionEvent)][0]
+        completion = next(e for e in events if isinstance(e, CompletionEvent))
         assert completion.result == "Done!"
 
 
@@ -397,9 +397,9 @@ class TestCallStreamAdapter:
         assert StreamEvents.ANSWER_END in event_types
 
         # Check ANSWER_END content
-        answer_end = [
+        answer_end = next(
             m for m in stream_messages if m.event == StreamEvents.ANSWER_END
-        ][0]
+        )
         assert answer_end.data["content"] == "Streamed answer"
 
     def test_call_stream_with_tool_calls(self):


### PR DESCRIPTION
## Summary
Refactored the core agent loop in `ToolCallingLLM` to use a unified event-driven architecture via a new `_run_loop()` generator method. This eliminates code duplication between `call()` and `call_stream()` by having both methods delegate to the same generator that yields typed `AgentEvent` objects.

## Key Changes

- **New `_run_loop()` generator method**: Extracted the core agent loop logic into a single generator that yields typed `AgentEvent` objects (`IterationStartEvent`, `LLMResponseEvent`, `ToolStartEvent`, `ToolResultEvent`, `TokenCountEvent`, `CompletionEvent`, `ApprovalRequiredEvent`, `CompactionEvent`). This is the single source of truth for agent behavior.

- **New `agent_events.py` module**: Created dataclass-based event types that represent all significant state changes during agent execution. These events are strongly typed and carry all relevant context.

- **Refactored `call()` method**: Now a thin adapter that consumes `_run_loop()` events and converts them to the `LLMResult` return type. Handles reasoning content logging.

- **Refactored `call_stream()` method**: Simplified to delegate to `_run_loop()` and map `AgentEvent` objects to `StreamMessage` objects, eliminating ~180 lines of duplicated loop logic.

- **Streaming mode approval handling**: Added `enable_tool_approval` parameter to `_run_loop()` to support two approval modes:
  - Streaming mode (`enable_tool_approval=True`): Yields `ApprovalRequiredEvent` and pauses the loop
  - Non-streaming mode (`enable_tool_approval=False`): Handles approvals via callback and continues

- **Improved token counting**: Token counts are now computed and yielded as `TokenCountEvent` after both LLM responses and tool results, with metadata properly accumulated.

- **Better cost tracking**: Compaction costs are logged with detailed breakdowns and accumulated consistently across both code paths.

- **Session prefix extraction**: Added support for extracting and re-extracting bash session approved prefixes from conversation history.

## Implementation Details

- The `_run_loop()` generator maintains all state (messages, costs, tool calls, metadata) and yields events at key points in the loop lifecycle.
- Both `call()` and `call_stream()` now share identical loop behavior, reducing maintenance burden and ensuring consistency.
- Event types are immutable dataclasses with clear semantics, making the event flow explicit and testable.
- Added comprehensive test suite (`test_agent_events.py`) covering simple Q&A, tool calls, approval workflows, and both adapter methods.
- Preserved all existing behavior including error handling, context window limiting, and tool execution semantics.

https://claude.ai/code/session_01GmtD2tcMAFVGeW3wyzLYwe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event-driven agent lifecycle with typed events for iterations, token counts, LLM responses, tool starts/results, compaction, completion, and approval flows.
  * Unified generator-based execution powering streaming and non-streaming paths, session-prefix handling, and richer observability of costs and tool interactions.
  * Streaming support for tool approvals with configurable approval handling.

* **Tests**
  * Added comprehensive tests covering QA, tool-call, approval (streaming and non-streaming), and streaming adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->