### PR TITLE
Add frontend tool support for client-side tool execution

### DIFF
--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -85,6 +85,35 @@ class ToolApprovalDecision(BaseModel):
     feedback: Optional[str] = None  # User feedback when denying a tool call
 
 
+class FrontendToolDefinition(BaseModel):
+    """A tool defined by the frontend client, not by Holmes.
+
+    The LLM can call these tools, but execution happens on the client side.
+    When the LLM calls a frontend tool, the stream pauses and the client
+    receives the tool call details to execute and return results.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class FrontendToolResult(BaseModel):
+    """Result of a frontend tool execution, sent by the client to resume the stream."""
+
+    tool_call_id: str
+    tool_name: str
+    result: str  # Always a string; serialize complex data as JSON if needed
+
+
+class PendingFrontendToolCall(BaseModel):
+    """A frontend tool call that the LLM requested, waiting for client execution."""
+
+    tool_call_id: str
+    tool_name: str
+    arguments: Dict[str, Any]
+
+
 class ChatRequestBaseModel(BaseModel):
     conversation_history: Optional[list[dict]] = None
     model: Optional[str] = None
@@ -93,6 +122,14 @@ class ChatRequestBaseModel(BaseModel):
         False  # Optional boolean for backwards compatibility
     )
     tool_decisions: Optional[List[ToolApprovalDecision]] = None
+    frontend_tools: Optional[List[FrontendToolDefinition]] = Field(
+        default=None,
+        description="Tools defined by the frontend client. Must be sent on every request (not persisted). Requires stream=true.",
+    )
+    frontend_tool_results: Optional[List[FrontendToolResult]] = Field(
+        default=None,
+        description="Results from frontend tool executions, sent to resume a paused stream.",
+    )
     additional_system_prompt: Optional[str] = None
     trace_span: Optional[Any] = (
         None  # Optional span for tracing and heartbeat callbacks
@@ -153,4 +190,5 @@ class ChatResponse(BaseModel):
     tool_calls: Optional[List[ToolCallResult]] = []
     follow_up_actions: Optional[List[FollowUpAction]] = []
     pending_approvals: Optional[List[PendingToolApproval]] = None
+    pending_frontend_tool_calls: Optional[List[PendingFrontendToolCall]] = None
     metadata: Optional[Dict[Any, Any]] = None

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -22,6 +22,8 @@ from holmes.core.llm import LLM
 from holmes.core.llm_usage import RequestStats
 
 from holmes.core.models import (
+    FrontendToolResult,
+    PendingFrontendToolCall,
     PendingToolApproval,
     ToolApprovalDecision,
     ToolCallResult,
@@ -188,6 +190,53 @@ class ToolCallingLLM:
                     return config.builtin_allowlist != "none"
                 return False
         return False
+
+    @staticmethod
+    def _inject_frontend_tool_results(
+        messages: List[Dict[str, Any]],
+        frontend_tool_results: List[FrontendToolResult],
+    ) -> tuple[List[Dict[str, Any]], list[StreamMessage]]:
+        """Inject frontend tool results into the conversation as tool messages.
+
+        Finds the pending frontend tool calls in assistant messages and inserts
+        the corresponding tool result messages right after them.
+
+        Returns updated messages and stream events for each result.
+        """
+        events: list[StreamMessage] = []
+        results_by_id = {r.tool_call_id: r for r in frontend_tool_results}
+
+        # Find pending frontend tool calls and clear their markers
+        insertion_points: list[tuple[int, FrontendToolResult]] = []
+        for i in reversed(range(len(messages))):
+            msg = messages[i]
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                for tool_call in msg.get("tool_calls", []):
+                    tc_id = tool_call.get("id")
+                    if tool_call.get("pending_frontend") and tc_id in results_by_id:
+                        del tool_call["pending_frontend"]
+                        insertion_points.append((i, results_by_id[tc_id]))
+
+        # Insert results after the assistant message (in order)
+        for msg_index, result in insertion_points:
+            tool_call_result = ToolCallResult(
+                tool_call_id=result.tool_call_id,
+                tool_name=result.tool_name,
+                description=result.tool_name,
+                result=StructuredToolResult(
+                    status=StructuredToolResultStatus.SUCCESS,
+                    data=result.result,
+                ),
+            )
+            messages.insert(msg_index + 1, tool_call_result.to_llm_message())
+            events.append(
+                StreamMessage(
+                    event=StreamEvents.TOOL_RESULT,
+                    data=tool_call_result.to_client_dict(),
+                )
+            )
+
+        return messages, events
 
     def _execute_tool_decisions(
         self,
@@ -692,6 +741,9 @@ class ToolCallingLLM:
         msgs: Optional[list[dict]] = None,
         enable_tool_approval: bool = False,
         tool_decisions: List[ToolApprovalDecision] | None = None,
+        frontend_tool_names: Optional[set[str]] = None,
+        frontend_openai_tools: Optional[list[dict]] = None,
+        frontend_tool_results: Optional[List[FrontendToolResult]] = None,
         request_context: Optional[Dict[str, Any]] = None,
         trace_span: Any = None,
         cancel_event: Optional[threading.Event] = None,
@@ -701,11 +753,31 @@ class ToolCallingLLM:
         """
         This function DOES NOT call llm.completion(stream=true).
         This function streams holmes one iteration at a time instead of waiting for all iterations to complete.
