### PR TITLE
Add per-toolset prerequisite timeout to prevent startup hangs

### DIFF
--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -775,6 +775,11 @@ class Toolset(BaseModel):
     _initialized: bool = PrivateAttr(default=True)
     _init_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
+    # Set by the prerequisite-check timeout handler to tell a still-running
+    # background worker to stop mutating self.status / self.error after the
+    # main thread has already marked this toolset FAILED.
+    _prereq_aborted: bool = PrivateAttr(default=False)
+
     # status fields that be cached
     type: Optional[ToolsetType] = None
     path: Optional[FilePath] = None
@@ -917,7 +922,9 @@ class Toolset(BaseModel):
         return self.config is None
 
     def check_prerequisites(self, silent: bool = False):
-        self.status = ToolsetStatusEnum.ENABLED
+        if self._prereq_aborted:
+            # Timeout handler has already finalized status; don't touch it.
+            return
 
         # Sort prerequisites by type to fail fast on missing env vars before
         # running slow commands (e.g., ArgoCD checks that timeout):
@@ -927,7 +934,15 @@ class Toolset(BaseModel):
         # 4. Command checks (slowest - may timeout or hang)
         sorted_prereqs = sorted(self.prerequisites, key=_prereq_priority)
 
+        # Accumulate results in locals so we can commit atomically at the end
+        # — a concurrent timeout-handler may declare this toolset FAILED while
+        # we're mid-check, and we must not overwrite that decision.
+        local_status: ToolsetStatusEnum = ToolsetStatusEnum.ENABLED
+        local_error: Optional[str] = None
+
         for prereq in sorted_prereqs:
+            if self._prereq_aborted:
+                return
             if isinstance(prereq, ToolsetCommandPrerequisite):
                 try:
                     command = self.interpolate_command(prereq.command)
@@ -943,47 +958,53 @@ class Toolset(BaseModel):
                         prereq.expected_output
                         and prereq.expected_output not in result.stdout
                     ):
-                        self.status = ToolsetStatusEnum.FAILED
-                        self.error = f"`{prereq.command}` did not include `{prereq.expected_output}`"
+                        local_status = ToolsetStatusEnum.FAILED
+                        local_error = f"`{prereq.command}` did not include `{prereq.expected_output}`"
                 except subprocess.CalledProcessError as e:
-                    self.status = ToolsetStatusEnum.FAILED
+                    local_status = ToolsetStatusEnum.FAILED
                     stderr = (e.stderr or "").strip()
                     detail = f": {stderr}" if stderr else ""
