### PR TITLE
Add Supabase Realtime availability check before starting conversation worker

### DIFF
--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -756,6 +756,25 @@ class SupabaseDal:
 
         return self.account_id, session_token
 
+    def is_realtime_enabled(self) -> bool:
+        """Check whether Supabase Realtime is enabled for this project.
+
+        Calls the ``is_realtime_enabled`` Postgres RPC, which returns true when
+        the ``realtime.messages`` table exists. Returns False when the store is
+        disabled or when the RPC call fails.
+        """
+        if not self.enabled:
+            return False
+        try:
+            res = self.client.rpc("is_realtime_enabled", {}).execute()
+            return bool(res.data)
+        except Exception:
+            logging.exception(
+                "Supabase error while checking is_realtime_enabled",
+                exc_info=True,
+            )
+            return False
+
     def upsert_holmes_status(self, holmes_status_data: dict) -> None:
         if not self.enabled:
             logging.info(

--- a/holmes/utils/holmes_status.py
+++ b/holmes/utils/holmes_status.py
@@ -78,7 +78,8 @@ def update_holmes_status_in_db(
         is_robusta_ai_enabled=config.should_try_robusta_ai,
         supports_realtime_conversations=bool(ENABLE_CONVERSATION_WORKER)
         and realtime_enabled,
-        requires_realtime_broadcast=bool(CONVERSATION_WORKER_USE_REALTIME_BROADCAST)
+        requires_realtime_broadcast=bool(ENABLE_CONVERSATION_WORKER)
+        and bool(CONVERSATION_WORKER_USE_REALTIME_BROADCAST)
         and realtime_enabled,
         namespace=_detect_runner_namespace(),
     )

--- a/holmes/utils/holmes_status.py
+++ b/holmes/utils/holmes_status.py
@@ -65,7 +65,7 @@ class HolmesMetadata:
 
 def update_holmes_status_in_db(
     dal: SupabaseDal, config: Config, realtime_enabled: bool = True
-):
+) -> None:
     logging.info("Updating status of holmes")
 
     if not config.cluster_name:

--- a/holmes/utils/holmes_status.py
+++ b/holmes/utils/holmes_status.py
@@ -63,7 +63,9 @@ class HolmesMetadata:
     namespace: Optional[str] = None
 
 
-def update_holmes_status_in_db(dal: SupabaseDal, config: Config):
+def update_holmes_status_in_db(
+    dal: SupabaseDal, config: Config, realtime_enabled: bool = True
+):
     logging.info("Updating status of holmes")
 
     if not config.cluster_name:
@@ -74,8 +76,10 @@ def update_holmes_status_in_db(dal: SupabaseDal, config: Config):
 
     metadata = HolmesMetadata(
         is_robusta_ai_enabled=config.should_try_robusta_ai,
-        supports_realtime_conversations=bool(ENABLE_CONVERSATION_WORKER),
-        requires_realtime_broadcast=bool(CONVERSATION_WORKER_USE_REALTIME_BROADCAST),
+        supports_realtime_conversations=bool(ENABLE_CONVERSATION_WORKER)
+        and realtime_enabled,
+        requires_realtime_broadcast=bool(CONVERSATION_WORKER_USE_REALTIME_BROADCAST)
+        and realtime_enabled,
         namespace=_detect_runner_namespace(),
     )
 

--- a/server.py
+++ b/server.py
@@ -135,15 +135,25 @@ def sync_before_server_start():
             "Skipping holmes status and toolsets synchronization - not connected to Robusta platform"
         )
         return
+
+    realtime_enabled = True
+    if ENABLE_CONVERSATION_WORKER:
+        realtime_enabled = dal.is_realtime_enabled()
+        if not realtime_enabled:
+            logging.warning(
+                "Supabase Realtime is not enabled for this project (realtime.messages table not found). "
+                "Conversation worker will not be started, and realtime conversation flags will be disabled."
+            )
+
     try:
-        update_holmes_status_in_db(dal, config)
+        update_holmes_status_in_db(dal, config, realtime_enabled=realtime_enabled)
     except Exception:
         logging.error("Failed to update holmes status", exc_info=True)
     try:
         holmes_sync_toolsets_status(dal, config)
     except Exception:
         logging.error("Failed to synchronise holmes toolsets", exc_info=True)
-    if conversation_worker is not None:
+    if conversation_worker is not None and realtime_enabled:
         try:
             conversation_worker.start()
         except Exception:


### PR DESCRIPTION
## Summary
This PR adds a check to verify that Supabase Realtime is enabled before starting the conversation worker and advertising realtime conversation support. This prevents errors when the Realtime service is not available for a Supabase project.

## Key Changes
- **New method in SupabaseDal**: Added `is_realtime_enabled()` that calls a Postgres RPC to check if the `realtime.messages` table exists, returning `False` if the store is disabled or the RPC call fails
- **Server startup logic**: Modified `sync_before_server_start()` to check realtime availability when `ENABLE_CONVERSATION_WORKER` is enabled, logging a warning if unavailable
- **Conditional worker startup**: The conversation worker is now only started if both `conversation_worker` is not None AND realtime is enabled
- **Holmes status metadata**: Updated `update_holmes_status_in_db()` to accept a `realtime_enabled` parameter and only advertise realtime conversation support when both the feature is enabled AND realtime is actually available

## Implementation Details
- The `is_realtime_enabled()` method gracefully handles exceptions and returns `False` on any RPC failure, ensuring the system degrades safely
- The realtime availability check is only performed when conversation worker support is explicitly enabled
- Both `supports_realtime_conversations` and `requires_realtime_broadcast` metadata flags now depend on actual Realtime availability, not just configuration flags

https://claude.ai/code/session_01NyFdknWjigogfuUGaCDjpe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of Realtime availability for the configured Supabase project.

* **Improvements**
  * Conversation features now validate Realtime at startup and will be disabled with a warning if unavailable.
  * Service status updates now include detected Realtime availability to keep runtime behavior consistent.
  * Detection failures are logged and treated as Realtime disabled to avoid startup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->