### PR TITLE
Holmes update mcp server instructions update

### DIFF
--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -709,6 +709,11 @@ class Toolset(BaseModel):
             if field in self.__class__.model_fields and value not in (None, [], {}, ""):
                 setattr(self, field, value)
 
+        # Re-render llm_instructions after override, since they may contain Jinja2 templates
+        # that reference tool names or config values which could have changed.
+        if self.llm_instructions:
+            self._load_llm_instructions(self.llm_instructions)
+
     @model_validator(mode="before")
     def preprocess_tools(cls, values):
         transformers = values.get("transformers", None)

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -475,6 +475,9 @@ class RemoteMCPToolset(Toolset):
         # Set icon from config if specified
         if self.icon_url is None and self.config:
             self.icon_url = self.config.get("icon_url")
+        # Render llm_instructions (may contain Jinja2 templates)
+        if self.llm_instructions:
+            self._load_llm_instructions(self.llm_instructions)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/config_class/test_mcp_llm_instructions_override.py
+++ b/tests/config_class/test_mcp_llm_instructions_override.py
@@ -1,0 +1,91 @@
+import yaml
+
+from holmes.plugins.toolsets import load_toolsets_from_config
+from holmes.plugins.toolsets.mcp.toolset_mcp import RemoteMCPToolset
+
+
+initial_config_str = """
+  mcp_grafana:
+    type: mcp
+    url: "http://mcp-server:8080"
+    description: "Grafana MCP server"
+    llm_instructions: "Use these tools to query Grafana dashboards."
+    config:
+      url: "http://mcp-server:8080"
+"""
+
+updated_config_str = """
+  mcp_grafana:
+    type: mcp
+    url: "http://mcp-server:8080"
+    description: "Grafana MCP server"
+    llm_instructions: "UPDATED: Use these tools to query Prometheus via Grafana."
+    config:
+      url: "http://mcp-server:8080"
+"""
+
+
+def test_mcp_toolset_loads_llm_instructions():
+    """Test that RemoteMCPToolset renders llm_instructions on creation."""
+    config = yaml.safe_load(initial_config_str)
+    toolsets = load_toolsets_from_config(toolsets=config, strict_check=False)
+    assert len(toolsets) == 1
+    toolset = toolsets[0]
+    assert isinstance(toolset, RemoteMCPToolset)
+    assert toolset.llm_instructions == "Use these tools to query Grafana dashboards."
+
+
+def test_mcp_toolset_override_updates_llm_instructions():
+    """Test that override_with() updates llm_instructions when config changes.
+
+    This verifies the fix for the bug where changing llm_instructions in a
+    ConfigMap and restarting the pod would not update the instructions because
+    override_with() did not re-render them.
+    """
+    initial_config = yaml.safe_load(initial_config_str)
+    updated_config = yaml.safe_load(updated_config_str)
+
+    initial_toolsets = load_toolsets_from_config(
+        toolsets=initial_config, strict_check=False
+    )
+    updated_toolsets = load_toolsets_from_config(
+        toolsets=updated_config, strict_check=False
+    )
+
+    assert len(initial_toolsets) == 1
+    assert len(updated_toolsets) == 1
+
+    original = initial_toolsets[0]
+    override = updated_toolsets[0]
+
+    assert original.llm_instructions == "Use these tools to query Grafana dashboards."
+
+    # Simulate what add_or_merge_onto_toolsets does when names match
+    original.override_with(override)
+
+    assert (
+        original.llm_instructions
+        == "UPDATED: Use these tools to query Prometheus via Grafana."
+    )
+
+
+def test_mcp_toolset_override_with_jinja_template():
+    """Test that override_with() re-renders Jinja2 templates in llm_instructions."""
+    config_with_template = yaml.safe_load(
+        """
+  mcp_test:
+    type: mcp
+    url: "http://mcp-server:8080"
+    description: "Test MCP"
+    llm_instructions: "Available tools: {{ tool_names | join(', ') }}"
+    config:
+      url: "http://mcp-server:8080"
+"""
+    )
+
+    toolsets = load_toolsets_from_config(
+        toolsets=config_with_template, strict_check=False
+    )
+    toolset = toolsets[0]
+    # With no tools loaded (no real MCP server), tool_names is empty
+    assert "Available tools:" in toolset.llm_instructions


### PR DESCRIPTION
The first time you created the MCP server in the ConfigMap, Robusta platform synced that config and stored it server-side. That stored copy included the original llm_instructions.

From that point on, every pod restart:

Platform config loads first — Robusta platform sends its stored copy (with the original llm_instructions) → creates RemoteMCPToolset with the old instructions
ConfigMap loads second — your updated config creates a new RemoteMCPToolset with the new instructions
Merge by name — same name exists, so override_with() runs → copies the new llm_instructions string via setattr but never re-renders it
The bug is that override_with() silently dropped the update. But the deeper reason the old value was there in the first place is that the platform cached your original config and always loaded it as the base toolset before the ConfigMap merge happened.

When you renamed the MCP server, the names didn't match — no merge occurred. The ConfigMap toolset was added fresh, bypassing the platform's cached copy entirely. That's why renaming appeared to fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LLM instructions containing dynamic templates now properly update and render when configurations change or during system initialization.

* **Tests**
  * Added comprehensive tests for toolset configuration updates and instruction template rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->