### PR TITLE
fix(http-toolset): reject path-traversal segments in endpoint whitelist (CWE-918/CWE-22)

### DIFF
--- a/holmes/plugins/toolsets/http/http_toolset.py
+++ b/holmes/plugins/toolsets/http/http_toolset.py
@@ -2,8 +2,9 @@ import fnmatch
 import json
 import logging
 import os
+import posixpath
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Type
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import requests  # type: ignore
 from pydantic import BaseModel, Field, model_validator
@@ -330,16 +331,39 @@ class HttpToolset(Toolset):
         except Exception as e:
             return None, f"Invalid URL: {e}"
 
-        if not parsed.scheme or not parsed.netloc:
+        if parsed.scheme.lower() not in ("http", "https"):
+            return None, f"Unsupported URL scheme: {parsed.scheme!r}"
+
+        if not parsed.netloc:
             return None, f"Invalid URL format: {url}"
 
         host = parsed.hostname or parsed.netloc
         path = parsed.path or "/"
 
+        # Reject path-traversal segments. urllib3/requests normalise ".." in
+        # the URL before sending, which would otherwise let an LLM-supplied
+        # URL escape the configured path whitelist (CWE-22 / CWE-918).
+        # Check both the raw and percent-decoded path so encodings like
+        # "%2e%2e" cannot bypass the check.
+        for candidate in (path, unquote(path)):
+            segments = candidate.split("/")
+            if any(seg in ("..", ".") for seg in segments):
+                return (
+                    None,
+                    "URL rejected: path contains '.' or '..' traversal segments. "
+                    "Use a fully-resolved path that matches the configured whitelist.",
+                )
+
+        # Normalise the path for matching so that benign duplicate slashes
+        # behave as expected without changing semantics.
+        normalised_path = posixpath.normpath(path)
+        if path.endswith("/") and not normalised_path.endswith("/"):
+            normalised_path += "/"
+
         for endpoint in self.http_config.endpoints:
             for host_pattern in endpoint.hosts:
                 if self._match_host(host, host_pattern):
