### PR TITLE
docs: clarify health check docs and sync operator intro

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,14 +47,6 @@ While the operator itself runs in Kubernetes, health checks can query any data s
 
 **[Connect your data sources](data-sources/recommended-setup.md)** to unlock deeper investigations with metrics, logs, and cloud provider access.
 
-## New: Operator Mode — Find Problems 24/7 in the Background
-
-With **[Operator Mode](operator/index.md)**, HolmesGPT runs in the background 24/7, spots problems before your customers notice, and messages you in Slack with the fix. Connect the [GitHub integration](data-sources/builtin-toolsets/github-mcp.md) and it can even open PRs to fix what it finds.
-
-- **[Deployment Verification](operator/deployment-verification.md)** - Deploy a health check alongside your app to verify the new version is healthy
-- **[Scheduled Health Checks](operator/scheduled-health-checks.md)** - Continuously monitor services and catch regressions automatically
-- **Not just Kubernetes** - Holmes investigates across your entire stack (VMs, cloud services, databases, SaaS platforms), so operator checks can query any [connected data source](data-sources/builtin-toolsets/index.md)
-
 ## Need Help?
 
 - **[Join our Slack](https://cloud-native.slack.com/archives/C0A1SPQM5PZ){:target="_blank"}** - Get help from the community


### PR DESCRIPTION
## Summary

- Remove "You Can Also:" prefix from deployment-verification heading
- Sync operator intro text across all three pages (README, main docs index, operator index) using the same "Most AI agents" framing
- Move operator section above the terminal GIF on the main docs page so it's the first thing visitors see

https://claude.ai/code/session_01FoAqz3t5mZoEYEbJMurnoW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Operator Mode section with expanded descriptions of background operation capabilities, Slack messaging, and GitHub integration features.
  * Added documentation links for Deployment Verification and Scheduled Health Checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->