-                    self.error = (
+                    local_error = (
                         f"`{prereq.command}` failed with exit code {e.returncode}{detail}"
                     )
 
             elif isinstance(prereq, ToolsetEnvironmentPrerequisite):
                 for env_var in prereq.env:
                     if env_var not in os.environ:
-                        self.status = ToolsetStatusEnum.FAILED
-                        self.error = f"Environment variable {env_var} was not set"
+                        local_status = ToolsetStatusEnum.FAILED
+                        local_error = f"Environment variable {env_var} was not set"
 
             elif isinstance(prereq, StaticPrerequisite):
                 if not prereq.enabled:
-                    self.status = ToolsetStatusEnum.FAILED
-                    self.error = f"{prereq.disabled_reason}"
+                    local_status = ToolsetStatusEnum.FAILED
+                    local_error = f"{prereq.disabled_reason}"
 
             elif isinstance(prereq, CallablePrerequisite):
                 try:
                     (enabled, error_message) = prereq.callable(self.config or {})
                     if not enabled:
-                        self.status = ToolsetStatusEnum.FAILED
+                        local_status = ToolsetStatusEnum.FAILED
                     if error_message:
-                        self.error = f"{error_message}"
+                        local_error = f"{error_message}"
                 except Exception as e:
                     logger.exception(f"Toolset {self.name} prerequisite check failed")
-                    self.status = ToolsetStatusEnum.FAILED
-                    self.error = f"Prerequisite call failed unexpectedly: {str(e)}"
+                    local_status = ToolsetStatusEnum.FAILED
+                    local_error = f"Prerequisite call failed unexpectedly: {str(e)}"
 
-            if (
-                self.status == ToolsetStatusEnum.DISABLED
-                or self.status == ToolsetStatusEnum.FAILED
-            ):
-                if not silent:
-                    display_logger.info(f"❌ Toolset {self.name}: {self.error}")
+            if local_status in (ToolsetStatusEnum.DISABLED, ToolsetStatusEnum.FAILED):
                 # no point checking further prerequisites if one failed
-                return
+                break
+
+        if self._prereq_aborted:
+            # Timeout handler claimed this toolset while we were running; honor it.
+            return
+
+        self.status = local_status
+        self.error = local_error
+        if local_status in (ToolsetStatusEnum.DISABLED, ToolsetStatusEnum.FAILED):
+            if not silent:
+                display_logger.info(f"❌ Toolset {self.name}: {self.error}")
+            return
 
         if not silent:
             display_logger.info(f"✅ Toolset {self.name}")

--- a/holmes/core/toolset_manager.py
+++ b/holmes/core/toolset_manager.py
@@ -2,10 +2,33 @@ import concurrent.futures
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 display_logger = logging.getLogger("holmes.display.toolset_manager")
+
+# Default per-prerequisite-check timeout. Datasources that fail to respond
+# within this many seconds are marked failed so startup can proceed.
+# Override with the HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS env var.
+DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS = 20.0
+
+
+def _get_prereq_timeout_seconds() -> float:
+    raw = os.environ.get("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS")
+    if not raw:
+        return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        logging.warning(
+            f"Invalid HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS={raw!r}; "
+            f"falling back to {DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS}s"
+        )
+        return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+    if value <= 0:
+        return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+    return value
 
 from benedict import benedict
 from pydantic import FilePath
@@ -203,25 +226,77 @@ class ToolsetManager:
         toolsets: list[Toolset],
         silent: bool = False,
         on_event: EventCallback = None,
+        timeout_seconds: Optional[float] = None,
     ):
-        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-            future_to_toolset = {}
+        """Run prerequisite checks for each toolset in parallel with a timeout.
+
+        Toolsets whose checks don't return within ``timeout_seconds`` are
+        marked FAILED so a hung datasource can't block startup. The timeout
+        defaults to ``HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS`` (or 20s).
+        Background threads for stuck checks are not forcibly killed — the
+        executor is shut down without waiting so they unblock when (or if)
+        the underlying call returns.
+        """
+        if timeout_seconds is None:
+            timeout_seconds = _get_prereq_timeout_seconds()
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        try:
+            future_to_toolset: dict[concurrent.futures.Future, Toolset] = {}
             for toolset in toolsets:
                 if on_event is not None:
                     on_event(StatusEvent(kind=StatusEventKind.TOOLSET_CHECKING, name=toolset.name))
                 future_to_toolset[executor.submit(toolset.check_prerequisites, silent)] = toolset
 
-            for future in concurrent.futures.as_completed(future_to_toolset):
-                if on_event is not None:
+            deadline = time.monotonic() + timeout_seconds
+            pending = set(future_to_toolset.keys())
+            while pending:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                done, pending = concurrent.futures.wait(
+                    pending,
+                    timeout=remaining,
+                    return_when=concurrent.futures.FIRST_COMPLETED,
+                )
+                if not done:
+                    break
+                for future in done:
                     ts = future_to_toolset[future]
+                    if on_event is not None:
+                        on_event(
+                            StatusEvent(
+                                kind=StatusEventKind.TOOLSET_READY,
+                                name=ts.name,
+                                status=ToolsetStatus(ts.status.value),
+                                error=ts.error or "",
+                            )
+                        )
+
+            for future in pending:
+                ts = future_to_toolset[future]
+                ts.status = ToolsetStatusEnum.FAILED
+                ts.error = (
+                    f"Prerequisite check did not complete within "
+                    f"{timeout_seconds:g}s (datasource unreachable or too slow). "
+                    f"Increase the limit with HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS."
+                )
+                future.cancel()
+                if not silent:
+                    display_logger.warning(
+                        f"⏱  Toolset {ts.name}: timed out after {timeout_seconds:g}s"
+                    )
+                if on_event is not None:
                     on_event(
                         StatusEvent(
                             kind=StatusEventKind.TOOLSET_READY,
                             name=ts.name,
-                            status=ToolsetStatus(ts.status.value),
-                            error=ts.error or "",
+                            status=ToolsetStatus.FAILED,
+                            error=ts.error,
                         )
                     )
