### PR TITLE
[ROB-3715] Filter skills by enabled and clusters columns

### DIFF
--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -604,6 +604,7 @@ class SupabaseDal:
                 .select("*")
                 .eq("account_id", self.account_id)
                 .eq("subject_type", "RunbookCatalog")
+                .eq("enabled", True)
                 .execute()
             )
             if not res.data:
@@ -614,15 +615,19 @@ class SupabaseDal:
                 id = row.get("runbook_id")
                 symptom = row.get("symptoms")
                 title = row.get("subject_name")
+                clusters = row.get("clusters")
                 if not symptom:
-                    logging.warning("Skipping runbook with empty symptom: %s", id)
+                    logging.warning("Skipping skill with empty symptom: %s", id)
+                    continue
+                # Filter by cluster: null means all clusters, otherwise check membership
+                if clusters is not None and self.cluster not in clusters:
                     continue
                 instructions.append(
                     RobustaSkillInstruction(id=id, symptom=symptom, title=title)
                 )
             return instructions
         except Exception:
-            logging.exception("Failed to fetch RunbookCatalog", exc_info=True)
+            logging.exception("Failed to fetch skill catalog", exc_info=True)
             return None
 
     def get_skill_content(


### PR DESCRIPTION
- get_skill_catalog: add .eq("enabled", True) to query, filter rows where clusters is not null and self.cluster not in clusters
- get_resource_instructions: add .eq("enabled", True), iterate rows to find first matching cluster (null = all clusters)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill catalog to correctly display only enabled skills, exclude incomplete entries, and properly apply cluster filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->