### PR TITLE
[ROB-0000] bugfix robusta

### DIFF
--- a/holmes/plugins/toolsets/robusta/robusta.py
+++ b/holmes/plugins/toolsets/robusta/robusta.py
@@ -89,7 +89,7 @@ def _parse_cluster_scope(params: Dict) -> Optional[List[str]]:
     Filter out null values so that all_clusters / current-cluster fallback works.
     """
     # Filter null values from the clusters array
-    clusters = [c for c in (params.get("clusters") or []) if c is not None]
+    clusters = [c for c in (params.get("clusters") or []) if c is not None and c != ""]
     if clusters:
         return clusters
     # If no valid clusters specified, check all_clusters flag


### PR DESCRIPTION
## Fix cluster parameter parsing in Robusta tools

Two bugs in how LLMs pass the `clusters` parameter to Robusta tools:

- LLMs sometimes pass cluster names as objects (`[{"name": "my-cluster"}]`) instead of plain strings. Added `items` schema to the parameter definition to enforce string elements.

I asked holmes why it passed objects:
<img width="858" height="424" alt="Screenshot 2026-03-26 at 10 42 15" src="https://github.com/user-attachments/assets/4b631de6-affb-422d-944a-573e7ab7d78f" />
After the change:
<img width="842" height="386" alt="Screenshot 2026-03-26 at 10 47 51" src="https://github.com/user-attachments/assets/05e6c518-0488-4fc3-8edf-46bb1c9b1b88" />
And verified it worked in a new chat

- LLMs pass `clusters: [null]` instead of omitting the parameter when no clusters are selected. Since `[null]` is truthy, it always takes the `clusters` branch and skips the `all_clusters` fallback, resulting in queries that match nothing. Extracted `_parse_cluster_scope` to filter null values before evaluating cluster scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster list handling now ignores null/empty entries, improving consistency across recommendation and issue tools.

* **Refactor**
  * Cluster parameter validation tightened by enforcing string-type elements for cluster arrays, reducing unexpected inputs and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->