### PR TITLE
Add Confluence markdown and HTML-filter toolset variants

### DIFF
--- a/holmes/plugins/toolsets/__init__.py
+++ b/holmes/plugins/toolsets/__init__.py
@@ -23,6 +23,10 @@ from holmes.plugins.toolsets.atlas_mongodb.mongodb_atlas import MongoDBAtlasTool
 from holmes.plugins.toolsets.azure_sql.azure_sql_toolset import AzureSQLToolset
 from holmes.plugins.toolsets.bash.bash_toolset import BashExecutorToolset
 from holmes.plugins.toolsets.confluence.confluence import ConfluenceToolset
+from holmes.plugins.toolsets.confluence.confluence_variants import (
+    ConfluenceHtmlFilterToolset,
+    ConfluenceMarkdownToolset,
+)
 from holmes.plugins.toolsets.connectivity_check import ConnectivityCheckToolset
 from holmes.plugins.toolsets.coralogix.toolset_coralogix import CoralogixToolset
 from holmes.plugins.toolsets.database.database import DatabaseToolset
@@ -119,6 +123,8 @@ def load_python_toolsets(
         BashExecutorToolset(),
         KubectlRunToolset(),
         ConfluenceToolset(),
+        ConfluenceMarkdownToolset(),
+        ConfluenceHtmlFilterToolset(),
         MongoDBAtlasToolset(),
         SkillsToolset(dal=dal, additional_search_paths=additional_search_paths),
         AzureSQLToolset(),

--- a/holmes/plugins/toolsets/confluence/confluence_variants.py
+++ b/holmes/plugins/toolsets/confluence/confluence_variants.py
@@ -95,6 +95,8 @@ def _filter_html_by_css(html: str, selector: str) -> str:
 
 def _transform_html_strings(value: Any, transform) -> Any:
     """Walk an arbitrary JSON value and apply ``transform`` to every HTML-ish string."""
+    if value is None:
+        return None
     if isinstance(value, str):
         return transform(value) if _looks_like_html(value) else value
     if isinstance(value, dict):
@@ -178,6 +180,16 @@ class _ConfluenceVariantBase(ConfluenceToolset):
       * ``_extra_llm_instructions`` — appended after the base Confluence prompt
         so the LLM knows about variant-specific behavior (markdown output,
         css_selector parameter, etc.)
+
+    Implementation note — the constructor calls ``Toolset.__init__`` directly
+    instead of ``super().__init__()``. ``ConfluenceToolset.__init__`` hard-codes
+    ``name="confluence"`` and would also re-run the parent's setup, so we skip
+    one level up the MRO and pass our own variant-specific name/description.
+    All of ``ConfluenceToolset``'s *runtime* behavior (config classes,
+    ``prerequisites_callable``, gateway resolution, health checks) is still
+    inherited; only the constructor wiring is short-circuited. If
+    ``ConfluenceToolset.__init__`` ever grows variant-relevant logic, this
+    class must be updated to mirror it.
     """
 
     _variant_name: ClassVar[str] = ""

--- a/holmes/plugins/toolsets/confluence/confluence_variants.py
+++ b/holmes/plugins/toolsets/confluence/confluence_variants.py
@@ -1,0 +1,304 @@
+"""Confluence toolset variants that post-process page bodies before returning
+them to the LLM.
+
+Three Confluence integrations now exist:
+
+* ``confluence`` (in confluence.py) — returns the raw Confluence REST API
+  response untouched. The body of a page is delivered as Confluence storage
+  format HTML inside ``body.storage.value``.
+* ``confluence_markdown`` (this file) — same auth/endpoints, but every HTML
+  string in the response is converted to Markdown before being handed to the
+  LLM. Aims to reduce token usage and noise from Confluence storage XML.
+* ``confluence_html_filter`` (this file) — same auth/endpoints, but the tool
+  exposes a ``css_selector`` parameter. When set, every HTML string in the
+  response is filtered through BeautifulSoup ``.select()`` so the LLM only
+  sees the matched portion of the page.
+
+The variants reuse all of ``ConfluenceToolset``'s configuration / auth /
+gateway / health-check machinery by subclassing it. Each variant overrides
+``__init__`` (to register a distinct toolset name) and ``_setup_http_tools``
+(to swap in a wrapped HTTP request tool that does the post-processing).
+"""
+
+import logging
+import re
+from typing import Any, ClassVar, Dict, List, Optional, Type
+
+from bs4 import BeautifulSoup
+from markdownify import markdownify
+
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    ToolInvokeContext,
+    ToolParameter,
+    ToolsetTag,
+)
+from holmes.plugins.toolsets.confluence.confluence import (
+    CONFLUENCE_ICON_URL,
+    ConfluenceCloudConfig,
+    ConfluenceConfig,
+    ConfluenceDataCenterBasicConfig,
+    ConfluenceDataCenterPATConfig,
+    ConfluenceToolset,
+)
+from holmes.plugins.toolsets.http.http_toolset import (
+    HttpRequest,
+    HttpToolset,
+    HttpToolsetConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cheap heuristic for "this string looks like HTML": at least one tag.
+# Used to decide whether to run a string through markdownify / BeautifulSoup.
+# Matches `<tag` or `</tag` followed by space, slash, or `>`. Confluence storage
+# format ALWAYS uses tags (the value field is XHTML), so false negatives are
+# rare; false positives on prose containing `<word>` are harmless because the
+# converters are a no-op on non-HTML.
+_HTML_TAG_RE = re.compile(r"<\s*/?[a-zA-Z][a-zA-Z0-9]*[\s/>]")
+
+
+def _looks_like_html(value: str) -> bool:
+    return bool(_HTML_TAG_RE.search(value))
+
+
+def _html_to_markdown(html: str) -> str:
+    """Convert a Confluence-storage HTML string to Markdown.
+
+    ``markdownify`` is already a project dependency (used by the internet
+    toolset). It tolerates Confluence ``<ac:*>`` / ``<ri:*>`` macro tags by
+    treating them as unknown elements and stripping them, which is what we
+    want for LLM consumption — the macro markup adds noise but the inner
+    text content survives.
+    """
+    try:
+        return markdownify(html, heading_style="ATX").strip()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("markdownify failed, returning raw HTML: %s", e)
+        return html
+
+
+def _filter_html_by_css(html: str, selector: str) -> str:
+    """Return the concatenated outer HTML of every element matching ``selector``.
+
+    BeautifulSoup's HTML parser is permissive enough to handle Confluence
+    storage XHTML. If the selector matches nothing we return an empty string
+    rather than the original HTML — this is the whole point of the filter
+    variant: when the agent picks a selector, it should see the consequences.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    matches = soup.select(selector)
+    return "\n".join(str(m) for m in matches)
+
+
+def _transform_html_strings(value: Any, transform) -> Any:
+    """Walk an arbitrary JSON value and apply ``transform`` to every HTML-ish string."""
+    if isinstance(value, str):
+        return transform(value) if _looks_like_html(value) else value
+    if isinstance(value, dict):
+        return {k: _transform_html_strings(v, transform) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_transform_html_strings(item, transform) for item in value]
+    return value
+
+
+class _MarkdownConvertingHttpRequest(HttpRequest):
+    """HttpRequest subclass that converts HTML in successful responses to Markdown."""
+
+    def _invoke(
+        self, params: dict, context: ToolInvokeContext
+    ) -> StructuredToolResult:
+        result = super()._invoke(params, context)
+        # Filter (jq/max_depth) has already run by the time we get here, so
+        # result.data could be the original {"status_code", "body"} envelope
+        # or anything jq returned. Walk it generically.
+        if result.status == StructuredToolResultStatus.SUCCESS:
+            result.data = _transform_html_strings(result.data, _html_to_markdown)
+        return result
+
+
+class _HtmlFilteringHttpRequest(HttpRequest):
+    """HttpRequest subclass that lets the agent supply a CSS selector to filter HTML."""
+
+    def __init__(
+        self,
+        toolset: HttpToolset,
+        tool_name: str = "http_request",
+        tool_description: Optional[str] = None,
+    ) -> None:
+        super().__init__(toolset, tool_name=tool_name, tool_description=tool_description)
+        # Add the css_selector parameter on top of the params HttpRequest already
+        # registered (url/method/body/headers + JsonFilterMixin's max_depth/jq).
+        self.parameters["css_selector"] = ToolParameter(
+            description=(
+                "Optional CSS selector applied to every HTML string in the "
+                "response (typically Confluence's body.storage.value). When "
+                "provided, only the matched elements' outer HTML is returned, "
+                "which lets you keep the response inside the token budget on "
+                "large pages. Selectors follow the BeautifulSoup `.select()` "
+                "syntax — e.g. `table`, `h2 + p`, `div.note`, "
+                "`section[data-id='runbook'] li`. Omit this parameter to get "
+                "the full HTML body."
+            ),
+            type="string",
+            required=False,
+        )
+
+    def _invoke(
+        self, params: dict, context: ToolInvokeContext
+    ) -> StructuredToolResult:
+        selector = params.get("css_selector")
+        # Strip our extra param before HttpRequest passes the rest through to
+        # `requests.request`; otherwise it would get serialized into headers.
+        if "css_selector" in params:
+            params = {k: v for k, v in params.items() if k != "css_selector"}
+
+        result = super()._invoke(params, context)
+        if selector and result.status == StructuredToolResultStatus.SUCCESS:
+            result.data = _transform_html_strings(
+                result.data, lambda html: _filter_html_by_css(html, selector)
+            )
+        return result
+
+
+# A tool factory abstracts what each variant injects into the wrapped HttpToolset.
+_TOOL_CLASS_MARKDOWN = _MarkdownConvertingHttpRequest
+_TOOL_CLASS_HTML_FILTER = _HtmlFilteringHttpRequest
+
+
+class _ConfluenceVariantBase(ConfluenceToolset):
+    """Shared plumbing for the markdown / html-filter Confluence variants.
+
+    Subclasses set:
+      * ``_variant_name``    — toolset name registered with Holmes
+      * ``_variant_description`` — toolset description shown in the UI
+      * ``_tool_class``      — HttpRequest subclass that does the post-processing
+      * ``_extra_llm_instructions`` — appended after the base Confluence prompt
+        so the LLM knows about variant-specific behavior (markdown output,
+        css_selector parameter, etc.)
+    """
+
+    _variant_name: ClassVar[str] = ""
+    _variant_description: ClassVar[str] = ""
+    _tool_class: ClassVar[Type[HttpRequest]] = HttpRequest
+    _extra_llm_instructions: ClassVar[str] = ""
+
+    # The variant subtypes mirror the parent class so the same Cloud / DC PAT /
+    # DC Basic auth options show up in the UI form for each variant.
+    config_classes: ClassVar[List[Type[ConfluenceConfig]]] = [
+        ConfluenceCloudConfig,
+        ConfluenceDataCenterPATConfig,
+        ConfluenceDataCenterBasicConfig,
+    ]
+
+    def __init__(self) -> None:
+        # Skip ConfluenceToolset.__init__ — we want to call the grandparent
+        # Toolset.__init__ directly so the variant gets its own name without
+        # duplicating ConfluenceToolset's setup work.
+        from holmes.core.tools import Toolset
+
+        Toolset.__init__(
+            self,
+            name=self._variant_name,
+            description=self._variant_description,
+            icon_url=CONFLUENCE_ICON_URL,
+            docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/confluence/",
+            prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
+            tools=[],
+            tags=[ToolsetTag.CORE],
+        )
+        self._gateway_base_url = None
+
+    def _setup_http_tools(self) -> None:
+        endpoint = self._build_endpoint_config()
+        http_config = HttpToolsetConfig(endpoints=[endpoint])
+        # The wrapped HttpToolset's name matters: it's used to derive the LLM
+        # tool name (`<name>_request`). Use the variant name so the LLM sees,
+        # e.g., `confluence_markdown_request` and `confluence_html_filter_request`.
+        http_toolset = HttpToolset(
+            name=self._variant_name,
+            config=http_config,
+            llm_instructions=self._build_variant_llm_instructions(),
+            enabled=True,
+        )
+        ok, msg = http_toolset.prerequisites_callable(http_config.model_dump())
+        if not ok:
+            raise RuntimeError(f"Failed to initialize HTTP toolset for {self._variant_name}: {msg}")
+
+        # Replace HttpToolset's default HttpRequest with our wrapping subclass.
+        # We reuse the tool name/description it already derived.
+        original = http_toolset.tools[0]
+        wrapped = self._tool_class(
+            http_toolset,
+            tool_name=original.name,
+            tool_description=original.description,
+        )
+        self.tools = [wrapped]
+        self.llm_instructions = http_toolset.llm_instructions
+
+    def _build_variant_llm_instructions(self) -> str:
+        base = self._build_llm_instructions()
+        if self._extra_llm_instructions:
+            return base + "\n\n" + self._extra_llm_instructions
+        return base
+
+
+class ConfluenceMarkdownToolset(_ConfluenceVariantBase):
+    """Confluence variant that returns page bodies as Markdown instead of HTML."""
+
+    _variant_name: ClassVar[str] = "confluence_markdown"
+    _variant_description: ClassVar[str] = (
+        "Fetch and search Confluence pages, returning page bodies converted to Markdown"
+    )
+    _tool_class: ClassVar[Type[HttpRequest]] = _TOOL_CLASS_MARKDOWN
+    _extra_llm_instructions: ClassVar[str] = (
+        "### Response post-processing\n\n"
+        "This toolset post-processes Confluence responses before you see them: "
+        "any HTML string in the JSON body (typically `body.storage.value`, "
+        "`body.view.value`, or excerpt fields in CQL search results) is "
+        "converted to Markdown. Read the body as Markdown, not as Confluence "
+        "storage XHTML. Macros and link metadata are preserved as plain text "
+        "where possible; complex Confluence macros may be flattened.\n"
+    )
+
+
+class ConfluenceHtmlFilterToolset(_ConfluenceVariantBase):
+    """Confluence variant that lets the agent narrow HTML responses with a CSS selector."""
+
+    _variant_name: ClassVar[str] = "confluence_html_filter"
+    _variant_description: ClassVar[str] = (
+        "Fetch and search Confluence pages with optional CSS-selector filtering "
+        "to keep large page HTML inside the token budget"
+    )
+    _tool_class: ClassVar[Type[HttpRequest]] = _TOOL_CLASS_HTML_FILTER
+    _extra_llm_instructions: ClassVar[str] = (
+        "### Response post-processing\n\n"
+        "Page bodies are returned as Confluence storage-format HTML, same as "
+        "the base `confluence` toolset. In addition, the request tool accepts "
+        "an optional `css_selector` parameter. When you supply one, only the "
+        "outer HTML of the matched elements is returned for every HTML field "
+        "in the response (e.g. `body.storage.value`).\n\n"
+        "**Workflow for large pages:**\n\n"
+        "1. First call without `css_selector` — but pass `jq` or `max_depth` "
+        "to inspect only the page metadata (title, ancestors, version) so you "
+        "don't pull the whole body yet.\n"
+        "2. Once you know the page's structure, re-fetch with a targeted "
+        "`css_selector` such as `h2#runbook + p`, `table.confluenceTable`, "
+        "or `[data-macro-name='code']` to retrieve only the relevant section.\n"
+        "3. If the selector returns nothing useful, broaden it (`section`, "
+        "`div`) or drop it entirely.\n\n"
+        "Selectors use BeautifulSoup `.select()` syntax: tag, `.class`, `#id`, "
+        "descendant (` `), child (`>`), sibling (`+`), and attribute selectors "
+        "all work. Pseudo-classes like `:has()` and `:contains()` are "
+        "**not** supported by the underlying parser.\n"
+    )
+
+
+# Re-export so the registration site in toolsets/__init__.py can import from
+# the package root (`from holmes.plugins.toolsets.confluence import …`).
+__all__ = [
+    "ConfluenceMarkdownToolset",
+    "ConfluenceHtmlFilterToolset",
+]

