### PR TITLE
ROB-3465 support client secret in cli oauth flow + option to set auth callback…

### DIFF
--- a/holmes/core/oauth_config.py
+++ b/holmes/core/oauth_config.py
@@ -117,6 +117,7 @@ class OAuthEndpoints:
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     client_id: Optional[str] = None
+    client_secret: Optional[str] = None
     scopes: Optional[List[str]] = None
     registration_endpoint: Optional[str] = None
 
@@ -134,7 +135,7 @@ class MCPOAuthConfig(BaseModel):
     authorization_url: Optional[str] = Field(default=None, description="IdP authorization endpoint URL. Auto-discovered if omitted.")
     token_url: Optional[str] = Field(default=None, description="IdP token endpoint URL. Auto-discovered if omitted.")
     client_id: Optional[str] = Field(default=None, description="OAuth public client ID. Auto-registered via DCR if omitted.")
-    client_secret: Optional[str] = Field(default=None, description="OAuth client secret for confidential clients (e.g. Azure AD). Used as fallback when the frontend does not provide one.")
+    client_secret: Optional[str] = Field(default=None, description="OAuth client secret for confidential clients.")
     scopes: Optional[List[str]] = Field(default=None, description="OAuth scopes to request.")
     registration_endpoint: Optional[str] = Field(default=None, description="DCR endpoint (auto-populated during discovery, sent to frontend for client registration).")
 

--- a/holmes/core/oauth_utils.py
+++ b/holmes/core/oauth_utils.py
@@ -1,6 +1,7 @@
 """Shared OAuth utilities: token exchange, PKCE, DCR, CLI flow, and discovery."""
 
 import logging
+import os
 import secrets
 import socket
 import threading
@@ -139,7 +140,6 @@ def start_oauth_callback_server(port: int = 0) -> Tuple[Any, Dict[str, Any], thr
     """Start a local HTTP server to receive the OAuth callback.
 
     If port=0, the OS picks a free port. Returns (server, result_dict, event, actual_port).
-    Caller must call wait_for_oauth_callback_event() then server.shutdown()/server_close().
     """
     result: Dict[str, Any] = {}
     callback_event = threading.Event()
@@ -224,9 +224,14 @@ def cli_oauth_flow(oauth: OAuthEndpoints, server_name: str) -> Optional[Dict[str
         logger.warning("CLI OAuth %s: no client_id and no registration_endpoint", server_name)
         return None
 
-    # Start the callback server first (port=0 → OS picks free port, no race condition)
+    # Determine callback port: env var or ephemeral (0)
+    port = int(os.environ.get("HOLMES_OAUTH_CALLBACK_PORT", "0"))
+    if port:
+        logger.info("CLI OAuth %s: using static callback port %d (from HOLMES_OAUTH_CALLBACK_PORT)", server_name, port)
+
+    # Start the callback server (port=0 → OS picks free port, no race condition)
     try:
-        server, result_dict, callback_event, callback_port = start_oauth_callback_server(port=0)
+        server, result_dict, callback_event, callback_port = start_oauth_callback_server(port=port)
     except OSError as e:
         logger.warning("CLI OAuth %s: failed to start callback server: %s", server_name, e)
         return None
@@ -280,6 +285,7 @@ def cli_oauth_flow(oauth: OAuthEndpoints, server_name: str) -> Optional[Dict[str
             redirect_uri=redirect_uri,
             client_id=oauth.client_id,
             code_verifier=code_verifier,
+            client_secret=oauth.client_secret,
         )
     except OAuthTokenExchangeError as e:
         logger.warning("CLI OAuth %s: token exchange failed: %s", server_name, e)

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -319,6 +319,7 @@ class RemoteMCPTool(Tool):
                 authorization_url=oauth_config.authorization_url,
                 token_url=oauth_config.token_url,
                 client_id=oauth_config.client_id,
+                client_secret=oauth_config.client_secret,
                 scopes=oauth_config.scopes,
                 registration_endpoint=oauth_config.registration_endpoint,
             )


### PR DESCRIPTION
CLI oauth flow support client secret + fixed oauth callback port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth configuration now supports client credentials for confidential-client authentication flows.
  * OAuth callback port is now configurable via the `HOLMES_OAUTH_CALLBACK_PORT` environment variable (defaults to ephemeral port).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->