+
+        Args:
+            frontend_tool_names: Set of tool names that are frontend-defined. When the LLM
+                calls one of these, the stream pauses for client-side execution.
+            frontend_openai_tools: Frontend tool definitions in OpenAI format, appended to
+                the built-in tools list sent to the LLM.
+            frontend_tool_results: Results from previous frontend tool executions, used to
+                resume a paused stream.
         """
         if trace_span is None:
             trace_span = DummySpan()
 
         all_tool_calls: list[dict] = []
+        frontend_tool_names = frontend_tool_names or set()
+
+        # Process frontend tool results if provided (resuming after pause)
+        if msgs and frontend_tool_results:
+            logging.info(f"Processing {len(frontend_tool_results)} frontend tool results")
+            msgs, fe_events = self._inject_frontend_tool_results(
+                msgs, frontend_tool_results
+            )
+            for ev in fe_events:
+                yield ev
+                if ev.event == StreamEvents.TOOL_RESULT:
+                    all_tool_calls.append(ev.data)
 
         # Process tool decisions if provided
         if msgs and tool_decisions:
@@ -722,6 +794,9 @@ class ToolCallingLLM:
         messages: list[dict] = list(msgs) if msgs else []
         tool_calls: list[dict] = []
         tools: Optional[list] = self._get_tools()
+        # Append frontend-defined tools to the tools list for the LLM
+        if frontend_openai_tools and tools is not None:
+            tools = tools + frontend_openai_tools
         max_steps = self.max_steps
         metadata: Dict[Any, Any] = {}
         stats = RequestStats()
@@ -876,13 +951,39 @@ class ToolCallingLLM:
 
             # Check if any tools require approval first
             pending_approvals = []
+            pending_frontend_calls: list[PendingFrontendToolCall] = []
+
+            # Separate frontend tool calls from backend tool calls
+            backend_tools_to_call = []
+            for t in tools_to_call:  # type: ignore
+                if t.function.name in frontend_tool_names:
+                    # Frontend tool: don't execute, collect for client
+                    tool_params = {}
+                    try:
+                        tool_params = json.loads(t.function.arguments)
+                    except Exception:
+                        logging.warning(f"Failed to parse frontend tool arguments: {t.function.arguments}")
+
+                    pending_frontend_calls.append(
+                        PendingFrontendToolCall(
+                            tool_call_id=t.id,
+                            tool_name=t.function.name,
+                            arguments=tool_params,
+                        )
+                    )
+                    yield StreamMessage(
+                        event=StreamEvents.START_TOOL,
+                        data={"tool_name": t.function.name, "id": t.id, "frontend": True},
+                    )
+                else:
+                    backend_tools_to_call.append(t)
 
             # Extract session approved prefixes from conversation history
             session_prefixes = extract_bash_session_prefixes(messages)
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
                 futures = []
-                for tool_index, t in enumerate(tools_to_call, 1):  # type: ignore
+                for tool_index, t in enumerate(backend_tools_to_call, 1):
                     tool_number = tool_number_offset + tool_index
 
                     future = executor.submit(
@@ -959,16 +1060,23 @@ class ToolCallingLLM:
                 # Emit updated token counts after tool results
                 yield self._emit_token_count(messages, tools, full_response, limit_result, metadata, stats)
 
-                # If we have approval required tools, end the stream with pending approvals
-                if pending_approvals:
-                    # Mark pending tool calls in assistant messages
+                # If we have pending frontend tool calls or approval required tools, pause the stream
+                if pending_frontend_calls or pending_approvals:
+                    # Mark pending approval tool calls in assistant messages
                     for approval in pending_approvals:
                         tool_call = self.find_assistant_tool_call_request(
                             tool_call_id=approval.tool_call_id, messages=messages
                         )
                         tool_call["pending_approval"] = True
 
-                    # End stream with approvals required
+                    # Mark pending frontend tool calls in assistant messages
+                    for fe_call in pending_frontend_calls:
+                        tool_call = self.find_assistant_tool_call_request(
+                            tool_call_id=fe_call.tool_call_id, messages=messages
+                        )
+                        tool_call["pending_frontend"] = True
+
+                    # End stream with approvals/frontend calls required
                     yield StreamMessage(
                         event=StreamEvents.APPROVAL_REQUIRED,
                         data={
@@ -976,6 +1084,9 @@ class ToolCallingLLM:
                             "messages": messages,
                             "pending_approvals": [
                                 approval.model_dump() for approval in pending_approvals
+                            ],
+                            "pending_frontend_tool_calls": [
+                                fe_call.model_dump() for fe_call in pending_frontend_calls
                             ],
                             "requires_approval": True,
                             "num_llm_calls": i,
@@ -990,6 +1101,9 @@ class ToolCallingLLM:
                 # Re-fetch tools if runbook was just activated (enables restricted tools)
                 if self._runbook_in_use and tools is not None:
                     new_tools = self._get_tools()
+                    # Re-append frontend tools after refresh
+                    if frontend_openai_tools:
+                        new_tools = new_tools + frontend_openai_tools
                     if len(new_tools) != len(tools):
                         logging.info(
                             f"Runbook activated - refreshing tools list ({len(tools)} -> {len(new_tools)} tools)"

--- a/holmes/utils/stream.py
+++ b/holmes/utils/stream.py
@@ -90,6 +90,11 @@ def stream_chat_formatter(
                 response_data["pending_approvals"] = message.data.get(
                     "pending_approvals", []
                 )
+                pending_frontend = message.data.get(
+                    "pending_frontend_tool_calls", []
+                )
+                if pending_frontend:
+                    response_data["pending_frontend_tool_calls"] = pending_frontend
 
                 yield create_sse_message(
                     StreamEvents.APPROVAL_REQUIRED.value, response_data

--- a/server.py
+++ b/server.py
@@ -45,6 +45,7 @@ from holmes.core.conversations import (
 from holmes.core.models import (
     ChatRequest,
     ChatResponse,
+    FrontendToolDefinition,
     FollowUpAction,
 )
 from holmes.core.prompt import PromptComponent
@@ -311,6 +312,47 @@ def _stream_with_storage_cleanup(storage, stream_generator, req_info):
         storage.__exit__(None, None, None)
 
 
+def _frontend_tools_to_openai_format(
+    frontend_tools: List[FrontendToolDefinition],
+) -> list[dict]:
+    """Convert frontend tool definitions to OpenAI function-calling format."""
+    openai_tools = []
+    for ft in frontend_tools:
+        tool_def: dict = {
+            "type": "function",
+            "function": {
+                "name": ft.name,
+                "description": ft.description,
+            },
+        }
+        if ft.parameters:
+            tool_def["function"]["parameters"] = ft.parameters
+        openai_tools.append(tool_def)
+    return openai_tools
+
+
+def _validate_frontend_tools(
+    chat_request: ChatRequest,
+    builtin_tool_names: set[str],
+) -> None:
+    """Validate frontend tools configuration. Raises HTTPException on error."""
+    if not chat_request.frontend_tools:
+        return
+
+    if not chat_request.stream:
+        raise HTTPException(
+            status_code=400,
+            detail="frontend_tools requires stream=true. Frontend tools need the SSE pause/resume flow.",
+        )
+
+    for ft in chat_request.frontend_tools:
+        if ft.name in builtin_tool_names:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Frontend tool name '{ft.name}' conflicts with a built-in Holmes tool. Use a distinctive name.",
+            )
+
+
 @app.post("/api/chat")
 def chat(chat_request: ChatRequest, http_request: Request):
     try:
@@ -368,6 +410,20 @@ def chat(chat_request: ChatRequest, http_request: Request):
         ai = config.create_toolcalling_llm(
             dal=dal, model=chat_request.model, tool_results_dir=tool_results_dir
         )
+
+        # Validate frontend tools against built-in tool names
+        builtin_tool_names = set(getattr(ai.tool_executor, "tools_by_name", {}).keys())
+        _validate_frontend_tools(chat_request, builtin_tool_names)
+
+        # Build frontend tools OpenAI definitions and name set
+        frontend_openai_tools: list[dict] = []
+        frontend_tool_names: set[str] = set()
+        if chat_request.frontend_tools:
+            frontend_openai_tools = _frontend_tools_to_openai_format(
+                chat_request.frontend_tools
+            )
+            frontend_tool_names = {ft.name for ft in chat_request.frontend_tools}
+
         global_instructions = dal.get_global_instructions_for_account()
         messages = build_chat_messages(
             chat_request.ask,
@@ -387,6 +443,9 @@ def chat(chat_request: ChatRequest, http_request: Request):
                     msgs=messages,
                     enable_tool_approval=chat_request.enable_tool_approval or False,
                     tool_decisions=chat_request.tool_decisions,
+                    frontend_tool_names=frontend_tool_names if frontend_tool_names else None,
+                    frontend_openai_tools=frontend_openai_tools if frontend_openai_tools else None,
+                    frontend_tool_results=chat_request.frontend_tool_results,
                     response_format=chat_request.response_format,
                     request_context=request_context,
                 ),
@@ -415,6 +474,8 @@ def chat(chat_request: ChatRequest, http_request: Request):
                 )
             finally:
                 storage.__exit__(None, None, None)
+    except HTTPException:
+        raise
     except AuthenticationError as e:
         raise HTTPException(status_code=401, detail=e.message)
     except litellm.exceptions.RateLimitError as e:

--- a/tests/test_frontend_tools.py
+++ b/tests/test_frontend_tools.py
@@ -1,0 +1,491 @@
+import json
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from holmes.core.llm import LLM, ContextWindowUsage
+from holmes.core.models import (
+    FrontendToolDefinition,
+    FrontendToolResult,
+    PendingFrontendToolCall,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+)
+from holmes.core.tool_calling_llm import ToolCallingLLM
+from holmes.core.tools_utils.tool_executor import ToolExecutor
+from holmes.utils.stream import StreamEvents
+from server import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def create_mock_llm_response(content="Test response", tool_calls=None):
+    """Create a mock LLM response."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = MagicMock()
+    mock_response.choices[0].message.content = content
+    mock_response.choices[0].message.tool_calls = tool_calls
+    mock_response.choices[0].message.reasoning_content = None
+    mock_response.choices[0].message.model_dump.return_value = {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+            for tc in (tool_calls or [])
+        ]
+        if tool_calls
+        else None,
+    }
+    mock_response.to_json.return_value = json.dumps(
+        {"choices": [{"message": {"content": content}}]}
+    )
+    return mock_response
+
+
+def create_mock_tool_call(
+    tool_call_id="call_xyz9", tool_name="ask_user_for_name", arguments=None
+):
+    """Create a mock tool call object."""
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = tool_call_id
+    mock_tool_call.function = MagicMock()
+    mock_tool_call.function.name = tool_name
+    mock_tool_call.function.arguments = json.dumps(
+        arguments
+        or {"title": "On-Call Engineer", "prompt_text": "What is your name?"}
+    )
+    return mock_tool_call
+
+
+def parse_sse_events(response_text: str) -> list[dict]:
+    """Parse SSE events from response text."""
+    events = []
+    event_type = None
+    for line in response_text.split("\n"):
+        if line.startswith("event: "):
+            event_type = line[7:]
+        elif line.startswith("data: "):
+            try:
+                data = json.loads(line[6:])
+                events.append({"event": event_type, "data": data})
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+def setup_mock_ai(mock_tool_executor, mock_llm, tool_calls_response, final_response):
+    """Create a ToolCallingLLM with mocked dependencies."""
+    ai = ToolCallingLLM(
+        tool_executor=mock_tool_executor,
+        max_steps=5,
+        llm=mock_llm,
+        tool_results_dir=None,
+    )
+
+    mock_llm.count_tokens.return_value = ContextWindowUsage(
+        total_tokens=100,
+        system_tokens=0,
+        tools_to_call_tokens=0,
+        tools_tokens=0,
+        user_tokens=0,
+        assistant_tokens=0,
+        other_tokens=0,
+    )
+    mock_llm.get_context_window_size.return_value = 128000
+    mock_llm.get_maximum_output_token.return_value = 4096
+    mock_llm.model = "gpt-4o"
+    mock_llm.completion.side_effect = [tool_calls_response, final_response]
+
+    mock_tool_executor.get_all_tools_openai_format.return_value = []
+    mock_tool_executor.tools_by_name = {}
+
+    mock_toolset = MagicMock()
+    mock_toolset.name = "test"
+    mock_toolset.status = MagicMock()
+    mock_toolset.status.value = "enabled"
+    mock_tool_executor.toolsets = [mock_toolset]
+
+    return ai
+
+
+class TestFrontendToolModels:
+    """Test the new frontend tool models."""
+
+    def test_frontend_tool_definition(self):
+        tool = FrontendToolDefinition(
+            name="ask_user_for_name",
+            description="Opens a modal dialog asking the user for their name.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "prompt_text": {"type": "string"},
+                },
+                "required": ["title", "prompt_text"],
+            },
+        )
+        assert tool.name == "ask_user_for_name"
+        assert "modal" in tool.description
+
+    def test_frontend_tool_result(self):
+        result = FrontendToolResult(
+            tool_call_id="call_xyz9",
+            tool_name="ask_user_for_name",
+            result="Alice Chen",
+        )
+        assert result.result == "Alice Chen"
+
+    def test_pending_frontend_tool_call(self):
+        pending = PendingFrontendToolCall(
+            tool_call_id="call_xyz9",
+            tool_name="ask_user_for_name",
+            arguments={"title": "On-Call Engineer", "prompt_text": "What is your name?"},
+        )
+        assert pending.arguments["title"] == "On-Call Engineer"
+
+
+class TestFrontendToolValidation:
+    """Test server-side validation of frontend tools."""
+
+    @patch("holmes.core.supabase_dal.SupabaseDal._SupabaseDal__load_robusta_config")
+    @patch("holmes.config.Config.create_toolcalling_llm")
+    @patch(
+        "holmes.core.supabase_dal.SupabaseDal.get_global_instructions_for_account"
+    )
+    def test_frontend_tools_require_streaming(
+        self,
+        mock_get_global_instructions,
+        mock_create_toolcalling_llm,
+        mock_load_robusta_config,
+        client,
+    ):
+        """Frontend tools with stream=false should return 400."""
+        mock_load_robusta_config.return_value = None
+        mock_get_global_instructions.return_value = []
+
+        mock_ai = MagicMock()
+        mock_ai.tool_executor = MagicMock()
+        mock_ai.tool_executor.tools_by_name = {}
+        mock_create_toolcalling_llm.return_value = mock_ai
+
+        payload = {
+            "ask": "Hello",
+            "conversation_history": [
+                {"role": "system", "content": "You are a helpful assistant."}
+            ],
+            "stream": False,
+            "frontend_tools": [
+                {
+                    "name": "ask_user_for_name",
+                    "description": "Ask user for name",
+                    "parameters": {},
+                }
+            ],
+        }
+
+        response = client.post("/api/chat", json=payload)
+        assert response.status_code == 400
+        assert "stream=true" in response.json()["detail"]
+
+    @patch("holmes.core.supabase_dal.SupabaseDal._SupabaseDal__load_robusta_config")
+    @patch("holmes.config.Config.create_toolcalling_llm")
+    @patch(
+        "holmes.core.supabase_dal.SupabaseDal.get_global_instructions_for_account"
+    )
+    def test_frontend_tool_name_collision(
+        self,
+        mock_get_global_instructions,
+        mock_create_toolcalling_llm,
+        mock_load_robusta_config,
+        client,
+    ):
+        """Frontend tool name colliding with built-in tool should return 400."""
+        mock_load_robusta_config.return_value = None
+        mock_get_global_instructions.return_value = []
+
+        mock_ai = MagicMock()
+        mock_ai.tool_executor = MagicMock()
+        mock_ai.tool_executor.tools_by_name = {"kubectl_get": MagicMock()}
+        mock_create_toolcalling_llm.return_value = mock_ai
+
+        payload = {
+            "ask": "Hello",
+            "conversation_history": [
+                {"role": "system", "content": "You are a helpful assistant."}
+            ],
+            "stream": True,
+            "frontend_tools": [
+                {
+                    "name": "kubectl_get",
+                    "description": "This conflicts",
+                    "parameters": {},
+                }
+            ],
+        }
+
+        response = client.post("/api/chat", json=payload)
+        assert response.status_code == 400
+        assert "conflicts" in response.json()["detail"]
+
+
+class TestFrontendToolCallStream:
+    """Test the frontend tool call flow in call_stream."""
+
+    def test_frontend_tool_pauses_stream(self):
+        """When LLM calls a frontend tool, the stream should pause with pending_frontend_tool_calls."""
+        mock_llm = MagicMock(spec=LLM)
+        mock_tool_executor = MagicMock(spec=ToolExecutor)
+
+        frontend_tool_call = create_mock_tool_call()
+        tool_calls_response = create_mock_llm_response(
+            content="Let me get the on-call engineer's name.",
+            tool_calls=[frontend_tool_call],
+        )
+        final_response = create_mock_llm_response(
+            content="Done.", tool_calls=None
+        )
+
+        ai = setup_mock_ai(
+            mock_tool_executor, mock_llm, tool_calls_response, final_response
+        )
+
+        frontend_tool_names = {"ask_user_for_name"}
+        frontend_openai_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "ask_user_for_name",
+                    "description": "Opens a modal dialog.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "prompt_text": {"type": "string"},
+                        },
+                        "required": ["title", "prompt_text"],
+                    },
+                },
+            }
+        ]
+
+        events = list(
+            ai.call_stream(
+                msgs=[
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Ask for name"},
+                ],
+                frontend_tool_names=frontend_tool_names,
+                frontend_openai_tools=frontend_openai_tools,
+            )
+        )
+
+        # Find the approval_required event
+        approval_events = [
+            e for e in events if e.event == StreamEvents.APPROVAL_REQUIRED
+        ]
+        assert len(approval_events) == 1
+
+        approval_data = approval_events[0].data
+        assert approval_data["requires_approval"] is True
+        assert len(approval_data["pending_frontend_tool_calls"]) == 1
+        assert approval_data["pending_frontend_tool_calls"][0]["tool_name"] == "ask_user_for_name"
+        assert approval_data["pending_frontend_tool_calls"][0]["tool_call_id"] == "call_xyz9"
+        assert approval_data["pending_frontend_tool_calls"][0]["arguments"]["title"] == "On-Call Engineer"
+
+        # Should also have the start_tool event with frontend=True
+        start_events = [e for e in events if e.event == StreamEvents.START_TOOL]
+        frontend_starts = [e for e in start_events if e.data.get("frontend")]
+        assert len(frontend_starts) == 1
+        assert frontend_starts[0].data["tool_name"] == "ask_user_for_name"
+
+    def test_frontend_tool_results_resume_stream(self):
+        """After receiving frontend tool results, the stream should resume."""
+        mock_llm = MagicMock(spec=LLM)
+        mock_tool_executor = MagicMock(spec=ToolExecutor)
+
+        # Only need the final response since we're resuming
+        final_response = create_mock_llm_response(
+            content="The on-call engineer is Alice Chen.", tool_calls=None
+        )
+
+        ai = ToolCallingLLM(
+            tool_executor=mock_tool_executor,
+            max_steps=5,
+            llm=mock_llm,
+            tool_results_dir=None,
+        )
+
+        mock_llm.count_tokens.return_value = ContextWindowUsage(
+            total_tokens=100,
+            system_tokens=0,
+            tools_to_call_tokens=0,
+            tools_tokens=0,
+            user_tokens=0,
+            assistant_tokens=0,
+            other_tokens=0,
+        )
+        mock_llm.get_context_window_size.return_value = 128000
+        mock_llm.get_maximum_output_token.return_value = 4096
+        mock_llm.model = "gpt-4o"
+        mock_llm.completion.return_value = final_response
+
+        mock_tool_executor.get_all_tools_openai_format.return_value = []
+        mock_tool_executor.tools_by_name = {}
+        mock_toolset = MagicMock()
+        mock_toolset.name = "test"
+        mock_toolset.status = MagicMock()
+        mock_toolset.status.value = "enabled"
+        mock_tool_executor.toolsets = [mock_toolset]
+
+        # Simulate the conversation history from a paused stream
+        conversation_history = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Ask for name"},
+            {
+                "role": "assistant",
+                "content": "Let me get the name.",
+                "tool_calls": [
+                    {
+                        "id": "call_xyz9",
+                        "type": "function",
+                        "function": {
+                            "name": "ask_user_for_name",
+                            "arguments": json.dumps(
+                                {
+                                    "title": "On-Call Engineer",
+                                    "prompt_text": "What is your name?",
+                                }
+                            ),
+                        },
+                        "pending_frontend": True,
+                    }
+                ],
+            },
+        ]
+
+        frontend_tool_results = [
+            FrontendToolResult(
+                tool_call_id="call_xyz9",
+                tool_name="ask_user_for_name",
+                result="Alice Chen",
+            )
+        ]
+
+        events = list(
+            ai.call_stream(
+                msgs=conversation_history,
+                frontend_tool_names={"ask_user_for_name"},
+                frontend_tool_results=frontend_tool_results,
+            )
+        )
+
+        # Should have tool_result events from the frontend tool result injection
+        tool_result_events = [
+            e for e in events if e.event == StreamEvents.TOOL_RESULT
+        ]
+        assert len(tool_result_events) >= 1
+        assert tool_result_events[0].data["tool_name"] == "ask_user_for_name"
+
+        # Should end with ANSWER_END
+        answer_events = [
+            e for e in events if e.event == StreamEvents.ANSWER_END
+        ]
+        assert len(answer_events) == 1
+        assert "Alice Chen" in answer_events[0].data["content"]
+
+
+class TestFrontendToolE2E:
+    """End-to-end test of frontend tools via the HTTP API."""
+
+    @patch("holmes.core.supabase_dal.SupabaseDal._SupabaseDal__load_robusta_config")
+    @patch("holmes.config.Config.create_toolcalling_llm")
+    @patch(
+        "holmes.core.supabase_dal.SupabaseDal.get_global_instructions_for_account"
+    )
+    def test_streaming_frontend_tool_flow(
+        self,
+        mock_get_global_instructions,
+        mock_create_toolcalling_llm,
+        mock_load_robusta_config,
+        client,
+    ):
+        """Test the full SSE flow: request -> pause with frontend tool -> resume with result."""
+        mock_load_robusta_config.return_value = None
+        mock_get_global_instructions.return_value = []
+
+        mock_llm = MagicMock(spec=LLM)
+        mock_tool_executor = MagicMock(spec=ToolExecutor)
+
+        frontend_tool_call = create_mock_tool_call()
+        tool_calls_response = create_mock_llm_response(
+            content="Let me get the name.",
+            tool_calls=[frontend_tool_call],
+        )
+        final_response = create_mock_llm_response(
+            content="Done.", tool_calls=None
+        )
+
+        ai = setup_mock_ai(
+            mock_tool_executor, mock_llm, tool_calls_response, final_response
+        )
+        mock_create_toolcalling_llm.return_value = ai
+
+        payload = {
+            "ask": "Ask the user for their on-call name",
+            "conversation_history": [
+                {"role": "system", "content": "You are a helpful assistant."}
+            ],
+            "stream": True,
+            "frontend_tools": [
+                {
+                    "name": "ask_user_for_name",
+                    "description": "Opens a modal dialog asking the user for their name.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string",
+                                "description": "The title shown in the modal dialog",
+                            },
+                            "prompt_text": {
+                                "type": "string",
+                                "description": "The question to ask the user",
+                            },
+                        },
+                        "required": ["title", "prompt_text"],
+                    },
+                }
+            ],
+        }
+
+        response = client.post("/api/chat", json=payload)
+        assert response.status_code == 200
+
+        events = parse_sse_events(response.text)
+
+        # Find the approval_required event
+        approval_events = [
+            e for e in events if e["event"] == "approval_required"
+        ]
+        assert len(approval_events) == 1
+
+        approval_data = approval_events[0]["data"]
+        assert approval_data["requires_approval"] is True
+        assert len(approval_data.get("pending_frontend_tool_calls", [])) == 1
+        assert (
+            approval_data["pending_frontend_tool_calls"][0]["tool_name"]
+            == "ask_user_for_name"
+        )

