### PR TITLE
Rename grafana-dashboard tag to grafana

### DIFF
--- a/.claude/skills/create-eval/references/running-evals.md
+++ b/.claude/skills/create-eval/references/running-evals.md
@@ -100,7 +100,7 @@ nohup poetry run pytest -k "test_name" --no-cov > test.log 2>&1 &
 Only use tags from `pyproject.toml` markers section. Invalid tags cause test collection failures.
 
 Tag naming conventions:
-- Service-specific: `grafana-dashboard`, `prometheus`, `loki`
+- Service-specific: `grafana`, `prometheus`, `loki`
 - Functionality: `question-answer`, `chain-of-causation`
 - Difficulty: `easy`, `medium`, `hard`
 - Infrastructure: `kubernetes`, `database`, `traces`

--- a/.claude/skills/create-eval/references/test-case-format.md
+++ b/.claude/skills/create-eval/references/test-case-format.md
@@ -38,7 +38,7 @@ Test categorization. Only use tags from `pyproject.toml` markers. Invalid tags c
 
 Common tags:
 - Difficulty: `easy`, `medium`, `hard`
-- Infrastructure: `kubernetes`, `prometheus`, `loki`, `grafana-dashboard`, `elasticsearch`, `datadog`
+- Infrastructure: `kubernetes`, `prometheus`, `loki`, `grafana`, `elasticsearch`, `datadog`
 - Type: `question-answer`, `chain-of-causation`, `logs`, `metrics`, `traces`
 - Special: `regression` (must always pass), `no-cicd` (skip in CI), `fast` (quick tests)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ markers = [
     "coralogix: Runs coralogix evals",
     "fast: Fast cloud-only tests that don't require Kubernetes infrastructure",
     "frontend: Run frontend tests",
-    "grafana-dashboard: Tests involving Grafana dashboard interactions",
+    "grafana: Tests involving Grafana dashboard interactions",
     "elasticsearch: Tests for Elasticsearch/OpenSearch toolset functionality",
     "integration: Integration tests requiring external services (e.g., running server, real APIs)",
     "confluence: Tests for Confluence page fetching toolset",

--- a/tests/llm/fixtures/test_ask_holmes/177_grafana_home_dashboard/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/177_grafana_home_dashboard/test_case.yaml
@@ -71,4 +71,4 @@ tags:
   - question-answer
   - metrics
   - kubernetes
-  - grafana-dashboard
+  - grafana

--- a/tests/llm/fixtures/test_ask_holmes/178_grafana_search_dashboard_query/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/178_grafana_search_dashboard_query/test_case.yaml
@@ -113,4 +113,4 @@ tags:
   - question-answer
   - metrics
   - kubernetes
-  - grafana-dashboard
+  - grafana

--- a/tests/llm/fixtures/test_ask_holmes/179_grafana_big_dashboard_query/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/179_grafana_big_dashboard_query/test_case.yaml
@@ -136,5 +136,5 @@ tags:
   - question-answer
   - metrics
   - kubernetes
-  - grafana-dashboard
+  - grafana
   - benchmark


### PR DESCRIPTION
## Summary
Standardize the Grafana test tag by renaming `grafana-dashboard` to `grafana` across all test configurations and documentation.

## Key Changes
- Updated pytest marker definition in `pyproject.toml` from `grafana-dashboard` to `grafana`
- Updated tag naming convention documentation in `running-evals.md`
- Updated common tags reference in `test-case-format.md`
- Updated all test case YAML files to use the new `grafana` tag:
  - `177_grafana_home_dashboard/test_case.yaml`
  - `178_grafana_search_dashboard_query/test_case.yaml`
  - `179_grafana_big_dashboard_query/test_case.yaml`

## Details
This change simplifies the tag naming convention by removing the `-dashboard` suffix, making it consistent with other service-specific tags like `prometheus` and `loki`. The new `grafana` tag maintains the same functionality while providing a cleaner, more concise naming scheme.

https://claude.ai/code/session_011ahaBPboUsZxyXVcvrCJi4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test tag naming conventions for consistency across test configuration and documentation.
  * Streamlined Grafana-related test categorization to use simplified naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->