### PR TITLE
optional opentelemetry tracing supported by helm

### DIFF
--- a/docs/installation/kubernetes-installation.md
+++ b/docs/installation/kubernetes-installation.md
@@ -133,6 +133,37 @@ Deploy HolmesGPT as a service in your Kubernetes cluster with an HTTP API.
    helm install holmesgpt robusta/holmes -f values.yaml
    ```
 
+## Optional: OpenTelemetry instrumentation
+
+You can enable optional OpenTelemetry (OTLP) tracing to send traces to an OpenTelemetry Collector or compatible backend (e.g. Jaeger, Tempo, Grafana Cloud). When enabled, the chart injects the OTLP environment variables consumed by Holmes’ built-in tracer; if you also want auto-instrumentation, the container entrypoint needs to be wrapped accordingly.
+
+To enable:
+
+1. Set **`otlp.enabled`** to `true` and set **`otlp.endpoint`** to your collector URL (e.g. `http://otel-collector.observability.svc:4317`).
+2. Ensure your Holmes image includes the OpenTelemetry dependencies (the default image does).
+
+Add (or merge) the following into your `values.yaml`:
+
+    # values.yaml (merge with your existing modelList, additionalEnvVars, etc.)
+    otlp:
+      enabled: true
+      service: holmesgpt          # OTEL_SERVICE_NAME
+      endpoint: "http://otel-collector.observability.svc:4317"
+      metrics: "none"             # optional; set to "otlp" to export metrics
+      logs: "none"                # optional; set to "otlp" to export logs
+      # protocol: "grpc"          # optional; default is grpc, use "http/protobuf" for HTTP
+      # insecure: "true"          # optional; set for plaintext (e.g. same-cluster collector)
+      # headers: "key1=value1,key2=value2"   # optional; auth or tenant headers
+      # excludedUrls: optional. If omitted, the chart sets OTEL_PYTHON_FASTAPI_EXCLUDED_URLS to "/healthz,/readyz".
+      # If you set excludedUrls (including ""), that exact value is used—an empty string clears the default exclusions
+      # so health/readiness routes are not excluded from tracing (OpenTelemetry Python FastAPI semantics).
+
+Then install or upgrade as usual:
+
+    helm upgrade --install holmesgpt robusta/holmes -f values.yaml
+
+If **`otlp.enabled`** is `false` or **`otlp.endpoint`** is empty, the server runs without the OpenTelemetry wrapper and no OTLP env vars are set.
+
 ## Usage
 
 After installation, test the service with a simple API call:

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -98,7 +98,7 @@ spec:
           {{- with .Values.containerSecurityContext }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-        command: ["python3", "-u", "server.py"]
+        command: ["python3", "-u", "{{ if .Values.experimental.aguiServer.enabled }}experimental/ag-ui/server-agui.py{{ else }}server.py{{ end }}"]
         {{- if .Values.args }}
         args:
         {{- toYaml .Values.args | nindent 8 }}
@@ -129,6 +129,35 @@ spec:
             value: {{ include "holmes.enableTelemetry" . | quote }}
           - name: SENTRY_DSN
             value: {{ .Values.sentryDSN }}
+          {{- if and .Values.otlp.enabled .Values.otlp.endpoint }}
+          - name: OTEL_SERVICE_NAME
+            value: {{ .Values.otlp.service | quote }}
+          - name: OTEL_METRICS_EXPORTER
+            value: {{ .Values.otlp.metrics | quote }}
+          - name: OTEL_LOGS_EXPORTER
+            value: {{ .Values.otlp.logs | quote }}
+          {{- if .Values.otlp.protocol }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otlp.protocol | quote }}
+          {{- end }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otlp.endpoint | quote }}
+          {{- if .Values.otlp.insecure }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otlp.insecure | quote }}
+          {{- end }}
+          {{- if .Values.otlp.headers }}
+          - name: OTEL_EXPORTER_OTLP_HEADERS
+            value: {{ .Values.otlp.headers | quote }}
+          {{- end }}
+          {{- if hasKey .Values.otlp "excludedUrls" }}
+          - name: OTEL_PYTHON_FASTAPI_EXCLUDED_URLS
+            value: {{ .Values.otlp.excludedUrls | quote }}
+          {{- else }}
+          - name: OTEL_PYTHON_FASTAPI_EXCLUDED_URLS
+            value: "/healthz,/readyz"
+          {{- end }}
+          {{- end }}
           {{ if .Values.certificate -}}
           - name: CERTIFICATE
             value: {{ .Values.certificate }}

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -102,7 +102,7 @@ spec:
           {{- with .Values.containerSecurityContext }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-        command: ["python3", "-u", "server.py"]
+        command: ["python3", "-u", "{{ if .Values.experimental.aguiServer.enabled }}experimental/ag-ui/server-agui.py{{ else }}server.py{{ end }}"]
         {{- if .Values.args }}
         args:
         {{- toYaml .Values.args | nindent 8 }}
@@ -170,6 +170,35 @@ spec:
           {{- if $tls.caCertsSecretKey }}
           - name: HOLMES_SSL_CA_CERTS
             value: /etc/holmes/tls/ca.crt
+          {{- end }}
+          {{- end }}
+          {{- if and .Values.otlp.enabled .Values.otlp.endpoint }}
+          - name: OTEL_SERVICE_NAME
+            value: {{ .Values.otlp.service | quote }}
+          - name: OTEL_METRICS_EXPORTER
+            value: {{ .Values.otlp.metrics | quote }}
+          - name: OTEL_LOGS_EXPORTER
+            value: {{ .Values.otlp.logs | quote }}
+          {{- if .Values.otlp.protocol }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otlp.protocol | quote }}
+          {{- end }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otlp.endpoint | quote }}
+          {{- if .Values.otlp.insecure }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otlp.insecure | quote }}
+          {{- end }}
+          {{- if .Values.otlp.headers }}
+          - name: OTEL_EXPORTER_OTLP_HEADERS
+            value: {{ .Values.otlp.headers | quote }}
+          {{- end }}
+          {{- if hasKey .Values.otlp "excludedUrls" }}
+          - name: OTEL_PYTHON_FASTAPI_EXCLUDED_URLS
+            value: {{ .Values.otlp.excludedUrls | quote }}
+          {{- else }}
+          - name: OTEL_PYTHON_FASTAPI_EXCLUDED_URLS
+            value: "/healthz,/readyz"
           {{- end }}
           {{- end }}
           {{ if .Values.certificate -}}

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -1,6 +1,25 @@
 certificate: "" # base64 encoded
 logLevel: INFO
 