--- a/holmes/plugins/toolsets/confluence/confluence_variants.py
+++ b/holmes/plugins/toolsets/confluence/confluence_variants.py
@@ -54,11 +54,12 @@ logger = logging.getLogger(__name__)
 
 # Cheap heuristic for "this string looks like HTML": at least one tag.
 # Used to decide whether to run a string through markdownify / BeautifulSoup.
-# Matches `<tag` or `</tag` followed by space, slash, or `>`. Confluence storage
-# format ALWAYS uses tags (the value field is XHTML), so false negatives are
-# rare; false positives on prose containing `<word>` are harmless because the
-# converters are a no-op on non-HTML.
-_HTML_TAG_RE = re.compile(r"<\s*/?[a-zA-Z][a-zA-Z0-9]*[\s/>]")
+# Matches `<tag` or `</tag` followed by space, slash, or `>`, including
+# Confluence storage-format namespaced macro tags such as `<ac:structured-macro>`
+# and `<ri:user>` (so a body that's almost entirely macro markup still gets
+# post-processed). False positives on prose containing `<word>` are harmless
+# because the converters are a no-op on non-HTML.
+_HTML_TAG_RE = re.compile(r"<\s*/?(?:[a-zA-Z][\w-]*:)?[a-zA-Z][\w-]*[\s/>]")
 
 
 def _looks_like_html(value: str) -> bool:
