### PR TITLE
Add --skip-cleanup option to Supabase fixture for test debugging

### DIFF
--- a/tests/core/conversations_worker/integration/__init__.py
+++ b/tests/core/conversations_worker/integration/__init__.py
@@ -299,11 +299,13 @@ class SupabaseFixture:
 
 
 @pytest.fixture(scope="session")
-def supabase_fx() -> SupabaseFixture:
+def supabase_fx(request) -> SupabaseFixture:
     """Session-scoped Supabase client fixture.
 
     Requires ROBUSTA_UI_TOKEN and CLUSTER_NAME environment variables.
-    Performs best-effort cleanup of created conversations after the session.
+    Performs best-effort cleanup of created conversations after the session,
+    unless ``--skip-cleanup`` is passed (useful for inspecting the rows that
+    a test left behind in the DB).
     """
     decoded = _decode_token()
     cluster_id = os.environ.get("CLUSTER_NAME")
@@ -332,6 +334,15 @@ def supabase_fx() -> SupabaseFixture:
         use_pgchanges=use_pgchanges,
     )
     yield fx
+
+    if request.config.getoption("--skip-cleanup"):
+        if fx._created_conversations:
+            logging.warning(
+                "--skip-cleanup set: leaving %d conversation(s) in the DB: %s",
+                len(fx._created_conversations),
+                fx._created_conversations,
+            )
+        return
 
     # Best-effort teardown: stop any still-active conversations and delete them
     for cid in fx._created_conversations:


### PR DESCRIPTION
## Summary
Added a `--skip-cleanup` command-line option to the Supabase test fixture that allows developers to preserve test data in the database for inspection and debugging purposes.

## Key Changes
- Modified `supabase_fx()` fixture to accept `request` parameter for accessing pytest config options
- Added conditional cleanup logic that checks for `--skip-cleanup` flag before performing teardown
- When `--skip-cleanup` is enabled, the fixture logs a warning message listing the conversations left in the database instead of deleting them
- Updated fixture docstring to document the new `--skip-cleanup` option and its use case

## Implementation Details
- The fixture now uses `request.config.getoption("--skip-cleanup")` to check if the flag was passed
- If cleanup is skipped and conversations exist, a warning is logged with the count and IDs of created conversations
- The early return prevents the normal teardown logic from executing when the flag is set
- This is useful for post-test database inspection without requiring manual cleanup reversal

https://claude.ai/code/session_01Mcck4xXAkLx5qmwYSgxdde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixture to support optional cleanup skipping for debugging purposes during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->