### PR TITLE
fix(bash,prometheus): handle string timeout and improve unparseable command validation

### DIFF
--- a/holmes/plugins/toolsets/bash/bash_toolset.py
+++ b/holmes/plugins/toolsets/bash/bash_toolset.py
@@ -195,6 +195,11 @@ class RunBashCommand(Tool):
         command_str = params.get("command")
         suggested_prefixes = params.get("suggested_prefixes", [])
         timeout = params.get("timeout", 30)
+        # LLM may pass timeout as string — ensure it's an int for subprocess
+        try:
+            timeout = int(timeout)
+        except (TypeError, ValueError):
+            timeout = 30
 
         # Validate required parameters
         if not command_str:

--- a/holmes/plugins/toolsets/bash/validation.py
+++ b/holmes/plugins/toolsets/bash/validation.py
@@ -7,6 +7,7 @@ against allow/deny lists, with support for composed commands (pipes, &&, etc.).
 
 import logging
 import re
+import shlex
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple
@@ -324,6 +325,57 @@ def validate_command(
                 deny_reason=DenyReason.DENY_LIST,
                 message=f"Command matches deny list pattern '{denied}'. This command is blocked by configuration.",
             )
+
+        # Fallback: use shlex to tokenize (respects quoting), then split
+        # tokens into command segments by shell operators (|, &&, ;, etc.).
+        # bashlex may fail on valid commands with special chars in quoted
+        # arguments (e.g. parentheses in PromQL queries passed to curl).
+        SHELL_OPERATORS = {"|", "||", "&&", ";", "&"}
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            # shlex can't parse either — fall through to approval
+            return ValidationResult(
+                status=ValidationStatus.APPROVAL_REQUIRED,
+                message="Command contains complex syntax which requires approval.",
+                prefixes_needing_approval=[],
+            )
+
+        # Group tokens into segments separated by shell operators
+        segments_from_shlex: List[str] = []
+        current_segment: List[str] = []
+        for token in tokens:
+            if token in SHELL_OPERATORS:
+                if current_segment:
+                    segments_from_shlex.append(" ".join(current_segment))
+                    current_segment = []
+            else:
+                current_segment.append(token)
+        if current_segment:
+            segments_from_shlex.append(" ".join(current_segment))
+
+        if not segments_from_shlex:
+            return ValidationResult(
+                status=ValidationStatus.APPROVAL_REQUIRED,
+                message="Command contains complex syntax which requires approval.",
+                prefixes_needing_approval=[],
+            )
+
+        all_allowed = True
+        for seg in segments_from_shlex:
+            seg_result = validate_segment(seg, allow_list, deny_list)
+            if seg_result.status == ValidationStatus.DENIED:
+                return seg_result
+            if seg_result.status != ValidationStatus.ALLOWED:
+                all_allowed = False
+                break
+
+        if all_allowed:
+            logger.info(
+                f"Command allowed via fallback validation (bashlex parse failed): {command[:200]}"
+            )
+            return ValidationResult(status=ValidationStatus.ALLOWED)
+
         return ValidationResult(
             status=ValidationStatus.APPROVAL_REQUIRED,
             message="Command contains complex syntax which requires approval.",

--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1378,6 +1378,11 @@ class ExecuteInstantQuery(BasePrometheusTool):
             default_timeout = self.toolset.config.query_timeout_seconds_default
             max_timeout = self.toolset.config.query_timeout_seconds_hard_max
             timeout = params.get("timeout", default_timeout)
+            # LLM may pass timeout as string — ensure numeric type
+            try:
+                timeout = int(timeout)
+            except (TypeError, ValueError):
+                timeout = default_timeout
             if timeout > max_timeout:
                 timeout = max_timeout
                 logging.warning(
@@ -1632,6 +1637,11 @@ class ExecuteRangeQuery(BasePrometheusTool):
             default_timeout = self.toolset.config.query_timeout_seconds_default
             max_timeout = self.toolset.config.query_timeout_seconds_hard_max
             timeout = params.get("timeout", default_timeout)
+            # LLM may pass timeout as string — ensure numeric type
+            try:
+                timeout = int(timeout)
+            except (TypeError, ValueError):
+                timeout = default_timeout
             if timeout > max_timeout:
                 timeout = max_timeout
                 logging.warning(

--- a/tests/test_bash_toolset_validation.py
+++ b/tests/test_bash_toolset_validation.py
@@ -1042,6 +1042,43 @@ class TestCompoundStatements:
         assert result.status == ValidationStatus.APPROVAL_REQUIRED
         assert result.message == "Command contains complex syntax which requires approval."
 
+    def test_curl_with_parentheses_in_args_allowed(self):
+        """curl with parentheses in quoted args (e.g. PromQL) should be allowed via fallback."""
+        config = BashExecutorConfig(allow=["curl", "jq"])
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(
+            "curl -sG 'http://vmselect:8481/select/0/prometheus/api/v1/query' "
+            "--data-urlencode 'query=topk(10, nvme_smart_log_media_errors)' | jq .data.result",
+            ["curl", "jq"],
+            allow_list,
+            deny_list,
+        )
+        assert result.status == ValidationStatus.ALLOWED
+
+    def test_curl_with_parentheses_pipe_not_allowed_prefix(self):
+        """curl with parentheses piped to non-allowed command still requires approval."""
+        config = BashExecutorConfig(allow=["curl"])
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(
+            "curl -sG 'http://example.com/api' --data-urlencode 'query=topk(10, metric)' | python3 -c 'import sys'",
+            ["curl", "python3"],
+            allow_list,
+            deny_list,
+        )
+        assert result.status == ValidationStatus.APPROVAL_REQUIRED
+
+    def test_curl_with_parentheses_denied_command(self):
+        """curl with parentheses piped to denied command is still denied."""
+        config = BashExecutorConfig(allow=["curl"], deny=["rm"])
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(
+            "curl -sG 'http://example.com' --data-urlencode 'query=topk(10, x)' | rm -rf /",
+            ["curl", "rm"],
+            allow_list,
+            deny_list,
+        )
+        assert result.status == ValidationStatus.DENIED
+
 
 # ==================== Integration: requires_approval prefixes_to_save ====================
 


### PR DESCRIPTION
## Related Issues

- Fixes #1727 — Bash toolset: TypeError when LLM passes timeout as string
- Fixes #1728 — Bash toolset: commands with unquoted parentheses always require approval even when all segments are allowed
- Related to #1677 — Prometheus toolset: same timeout TypeError

## Changes

### 1. Timeout type coercion (bash + prometheus toolsets)

LLMs sometimes pass the `timeout` tool parameter as a string (`"30"`) instead of an integer. This causes:

- **Bash toolset**: `TypeError: unsupported operand type(s) for +: 'float' and 'str'` in `subprocess.communicate(timeout=timeout)`
- **Prometheus toolset**: `TypeError: '>' not supported between instances of 'str' and 'int'` in timeout comparison

Fix: cast `timeout` to `int` with a try/except fallback to the default value.

### 2. shlex-based fallback for unparseable commands (bash toolset)

When `bashlex.parse()` fails (e.g. unquoted parentheses in PromQL queries like `query=topk(10, metric)`), the current code always returns `APPROVAL_REQUIRED`. In server mode (e.g. Keep/Robusta integrations), there is no user to approve, so these commands silently fail.

Added a fallback that uses `shlex.split()` (stdlib, respects shell quoting) to tokenize the command, then groups tokens into segments by shell operators (`|`, `&&`, `;`, `&`) and validates each segment against the allow/deny lists. If all segments are allowed, the command is permitted.

Security is preserved:
- Hardcoded blocks and deny list are checked on the raw string **before** the fallback
- Each segment in the fallback goes through the full `validate_segment()` deny → allow → approval pipeline
- If any segment is not in the allow list, the behavior is unchanged (`APPROVAL_REQUIRED`)
- If `shlex.split()` also fails, falls through to `APPROVAL_REQUIRED`

### Tests

Added 3 test cases to `test_bash_toolset_validation.py`:
- `curl` with parentheses in args piped to `jq` (both allowed) → `ALLOWED`
- `curl` with parentheses piped to non-allowed command → `APPROVAL_REQUIRED`
- `curl` with parentheses piped to denied command → `DENIED`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout parameter handling in Bash and Prometheus tools to gracefully convert string values to integers, preventing type errors.

* **New Features**
  * Added fallback command validation for complex Bash commands that may not parse with the primary parser.

* **Tests**
  * Expanded test coverage for edge cases in command validation with special characters and piped operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->