### PR TITLE
fix(toolsets/kubernetes): use --slurpfile in kubernetes_jq_query to avoid ARG_MAX

### DIFF
--- a/holmes/plugins/toolsets/kubernetes.yaml
+++ b/holmes/plugins/toolsets/kubernetes.yaml
@@ -153,19 +153,29 @@ toolsets:
           err_content=$(cat "$err_file" 2>/dev/null)
           rm -f "$err_file"
 
-          # Output results as a JSON object with metadata
+          # Output results as a JSON object with metadata.
+          # Write the matches to a temp file and feed jq via --slurpfile
+          # instead of --argjson. --argjson puts the whole JSON on jq's
+          # argv, which fails with E2BIG ("Argument list too long") when
+          # matches exceed Linux ARG_MAX (~128 KiB) — easy to hit on
+          # clusters with many resources of the queried kind, since the
+          # pagination loop above has no cap on $ALL_MATCHES size.
+          # --slurpfile reads the file and wraps its contents in an outer
+          # array, which we unwrap with $results[0] in the expression.
+          results_file=$(mktemp)
           if [ -n "$ALL_MATCHES" ]; then
-            RESULTS=$(echo "$ALL_MATCHES" | jq -s '.')
+            echo "$ALL_MATCHES" | jq -s '.' > "$results_file"
           else
-            RESULTS="[]"
+            echo '[]' > "$results_file"
           fi
 
           jq -n \
-            --argjson results "$RESULTS" \
+            --slurpfile results "$results_file" \
             --argjson total_items_processed "$PROCESSED" \
             --argjson matches_found "$TOTAL_MATCHES" \
             --arg stderr "$err_content" \
-            '{total_items_processed: $total_items_processed, matches_found: $matches_found, results: $results, stderr: (if $stderr == "" then null else $stderr end)}'
+            '{total_items_processed: $total_items_processed, matches_found: $matches_found, results: $results[0], stderr: (if $stderr == "" then null else $stderr end)}'
+          rm -f "$results_file"
         transformers:
           - name: llm_summarize
             config:


### PR DESCRIPTION
## Summary

`kubernetes_jq_query` fails with `/tmp/tmpXXXXXXXX.sh: line NN: /usr/bin/jq: Argument list too long` whenever the accumulated matches from its pagination loop exceed Linux `ARG_MAX` (~128 KiB on most distros). On clusters with many resources of the queried kind, or on cluster-wide queries, this reliably trips — the tool call returns nothing usable to the LLM and the investigation silently degrades.

Root cause is the final jq call at the end of the script:

```bash
jq -n --argjson results "$RESULTS" ...
```

`--argjson` puts the entire JSON array on jq's `argv`. `exec()` caps argv + envp at `ARG_MAX`, so large match sets hit `E2BIG`. The pagination loop has no cap on `$ALL_MATCHES` size, so any namespace / kind with enough matches triggers it.

## Fix

Write `$ALL_MATCHES` to a tempfile and pass it to jq via `--slurpfile`, which reads from a file descriptor and bypasses `argv`. `--slurpfile` wraps the file content in an outer array, so the final expression unwraps with `$results[0]`. The tempfile is removed after the jq call, matching the existing `err_file` cleanup style in the same script.

Sibling tools (`kubernetes_count`, `kubernetes_tabular_query`) also use `--argjson` but their payloads are bounded (preview is capped to ~2 KB), so this PR leaves them untouched.

## Validation

Validated against `robustadev/holmes:0.24.3` in a live AKS cluster:

- **Repro (pre-fix):** synthetic input of 1,000 items (141 KB JSON) inside the running pod → `jq: Argument list too long` at `jq -n` line.
- **Post-fix:** same input → all 1,000 items returned, no error.

No new unit test added: the toolset script is bash-in-YAML and there is no existing pattern in `tests/plugins/toolsets/kubernetes/` that exercises the generated shell script. Happy to add one if there's a preferred harness.

## Test plan

- [x] Linting / no syntax regression in `holmes/plugins/toolsets/kubernetes.yaml`
- [x] Manual repro + fix confirmed in-cluster with a > `ARG_MAX` payload
- [ ] Reviewer to confirm no existing test hits the old `--argjson results` path that would need updating

## Notes for reviewers

- Diff is small — replaces one `--argjson results "$RESULTS"` with a `--slurpfile` + tempfile pattern, plus a comment block explaining the ARG_MAX trap for future maintainers.
- Same fix is currently deployed out-of-band as a ConfigMap subPath overlay over `/app/holmes/plugins/toolsets/kubernetes.yaml` in our cluster; we'd like to drop that overlay once this merges and we bump past it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the Kubernetes toolset by fixing an issue that could cause query failures or inconsistent output when processing large result sets; now handles large outputs reliably and ensures proper cleanup so commands complete predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->