### PR TITLE
fix timeout error

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -50,7 +50,7 @@ from holmes.utils.pydantic_utils import ToolsetConfig
 PROMETHEUS_RULES_CACHE_KEY = "cached_prometheus_rules"
 PROMETHEUS_METADATA_API_LIMIT = 100  # Default limit for Prometheus metadata APIs (series, labels, metadata) to prevent overwhelming responses
 # Default timeout values for PromQL queries
-DEFAULT_QUERY_TIMEOUT_SECONDS = 20
+DEFAULT_QUERY_TIMEOUT_SECONDS = 30
 MAX_QUERY_TIMEOUT_SECONDS = 180
 # Default timeout for metadata API calls (discovery endpoints)
 DEFAULT_METADATA_TIMEOUT_SECONDS = 20
@@ -1377,7 +1377,7 @@ class ExecuteInstantQuery(BasePrometheusTool):
             # Get timeout parameter and enforce limits
             default_timeout = self.toolset.config.query_timeout_seconds_default
             max_timeout = self.toolset.config.query_timeout_seconds_hard_max
-            timeout = params.get("timeout", default_timeout)
+            timeout = params.get("timeout") or default_timeout
             if timeout > max_timeout:
                 timeout = max_timeout
                 logging.warning(
@@ -1631,7 +1631,7 @@ class ExecuteRangeQuery(BasePrometheusTool):
             # Get timeout parameter and enforce limits
             default_timeout = self.toolset.config.query_timeout_seconds_default
             max_timeout = self.toolset.config.query_timeout_seconds_hard_max
-            timeout = params.get("timeout", default_timeout)
+            timeout = params.get("timeout") or default_timeout
             if timeout > max_timeout:
                 timeout = max_timeout
                 logging.warning(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased default Prometheus query timeout from 20 to 30 seconds.
  * Improved timeout parameter handling to properly use default timeout when invalid values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->