+        finally:
+            executor.shutdown(wait=False)
 
     @staticmethod
     def _check_config_prerequisites(toolsets: list[Toolset]) -> None:

--- a/holmes/core/toolset_manager.py
+++ b/holmes/core/toolset_manager.py
@@ -6,6 +6,20 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
+from benedict import benedict
+from pydantic import FilePath
+
+from holmes.core.config import config_path_dir
+from holmes.core.init_event import EventCallback, StatusEvent, StatusEventKind, ToolsetStatus
+from holmes.core.supabase_dal import SupabaseDal
+from holmes.core.tools import PrerequisiteCacheMode, Toolset, ToolsetStatusEnum, ToolsetTag, ToolsetType
+from holmes.plugins.toolsets import load_builtin_toolsets, load_toolsets_from_config
+from holmes.utils.config_hash import check_and_update_config_hashes
+from holmes.utils.definitions import CUSTOM_TOOLSET_LOCATION
+
+if TYPE_CHECKING:
+    pass
+
 display_logger = logging.getLogger("holmes.display.toolset_manager")
 
 # Default per-prerequisite-check timeout. Datasources that fail to respond
@@ -14,7 +28,8 @@ display_logger = logging.getLogger("holmes.display.toolset_manager")
 DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS = 20.0
 
 
-def _get_prereq_timeout_seconds() -> float:
+def get_prereq_timeout_seconds() -> float:
+    """Resolve the prerequisite-check timeout from env or fall back to default."""
     raw = os.environ.get("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS")
     if not raw:
         return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
@@ -30,19 +45,6 @@ def _get_prereq_timeout_seconds() -> float:
         return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
     return value
 
-from benedict import benedict
-from pydantic import FilePath
-
-from holmes.core.config import config_path_dir
-from holmes.core.init_event import EventCallback, StatusEvent, StatusEventKind, ToolsetStatus
-from holmes.core.supabase_dal import SupabaseDal
-from holmes.core.tools import PrerequisiteCacheMode, Toolset, ToolsetStatusEnum, ToolsetTag, ToolsetType
-from holmes.plugins.toolsets import load_builtin_toolsets, load_toolsets_from_config
-from holmes.utils.config_hash import check_and_update_config_hashes
-from holmes.utils.definitions import CUSTOM_TOOLSET_LOCATION
-
-if TYPE_CHECKING:
-    pass
 
 DEFAULT_TOOLSET_STATUS_LOCATION = os.path.join(config_path_dir, "toolsets_status.json")
 
@@ -238,7 +240,7 @@ class ToolsetManager:
         the underlying call returns.
         """
         if timeout_seconds is None:
-            timeout_seconds = _get_prereq_timeout_seconds()
+            timeout_seconds = get_prereq_timeout_seconds()
 
         if not toolsets:
             return
@@ -284,7 +286,7 @@ class ToolsetManager:
                     # otherwise leave ts in a stale state.
                     try:
                         future.result()
-                    except BaseException as exc:  # noqa: BLE001
+                    except Exception as exc:
                         logging.exception(
                             "Toolset %s prerequisite worker crashed", ts.name
                         )

--- a/holmes/core/toolset_manager.py
+++ b/holmes/core/toolset_manager.py
@@ -278,6 +278,18 @@ class ToolsetManager:
                     break
                 for future in done:
                     ts = future_to_toolset[future]
+                    # Surface unexpected exceptions from the worker —
+                    # check_prerequisites catches the common ones, but a
+                    # crash in interpolate_command, subprocess, etc. would
+                    # otherwise leave ts in a stale state.
+                    try:
+                        future.result()
+                    except BaseException as exc:  # noqa: BLE001
+                        logging.exception(
+                            "Toolset %s prerequisite worker crashed", ts.name
+                        )
+                        ts.status = ToolsetStatusEnum.FAILED
+                        ts.error = f"Prerequisite check failed unexpectedly: {exc!s}"
                     if on_event is not None:
                         on_event(
                             StatusEvent(

--- a/holmes/core/toolset_manager.py
+++ b/holmes/core/toolset_manager.py
@@ -42,6 +42,10 @@ def get_prereq_timeout_seconds() -> float:
         )
         return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
     if value <= 0:
+        logging.warning(
+            f"HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS={raw!r} is non-positive; "
+            f"falling back to {DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS}s"
+        )
         return DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
     return value
 
@@ -235,9 +239,16 @@ class ToolsetManager:
         Toolsets whose checks don't return within ``timeout_seconds`` are
         marked FAILED so a hung datasource can't block startup. The timeout
         defaults to ``HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS`` (or 20s).
-        Background threads for stuck checks are not forcibly killed — the
-        executor is shut down without waiting so they unblock when (or if)
-        the underlying call returns.
+
+        Note: the timeout bounds *reporting latency*, not worker lifetime.
+        Python cannot interrupt a thread blocked in C code (e.g.
+        ``subprocess.run`` without its own ``timeout=``, a socket connect
+        with no timeout). ``executor.shutdown(wait=False)`` lets us return
+        early, but the interpreter's atexit handler still joins all pool
+        threads on process exit, so a permanently stuck worker delays
+        shutdown. ``_prereq_aborted`` only stops the worker between
+        prerequisites, not mid-call. Toolset authors should set explicit
+        timeouts on the I/O calls they make from prerequisite callables.
         """
         if timeout_seconds is None:
             timeout_seconds = get_prereq_timeout_seconds()

