### PR TITLE
Add native Microsoft Teams destination support

### DIFF
--- a/holmes/checks/checks.py
+++ b/holmes/checks/checks.py
@@ -26,6 +26,7 @@ from holmes.core.issue import Issue, IssueStatus
 from holmes.core.tool_calling_llm import LLMResult, ToolCallingLLM
 from holmes.plugins.destinations.pagerduty.plugin import PagerDutyDestination
 from holmes.plugins.destinations.slack.plugin import SlackDestination
+from holmes.plugins.destinations.teams.plugin import TeamsDestination
 
 CHECK_RESPONSE_FORMAT = {
     "type": "json_schema",
@@ -233,6 +234,13 @@ class CheckRunner:
                 if not dest_config.integration_key:
                     errors.append(
                         f"PagerDuty destination '{name}': Missing integration_key in destination config"
+                    )
+
+            elif name == "teams":
+                # Check Teams configuration
+                if not dest_config.webhook_url:
+                    errors.append(
+                        f"Teams destination '{name}': Missing webhook_url in destination config"
                     )
 
             else:
@@ -491,6 +499,29 @@ class CheckRunner:
                 except Exception as e:
                     self.console.print(
                         f"  [red]Failed to send PagerDuty alert: {str(e)}[/red]"
+                    )
+
+            elif dest_name == "teams":
+                teams_config: Optional[DestinationConfig] = (
+                    self._destinations_config.get(dest_name)
+                )
+                if not teams_config or not teams_config.webhook_url:
+                    self.console.print(
+                        "  [yellow]Teams not configured (missing webhook_url)[/yellow]"
+                    )
+                    continue
+
+                try:
+                    teams = TeamsDestination(teams_config.webhook_url)
+                    teams.send_issue(issue, llm_result)
+
+                    if self.verbose:
+                        self.console.print(
+                            "  [green]Alert sent to Microsoft Teams[/green]"
+                        )
+                except Exception as e:
+                    self.console.print(
+                        f"  [red]Failed to send Teams alert: {str(e)}[/red]"
                     )
 
             else:

--- a/holmes/checks/checks_cli.py
+++ b/holmes/checks/checks_cli.py
@@ -58,6 +58,12 @@ def check(
         "--slack-webhook",
         help="Slack webhook URL for inline check alerts. Standalone option that doesn't require a bot token. Cannot be used with --slack-channel.",
     ),
+    teams_webhook: Optional[str] = typer.Option(
+        None,
+        "--teams-webhook",
+        help="Microsoft Teams incoming webhook URL for inline check alerts.",
+        envvar="TEAMS_WEBHOOK_URL",
+    ),
     slack_token: Optional[str] = typer.Option(
         None,
         "--slack-token",
@@ -132,10 +138,14 @@ def check(
                 slack_config["webhook_url"] = slack_webhook
             if slack_channel:
                 slack_config["channel"] = slack_channel
-            checks_config.destinations = {"slack": DestinationConfig(**slack_config)}
+            checks_config.destinations["slack"] = DestinationConfig(**slack_config)
+            checks_config.checks[0].destinations.append("slack")
 
-            # Add destination to the check
-            checks_config.checks[0].destinations = ["slack"]
+        if teams_webhook:
+            checks_config.destinations["teams"] = DestinationConfig(
+                webhook_url=teams_webhook
+            )
+            checks_config.checks[0].destinations.append("teams")
 
     else:
         # Determine checks file location

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -33,6 +33,7 @@ from holmes.plugins.runbooks import (
 if TYPE_CHECKING:
     from holmes.core.tool_calling_llm import ToolCallingLLM
     from holmes.plugins.destinations.slack import SlackDestination
+    from holmes.plugins.destinations.teams import TeamsDestination
     from holmes.plugins.sources.github import GitHubSource
     from holmes.plugins.sources.jira import JiraServiceManagementSource, JiraSource
     from holmes.plugins.sources.opsgenie import OpsGenieSource
@@ -84,6 +85,8 @@ class Config(RobustaBaseConfig):
 
     slack_token: Optional[SecretStr] = None
     slack_channel: Optional[str] = None
+
+    teams_webhook_url: Optional[str] = None
 
     pagerduty_api_key: Optional[SecretStr] = None
     pagerduty_user_email: Optional[str] = None
@@ -224,6 +227,7 @@ class Config(RobustaBaseConfig):
             "jira_query",
             "slack_token",
             "slack_channel",
+            "teams_webhook_url",
             "github_url",
             "github_owner",
             "github_repository",
@@ -501,6 +505,13 @@ class Config(RobustaBaseConfig):
         if self.slack_channel is None:
             raise ValueError("--slack-channel must be specified")
         return SlackDestination(self.slack_token.get_secret_value(), self.slack_channel)
+
+    def create_teams_destination(self) -> "TeamsDestination":
+        from holmes.plugins.destinations.teams import TeamsDestination
+
+        if self.teams_webhook_url is None:
+            raise ValueError("--teams-webhook-url must be specified")
+        return TeamsDestination(self.teams_webhook_url)
 
     @staticmethod
     def _format_token_count(n: int) -> str:

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -127,6 +127,12 @@ opt_slack_channel: Optional[str] = typer.Option(
     "--slack-channel",
     help="Slack channel if --destination=slack (experimental). E.g. #devops",
 )
+opt_teams_webhook_url: Optional[str] = typer.Option(
+    None,
+    "--teams-webhook-url",
+    help="Microsoft Teams incoming webhook URL if --destination=teams",
+    envvar="TEAMS_WEBHOOK_URL",
+)
 opt_json_output_file: Optional[str] = typer.Option(
     None,
     "--json-output-file",
@@ -204,6 +210,7 @@ def ask(
     destination: Optional[DestinationType] = opt_destination,
     slack_token: Optional[str] = opt_slack_token,
     slack_channel: Optional[str] = opt_slack_channel,
+    teams_webhook_url: Optional[str] = opt_teams_webhook_url,
     show_tool_output: bool = typer.Option(
         False,
         "--show-tool-output",
@@ -292,6 +299,7 @@ def ask(
         custom_toolsets_from_cli=custom_toolsets,
         slack_token=slack_token,
         slack_channel=slack_channel,
+        teams_webhook_url=teams_webhook_url,
     )
 
     # Create tracer if trace option is provided
@@ -463,6 +471,7 @@ def alertmanager(
     destination: Optional[DestinationType] = opt_destination,
     slack_token: Optional[str] = opt_slack_token,
     slack_channel: Optional[str] = opt_slack_channel,
+    teams_webhook_url: Optional[str] = opt_teams_webhook_url,
     json_output_file: Optional[str] = opt_json_output_file,
 ):
     """
@@ -483,6 +492,7 @@ def alertmanager(
         alertmanager_file=alertmanager_file,
         slack_token=slack_token,
         slack_channel=slack_channel,
+        teams_webhook_url=teams_webhook_url,
         custom_toolsets_from_cli=custom_toolsets,
     )
 

--- a/holmes/plugins/destinations/__init__.py
+++ b/holmes/plugins/destinations/__init__.py
@@ -3,4 +3,5 @@ from strenum import StrEnum
 
 class DestinationType(StrEnum):
     SLACK = "slack"
+    TEAMS = "teams"
     CLI = "cli"

--- a/holmes/plugins/destinations/teams/__init__.py
+++ b/holmes/plugins/destinations/teams/__init__.py
@@ -1,0 +1,2 @@
+# ruff: noqa: F401
+from .plugin import TeamsDestination

--- a/holmes/plugins/destinations/teams/plugin.py
+++ b/holmes/plugins/destinations/teams/plugin.py
@@ -1,0 +1,111 @@
+import logging
+
+import requests  # type:ignore
+
+from holmes.core.issue import Issue, IssueStatus
+from holmes.core.tool_calling_llm import LLMResult
+from holmes.plugins.interfaces import DestinationPlugin
+
+
+class TeamsDestination(DestinationPlugin):
+    """Microsoft Teams destination plugin using incoming webhooks (Adaptive Cards)."""
+
+    def __init__(self, webhook_url: str):
+        self.webhook_url = webhook_url
+
+    def send_issue(self, issue: Issue, result: LLMResult) -> None:
+        try:
+            payload = self._build_payload(issue, result)
+            response = requests.post(
+                self.webhook_url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            logging.info(f"Successfully sent issue to Microsoft Teams: {issue.name}")
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Failed to send issue to Microsoft Teams: {e}")
+            if hasattr(e, "response") and e.response is not None:
+                logging.error(f"Teams error response: {e.response.text}")
+
+    def _build_payload(self, issue: Issue, result: LLMResult) -> dict:
+        color = (
+            "attention" if issue.presentation_status == IssueStatus.OPEN else "good"
+        )
+
+        if issue.presentation_status and issue.show_status_in_title:
+            title = f"{issue.name} - {issue.presentation_status.value}"
+        else:
+            title = f"{issue.name}"
+
+        body: list[dict] = [
+            {
+                "type": "TextBlock",
+                "size": "Large",
+                "weight": "Bolder",
+                "text": title,
+                "color": color,
+                "wrap": True,
+            },
+            {
+                "type": "TextBlock",
+                "text": result.result or "",
+                "wrap": True,
+            },
+        ]
+
+        if issue.presentation_key_metadata:
+            body.append(
+                {
+                    "type": "TextBlock",
+                    "text": issue.presentation_key_metadata,
+                    "isSubtle": True,
+                    "wrap": True,
+                    "size": "Small",
+                }
+            )
+
+        if result.tool_calls:
+            tools_text = "**Tools used:** " + ", ".join(
+                tool.description for tool in result.tool_calls
+            )
+            body.append(
+                {
+                    "type": "TextBlock",
+                    "text": tools_text,
+                    "isSubtle": True,
+                    "wrap": True,
+                    "size": "Small",
+                }
+            )
+
+        actions: list[dict] = []
+        if issue.url:
+            actions.append(
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "View Issue",
+                    "url": issue.url,
+                }
+            )
+
+        card = {
+            "type": "AdaptiveCard",
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.4",
+            "body": body,
+        }
+        if actions:
+            card["actions"] = actions
+
+        return {
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "contentUrl": None,
+                    "content": card,
+                }
+            ],
+        }

--- a/holmes/utils/console/result.py
+++ b/holmes/utils/console/result.py
@@ -46,3 +46,7 @@ def handle_result(
     elif destination == DestinationType.SLACK:
         slack = config.create_slack_destination()
         slack.send_issue(issue, result)
+
+    elif destination == DestinationType.TEAMS:
+        teams = config.create_teams_destination()
+        teams.send_issue(issue, result)

--- a/tests/plugins/destinations/test_teams_destination.py
+++ b/tests/plugins/destinations/test_teams_destination.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.core.issue import Issue, IssueStatus
+from holmes.core.models import ToolCallResult
+from holmes.core.tool_calling_llm import LLMResult
+from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
+from holmes.plugins.destinations.teams.plugin import TeamsDestination
+
+
+@pytest.fixture
+def teams_destination():
+    return TeamsDestination(webhook_url="https://example.webhook.office.com/webhook/test")
+
+
+@pytest.fixture
+def sample_issue():
+    return Issue(
+        id="test-123",
+        name="High CPU Usage Alert",
+        source_type="prometheus",
+        source_instance_id="prod-cluster",
+        presentation_status=IssueStatus.OPEN,
+        url="https://grafana.example.com/alert/123",
+    )
+
+
+@pytest.fixture
+def sample_result():
+    return LLMResult(
+        result="The CPU usage is high due to a memory leak in the payment service.",
+        tool_calls=[],
+    )
+
+
+class TestTeamsDestinationPayload:
+    def test_build_payload_basic(self, teams_destination, sample_issue, sample_result):
+        payload = teams_destination._build_payload(sample_issue, sample_result)
+
+        assert payload["type"] == "message"
+        assert len(payload["attachments"]) == 1
+
+        attachment = payload["attachments"][0]
+        assert attachment["contentType"] == "application/vnd.microsoft.card.adaptive"
+
+        card = attachment["content"]
+        assert card["type"] == "AdaptiveCard"
+        assert card["version"] == "1.4"
+
+        # Title block (show_status_in_title defaults to True)
+        assert card["body"][0]["text"] == "High CPU Usage Alert - open"
+        assert card["body"][0]["color"] == "attention"  # OPEN status
+
+        # Result text
+        assert "CPU usage is high" in card["body"][1]["text"]
+
+        # Action link
+        assert card["actions"][0]["url"] == "https://grafana.example.com/alert/123"
+
+    def test_build_payload_resolved_issue(self, teams_destination, sample_result):
+        resolved_issue = Issue(
+            id="test-456",
+            name="Resolved Alert",
+            source_type="prometheus",
+            source_instance_id="prod",
+            presentation_status=IssueStatus.CLOSED,
+        )
+        payload = teams_destination._build_payload(resolved_issue, sample_result)
+        card = payload["attachments"][0]["content"]
+
+        assert card["body"][0]["color"] == "good"
+        assert "actions" not in card  # No URL means no actions
+
+    def test_build_payload_with_status_in_title(
+        self, teams_destination, sample_result
+    ):
+        issue = Issue(
+            id="test-789",
+            name="Test Alert",
+            source_type="prometheus",
+            source_instance_id="prod",
+            presentation_status=IssueStatus.OPEN,
+            show_status_in_title=True,
+        )
+        payload = teams_destination._build_payload(issue, sample_result)
+        card = payload["attachments"][0]["content"]
+        assert "open" in card["body"][0]["text"].lower()
+
+    def test_build_payload_with_tool_calls(self, teams_destination, sample_issue):
+        tool_call = ToolCallResult(
+            tool_call_id="call_1",
+            tool_name="kubectl_get",
+            description="kubectl get pods",
+            result=StructuredToolResult(data="pod-1 Running", status=StructuredToolResultStatus.SUCCESS),
+        )
+        result = LLMResult(
+            result="Found issue.",
+            tool_calls=[tool_call],
+        )
+        payload = teams_destination._build_payload(sample_issue, result)
+        card = payload["attachments"][0]["content"]
+
+        # Should have a tools-used text block
+        tools_block = [b for b in card["body"] if "Tools used" in b.get("text", "")]
+        assert len(tools_block) == 1
+        assert "kubectl get pods" in tools_block[0]["text"]
+
+
+class TestTeamsDestinationSend:
+    @patch("holmes.plugins.destinations.teams.plugin.requests.post")
+    def test_send_issue_success(
+        self, mock_post, teams_destination, sample_issue, sample_result
+    ):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        teams_destination.send_issue(sample_issue, sample_result)
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "https://example.webhook.office.com/webhook/test"
+        assert call_args[1]["headers"]["Content-Type"] == "application/json"
+
+    @patch("holmes.plugins.destinations.teams.plugin.requests.post")
+    def test_send_issue_failure_logs_error(
+        self, mock_post, teams_destination, sample_issue, sample_result, caplog
+    ):
+        import requests as req
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = req.exceptions.HTTPError(
+            "403 Forbidden"
+        )
+        mock_response.text = "Forbidden"
+        mock_post.return_value = mock_response
+
+        teams_destination.send_issue(sample_issue, sample_result)
+
+        assert any("Failed to send issue to Microsoft Teams" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Adds `TeamsDestination` plugin using Microsoft Teams incoming webhooks with Adaptive Cards for rich message formatting
- Integrates Teams across all destination surfaces: CLI (`--destination=teams --teams-webhook-url`), health checks (`--teams-webhook`), and config file (`teams_webhook_url`)
- Supports `TEAMS_WEBHOOK_URL` environment variable for configuration

## Changes

**New files:**
- `holmes/plugins/destinations/teams/plugin.py` — Teams destination plugin using Adaptive Cards v1.4
- `tests/plugins/destinations/test_teams_destination.py` — 6 unit tests covering payload building and send behavior

**Modified files:**
- `holmes/plugins/destinations/__init__.py` — Added `TEAMS` to `DestinationType` enum
- `holmes/config.py` — Added `teams_webhook_url` config field and `create_teams_destination()` factory
- `holmes/main.py` — Added `--teams-webhook-url` CLI option to `ask` and `investigate` commands
- `holmes/utils/console/result.py` — Added Teams routing in `handle_result()`
- `holmes/checks/checks.py` — Added Teams validation and alert sending in health checks
- `holmes/checks/checks_cli.py` — Added `--teams-webhook` option for inline checks

## Usage

```bash
# CLI ask/investigate
holmes ask "what pods are crashing?" --destination=teams --teams-webhook-url https://xxx.webhook.office.com/...

# Health checks
holmes checks run -c "are all pods healthy?" --teams-webhook https://xxx.webhook.office.com/... --mode alert

# Config file
teams_webhook_url: https://xxx.webhook.office.com/...

# Environment variable
export TEAMS_WEBHOOK_URL=https://xxx.webhook.office.com/...
```

## Test plan

- [x] All 6 new unit tests pass (`poetry run pytest tests/plugins/destinations/test_teams_destination.py`)
- [ ] Manual test with a real Teams incoming webhook URL
- [ ] Verify health check alerts render correctly in Teams

https://claude.ai/code/session_01YWtt3PF3TLZ4Zks6B5sUVu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft Teams as a new alert destination type with Adaptive Card formatting
  * New `--teams-webhook-url` CLI option and `TEAMS_WEBHOOK_URL` environment variable for webhook configuration
  * Teams alerts include issue status, result details, tool usage information, and direct links to issues

* **Tests**
  * Added comprehensive test coverage for Teams destination functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->