### PR TITLE
fix: env var resolution fails for empty string values in toolset config

### DIFF
--- a/holmes/utils/env.py
+++ b/holmes/utils/env.py
@@ -37,11 +37,11 @@ def replace_env_vars_values(values: dict[str, Any]) -> dict[str, Any]:
     for key, value in values.items():
         if isinstance(value, str):
             env_var_value = get_env_replacement(value)
-            if env_var_value:
+            if env_var_value is not None:
                 values[key] = env_var_value
         elif isinstance(value, SecretStr):
             env_var_value = get_env_replacement(value.get_secret_value())
-            if env_var_value:
+            if env_var_value is not None:
                 values[key] = SecretStr(env_var_value)
         elif isinstance(value, dict):
             replace_env_vars_values(value)

--- a/tests/plugins/toolsets/test_load_config.py
+++ b/tests/plugins/toolsets/test_load_config.py
@@ -85,3 +85,92 @@ def test_load_toolsets_from_config(monkeypatch):
     assert config.get("api_key") == "glsa_sdj1q2o3prujpqfd"
     assert config.get("api_url") == "https://my-grafana.com/"
     assert config.get("grafana_datasource_uid") == "my_grafana_datasource_uid"
+
+
+# Config with env vars nested inside a list (clusters pattern)
+toolsets_config_nested_str = """
+rabbitmq/core:
+    enabled: true
+    config:
+        clusters:
+            - id: my-rabbit
+              api_url: "http://rabbitmq.local:15672"
+              username: "{{ env.RABBITMQ_USERNAME }}"
+              password: "{{ env.RABBITMQ_PASSWORD }}"
+"""
+
+nested_env_vars = {
+    "RABBITMQ_USERNAME": "rabbit_user_123",
+    "RABBITMQ_PASSWORD": "rabbit_pass_456",
+}
+
+
+def test_load_toolsets_from_config_nested_env_vars(monkeypatch):
+    """Env vars inside list items (e.g. clusters) must be resolved."""
+    for key, value in nested_env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    toolsets_config = yaml.safe_load(toolsets_config_nested_str)
+    definitions = load_toolsets_from_config(
+        toolsets=toolsets_config, strict_check=False
+    )
+    assert len(definitions) == 1
+    rabbitmq = definitions[0]
+    config = rabbitmq.config
+    assert config
+    clusters = config.get("clusters")
+    assert clusters and len(clusters) == 1
+    cluster = clusters[0]
+    assert cluster["username"] == "rabbit_user_123"
+    assert cluster["password"] == "rabbit_pass_456"
+    assert cluster["api_url"] == "http://rabbitmq.local:15672"
+
+
+# Config mimicking Kafka multi-cluster with env vars in list items
+toolsets_config_kafka_str = """
+kafka/admin:
+    enabled: true
+    config:
+        clusters:
+            - name: DEV_PLATFORM
+              broker: "pkc-4nym6.us-east-1.aws.confluent.cloud:9092"
+              username: "{{ env.KAFKA_DEV_PLATFORM_API_KEY }}"
+              password: "{{ env.KAFKA_DEV_PLATFORM_SECRET }}"
+              sasl_mechanism: PLAIN
+              security_protocol: SASL_SSL
+            - name: DEV_ANALYTICS
+              broker: "pkc-d93do.us-east-1.aws.confluent.cloud:9092"
+              username: "{{ env.KAFKA_DEV_ANALYTICS_API_KEY }}"
+              password: "{{ env.KAFKA_DEV_ANALYTICS_SECRET }}"
+              sasl_mechanism: PLAIN
+              security_protocol: SASL_SSL
+"""
+
+kafka_env_vars = {
+    "KAFKA_DEV_PLATFORM_API_KEY": "platform_key",
+    "KAFKA_DEV_PLATFORM_SECRET": "platform_secret",
+    "KAFKA_DEV_ANALYTICS_API_KEY": "analytics_key",
+    "KAFKA_DEV_ANALYTICS_SECRET": "analytics_secret",
+}
+
+
+def test_load_toolsets_from_config_kafka_multi_cluster_env_vars(monkeypatch):
+    """Env vars in multiple list items must all be resolved (Kafka multi-cluster)."""
+    for key, value in kafka_env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    toolsets_config = yaml.safe_load(toolsets_config_kafka_str)
+    definitions = load_toolsets_from_config(
+        toolsets=toolsets_config, strict_check=False
+    )
+    assert len(definitions) == 1
+    kafka = definitions[0]
+    config = kafka.config
+    assert config
+    clusters = config.get("clusters")
+    assert clusters and len(clusters) == 2
+
+    assert clusters[0]["username"] == "platform_key"
+    assert clusters[0]["password"] == "platform_secret"
+    assert clusters[1]["username"] == "analytics_key"
+    assert clusters[1]["password"] == "analytics_secret"

