### PR TITLE
ROB-3465 cli add client secret option

### DIFF
--- a/holmes/core/oauth_config.py
+++ b/holmes/core/oauth_config.py
@@ -117,6 +117,7 @@ class OAuthEndpoints:
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     client_id: Optional[str] = None
+    client_secret: Optional[str] = None
     scopes: Optional[List[str]] = None
     registration_endpoint: Optional[str] = None
 
@@ -134,6 +135,7 @@ class MCPOAuthConfig(BaseModel):
     authorization_url: Optional[str] = Field(default=None, description="IdP authorization endpoint URL. Auto-discovered if omitted.")
     token_url: Optional[str] = Field(default=None, description="IdP token endpoint URL. Auto-discovered if omitted.")
     client_id: Optional[str] = Field(default=None, description="OAuth public client ID. Auto-registered via DCR if omitted.")
+    client_secret: Optional[str] = Field(default=None, description="OAuth client secret for confidential clients (e.g. Azure AD apps without public client flows).")
     scopes: Optional[List[str]] = Field(default=None, description="OAuth scopes to request.")
     registration_endpoint: Optional[str] = Field(default=None, description="DCR endpoint (auto-populated during discovery, sent to frontend for client registration).")
 

--- a/holmes/core/oauth_utils.py
+++ b/holmes/core/oauth_utils.py
@@ -280,6 +280,7 @@ def cli_oauth_flow(oauth: OAuthEndpoints, server_name: str) -> Optional[Dict[str
             redirect_uri=redirect_uri,
             client_id=oauth.client_id,
             code_verifier=code_verifier,
+            client_secret=oauth.client_secret,
         )
     except OAuthTokenExchangeError as e:
         logger.warning("CLI OAuth %s: token exchange failed: %s", server_name, e)

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -317,6 +317,7 @@ class RemoteMCPTool(Tool):
                 authorization_url=oauth_config.authorization_url,
                 token_url=oauth_config.token_url,
                 client_id=oauth_config.client_id,
+                client_secret=oauth_config.client_secret,
                 scopes=oauth_config.scopes,
                 registration_endpoint=oauth_config.registration_endpoint,
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth configuration now supports optional client secret fields for confidential client applications
  * CLI OAuth authentication flow enhanced to include client secret during token exchange
  * Improved compatibility with OAuth applications requiring client credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->