-                    if self._match_path(path, endpoint.paths):
+                    if self._match_path(normalised_path, endpoint.paths):
                         return endpoint, None
 
         return (

--- a/tests/plugins/toolsets/http/test_http_toolset.py
+++ b/tests/plugins/toolsets/http/test_http_toolset.py
@@ -158,6 +158,36 @@ class TestHttpToolsetHostMatching:
         assert "api.github.com" in endpoint.hosts
 
 
+    def test_path_traversal_dotdot_rejected(self, toolset):
+        # CWE-22 / CWE-918: '..' in path must not bypass the whitelist;
+        # urllib3 normalises '..' before sending.
+        endpoint, error = toolset.match_endpoint(
+            "https://example.com/api/../admin"
+        )
+        assert endpoint is None
+        assert error is not None and "traversal" in error
+
+    def test_path_traversal_encoded_rejected(self, toolset):
+        endpoint, error = toolset.match_endpoint(
+            "https://example.com/api/%2e%2e/admin"
+        )
+        assert endpoint is None
+        assert error is not None and "traversal" in error
+
+    def test_path_single_dot_segment_rejected(self, toolset):
+        endpoint, error = toolset.match_endpoint(
+            "https://example.com/api/./users"
+        )
+        assert endpoint is None
+        assert error is not None and "traversal" in error
+
+    def test_non_http_scheme_rejected(self, toolset):
+        # file:// and similar schemes must not be honoured by the HTTP toolset.
+        endpoint, error = toolset.match_endpoint("file:///etc/passwd")
+        assert endpoint is None
+        assert error is not None
+
+
 class TestHttpToolsetMethodCheck:
     @pytest.fixture
     def toolset(self):

--- a/tests/plugins/toolsets/http/test_http_toolset.py
+++ b/tests/plugins/toolsets/http/test_http_toolset.py
@@ -186,6 +186,7 @@ class TestHttpToolsetHostMatching:
         endpoint, error = toolset.match_endpoint("file:///etc/passwd")
         assert endpoint is None
         assert error is not None
+        assert "Unsupported URL scheme" in error
 
 
 class TestHttpToolsetMethodCheck:


### PR DESCRIPTION
## Summary

The HTTP toolset's endpoint whitelist (`HttpToolset.match_endpoint` in `holmes/plugins/toolsets/http/http_toolset.py`) matches the URL path with `fnmatch` against the configured `paths` patterns *before* the URL is normalised. However, `urllib3`/`requests` resolve `..` and `.` segments while preparing the request, so a URL that passes the whitelist can hit a completely different path on the wire.

This means an attacker who can influence the LLM (e.g. via prompt-injection content in alerts, issue descriptions, or logs that HolmesGPT investigates) can cause the toolset to issue requests against paths on the configured host that the operator never intended to expose — for example reaching `/admin/...` on a host that was only whitelisted for `/wiki/rest/api/*`.

- **CWE:** CWE-918 (SSRF) / CWE-22 (Path Traversal in validator)
- **File:** `holmes/plugins/toolsets/http/http_toolset.py` — `HttpToolset.match_endpoint`
- **Severity:** Medium — requires the HTTP toolset to be configured and a prompt-injection vector, but bypasses an explicit security control (the path whitelist).

## Data flow

1. Operator configures an HTTP toolset endpoint, e.g. host `confluence.internal`, paths `["/wiki/rest/api/*"]`.
2. LLM (influenced by attacker-controlled investigated content) calls the HTTP tool with `https://confluence.internal/wiki/rest/api/../../admin/secret`.
3. `match_endpoint` runs `fnmatch("/wiki/rest/api/../../admin/secret", "/wiki/rest/api/*")` → **True**, so the request is approved.
4. `requests.Request(...).prepare().url` normalises the path → the actual request goes to `https://confluence.internal/admin/secret`.
5. The whitelist is bypassed and an unintended path is fetched (and its response returned to the LLM/user).

We verified both behaviours locally:

```python
>>> import fnmatch
>>> fnmatch.fnmatch("/wiki/rest/api/../../admin/secret", "/wiki/rest/api/*")
True
>>> import requests
>>> requests.Request("GET", "http://example.com/api/foo/../../admin").prepare().url
'http://example.com/admin'
```

## Fix

Minimal, defensive changes in `match_endpoint`:

1. Restrict accepted schemes to `http` / `https` (rejects `file://`, `gopher://`, etc.).
2. Reject any path containing `.` or `..` segments — checked on **both** the raw path and its percent-decoded form, so `%2e%2e` cannot bypass the check.
3. Normalise the path with `posixpath.normpath` before passing it to `_match_path`, so duplicate slashes and other benign noise behave consistently.

The fix is intentionally narrow: it only tightens the validator and does not change endpoint configuration semantics or the request pipeline. Requests to legitimate paths continue to work unchanged.

## Tests

Added four focused tests in `tests/plugins/toolsets/http/test_http_toolset.py`:

- `test_path_traversal_dotdot_rejected` — literal `..` segment is rejected.
- `test_path_traversal_encoded_rejected` — `%2e%2e` is rejected.
- `test_path_single_dot_segment_rejected` — `/./` segment is rejected.
- `test_non_http_scheme_rejected` — `file:///etc/passwd` is rejected.

Full test file passes:

```
tests/plugins/toolsets/http/test_http_toolset.py ... 86 passed
```

## Security analysis

The exploit preconditions are realistic for HolmesGPT's deployment model:

- The HTTP toolset is configured to talk to an internal service whose host also serves more sensitive paths than the whitelisted prefix (Confluence/Jira/Grafana style apps with admin endpoints under the same host are common).
- The investigated data (alert annotations, issue text, log lines) can influence what the LLM passes as `url` to the HTTP tool. Prompt-injection through investigated content is part of HolmesGPT's documented threat surface.

After the fix, an attacker controlling the LLM-supplied URL can no longer escape the configured prefix on a whitelisted host, because any `..`/`.` segment (raw or percent-encoded) is rejected up front and the path is normalised before fnmatch.

### Adversarial review

Before submitting we tried to disprove this finding. We considered whether `requests`/`urllib3` might preserve `..` on the wire (it does not — it normalises), whether the existing `_match_path` already handled traversal (it uses plain `fnmatch`, which treats `..` as ordinary characters), and whether the preconditions already grant equivalent access (they don't — the attacker's prompt-injection capability does not, on its own, let them reach off-prefix paths on whitelisted internal hosts; that ability is exactly what this bug provides). We also checked that the fix does not over-block — paths without traversal segments continue to match as before, and the existing host/path tests still pass.

cc @lewiswigmore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened HTTP endpoint validation: now enforces HTTP/HTTPS, requires a host, blocks path traversal (including encoded and single-dot variants), and normalizes paths while preserving trailing slashes for more accurate and secure matching.

* **Tests**
  * Added tests for path traversal (raw and encoded), single-dot segments, and rejection of non-HTTP schemes to verify endpoint matching and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->