### PR TITLE
Add HolmesGPT version to AI assistant introduction

### DIFF
--- a/holmes/core/prompt.py
+++ b/holmes/core/prompt.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from holmes.plugins.prompts import load_and_render_prompt
 from holmes.plugins.runbooks import RunbookCatalog
 from holmes.utils.global_instructions import Instructions, generate_runbooks_args
+from holmes.version import get_version
 
 
 class PromptComponent(str, Enum):
@@ -188,6 +189,7 @@ def build_system_prompt(
     toolset_instructions_enabled = is_enabled(PromptComponent.TOOLSET_INSTRUCTIONS)
 
     template_context = {
+        "holmes_version": get_version(),
         "intro_enabled": is_enabled(PromptComponent.INTRO),
         "ask_user_enabled": ask_user_enabled and is_enabled(PromptComponent.ASK_USER),
         "todowrite_enabled": is_enabled(PromptComponent.TODOWRITE_INSTRUCTIONS),

--- a/holmes/plugins/prompts/generic_ask.jinja2
+++ b/holmes/plugins/prompts/generic_ask.jinja2
@@ -1,5 +1,5 @@
 {% if intro_enabled %}
-You are a tool-calling AI assist provided with common devops and IT tools that you can use to troubleshoot problems or answer questions.
+You are HolmesGPT version {{ holmes_version }}, a tool-calling AI assist provided with common devops and IT tools that you can use to troubleshoot problems or answer questions.
 Whenever possible you MUST first use tools to investigate then answer the question.
 Ask for multiple tool calls at the same time as it saves time for the user.
 Do not say 'based on the tool output' or explicitly refer to tools at all.


### PR DESCRIPTION
## Summary
This change adds version information to the HolmesGPT AI assistant's introduction prompt, making it clear to users which version of HolmesGPT they are interacting with.

## Key Changes
- Import `get_version()` function from `holmes.version` module
- Add `holmes_version` to the template context in `PromptComponent.build_prompt()`
- Update the generic ask prompt template to include the version number in the assistant's introduction message

## Implementation Details
The version is now dynamically injected into the prompt template context and displayed in the initial system message as "HolmesGPT version X.X.X". This provides transparency to users about which version of the tool is responding to their requests.

https://claude.ai/code/session_01CCax8DktBhiqXWzSJyL4ny

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI assistant now displays version information within system prompts, allowing users to see which version of HolmesGPT they are interacting with.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->