--- a/holmes/core/toolset_manager.py
+++ b/holmes/core/toolset_manager.py
@@ -240,7 +240,19 @@ class ToolsetManager:
         if timeout_seconds is None:
             timeout_seconds = _get_prereq_timeout_seconds()
 
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        if not toolsets:
+            return
+
+        # Size the pool to the batch so no toolset has to wait in the queue.
+        # A queued toolset would inherit whatever time is left on the deadline
+        # and could be reported as "timed out" without ever having run.
+        max_workers = max(1, len(toolsets))
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+        # Reset any abort flag from a previous call so we don't no-op the check.
+        for toolset in toolsets:
+            toolset._prereq_aborted = False
+
         try:
             future_to_toolset: dict[concurrent.futures.Future, Toolset] = {}
             for toolset in toolsets:
@@ -248,6 +260,9 @@ class ToolsetManager:
                     on_event(StatusEvent(kind=StatusEventKind.TOOLSET_CHECKING, name=toolset.name))
                 future_to_toolset[executor.submit(toolset.check_prerequisites, silent)] = toolset
 
+            # Single deadline shared across the batch. With max_workers ==
+            # len(toolsets) every check starts immediately, so this functions
+            # as a per-toolset wall-clock budget too.
             deadline = time.monotonic() + timeout_seconds
             pending = set(future_to_toolset.keys())
             while pending:
@@ -275,6 +290,11 @@ class ToolsetManager:
 
             for future in pending:
                 ts = future_to_toolset[future]