--- a/tests/test_load_config.py
+++ b/tests/test_load_config.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from holmes.utils.env import get_env_replacement
+from holmes.utils.env import get_env_replacement, replace_env_vars_values
 
 
 @pytest.mark.parametrize(
@@ -95,3 +95,121 @@ def test_get_env_replacement_exceptions(
 
     with pytest.raises(expected_exception_type, match=expected_exception_message_regex):
         get_env_replacement(input_value)
+
+
+class TestReplaceEnvVarsValues:
+    """Tests for replace_env_vars_values with nested structures (dicts and lists)."""
+
+    def test_flat_dict(self, monkeypatch):
+        monkeypatch.setenv("API_KEY", "secret123")
+        monkeypatch.setenv("API_URL", "https://example.com")
+        values = {
+            "api_key": "{{ env.API_KEY }}",
+            "api_url": "{{ env.API_URL }}",
+            "static_field": "no_replacement",
+        }
+        result = replace_env_vars_values(values)
+        assert result["api_key"] == "secret123"
+        assert result["api_url"] == "https://example.com"
+        assert result["static_field"] == "no_replacement"
+
+    def test_nested_dict(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "db.example.com")
+        values = {
+            "config": {
+                "host": "{{ env.DB_HOST }}",
+                "port": 5432,
+            }
+        }
+        result = replace_env_vars_values(values)
+        assert result["config"]["host"] == "db.example.com"
+        assert result["config"]["port"] == 5432
+
+    def test_list_of_strings(self, monkeypatch):
+        monkeypatch.setenv("HOST1", "h1.example.com")
+        monkeypatch.setenv("HOST2", "h2.example.com")
+        values = {
+            "hosts": ["{{ env.HOST1 }}", "{{ env.HOST2 }}", "static"]
+        }
+        result = replace_env_vars_values(values)
+        assert result["hosts"] == ["h1.example.com", "h2.example.com", "static"]
+
+    def test_list_of_dicts_with_env_vars(self, monkeypatch):
+        """Reproducer for the reported bug: env vars inside list items (dicts) not resolved.
+
+        This mimics the RabbitMQ/Kafka clusters config structure:
+        clusters:
+          - name: DEV
+            username: "{{ env.RABBITMQ_USERNAME }}"
+            password: "{{ env.RABBITMQ_PASSWORD }}"
+        """
+        monkeypatch.setenv("RABBITMQ_USERNAME", "my_rabbit_user")
+        monkeypatch.setenv("RABBITMQ_PASSWORD", "my_rabbit_pass")
+        values = {
+            "config": {
+                "clusters": [
+                    {
+                        "id": "my-rabbit",
+                        "api_url": "http://rabbitmq.local:15672",
+                        "username": "{{ env.RABBITMQ_USERNAME }}",
+                        "password": "{{ env.RABBITMQ_PASSWORD }}",
+                    }
+                ]
+            }
+        }
+        result = replace_env_vars_values(values)
+        cluster = result["config"]["clusters"][0]
+        assert cluster["username"] == "my_rabbit_user"
+        assert cluster["password"] == "my_rabbit_pass"
+        assert cluster["api_url"] == "http://rabbitmq.local:15672"
+        assert cluster["id"] == "my-rabbit"
+
+    def test_multiple_clusters_with_env_vars(self, monkeypatch):
+        """Mimics the Kafka multi-cluster config from the bug report."""
+        monkeypatch.setenv("KAFKA_DEV_PLATFORM_API_KEY", "dev_key")
+        monkeypatch.setenv("KAFKA_DEV_PLATFORM_SECRET", "dev_secret")
+        monkeypatch.setenv("KAFKA_DEV_ANALYTICS_API_KEY", "analytics_key")
+        monkeypatch.setenv("KAFKA_DEV_ANALYTICS_SECRET", "analytics_secret")
+        values = {
+            "enabled": True,
+            "config": {
+                "clusters": [
+                    {
+                        "name": "DEV_PLATFORM",
+                        "broker": "pkc-4nym6.us-east-1.aws.confluent.cloud:9092",
+                        "username": "{{ env.KAFKA_DEV_PLATFORM_API_KEY }}",
+                        "password": "{{ env.KAFKA_DEV_PLATFORM_SECRET }}",
+                        "sasl_mechanism": "PLAIN",
+                        "security_protocol": "SASL_SSL",
+                    },
+                    {
+                        "name": "DEV_ANALYTICS",
+                        "broker": "pkc-d93do.us-east-1.aws.confluent.cloud:9092",
+                        "username": "{{ env.KAFKA_DEV_ANALYTICS_API_KEY }}",
+                        "password": "{{ env.KAFKA_DEV_ANALYTICS_SECRET }}",
+                        "sasl_mechanism": "PLAIN",
+                        "security_protocol": "SASL_SSL",
+                    },
+                ],
+            },
+        }
+        result = replace_env_vars_values(values)
+        cluster1 = result["config"]["clusters"][0]
+        cluster2 = result["config"]["clusters"][1]
+        assert cluster1["username"] == "dev_key"
+        assert cluster1["password"] == "dev_secret"
+        assert cluster2["username"] == "analytics_key"
+        assert cluster2["password"] == "analytics_secret"
+
+    def test_empty_env_var_value_in_nested_list(self, monkeypatch):
+        """An env var set to empty string should still replace the placeholder."""
+        monkeypatch.setenv("EMPTY_USER", "")
+        values = {
+            "clusters": [
+                {
+                    "username": "{{ env.EMPTY_USER }}",
+                }
+            ]
+        }
+        result = replace_env_vars_values(values)
+        assert result["clusters"][0]["username"] == ""


### PR DESCRIPTION
The `replace_env_vars_values` function used a truthiness check (`if env_var_value:`) which treated empty strings as falsy, leaving the `{{ env.XXX }}` placeholder unresolved when the env var was set to "". Changed to `if env_var_value is not None:` so empty string values are correctly substituted.

Added comprehensive tests for env var resolution in nested structures (dicts within lists) matching the RabbitMQ clusters and Kafka multi-cluster config patterns reported in the bug.

https://claude.ai/code/session_01DriEMPwd1rxW1rnYjNCQjC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable substitutions now correctly preserve empty string values when replacing placeholders in configurations, rather than skipping the replacement.

* **Tests**
  * Added comprehensive test coverage for environment variable substitution behavior, including nested structures and list elements in toolset configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->