### PR TITLE
fix(azure-sql-toolsets): fix wrong documentation link

### DIFF
--- a/holmes/plugins/toolsets/azure_sql/azure_sql_toolset.py
+++ b/holmes/plugins/toolsets/azure_sql/azure_sql_toolset.py
@@ -56,7 +56,7 @@ class AzureSQLToolset(BaseAzureSQLToolset):
             name="azure/sql",
             description="Analyzes Azure SQL Database performance, health, and operational issues using Azure REST APIs and Query Store data",
             prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
-            docs_url="https://kagi.com/proxy/png-clipart-microsoft-sql-server-microsoft-azure-sql-database-microsoft-text-logo-thumbnail.png?c=4Sg1bvcUGOrhnDzXgoBBa0G0j27ykgskX4a8cLrZp_quzqlpVGVG02OqQtezTxy7lB6ydmTKgbVAn_F7BxofxK6LKKUZSpjJ1huIAsXPVaXyakO4sWXFiX0Wz_8WjkA0AIlO_oFfW31AKaj5RcvGcr3siy0n5kW-GcqdpeBWsmm_huxUT6RycULFCDFBwuUzHvVl5TW3cYqlMxT8ecPZfg%3D%3D",
+            docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/azure-sql/",
             icon_url="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Azure_SQL_Database_logo.svg/1200px-Azure_SQL_Database_logo.svg.png",
             tags=[ToolsetTag.CORE],
             tools=[


### PR DESCRIPTION
solve https://github.com/HolmesGPT/holmesgpt/issues/1888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Azure SQL toolset documentation link to point to the official HolmesGPT documentation page for that toolset, ensuring users are directed to the correct, maintained resource. No functional behavior or tool capabilities were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->