### PR TITLE
Use built-in view ClusterRole instead of manually defining all permissions

### DIFF
--- a/docs/reference/kubernetes-permissions.md
+++ b/docs/reference/kubernetes-permissions.md
@@ -16,6 +16,22 @@ The complete ServiceAccount, ClusterRole, and ClusterRoleBinding definitions can
 
 [**View Service Account Template**](https://raw.githubusercontent.com/HolmesGPT/holmesgpt/refs/heads/master/helm/holmes/templates/holmesgpt-service-account.yaml)
 
+## RBAC Structure
+
+HolmesGPT uses a two-layer RBAC approach:
+
+1. **Built-in `view` ClusterRole** — The Helm chart binds the ServiceAccount to the Kubernetes built-in [`view`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) ClusterRole, which provides read-only access to standard namespace-scoped resources (pods, deployments, services, configmaps, jobs, etc.).
+
+2. **Supplementary ClusterRole** — A custom ClusterRole (`<release>-holmes-cluster-role`) grants additional read-only permissions for resources **not** covered by `view`:
+
+    - **Cluster-scoped resources**: nodes, namespaces, persistentvolumes, storageclasses
+    - **Metrics**: metrics.k8s.io (pod and node metrics)
+    - **RBAC**: clusterroles, clusterrolebindings, roles, rolebindings
+    - **Cluster infrastructure**: apiservices, customresourcedefinitions, webhookconfigurations
+    - **Events**: events (core and events.k8s.io API groups)
+    - **Monitoring CRDs**: Prometheus Operator resources (prometheuses, alertmanagers, servicemonitors, etc.)
+    - **Optional CRDs**: Argo, Flux, Kafka (Strimzi), KEDA, Crossplane, Istio, Gateway API, Velero, External Secrets (controlled via `crdPermissions` values)
+
 ## Adaptive Behavior
 
 HolmesGPT automatically adjusts its behavior based on available permissions:

--- a/helm/holmes/templates/holmesgpt-service-account.yaml
+++ b/helm/holmes/templates/holmesgpt-service-account.yaml
@@ -8,6 +8,19 @@ rules:
   {{- if .Values.customClusterRoleRules }}
 {{ toYaml .Values.customClusterRoleRules | indent 2 }}
   {{- end }}
+  # Cluster-scoped resources not included in the built-in "view" ClusterRole
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - namespaces
+      - nodes
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+
   - apiGroups:
       - "storage.k8s.io"
     resources:
@@ -16,6 +29,7 @@ rules:
       - list
       - get
       - watch
+
   - apiGroups:
       - "metrics.k8s.io"
     resources:
@@ -24,38 +38,6 @@ rules:
     verbs:
       - get
       - list
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - daemonsets
-      - deployments
-      - events
-      - namespaces
-      - persistentvolumes
-      - persistentvolumeclaims
-      - pods
-      - pods/status
-      - pods/log
-      - replicasets
-      - replicationcontrollers
-      - services
-      - serviceaccounts
-      - endpoints
-      - resourcequotas
-    verbs:
-      - get
-      - list
-      - watch
-
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
 
   - apiGroups:
       - "apiregistration.k8s.io"
@@ -70,53 +52,8 @@ rules:
     resources:
       - clusterroles
       - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "autoscaling"
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
-
-  - apiGroups:
-      - apps
-    resources:
-      - daemonsets
-      - deployments
-      - deployments/scale
-      - replicasets
-      - replicasets/scale
-      - statefulsets
-    verbs:
-      - get
-      - list
-      - watch
-
-  - apiGroups:
-      - extensions
-    resources:
-      - daemonsets
-      - deployments
-      - deployments/scale
-      - ingresses
-      - replicasets
-      - replicasets/scale
-      - replicationcontrollers/scale
-    verbs:
-      - get
-      - list
-      - watch
-
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
+      - roles
+      - rolebindings
     verbs:
       - get
       - list
@@ -149,36 +86,9 @@ rules:
       - watch
 
   - apiGroups:
-      - networking.k8s.io
-    resources:
-    - ingresses
-    - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - autoscaling
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - "policy"
     resources:
-    - poddisruptionbudgets
     - podsecuritypolicies
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-    - clusterroles
-    - clusterrolebindings
-    - roles
-    - rolebindings
     verbs:
       - get
       - list
@@ -423,6 +333,23 @@ imagePullSecrets:
 {{- toYaml .Values.serviceAccount.imagePullSecrets | nindent 2}}
 {{- end }}
 ---
+# Bind the built-in "view" ClusterRole for standard read-only access to
+# namespace-scoped resources (pods, deployments, services, configmaps, etc.)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-holmes-view-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "holmes.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+# Bind the supplementary ClusterRole for additional permissions not in "view"
+# (cluster-scoped resources, metrics, RBAC, CRDs, etc.)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Bind the service account to the Kubernetes built-in "view" ClusterRole for
standard namespace-scoped read-only access (pods, deployments, services, etc.)
and keep only a supplementary ClusterRole for permissions not in "view":
cluster-scoped resources (nodes, namespaces, PVs, storageclasses), metrics,
RBAC, CRDs, webhooks, events, and operator CRDs.

This also removes dead entries (daemonsets/deployments listed under the core
API group where they don't exist) and eliminates duplicate RBAC/autoscaling
rule blocks.

https://claude.ai/code/session_01TFeEVLmsp8TSf8kYX4iuH1
Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RBAC structure documentation describing the two-layer permission model using built-in Kubernetes view role and custom cluster-scoped permissions.

* **Refactor**
  * Reorganized RBAC configuration to separate standard namespace-scoped read-only access from additional cluster-scoped resource permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->