### PR TITLE
feat(helm): add configurable deployment rollout strategy

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -10,6 +10,10 @@ spec:
   replicas: {{ .Values.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.strategy }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: holmes

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -9,6 +9,17 @@ podAnnotations: {}
 replicas: 1
 imagePullPolicy: IfNotPresent
 
+# Deployment rollout strategy.
+# Leave unset (empty) to use the Kubernetes default (RollingUpdate with maxSurge=25%, maxUnavailable=25%).
+# Set maxSurge: 0 if you need zero extra capacity during upgrades (e.g. tight resource quotas).
+# Example:
+#   strategy:
+#     type: RollingUpdate
+#     rollingUpdate:
+#       maxSurge: 0
+#       maxUnavailable: 1
+strategy: {}
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## Summary

- Adds a `strategy` field to `values.yaml` that maps directly to the Kubernetes [Deployment strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) spec
- Wires it into `templates/holmes.yaml` using a conditional block — only emitted when the value is non-empty
- Default is `{}` (empty), so **no `strategy:` block is written** and Kubernetes keeps its own defaults (`RollingUpdate`, `maxSurge=25%`, `maxUnavailable=25%`). Existing users are completely unaffected.

## Motivation

Some environments have tight resource quotas that cannot accommodate an extra Holmes pod during a rolling upgrade. Setting `maxSurge: 0` tells Kubernetes to terminate the old pod before starting the new one, keeping the total pod count at `replicas` throughout the rollout (at the cost of a brief downtime window).

## Usage

```yaml
# values.yaml override — zero surge, one unavailable
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 1
```

## Test plan

- [x] `helm template` with default values → no `strategy:` block in rendered Deployment
- [x] `helm template --set strategy.type=RollingUpdate --set strategy.rollingUpdate.maxSurge=0 --set strategy.rollingUpdate.maxUnavailable=1` → correct block rendered at the right position in `spec:`
- [x] `helm lint helm/holmes` → 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Kubernetes Deployment rollout strategy configuration to the Holmes Helm chart, allowing users to customize deployment rollout behavior while maintaining Kubernetes defaults when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->