### PR TITLE
[ROB-0000] Add Atlassian admin setup steps to OAuth MCP docs

### DIFF
--- a/docs/data-sources/oauth-mcp-servers.md
+++ b/docs/data-sources/oauth-mcp-servers.md
@@ -70,6 +70,20 @@ To add an OAuth MCP server, set `mode: streamable-http` and `oauth.enabled: true
 
 === "Robusta Helm Chart with Platform"
 
+    **Before configuring Holmes, set up the Atlassian side:**
+
+    1. Go to [https://admin.atlassian.com/](https://admin.atlassian.com/) and select your organization
+    2. Navigate to **Rovo** → **Rovo MCP Server**
+    3. Click **Add domain** and enter your Robusta platform URL, matching your region:
+
+        | Region | URL |
+        |--------|-----|
+        | US (default) | `https://platform.robusta.dev/**` |
+        | EU | `https://eu.platform.robusta.dev/**` |
+        | AP | `https://ap.platform.robusta.dev/**` |
+
+    **Update your values and helm install or upgrade:**
+
     ```yaml
     holmes:
       mcp_servers:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prerequisite step requiring Atlassian domain configuration before setup.
  * Included region-specific URL mappings (US/EU/AP) for domain entry guidance.
  * Clarified installation/upgrade instructions to link the domain step with existing Helm configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->