+                # Tell the still-running worker to stop mutating ts.status /
+                # ts.error before we write our own FAILED state. Toolset.
+                # check_prerequisites accumulates results in locals and only
+                # commits once at the end after re-checking this flag.
+                ts._prereq_aborted = True
                 ts.status = ToolsetStatusEnum.FAILED
                 ts.error = (
                     f"Prerequisite check did not complete within "

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -51,7 +51,7 @@ from rich.text import Text
 from holmes.config import Config
 from holmes.core.config import config_path_dir
 from holmes.core.init_event import StatusEvent, StatusEventKind, ToolsetStatus
-from holmes.core.toolset_manager import _get_prereq_timeout_seconds
+from holmes.core.toolset_manager import get_prereq_timeout_seconds
 from holmes.core.feedback import (
     PRIVACY_NOTICE_BANNER,
     Feedback,
@@ -176,7 +176,7 @@ class InitProgressRenderer:
         self._timer_stop = threading.Event()
         # Read once — _build_display() runs every frame, and the env-var
         # parser also logs a warning when the value is invalid.
-        self._prereq_timeout_secs = _get_prereq_timeout_seconds()
+        self._prereq_timeout_secs = get_prereq_timeout_seconds()
 
     def _build_display(self) -> "Text":
         """Build the Rich renderable for the current state."""

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -214,10 +214,13 @@ class InitProgressRenderer:
         # Color escalates as the duration approaches the prerequisite timeout
         # so the user can see at a glance which datasource is the culprit.
         timeout_secs = self._prereq_timeout_secs
+        # Scale the "show as slow" threshold so it fires before the timeout
+        # even when HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS is set very low.
+        slow_threshold = min(_SLOW_THRESHOLD_SECS, timeout_secs * 0.5)
         slow: List[tuple[str, float]] = []
         for name, started_at in self._in_flight.items():
             duration = now - started_at
-            if duration >= _SLOW_THRESHOLD_SECS:
+            if duration >= slow_threshold:
                 slow.append((name, duration))
         if slow:
             slow.sort(key=lambda x: -x[1])  # longest first

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -174,6 +174,9 @@ class InitProgressRenderer:
         self._start_time: float = 0.0
         self._live: Optional[Any] = None  # Rich Live
         self._timer_stop = threading.Event()
+        # Read once — _build_display() runs every frame, and the env-var
+        # parser also logs a warning when the value is invalid.
+        self._prereq_timeout_secs = _get_prereq_timeout_seconds()
 
     def _build_display(self) -> "Text":
         """Build the Rich renderable for the current state."""
@@ -210,7 +213,7 @@ class InitProgressRenderer:
         # Show in-flight toolsets that are taking more than 1 second.
         # Color escalates as the duration approaches the prerequisite timeout
         # so the user can see at a glance which datasource is the culprit.
-        timeout_secs = _get_prereq_timeout_seconds()
+        timeout_secs = self._prereq_timeout_secs
         slow: List[tuple[str, float]] = []
         for name, started_at in self._in_flight.items():
             duration = now - started_at

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -51,6 +51,7 @@ from rich.text import Text
 from holmes.config import Config
 from holmes.core.config import config_path_dir
 from holmes.core.init_event import StatusEvent, StatusEventKind, ToolsetStatus
+from holmes.core.toolset_manager import _get_prereq_timeout_seconds
 from holmes.core.feedback import (
     PRIVACY_NOTICE_BANNER,
     Feedback,
@@ -206,7 +207,10 @@ class InitProgressRenderer:
             display.append("\n  ")
             display.append(f"  ready: {names}", style="green")
 
-        # Show in-flight toolsets that are taking more than 1 second
+        # Show in-flight toolsets that are taking more than 1 second.
+        # Color escalates as the duration approaches the prerequisite timeout
+        # so the user can see at a glance which datasource is the culprit.
+        timeout_secs = _get_prereq_timeout_seconds()
         slow: List[tuple[str, float]] = []
         for name, started_at in self._in_flight.items():
             duration = now - started_at
@@ -214,9 +218,18 @@ class InitProgressRenderer:
                 slow.append((name, duration))
         if slow:
             slow.sort(key=lambda x: -x[1])  # longest first
-            parts = [f"{name} ({dur:.0f}s)" for name, dur in slow]
             display.append("\n  ")
-            display.append(f"  checking: {', '.join(parts)}", style="yellow")
+            display.append("  checking: ", style="yellow")
+            for i, (name, dur) in enumerate(slow):
+                if i > 0:
+                    display.append(", ", style="yellow")
+                if dur >= timeout_secs:
+                    style = "bold red"
+                elif dur >= timeout_secs * 0.5:
+                    style = "bold yellow"
+                else:
+                    style = "yellow"
+                display.append(f"{name} ({dur:.0f}s)", style=style)
 
         if self._toolsets_failed:
             failed_names = ", ".join(name for name, _ in self._toolsets_failed[-4:])

--- a/tests/test_toolset_prereq_timeout.py
+++ b/tests/test_toolset_prereq_timeout.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from holmes.core import toolset_manager as tm
 from holmes.core.init_event import StatusEvent, StatusEventKind, ToolsetStatus
 from holmes.core.tools import (
     CallablePrerequisite,
@@ -115,10 +116,40 @@ def test_check_toolset_prerequisites_no_timeout_when_all_fast():
     assert all(e.status == ToolsetStatus.ENABLED for e in ready_events)
 
 
+def test_late_completion_does_not_overwrite_failed_status():
+    """A worker that finishes after the timeout must not flip the toolset back to ENABLED."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_then_succeed(_config: Dict[str, Any]) -> Tuple[bool, str]:
+        started.set()
+        # Wait for the timeout handler to mark us FAILED and set _prereq_aborted.
+        release.wait(timeout=5)
+        return True, ""
+
+    ts = _make_toolset("eventually_ok", slow_then_succeed)
+
+    try:
+        ToolsetManager.check_toolset_prerequisites(
+            [ts],
+            silent=True,
+            timeout_seconds=0.3,
+        )
+        # The worker is still running; let it finish so it tries to commit.
+        assert started.wait(timeout=2)
+        assert ts.status == ToolsetStatusEnum.FAILED
+        release.set()
+        # Give the worker a moment to attempt its commit.
+        time.sleep(0.2)
+        # Status must remain FAILED; the abort guard blocks the late write.
+        assert ts.status == ToolsetStatusEnum.FAILED
+        assert ts.error and "did not complete" in ts.error
+    finally:
+        release.set()
+
+
 def test_default_timeout_picked_up_from_env(monkeypatch):
     """The timeout default is read from HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS."""
-    from holmes.core import toolset_manager as tm
-
     monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "7.5")
     assert tm._get_prereq_timeout_seconds() == pytest.approx(7.5)
 

--- a/tests/test_toolset_prereq_timeout.py
+++ b/tests/test_toolset_prereq_timeout.py
@@ -116,6 +116,30 @@ def test_check_toolset_prerequisites_no_timeout_when_all_fast():
     assert all(e.status == ToolsetStatus.ENABLED for e in ready_events)
 
 
+def test_worker_exception_is_surfaced_as_failed():
+    """An unexpected exception from check_prerequisites is reported as FAILED."""
+    from unittest.mock import patch
+
+    fast = _make_toolset("a", lambda c: (True, ""))
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("kaboom")
+
+    events: List[StatusEvent] = []
+    with patch.object(type(fast), "check_prerequisites", boom):
+        ToolsetManager.check_toolset_prerequisites(
+            [fast],
+            silent=True,
+            on_event=events.append,
+            timeout_seconds=2.0,
+        )
+
+    assert fast.status == ToolsetStatusEnum.FAILED
+    assert "kaboom" in (fast.error or "")
+    ready = [e for e in events if e.kind == StatusEventKind.TOOLSET_READY]
+    assert ready and ready[0].status == ToolsetStatus.FAILED
+
+
 def test_late_completion_does_not_overwrite_failed_status():
     """A worker that finishes after the timeout must not flip the toolset back to ENABLED."""
     started = threading.Event()

--- a/tests/test_toolset_prereq_timeout.py
+++ b/tests/test_toolset_prereq_timeout.py
@@ -1,0 +1,132 @@
+"""Tests for the per-toolset prerequisite timeout in ToolsetManager."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from holmes.core.init_event import StatusEvent, StatusEventKind, ToolsetStatus
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    Tool,
+    Toolset,
+    ToolsetStatusEnum,
+)
+from holmes.core.toolset_manager import ToolsetManager
+
+
+class _NoopTool(Tool):
+    name: str = "noop"
+    description: str = "noop"
+
+    def _invoke(self, params: dict, user_approved: bool = False) -> StructuredToolResult:  # noqa: D401
+        return None  # type: ignore[return-value]
+
+    def get_parameterized_one_liner(self, params: Dict) -> str:
+        return ""
+
+
+class _SampleToolset(Toolset):
+    name: str = "sample"
+    description: str = "sample"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tools: List[Tool] = [_NoopTool()]
+
+
+def _make_toolset(name: str, prereq_callable) -> Toolset:
+    ts = _SampleToolset(
+        prerequisites=[CallablePrerequisite(callable=prereq_callable)],
+        config={},
+    )
+    ts.name = name
+    return ts
+
+
+def test_check_toolset_prerequisites_marks_slow_toolsets_failed():
+    """Toolsets that exceed the timeout are marked FAILED with a clear error."""
+    release = threading.Event()
+
+    def slow_callable(_config: Dict[str, Any]) -> Tuple[bool, str]:
+        # Block far longer than the test timeout. The executor is shut down
+        # without waiting, so we release the gate at end of test.
+        release.wait(timeout=10)
+        return True, ""
+
+    def fast_callable(_config: Dict[str, Any]) -> Tuple[bool, str]:
+        return True, ""
+
+    slow = _make_toolset("slow_ds", slow_callable)
+    fast = _make_toolset("fast_ds", fast_callable)
+
+    events: List[StatusEvent] = []
+
+    try:
+        start = time.monotonic()
+        ToolsetManager.check_toolset_prerequisites(
+            [slow, fast],
+            silent=True,
+            on_event=events.append,
+            timeout_seconds=0.5,
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 5.0, f"timeout was not enforced (took {elapsed:.2f}s)"
+
+        assert fast.status == ToolsetStatusEnum.ENABLED
+        assert slow.status == ToolsetStatusEnum.FAILED
+        assert "0.5s" in (slow.error or "")
+        assert "HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS" in (slow.error or "")
+
+        ready_events = {e.name: e for e in events if e.kind == StatusEventKind.TOOLSET_READY}
+        assert ready_events["fast_ds"].status == ToolsetStatus.ENABLED
+        assert ready_events["slow_ds"].status == ToolsetStatus.FAILED
+    finally:
+        release.set()
+
+
+def test_check_toolset_prerequisites_no_timeout_when_all_fast():
+    """All toolsets complete normally when none exceed the timeout."""
+
+    def fast_callable(_config: Dict[str, Any]) -> Tuple[bool, str]:
+        return True, ""
+
+    a = _make_toolset("a", fast_callable)
+    b = _make_toolset("b", fast_callable)
+
+    events: List[StatusEvent] = []
+    ToolsetManager.check_toolset_prerequisites(
+        [a, b],
+        silent=True,
+        on_event=events.append,
+        timeout_seconds=5.0,
+    )
+
+    assert a.status == ToolsetStatusEnum.ENABLED
+    assert b.status == ToolsetStatusEnum.ENABLED
+
+    ready_events = [e for e in events if e.kind == StatusEventKind.TOOLSET_READY]
+    assert {e.name for e in ready_events} == {"a", "b"}
+    assert all(e.status == ToolsetStatus.ENABLED for e in ready_events)
+
+
+def test_default_timeout_picked_up_from_env(monkeypatch):
+    """The timeout default is read from HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS."""
+    from holmes.core import toolset_manager as tm
+
+    monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "7.5")
+    assert tm._get_prereq_timeout_seconds() == pytest.approx(7.5)
+
+    monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "not-a-number")
+    assert tm._get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+
+    monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "0")
+    assert tm._get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+
+    monkeypatch.delenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", raising=False)
+    assert tm._get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS

--- a/tests/test_toolset_prereq_timeout.py
+++ b/tests/test_toolset_prereq_timeout.py
@@ -144,12 +144,16 @@ def test_late_completion_does_not_overwrite_failed_status():
     """A worker that finishes after the timeout must not flip the toolset back to ENABLED."""
     started = threading.Event()
     release = threading.Event()
+    finished = threading.Event()
 
     def slow_then_succeed(_config: Dict[str, Any]) -> Tuple[bool, str]:
         started.set()
         # Wait for the timeout handler to mark us FAILED and set _prereq_aborted.
         release.wait(timeout=5)
-        return True, ""
+        try:
+            return True, ""
+        finally:
+            finished.set()
 
     ts = _make_toolset("eventually_ok", slow_then_succeed)
 
@@ -163,8 +167,11 @@ def test_late_completion_does_not_overwrite_failed_status():
         assert started.wait(timeout=2)
         assert ts.status == ToolsetStatusEnum.FAILED
         release.set()
-        # Give the worker a moment to attempt its commit.
-        time.sleep(0.2)
+        # Block until the worker has actually returned, instead of sleeping.
+        # check_prerequisites runs after the callable returns and re-checks
+        # the abort flag before any commit, so once `finished` is set we know
+        # the post-release write window has elapsed.
+        assert finished.wait(timeout=5), "worker did not return after release"
         # Status must remain FAILED; the abort guard blocks the late write.
         assert ts.status == ToolsetStatusEnum.FAILED
         assert ts.error and "did not complete" in ts.error
@@ -175,13 +182,13 @@ def test_late_completion_does_not_overwrite_failed_status():
 def test_default_timeout_picked_up_from_env(monkeypatch):
     """The timeout default is read from HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS."""
     monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "7.5")