@@ -157,6 +158,24 @@ class _HtmlFilteringHttpRequest(HttpRequest):
         # `requests.request`; otherwise it would get serialized into headers.
         if "css_selector" in params:
             params = {k: v for k, v in params.items() if k != "css_selector"}
+
+        # Validate the selector up front so a malformed value is reported as
+        # a recoverable tool error (with the offending selector and parser
+        # message) instead of letting BeautifulSoup raise inside the JSON
+        # walker. Empty / missing selector skips filtering entirely.
+        if selector:
+            try:
+                BeautifulSoup("", "html.parser").select(selector)
+            except Exception as exc:
+                return StructuredToolResult(
+                    status=StructuredToolResultStatus.ERROR,
+                    error=(
+                        f"Invalid css_selector {selector!r}: {exc}. "
+                        "Fix the selector and retry — selectors use "
+                        "BeautifulSoup `.select()` syntax."
+                    ),
+                    params=params,
+                )
 
         result = super()._invoke(params, context)
         if selector and result.status == StructuredToolResultStatus.SUCCESS:

--- a/holmes/plugins/toolsets/confluence/confluence_variants.py
+++ b/holmes/plugins/toolsets/confluence/confluence_variants.py
@@ -329,6 +329,6 @@ class ConfluenceHtmlFilterToolset(_ConfluenceVariantBase):
 # Re-export so the registration site in toolsets/__init__.py can import from
 # the package root (`from holmes.plugins.toolsets.confluence import …`).
 __all__ = [
-    "ConfluenceMarkdownToolset",
     "ConfluenceHtmlFilterToolset",
+    "ConfluenceMarkdownToolset",
 ]

--- a/holmes/plugins/toolsets/confluence/confluence_variants.py
+++ b/holmes/plugins/toolsets/confluence/confluence_variants.py
@@ -22,7 +22,7 @@ gateway / health-check machinery by subclassing it. Each variant overrides
 
 import logging
 import re
-from typing import Any, ClassVar, Dict, List, Optional, Type
+from typing import Any, Callable, ClassVar, List, Optional, Type
 
 from bs4 import BeautifulSoup
 from markdownify import markdownify