--- a/tests/test_tool_calling_llm.py
+++ b/tests/test_tool_calling_llm.py
@@ -1132,7 +1132,7 @@ EXPECTED_ANSWER_END_KEYS = {
 }
 
 EXPECTED_APPROVAL_REQUIRED_KEYS = {
-    "content", "messages", "pending_approvals",
+    "content", "messages", "pending_approvals", "pending_frontend_tool_calls",
     "requires_approval", "num_llm_calls", "costs",
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for frontend-defined tools that can be called by the LLM but executed on the client side. When the LLM calls a frontend tool, the stream pauses and sends the tool call details to the client. The client executes the tool and sends back results to resume the stream.

## Key Changes

- **New Models** (`holmes/core/models.py`):
  - `FrontendToolDefinition`: Defines a tool with name, description, and parameters
  - `FrontendToolResult`: Carries results from client-side tool execution back to the LLM
  - `PendingFrontendToolCall`: Represents a tool call awaiting client execution
  - Extended `ChatRequestBaseModel` and `ChatResponse` to support frontend tools

- **Core Logic** (`holmes/core/tool_calling_llm.py`):
  - Added `_inject_frontend_tool_results()` method to inject frontend tool results into conversation history as tool messages
  - Modified `call_stream()` to:
    - Accept `frontend_tool_names`, `frontend_openai_tools`, and `frontend_tool_results` parameters
    - Append frontend tool definitions to the LLM's tool list
    - Separate frontend tool calls from backend tool calls during execution
    - Pause the stream when frontend tools are called (emit `APPROVAL_REQUIRED` event with pending calls)
    - Resume the stream when frontend tool results are provided
    - Mark pending frontend tool calls in assistant messages with `pending_frontend` flag

- **Server Integration** (`server.py`):
  - Added `_frontend_tools_to_openai_format()` to convert frontend tool definitions to OpenAI format
  - Added `_validate_frontend_tools()` to enforce:
    - Frontend tools require `stream=true`
    - Frontend tool names cannot conflict with built-in Holmes tools
  - Updated `/api/chat` endpoint to validate, convert, and pass frontend tools to the LLM

- **Stream Events** (`holmes/utils/stream.py`):
  - Updated stream formatter to include `pending_frontend_tool_calls` in approval_required events

- **Comprehensive Tests** (`tests/test_frontend_tools.py`):
  - Model validation tests
  - Server-side validation tests (streaming requirement, name collision detection)
  - Stream pause/resume flow tests
  - End-to-end HTTP API tests with SSE parsing

## Implementation Details

- Frontend tools are treated as a pause/resume mechanism: when called, the stream emits an `APPROVAL_REQUIRED` event with pending frontend tool calls instead of executing them
- Frontend tool results are injected back into the conversation as tool result messages, allowing the LLM to continue processing
- The `pending_frontend` flag marks tool calls awaiting client execution, distinguishing them from approval-required backend tools
- Frontend tools must be sent on every request (not persisted server-side) and require streaming to be enabled

https://claude.ai/code/session_0161G5obpzH4Ak5uMyFYEEe3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced frontend-defined tools allowing the LLM to request execution of client-defined tools during chat
  * Streaming chat can now pause for frontend tool execution and resume with results
  * Added request validation to prevent tool name conflicts and enforce streaming requirement

* **Tests**
  * Added comprehensive test suite covering end-to-end frontend tool functionality and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->