### PR TITLE
Clarify output_type parameter to prevent double conversion

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1561,7 +1561,7 @@ class ExecuteRangeQuery(BasePrometheusTool):
                     required=False,
                 ),
                 "output_type": ToolParameter(
-                    description="Specifies how to interpret the Prometheus result. Use 'Plain' for raw values, 'Bytes' to format byte values, 'Percentage' to scale 0–1 values into 0–100%, or 'CPUUsage' to convert values to cores (e.g., 500 becomes 500m, 2000 becomes 2).",
+                    description="Specifies how to interpret the Prometheus result. Use 'Plain' for raw values, 'Bytes' to format byte values, 'Percentage' to scale 0–1 values into 0–100%, or 'CPUUsage' to convert values to cores (e.g., 500 becomes 500m, 2000 becomes 2). Do NOT convert on your own in the query. E.g. if setting output_type=Percentage it is a mistake to have * 100 in the query and convert numbers yourself in the query from 0-1 range to 0-100. This will cause a double conversion as further conversion happens at formatting time",
                     type="string",
                     required=True,
                 ),


### PR DESCRIPTION
## Summary
Updated the documentation for the `output_type` parameter in the Prometheus toolset to clarify that users should not manually convert values in their queries when using output type formatting options.

## Key Changes
- Enhanced the `output_type` parameter description to explicitly warn against manual conversions in queries
- Added a concrete example showing how double conversion can occur (e.g., using `* 100` in a query when `output_type=Percentage` is set)
- Clarified that formatting conversions happen automatically at formatting time and should not be duplicated in the query itself

## Details
The change addresses a common user error where manual value conversions in Prometheus queries would conflict with the automatic conversions performed by the output type formatter. This could result in incorrect values being returned to users. The updated documentation now makes it clear that users should provide raw metric values and let the `output_type` parameter handle all necessary transformations.

https://claude.ai/code/session_01Hc36WEwXrkTHFv9AJju431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Improved parameter guidance to clarify correct configuration and prevent potential double conversion errors when using certain scaling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->