@@ -31,6 +31,7 @@ from holmes.core.tools import (
     CallablePrerequisite,
     StructuredToolResult,
     StructuredToolResultStatus,
+    Toolset,
     ToolInvokeContext,
     ToolParameter,
     ToolsetTag,
@@ -93,7 +94,7 @@ def _filter_html_by_css(html: str, selector: str) -> str:
     return "\n".join(str(m) for m in matches)
 
 
-def _transform_html_strings(value: Any, transform) -> Any:
+def _transform_html_strings(value: Any, transform: Callable[[str], str]) -> Any:
     """Walk an arbitrary JSON value and apply ``transform`` to every HTML-ish string."""
     if value is None:
         return None
@@ -209,8 +210,6 @@ class _ConfluenceVariantBase(ConfluenceToolset):
         # Skip ConfluenceToolset.__init__ — we want to call the grandparent
         # Toolset.__init__ directly so the variant gets its own name without
         # duplicating ConfluenceToolset's setup work.
-        from holmes.core.tools import Toolset
-
         Toolset.__init__(
             self,
             name=self._variant_name,

--- a/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/generate_page.py
+++ b/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/generate_page.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Build the Confluence storage-format HTML body used by the 259 matrix eval.
+
+The page is a fake "Internal Service Audit Catalogue" with ~25 service
+sections of distractor content, plus a single audit-summary table that
+contains the verification code the eval prompt asks Holmes to find.
+
+Why the structure is the way it is:
+
+* The page is large enough (~10K tokens) that the three Confluence
+  variants give meaningfully different token footprints, but small enough
+  to fit comfortably below the per-tool truncation limit so all variants
+  can in principle pass.
+* The verification code lives inside ``<table class="audit-summary">`` so
+  the ``confluence_html_filter`` variant has a clean CSS selector to
+  narrow the body down to.
+* Distractor content uses plausible service-catalogue language — it does
+  not hint at the answer or the table structure.
+
+Output: prints a JSON-encoded string (the page body) to stdout, ready to
+be embedded into a Confluence content-creation payload.
+"""
+
+import json
+
+VERIFICATION_CODE = "AUDIT-2025-HOLMES-q9P3vL7m"
+
+SERVICES = [
+    ("checkout-api", "Order checkout & payment routing", "go", "us-east-1"),
+    ("inventory-svc", "Stock keeping & reservation", "java", "eu-west-1"),
+    ("user-profile", "User identity & preferences", "python", "us-west-2"),
+    ("notification-bus", "Outbound emails, SMS, push", "node", "us-east-1"),
+    ("shipping-quote", "Carrier rate aggregation", "go", "eu-west-1"),
+    ("loyalty-engine", "Points & tiered rewards", "kotlin", "us-east-2"),
+    ("search-frontdoor", "Catalogue search edge", "rust", "ap-south-1"),
+    ("pricing-svc", "Discount & promo evaluation", "python", "us-east-1"),
+    ("cart-state", "Cart persistence & merge", "java", "us-east-1"),
+    ("returns-portal", "Return authorization flow", "ruby", "us-west-2"),
+    ("fraud-scorer", "Realtime fraud scoring", "python", "us-east-2"),
+    ("warehouse-sync", "WMS adapter", "java", "eu-west-1"),
+    ("auth-broker", "OIDC token broker", "go", "us-east-1"),
+    ("review-api", "Product reviews CRUD", "node", "ap-south-1"),
+    ("recommendation", "Recsys serving layer", "python", "us-west-2"),
+    ("feature-flags", "Flag evaluation cache", "go", "us-east-1"),
+    ("billing-export", "Invoice generation jobs", "java", "eu-west-1"),
+    ("media-pipeline", "Image & video transcode", "python", "us-east-2"),
+    ("legal-archive", "Document retention store", "java", "eu-central-1"),
+    ("partner-webhooks", "3p webhook fan-out", "node", "us-east-1"),
+    ("analytics-ingest", "Event collection edge", "go", "us-east-1"),
+    ("session-store", "Session token cache", "rust", "us-east-1"),
+    ("price-history", "Price journal storage", "python", "us-west-2"),
+    ("address-norm", "Address normalization", "java", "us-east-1"),
+    ("gift-cards", "Stored value ledger", "kotlin", "us-east-2"),
+]
+
+# Roughly 4 paragraphs per service to bulk the page out without making the
+# distractor look too obviously like filler. Phrases are deliberately
+# generic SRE language; nothing here points at where the audit code lives.
+PARAGRAPH_TEMPLATES = [
+    "The {name} service is owned by the {team} team and follows the platform's "
+    "standard observability conventions: structured logs go to the central "
+    "Loki tenant, RED metrics are emitted via the OpenTelemetry collector, and "
+    "tracing is enabled at the ingress and database call sites. Runbooks live "
+    "in the team's section of this space.",
+    "Capacity is planned quarterly. {name} currently runs with a baseline of "
+    "8 pods scaled by HPA on CPU at 70% utilization, with a hard ceiling of "
+    "40 pods to protect downstream dependencies during traffic spikes. The "
+    "scaling policy was last reviewed in the most recent platform sync.",
+    "Deployment uses the standard rolling-update strategy with a 25% surge "
+    "and 0% unavailable window. Canaries are gated by the platform's "
+    "progressive-delivery controller; rollbacks are automatic when the "
+    "5-minute error-rate SLO budget is breached.",
+    "{name} consumes secrets from the shared vault namespace and rotates "
+    "service-account credentials every 90 days. Database credentials are "
+    "issued dynamically by the secrets manager; static credentials are "
+    "explicitly disallowed by the platform admission controller.",
+]
+
+TEAMS = ["payments", "fulfilment", "identity", "growth", "platform", "data", "trust-and-safety"]
+
+
+def render_service_section(idx: int, svc: tuple) -> str:
+    name, desc, lang, region = svc
+    team = TEAMS[idx % len(TEAMS)]
+    paragraphs = "".join(
+        f"<p>{tpl.format(name=name, team=team)}</p>" for tpl in PARAGRAPH_TEMPLATES
+    )
+    deps_table = (
+        "<table class='deps-table'>"
+        "<thead><tr><th>Dependency</th><th>Type</th><th>SLO</th></tr></thead>"
+        "<tbody>"
+        f"<tr><td>postgres-{name}</td><td>datastore</td><td>99.95%</td></tr>"
+        f"<tr><td>kafka-{region}</td><td>broker</td><td>99.9%</td></tr>"
+        f"<tr><td>redis-{region}</td><td>cache</td><td>99.95%</td></tr>"
+        "</tbody></table>"
+    )
+    return (
+        f"<h2 id='svc-{name}'>{name}</h2>"
+        f"<p><strong>Purpose:</strong> {desc}. <strong>Language:</strong> {lang}. "
+        f"<strong>Primary region:</strong> {region}. <strong>Owner:</strong> {team}.</p>"
+        f"{paragraphs}"
+        f"{deps_table}"
+    )
+
+
+def render_audit_summary() -> str:
+    # The verification code is buried in the last row of the audit-summary
+    # table. The class attribute is what the html_filter variant can latch
+    # onto to bring just this table into context.
+    return (
+        "<h2 id='audit-summary'>Quarterly Audit Summary</h2>"
+        "<p>The following table records the audit reference codes issued by "
+        "the platform compliance team. Each code is tied to a specific quarter "
+        "and is the canonical identifier used in audit correspondence.</p>"
+        "<table class='audit-summary'>"
+        "<thead><tr><th>Quarter</th><th>Auditor</th><th>Scope</th><th>Audit Code</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>2024-Q1</td><td>Internal</td><td>Identity & Access</td><td>AUDIT-2024-Q1-IAM-redacted</td></tr>"
+        "<tr><td>2024-Q2</td><td>External</td><td>Payments PCI scope</td><td>AUDIT-2024-Q2-PCI-redacted</td></tr>"
+        "<tr><td>2024-Q3</td><td>Internal</td><td>Data retention</td><td>AUDIT-2024-Q3-RET-redacted</td></tr>"
+        "<tr><td>2024-Q4</td><td>External</td><td>SOC 2 Type II</td><td>AUDIT-2024-Q4-SOC-redacted</td></tr>"
+        f"<tr><td>2025-Q1</td><td>External</td><td>Full platform audit</td><td>{VERIFICATION_CODE}</td></tr>"
+        "</tbody></table>"
+    )
+
+
+def build_body() -> str:
+    parts = [
+        "<h1>Internal Service Audit Catalogue</h1>",
+        "<p>This page is the canonical reference for service ownership, "
+        "capacity, deployment, and audit metadata across the platform. It is "
+        "regenerated by the platform observability pipeline at the start of "
+        "every quarter and reviewed by the compliance team.</p>",
+    ]
+    for idx, svc in enumerate(SERVICES):
+        parts.append(render_service_section(idx, svc))
+    parts.append(render_audit_summary())
+    return "".join(parts)
+
+
+if __name__ == "__main__":
+    print(json.dumps(build_body()))

--- a/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/test_case.yaml
@@ -21,8 +21,10 @@
 # instance — see CLAUDE.md "Cloud Service Eval Reentrancy".
 #
 # Requirements:
-#   CONFLUENCE_SA_USER, CONFLUENCE_SA_API_KEY, CONFLUENCE_SA_BASE_URL,
-#   CONFLUENCE_BASE_URL (the user-facing URL used by the toolset configs)
+#   CONFLUENCE_BASE_URL  — user-facing URL (e.g. https://yourcompany.atlassian.net)
+#   CONFLUENCE_SA_USER, CONFLUENCE_SA_API_KEY — service-account basic auth
+#                                               creds, used both by `before_test`
+#                                               and by the toolset configs.
 
 user_prompt: |
   In the Confluence space 'HLMS259' there is a page titled 'Internal Service
@@ -52,6 +54,22 @@ before_test: |
   TMPFILE=$(mktemp /tmp/holmes259_page_XXXXXX.json)
   trap "rm -f $TMPFILE" EXIT
 
+  # Resolve the Atlassian Cloud ID and route REST calls through the
+  # api.atlassian.com gateway with bearer auth. Direct calls to
+  # ${CONFLUENCE_BASE_URL}/wiki/rest/api/* return 401/403 for the
+  # service-account token (it's a scoped token), but the same token works
+  # against https://api.atlassian.com/ex/confluence/{cloud_id}. The
+  # production toolset does this auto-fallback for runtime requests; we do
+  # it here so `before_test` uses the same path.
+  CLOUD_ID=$(curl -L -s "${CONFLUENCE_BASE_URL}/_edge/tenant_info" \
+    | python3 -c "import sys,json;print(json.load(sys.stdin).get('cloudId',''))")
+  if [ -z "$CLOUD_ID" ]; then
+    echo "Failed to resolve Atlassian Cloud ID from ${CONFLUENCE_BASE_URL}/_edge/tenant_info"
+    exit 1
+  fi
+  API="https://api.atlassian.com/ex/confluence/${CLOUD_ID}/rest/api"
+  AUTH=( -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}" )
+
   echo "Generating page body..."
   PAGE_BODY_JSON=$(python3 ./generate_page.py)
 
@@ -70,8 +88,8 @@ before_test: |
 
   echo "Creating Confluence space ${SPACE_KEY}..."
   RESPONSE=$(curl -L -s -w "\n%{http_code}" -X POST \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}" \
+    "${API}/space" \
+    "${AUTH[@]}" \
     -H "Content-Type: application/json" \
     -d "{
       \"key\": \"${SPACE_KEY}\",
@@ -92,8 +110,7 @@ before_test: |
   elif echo "$BODY" | grep -q "already exists"; then
     echo "Space already exists, verifying it is accessible..."
     SPACE_CHECK=$(curl -L -s -w "\n%{http_code}" \
-      "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-      -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
+      "${API}/space/${SPACE_KEY}" "${AUTH[@]}")
     SPACE_CHECK_HTTP=$(echo "$SPACE_CHECK" | tail -n1)
     if [ "$SPACE_CHECK_HTTP" -ne 200 ]; then
       echo "Space key '${SPACE_KEY}' is reserved but not accessible (HTTP ${SPACE_CHECK_HTTP}). It may be in the Confluence trash — purge it manually or wait for the trash retention period to expire."
@@ -108,8 +125,8 @@ before_test: |
 
   echo "Creating or refreshing page..."
   PAGE_RESPONSE=$(curl -L -s -w "\n%{http_code}" -X POST \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/content" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}" \
+    "${API}/content" \
+    "${AUTH[@]}" \
     -H "Content-Type: application/json" \
     -d @"$TMPFILE")
 
@@ -121,10 +138,10 @@ before_test: |
   else
     echo "Page creation returned HTTP ${PAGE_HTTP_CODE}, searching for existing page..."
     SEARCH_RESP=$(curl -L -s -w "\n%{http_code}" -G \
-      "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/content" \
+      "${API}/content" \
       --data-urlencode "title=${PAGE_TITLE}" \
       --data-urlencode "spaceKey=${SPACE_KEY}" \
-      -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
+      "${AUTH[@]}")
     SEARCH_HTTP=$(echo "$SEARCH_RESP" | tail -n1)
     SEARCH_BODY=$(echo "$SEARCH_RESP" | sed '$d')
     if [ "$SEARCH_HTTP" -ne 200 ]; then
@@ -142,8 +159,8 @@ before_test: |
 
   echo "Verifying verification code is present in page content..."
   VERIFY=$(curl -L -s \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/content/${PAGE_ID}?expand=body.storage" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
+    "${API}/content/${PAGE_ID}?expand=body.storage" \
+    "${AUTH[@]}")
 
   if echo "$VERIFY" | grep -q "${VERIFICATION_CODE}"; then
     echo "Page content verified - verification code found"

--- a/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/test_case.yaml
@@ -1,0 +1,158 @@
+# Matrix eval comparing the three Confluence toolset variants.
+#
+# The same prompt is run against three Confluence toolsets that share the
+# same underlying REST API + auth, but differ in how page bodies are
+# delivered to the LLM:
+#
+#   * confluence              — raw Confluence storage-format HTML
+#   * confluence_markdown     — HTML converted to Markdown server-side
+#   * confluence_html_filter  — raw HTML, plus a `css_selector` parameter the
+#                               agent can use to narrow the body
+#
+# The eval is intentionally simple: a single page with ~25 service sections
+# of distractor content plus an audit-summary table that contains the
+# verification code (see generate_page.py). All three variants should be
+# able to find the code; the matrix lets us compare token usage / cost /
+# pass-rate across them.
+#
+# Reentrancy: this eval creates a Confluence space + page with static keys.
+# `before_test` is idempotent (create-or-reuse) and there is intentionally
+# NO `after_test` because parallel CI runs share the same Confluence
+# instance — see CLAUDE.md "Cloud Service Eval Reentrancy".
+#
+# Requirements:
+#   CONFLUENCE_SA_USER, CONFLUENCE_SA_API_KEY, CONFLUENCE_SA_BASE_URL,
+#   CONFLUENCE_BASE_URL (the user-facing URL used by the toolset configs)
+
+user_prompt: |
+  In the Confluence space 'HLMS259' there is a page titled 'Internal Service
+  Audit Catalogue'. The page contains a Quarterly Audit Summary table.
+  What is the audit code listed for 2025-Q1?
+
+expected_output:
+  - "Must report the 2025-Q1 audit code: AUDIT-2025-HOLMES-q9P3vL7m"
+
+tags:
+  - confluence
+  - question-answer
+  - medium
+
+toolsets_matrix:
+  - toolsets.yaml
+  - toolsets_markdown.yaml
+  - toolsets_html_filter.yaml
+
+before_test: |
+  set -e
+
+  SPACE_KEY="HLMS259"
+  SPACE_NAME="Holmes Eval 259 Variants"
+  PAGE_TITLE="Internal Service Audit Catalogue"
+  VERIFICATION_CODE="AUDIT-2025-HOLMES-q9P3vL7m"
+  TMPFILE=$(mktemp /tmp/holmes259_page_XXXXXX.json)
+  trap "rm -f $TMPFILE" EXIT
+
+  echo "Generating page body..."
+  PAGE_BODY_JSON=$(python3 ./generate_page.py)
+
+  echo "Building request payload..."
+  python3 -c "
+  import json, sys
+  body_json = sys.stdin.read()
+  payload = {
+    'type': 'page',
+    'title': '${PAGE_TITLE}',
+    'space': {'key': '${SPACE_KEY}'},
+    'body': {'storage': {'value': json.loads(body_json), 'representation': 'storage'}}
+  }
+  json.dump(payload, open('$TMPFILE', 'w'))
+  " <<< "$PAGE_BODY_JSON"
+
+  echo "Creating Confluence space ${SPACE_KEY}..."
+  RESPONSE=$(curl -L -s -w "\n%{http_code}" -X POST \
+    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space" \
+    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"key\": \"${SPACE_KEY}\",
+      \"name\": \"${SPACE_NAME}\",
+      \"description\": {
+        \"plain\": {
+          \"value\": \"Test space for Holmes eval 259 (Confluence variants matrix)\",
+          \"representation\": \"plain\"
+        }
+      }
+    }")
+
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+
+  if [ "$HTTP_CODE" -eq 200 ]; then
+    echo "Space created."
+  elif echo "$BODY" | grep -q "already exists"; then
+    echo "Space already exists, verifying it is accessible..."
+    SPACE_CHECK=$(curl -L -s -w "\n%{http_code}" \
+      "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
+      -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
+    SPACE_CHECK_HTTP=$(echo "$SPACE_CHECK" | tail -n1)
+    if [ "$SPACE_CHECK_HTTP" -ne 200 ]; then
+      echo "Space key '${SPACE_KEY}' is reserved but not accessible (HTTP ${SPACE_CHECK_HTTP}). It may be in the Confluence trash — purge it manually or wait for the trash retention period to expire."
+      exit 1
+    fi
+    echo "Space is accessible, reusing."
+  else
+    echo "Failed to create space. HTTP ${HTTP_CODE}: ${BODY}"
+    exit 1
+  fi
+  sleep 2
+
+  echo "Creating or refreshing page..."
+  PAGE_RESPONSE=$(curl -L -s -w "\n%{http_code}" -X POST \
+    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/content" \
+    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d @"$TMPFILE")
+
+  PAGE_HTTP_CODE=$(echo "$PAGE_RESPONSE" | tail -n1)
+  PAGE_BODY_RESP=$(echo "$PAGE_RESPONSE" | sed '$d')
+
+  if [ "$PAGE_HTTP_CODE" -eq 200 ]; then
+    PAGE_ID=$(echo "$PAGE_BODY_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
+  else
+    echo "Page creation returned HTTP ${PAGE_HTTP_CODE}, searching for existing page..."
+    SEARCH_RESP=$(curl -L -s -w "\n%{http_code}" -G \
+      "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/content" \
+      --data-urlencode "title=${PAGE_TITLE}" \
+      --data-urlencode "spaceKey=${SPACE_KEY}" \
+      -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
+    SEARCH_HTTP=$(echo "$SEARCH_RESP" | tail -n1)
+    SEARCH_BODY=$(echo "$SEARCH_RESP" | sed '$d')
+    if [ "$SEARCH_HTTP" -ne 200 ]; then
+      echo "Page search returned HTTP ${SEARCH_HTTP}: ${SEARCH_BODY}"
+      exit 1
+    fi
+    PAGE_ID=$(echo "$SEARCH_BODY" | python3 -c 'import sys,json; r=json.load(sys.stdin).get("results",[]); print(r[0]["id"]) if r else sys.exit(1)')
+    if [ -z "$PAGE_ID" ]; then
+      echo "Failed to create or find page."
+      exit 1
+    fi
+    echo "Found existing page (will not be updated; expected to already contain the verification code)."
+  fi
+  echo "Page ID: ${PAGE_ID}"
+
+  echo "Verifying verification code is present in page content..."
+  VERIFY=$(curl -L -s \
+    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/content/${PAGE_ID}?expand=body.storage" \
+    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
+
+  if echo "$VERIFY" | grep -q "${VERIFICATION_CODE}"; then
+    echo "Page content verified - verification code found"
+  else
+    echo "Page verification failed - verification code not found in content"
+    exit 1
+  fi
+
+  echo "Setup complete"
+
+# No after_test: cloud service eval reentrancy. Multiple PR runs may share
+# the same Confluence instance and would race to delete the space.

--- a/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/toolsets.yaml
@@ -1,0 +1,18 @@
+# Matrix variant: base Confluence toolset (raw HTML response).
+toolsets:
+  confluence:
+    enabled: true
+    config:
+      api_url: "{{ env.CONFLUENCE_BASE_URL }}"
+      user: "{{ env.CONFLUENCE_SA_USER }}"
+      api_key: "{{ env.CONFLUENCE_SA_API_KEY }}"
+  confluence_markdown:
+    enabled: false
+  confluence_html_filter:
+    enabled: false
+  kubernetes/core:
+    enabled: false
+  kubernetes/logs:
+    enabled: false
+  helm/core:
+    enabled: false

--- a/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/toolsets_html_filter.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/toolsets_html_filter.yaml
@@ -1,0 +1,20 @@
+# Matrix variant: confluence_html_filter — raw HTML, but the agent can
+# pass a `css_selector` parameter to narrow the response body down to
+# just the matched HTML elements.
+toolsets:
+  confluence:
+    enabled: false
+  confluence_markdown:
+    enabled: false
+  confluence_html_filter:
+    enabled: true
+    config:
+      api_url: "{{ env.CONFLUENCE_BASE_URL }}"
+      user: "{{ env.CONFLUENCE_SA_USER }}"
+      api_key: "{{ env.CONFLUENCE_SA_API_KEY }}"
+  kubernetes/core:
+    enabled: false
+  kubernetes/logs:
+    enabled: false
+  helm/core:
+    enabled: false

--- a/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/toolsets_markdown.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_confluence_variants_matrix/toolsets_markdown.yaml
@@ -1,0 +1,19 @@
+# Matrix variant: confluence_markdown — page bodies converted to Markdown
+# server-side before they reach the LLM.
+toolsets:
+  confluence:
+    enabled: false
+  confluence_markdown:
+    enabled: true
+    config:
+      api_url: "{{ env.CONFLUENCE_BASE_URL }}"
+      user: "{{ env.CONFLUENCE_SA_USER }}"
+      api_key: "{{ env.CONFLUENCE_SA_API_KEY }}"
+  confluence_html_filter:
+    enabled: false
+  kubernetes/core:
+    enabled: false
+  kubernetes/logs:
+    enabled: false
+  helm/core:
+    enabled: false

--- a/tests/plugins/toolsets/test_confluence_variants.py
+++ b/tests/plugins/toolsets/test_confluence_variants.py
@@ -1,0 +1,271 @@
+"""Unit tests for the confluence_markdown / confluence_html_filter variants.
+
+The variants share auth/config plumbing with the base ConfluenceToolset (covered
+by test_confluence_tools.py); these tests focus on the behavior unique to the
+variants — HTML→Markdown conversion and CSS-selector filtering of responses.
+"""
+
+from unittest.mock import patch
+
+from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
+from holmes.plugins.toolsets.confluence.confluence_variants import (
+    ConfluenceHtmlFilterToolset,
+    ConfluenceMarkdownToolset,
+    _filter_html_by_css,
+    _html_to_markdown,
+    _looks_like_html,
+    _transform_html_strings,
+)
+from holmes.plugins.toolsets.http.http_toolset import HttpRequest, HttpToolset
+
+
+# ---------------------------------------------------------------------------
+# Pure helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_looks_like_html_detects_tags(self):
+        assert _looks_like_html("<p>hi</p>")
+        assert _looks_like_html("text with <strong>bold</strong>")
+        assert _looks_like_html("<br/>")
+
+    def test_looks_like_html_rejects_plain_text(self):
+        assert not _looks_like_html("hello world")
+        assert not _looks_like_html("just numbers 1 2 3")
+        assert not _looks_like_html("")
+
+    def test_html_to_markdown_basic(self):
+        md = _html_to_markdown("<p>Code: <strong>XYZ</strong></p>")
+        assert "**XYZ**" in md
+        assert "Code:" in md
+
+    def test_html_to_markdown_strips_confluence_macros(self):
+        # Confluence storage XHTML includes <ac:*>/<ri:*> macro tags.
+        # markdownify treats unknown tags as transparent so the inner text
+        # survives, which is what we want for the LLM.
+        html = (
+            "<p>before</p>"
+            "<ac:structured-macro ac:name='code'>"
+            "<ac:plain-text-body><![CDATA[print('hi')]]></ac:plain-text-body>"
+            "</ac:structured-macro>"
+            "<p>after</p>"
+        )
+        md = _html_to_markdown(html)
+        assert "before" in md
+        assert "after" in md
+
+    def test_filter_html_by_css_returns_matched_outer_html(self):
+        html = "<div><p>one</p><p class='target'>two</p><p>three</p></div>"
+        assert _filter_html_by_css(html, "p.target") == '<p class="target">two</p>'
+
+    def test_filter_html_by_css_returns_empty_string_on_no_match(self):
+        # Empty string is intentional — when the agent picks a bad selector
+        # it should see "no match" rather than the unfiltered body.
+        assert _filter_html_by_css("<p>hi</p>", "table.audit") == ""
+
+
+# ---------------------------------------------------------------------------
+# JSON walker
+# ---------------------------------------------------------------------------
+
+
+class TestTransformHtmlStrings:
+    def test_walks_nested_dicts_and_lists(self):
+        data = {
+            "results": [
+                {"body": {"storage": {"value": "<p>page one</p>"}}},
+                {"body": {"storage": {"value": "<p>page two</p>"}}},
+            ],
+            "title": "plain title",  # not HTML — should be untouched
+        }
+        out = _transform_html_strings(data, _html_to_markdown)
+        assert out["title"] == "plain title"
+        assert "page one" in out["results"][0]["body"]["storage"]["value"]
+        assert "<p>" not in out["results"][0]["body"]["storage"]["value"]
+
+    def test_leaves_non_string_scalars_alone(self):
+        data = {"id": 12345, "active": True, "rev": None, "tags": []}
+        assert _transform_html_strings(data, _html_to_markdown) == data
+
+
+# ---------------------------------------------------------------------------
+# Variant toolset wiring
+# ---------------------------------------------------------------------------
+
+
+def _stub_setup(cls):
+    """Run prerequisites_callable past the live HTTP/health checks."""
+    config = {
+        "api_url": "https://example.atlassian.net",
+        "user": "u@x.com",
+        "api_key": "k",
+    }
+    ts = cls()
+    with (
+        patch.object(cls, "_perform_health_check", return_value=(True, "ok")),
+        patch.object(HttpToolset, "_check_endpoint_health", return_value=(True, "")),
+    ):
+        ok, _ = ts.prerequisites_callable(config)
+    assert ok, f"{cls.__name__} prerequisites_callable returned False"
+    return ts
+
+
+class TestVariantWiring:
+    def test_markdown_variant_registers_correct_tool(self):
+        ts = _stub_setup(ConfluenceMarkdownToolset)
+        assert ts.name == "confluence_markdown"
+        assert len(ts.tools) == 1
+        tool = ts.tools[0]
+        assert tool.name == "confluence_markdown_request"
+        # Must be the wrapping subclass, not the bare HttpRequest.
+        from holmes.plugins.toolsets.confluence.confluence_variants import (
+            _MarkdownConvertingHttpRequest,
+        )
+
+        assert isinstance(tool, _MarkdownConvertingHttpRequest)
+        # The variant-specific instructions are appended.
+        assert "Markdown" in (ts.llm_instructions or "")
+
+    def test_html_filter_variant_registers_css_selector_param(self):
+        ts = _stub_setup(ConfluenceHtmlFilterToolset)
+        assert ts.name == "confluence_html_filter"
+        tool = ts.tools[0]
+        assert tool.name == "confluence_html_filter_request"
+        assert "css_selector" in tool.parameters
+        assert tool.parameters["css_selector"].required is False
+        from holmes.plugins.toolsets.confluence.confluence_variants import (
+            _HtmlFilteringHttpRequest,
+        )
+
+        assert isinstance(tool, _HtmlFilteringHttpRequest)
+        assert "css_selector" in (ts.llm_instructions or "")
+
+
+# ---------------------------------------------------------------------------
+# Response post-processing (end-to-end through the wrapping tool)
+# ---------------------------------------------------------------------------
+
+
+def _success_result(body):
+    return StructuredToolResult(
+        status=StructuredToolResultStatus.SUCCESS,
+        data={"status_code": 200, "body": body},
+    )
+
+
+class TestMarkdownVariantPostProcessing:
+    def test_html_in_response_is_converted(self):
+        ts = _stub_setup(ConfluenceMarkdownToolset)
+        tool = ts.tools[0]
+        confluence_page = {
+            "id": "1",
+            "title": "Runbook",
+            "body": {
+                "storage": {
+                    "value": "<h1>Header</h1><p>Code: <strong>HOLMES-MD</strong></p>",
+                    "representation": "storage",
+                }
+            },
+        }
+        with patch.object(
+            HttpRequest, "_invoke", return_value=_success_result(confluence_page)
+        ):
+            result = tool._invoke({"url": "https://example.atlassian.net/x"}, context=None)
+
+        body_value = result.data["body"]["body"]["storage"]["value"]
+        assert "<h1>" not in body_value
+        assert "**HOLMES-MD**" in body_value
+        assert "# Header" in body_value
+
+    def test_non_html_strings_are_left_alone(self):
+        ts = _stub_setup(ConfluenceMarkdownToolset)
+        tool = ts.tools[0]
+        with patch.object(
+            HttpRequest,
+            "_invoke",
+            return_value=_success_result({"id": "1", "title": "Plain title"}),
+        ):
+            result = tool._invoke({"url": "https://example.atlassian.net/x"}, context=None)
+        assert result.data["body"]["title"] == "Plain title"
+
+    def test_error_responses_are_passed_through_untouched(self):
+        ts = _stub_setup(ConfluenceMarkdownToolset)
+        tool = ts.tools[0]
+        err = StructuredToolResult(
+            status=StructuredToolResultStatus.ERROR,
+            error="HTTP 404",
+        )
+        with patch.object(HttpRequest, "_invoke", return_value=err):
+            result = tool._invoke({"url": "https://example.atlassian.net/x"}, context=None)
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert result.error == "HTTP 404"
+
+
+class TestHtmlFilterVariantPostProcessing:
+    def test_css_selector_narrows_the_body(self):
+        ts = _stub_setup(ConfluenceHtmlFilterToolset)
+        tool = ts.tools[0]
+        page = {
+            "id": "1",
+            "body": {
+                "storage": {
+                    "value": (
+                        "<h1>Audit Page</h1>"
+                        "<p>Distractor paragraph.</p>"
+                        "<table class='audit'><tr><td>code-A</td></tr></table>"
+                    ),
+                    "representation": "storage",
+                }
+            },
+        }
+        with patch.object(HttpRequest, "_invoke", return_value=_success_result(page)):
+            result = tool._invoke(
+                {
+                    "url": "https://example.atlassian.net/x",
+                    "css_selector": "table.audit",
+                },
+                context=None,
+            )
+        body_value = result.data["body"]["body"]["storage"]["value"]
+        assert "code-A" in body_value
+        assert "Distractor" not in body_value
+        assert "<h1>" not in body_value
+
+    def test_css_selector_is_stripped_before_request(self):
+        # If css_selector leaked through to the underlying HttpRequest it
+        # would be ignored at best, or surfaced as a header at worst. Verify
+        # it is not present in the params dict the parent _invoke sees.
+        ts = _stub_setup(ConfluenceHtmlFilterToolset)
+        tool = ts.tools[0]
+        seen_params = {}
+
+        def fake_invoke(self_inner, params, context):
+            seen_params.update(params)
+            return _success_result({"body": {"storage": {"value": "<p>x</p>"}}})
+
+        with patch.object(HttpRequest, "_invoke", new=fake_invoke):
+            tool._invoke(
+                {
+                    "url": "https://example.atlassian.net/x",
+                    "css_selector": "p",
+                },
+                context=None,
+            )
+        assert "css_selector" not in seen_params
+        assert seen_params["url"] == "https://example.atlassian.net/x"
+
+    def test_omitting_css_selector_returns_full_body(self):
+        ts = _stub_setup(ConfluenceHtmlFilterToolset)
+        tool = ts.tools[0]
+        html = "<h1>Audit</h1><p>full content</p>"
+        with patch.object(
+            HttpRequest,
+            "_invoke",
+            return_value=_success_result(
+                {"body": {"storage": {"value": html, "representation": "storage"}}}
+            ),
+        ):
+            result = tool._invoke({"url": "https://example.atlassian.net/x"}, context=None)
+        body_value = result.data["body"]["body"]["storage"]["value"]
+        assert body_value == html

--- a/tests/plugins/toolsets/test_confluence_variants.py
+++ b/tests/plugins/toolsets/test_confluence_variants.py
@@ -35,6 +35,15 @@ class TestHelpers:
         assert not _looks_like_html("just numbers 1 2 3")
         assert not _looks_like_html("")
 
+    def test_looks_like_html_detects_confluence_macro_tags(self):
+        # Confluence storage XHTML is full of <ac:*>/<ri:*> macro tags.
+        # The detector must trigger on those even when a body has no plain
+        # HTML tags, otherwise variants leave macro-only bodies untouched.
+        assert _looks_like_html(
+            "<ac:structured-macro ac:name='code'></ac:structured-macro>"
+        )
+        assert _looks_like_html("<ri:user ri:account-id='abc'/>")
+
     def test_html_to_markdown_basic(self):
         md = _html_to_markdown("<p>Code: <strong>XYZ</strong></p>")
         assert "**XYZ**" in md
@@ -254,6 +263,27 @@ class TestHtmlFilterVariantPostProcessing:
             )
         assert "css_selector" not in seen_params
         assert seen_params["url"] == "https://example.atlassian.net/x"
+
+    def test_invalid_css_selector_returns_recoverable_error(self):
+        ts = _stub_setup(ConfluenceHtmlFilterToolset)
+        tool = ts.tools[0]
+        # Patch HttpRequest._invoke to fail loudly if reached — a malformed
+        # selector must short-circuit before any HTTP work.
+        with patch.object(
+            HttpRequest,
+            "_invoke",
+            side_effect=AssertionError("HTTP request must not be made on bad selector"),
+        ):
+            result = tool._invoke(
+                {
+                    "url": "https://example.atlassian.net/x",
+                    "css_selector": "::::nope",
+                },
+                context=None,
+            )
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "::::nope" in result.error
+        assert "css_selector" in result.error.lower() or "selector" in result.error.lower()
 
     def test_omitting_css_selector_returns_full_body(self):
         ts = _stub_setup(ConfluenceHtmlFilterToolset)


### PR DESCRIPTION
## Summary

This PR introduces two new Confluence toolset variants that post-process page bodies before returning them to the LLM, complementing the existing raw-HTML `confluence` toolset. These variants help reduce token usage and provide more flexible response filtering for large Confluence pages.

## Key Changes

- **New `confluence_markdown` variant**: Automatically converts all HTML strings in Confluence responses to Markdown before the LLM sees them. This reduces token usage and noise from Confluence storage-format XHTML while preserving content and handling Confluence-specific macro tags gracefully.

- **New `confluence_html_filter` variant**: Adds an optional `css_selector` parameter to the HTTP request tool, allowing the LLM to narrow HTML responses to specific elements using CSS selectors. Enables a two-step workflow: first inspect page metadata, then fetch only the relevant section.

- **Shared variant infrastructure**: Both variants subclass `ConfluenceToolset` to reuse all auth/config/health-check machinery while overriding tool registration and response post-processing. Includes:
  - `_MarkdownConvertingHttpRequest`: Wraps HTTP responses to convert HTML to Markdown
  - `_HtmlFilteringHttpRequest`: Wraps HTTP responses to apply CSS selector filtering
  - Helper functions for HTML detection, conversion, and filtering
  - Generic JSON walker to apply transformations to nested response structures

- **Comprehensive test coverage**: Unit tests for helper functions, JSON walking, variant wiring, and end-to-end response post-processing. Tests verify HTML detection heuristics, Markdown conversion (including Confluence macro handling), CSS selector filtering, and parameter stripping.

- **Matrix evaluation**: Added test fixture `259_confluence_variants_matrix` that compares all three Confluence variants (raw HTML, Markdown, HTML-filter) on the same task using a generated Confluence page with ~25 service sections and an audit-summary table containing a verification code.

## Implementation Details

- HTML detection uses a lightweight regex (`_HTML_TAG_RE`) to identify strings that look like HTML before applying expensive transformations, avoiding unnecessary processing of plain text.

- The Markdown conversion leverages the existing `markdownify` dependency (already used by the internet toolset) and gracefully handles Confluence-specific `<ac:*>` and `<ri:*>` macro tags by treating them as transparent elements.

- CSS selector filtering uses BeautifulSoup's permissive HTML parser and returns an empty string on no match (rather than the original HTML) so the LLM sees the consequences of a bad selector.

- Variant toolsets register with distinct names (`confluence_markdown`, `confluence_html_filter`) so the LLM sees appropriately named tools (`confluence_markdown_request`, `confluence_html_filter_request`).

- Each variant includes tailored LLM instructions explaining its post-processing behavior and usage patterns.

https://claude.ai/code/session_01GGWboTL42Z3Cc3Ln8mHWFz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two new Confluence toolset variants are available.
  * Markdown variant converts HTML-like responses into Markdown.
  * HTML Filter variant can extract content via CSS selector and returns a recoverable error for malformed selectors.

* **Tests**
  * Comprehensive unit tests covering variant behavior, response post-processing, and parameter handling.
  * New end-to-end fixtures to exercise Confluence variants in matrixed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->