### PR TITLE
Add support for additional environment variables in Confluence MCP

### DIFF
--- a/helm/holmes/templates/mcp-servers/confluence-mcp/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/confluence-mcp/deployment.yaml
@@ -102,6 +102,9 @@ spec:
         - name: READ_ONLY_MODE
           value: "true"
         {{- end }}
+        {{- if .Values.mcpAddons.confluenceMcp.additionalEnvVars }}
+        {{- toYaml .Values.mcpAddons.confluenceMcp.additionalEnvVars | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.mcpAddons.confluenceMcp.resources | nindent 10 }}
         readinessProbe:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -624,6 +624,9 @@ mcpAddons:
 
     llmInstructions: ""
 
+    # Additional environment variables for the Confluence MCP container
+    additionalEnvVars: []
+
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
## Summary
This change adds support for injecting additional environment variables into the Confluence MCP container deployment, providing greater flexibility for configuration without requiring template modifications.

## Key Changes
- Added `additionalEnvVars` field to the Confluence MCP Helm values configuration (defaults to empty list)
- Updated the Confluence MCP deployment template to render any additional environment variables specified in the values
- Environment variables are injected after the existing READ_ONLY_MODE configuration

## Implementation Details
- The `additionalEnvVars` is implemented as a list that accepts standard Kubernetes environment variable definitions
- Uses `toYaml` with proper indentation (`nindent 8`) to maintain correct YAML formatting in the deployment spec
- Wrapped in a conditional block to only render when values are provided, maintaining clean output when not in use

https://claude.ai/code/session_013DLHJEqeYrJhiJWVoznaiQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to supply additional environment variables to the Confluence MCP container via Helm configuration. Users can now inject custom env vars to extend or customize the Confluence MCP deployment without changing probes, services, or other deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->