+# Experimental: run AG-UI server (experimental/ag-ui/server-agui.py) instead of server.py.
+# When true, the deployment serves the AG-UI endpoint at /api/agui/chat for ExampleOps-style UIs.
+experimental:
+  aguiServer:
+    enabled: false
+
+# OpenTelemetry instrumentation (env vars for opentelemetry-instrument)
+# Set otlp.endpoint to send traces to a collector
+otlp:
+  enabled: false
+  service: holmesgpt
+  metrics: "none"
+  logs: "none"
+  endpoint: "" # e.g. "http://otel-collector:4317"
+  # excludedUrls: omit for default "/healthz,/readyz"; set explicitly (including "") to override—see chart docs
+  # protocol: "grpc"       # OTLP protocol: "grpc" or "http/protobuf"
+  # insecure: "false"      # Set to "true" for plaintext
+  # headers: ""            # Optional headers as "key1=value1,key2=value2"
+
 additionalEnvVars: []
 additional_env_vars: []
 # Mirrors runner.additional_env_froms: a list of envFrom entries (secretRef /

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -25,6 +25,25 @@ tls:
   # enabled and the server requires & verifies client certificates.
   caCertsSecretKey: ""
 
+# Experimental: run AG-UI server (experimental/ag-ui/server-agui.py) instead of server.py.
+# When true, the deployment serves the AG-UI endpoint at /api/agui/chat for ExampleOps-style UIs.
+experimental:
+  aguiServer:
+    enabled: false
+
+# OpenTelemetry instrumentation (env vars for opentelemetry-instrument)
+# Set otlp.endpoint to send traces to a collector
+otlp:
+  enabled: false
+  service: holmesgpt
+  metrics: "none"
+  logs: "none"
+  endpoint: "" # e.g. "http://otel-collector:4317"
+  # excludedUrls: omit for default "/healthz,/readyz"; set explicitly (including "") to override—see chart docs
+  # protocol: "grpc"       # OTLP protocol: "grpc" or "http/protobuf"
+  # insecure: "false"      # Set to "true" for plaintext
+  # headers: ""            # Optional headers as "key1=value1,key2=value2"
+
 additionalEnvVars: []
 additional_env_vars: []
 # Mirrors runner.additional_env_froms: a list of envFrom entries (secretRef /


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OpenTelemetry (OTLP) tracing for Kubernetes Helm deployments (disabled by default).
  * Experimental AG‑UI server option (disabled by default) to expose an alternate AG‑UI endpoint.

* **Documentation**
  * Added Kubernetes Helm installation docs explaining how to enable OTLP, configure OTLP options (service, endpoint, metrics, logs, protocol/auth), and example values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->