-    assert tm._get_prereq_timeout_seconds() == pytest.approx(7.5)
+    assert tm.get_prereq_timeout_seconds() == pytest.approx(7.5)
 
     monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "not-a-number")
-    assert tm._get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+    assert tm.get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
 
     monkeypatch.setenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", "0")
-    assert tm._get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+    assert tm.get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
 
     monkeypatch.delenv("HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS", raising=False)
-    assert tm._get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS
+    assert tm.get_prereq_timeout_seconds() == tm.DEFAULT_TOOLSET_PREREQ_TIMEOUT_SECONDS

--- a/tests/test_toolset_prereq_timeout.py
+++ b/tests/test_toolset_prereq_timeout.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 import time
 from typing import Any, Dict, List, Tuple
+from unittest.mock import patch
 
 import pytest
 
@@ -118,8 +119,6 @@ def test_check_toolset_prerequisites_no_timeout_when_all_fast():
 
 def test_worker_exception_is_surfaced_as_failed():
     """An unexpected exception from check_prerequisites is reported as FAILED."""
-    from unittest.mock import patch
-
     fast = _make_toolset("a", lambda c: (True, ""))
 
     def boom(*_a, **_kw):
@@ -158,13 +157,15 @@ def test_late_completion_does_not_overwrite_failed_status():
     ts = _make_toolset("eventually_ok", slow_then_succeed)
 
     try:
+        # 1.0s gives the worker thread comfortable headroom to enter the
+        # callable on slow CI runners before the timeout handler fires.
         ToolsetManager.check_toolset_prerequisites(
             [ts],
             silent=True,
-            timeout_seconds=0.3,
+            timeout_seconds=1.0,
         )
         # The worker is still running; let it finish so it tries to commit.
-        assert started.wait(timeout=2)
+        assert started.wait(timeout=5), "worker never entered the callable"
         assert ts.status == ToolsetStatusEnum.FAILED
         release.set()
         # Block until the worker has actually returned, instead of sleeping.


### PR DESCRIPTION
## Summary
This PR adds a configurable timeout mechanism to toolset prerequisite checks to prevent hung datasources from blocking application startup. Toolsets that don't complete their prerequisite checks within the timeout are marked as FAILED with a clear error message.

## Key Changes
- **Timeout enforcement**: Added `timeout_seconds` parameter to `check_toolset_prerequisites()` with a default of 20 seconds (configurable via `HOLMES_TOOLSET_PREREQ_TIMEOUT_SECONDS` environment variable)
- **Graceful failure handling**: Toolsets exceeding the timeout are marked FAILED with an informative error message directing users to the environment variable for adjustment
- **Improved executor management**: Changed from context manager to explicit `shutdown(wait=False)` to allow background threads to continue without blocking
- **Better event handling**: Separated handling of completed vs. timed-out toolsets with appropriate status events
- **Enhanced UI feedback**: Updated the interactive display to show color-coded warnings as toolset checks approach the timeout threshold (yellow at 50%, bold red at 100%)
- **Environment variable support**: Added `_get_prereq_timeout_seconds()` helper function with validation and fallback to defaults

## Implementation Details
- Uses `concurrent.futures.wait()` with deadline tracking instead of `as_completed()` to enforce the timeout
- Timed-out futures are cancelled but background threads are not forcibly killed, allowing graceful cleanup
- The timeout is applied per-batch of toolsets, not per-individual toolset
- Invalid or zero values in the environment variable fall back to the default 20-second timeout
- Display escalates visual warnings as duration approaches the timeout to help users identify problematic datasources

https://claude.ai/code/session_01LyUnxrmPua5YaUqPbrHFnb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prerequisite checks now enforce a configurable per-toolset timeout; slow checks are highlighted in the progress display with color-coded durations.
  * Timeout can be set via environment variable with validation and a sensible default.

* **Bug Fixes**
  * Timed-out checks are cancelled and affected toolsets are marked FAILED with clear ready events and warnings.

* **Tests**
  * New tests cover timeout behavior, env-driven configuration, and emitted status events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->