### PR TITLE
feat(helm): add deploymentAnnotations support to MCP server templates

### DIFF
--- a/helm/holmes/templates/mcp-servers/azure/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/deployment.yaml
@@ -43,6 +43,10 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-azure-mcp-server
   namespace: {{ .Values.mcpAddons.azure.config.namespace | default .Release.Namespace }}
+  {{- with .Values.mcpAddons.azure.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-azure-mcp
     app.kubernetes.io/name: azure-mcp-server

--- a/helm/holmes/templates/mcp-servers/confluence-mcp/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/confluence-mcp/deployment.yaml
@@ -26,6 +26,10 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-confluence-mcp-server
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.mcpAddons.confluenceMcp.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-confluence-mcp
     app.kubernetes.io/name: confluence-mcp-server

--- a/helm/holmes/templates/mcp-servers/github/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/github/deployment.yaml
@@ -24,6 +24,10 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-github-mcp-server
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.mcpAddons.github.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-github-mcp
     app.kubernetes.io/name: github-mcp-server

--- a/helm/holmes/templates/mcp-servers/kubernetes-remediation/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/kubernetes-remediation/deployment.yaml
@@ -25,6 +25,10 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-k8s-remediation-mcp-server
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.mcpAddons.kubernetesRemediation.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-k8s-remediation-mcp
     app.kubernetes.io/name: k8s-remediation-mcp-server

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -344,6 +344,8 @@ mcpAddons:
   # Azure MCP Server Configuration
   azure:
     enabled: false
+    # Custom annotations to add to the Deployment metadata
+    deploymentAnnotations: {}
     # Service account configuration for Azure Workload Identity
     serviceAccount:
       create: true
@@ -409,6 +411,9 @@ mcpAddons:
   # To build your own image, see: https://github.com/robusta-dev/holmes-mcp-integrations/tree/master/servers/github
   github:
     enabled: false
+
+    # Custom annotations to add to the Deployment metadata
+    deploymentAnnotations: {}
 
     image: "github-mcp:1.0.1"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
@@ -557,6 +562,9 @@ mcpAddons:
   # WARNING: This addon can execute write operations. Configure allowedCommands carefully.
   kubernetesRemediation:
     enabled: false
+
+    # Custom annotations to add to the Deployment metadata
+    deploymentAnnotations: {}
 
     image: "kubernetes-remediation-mcp:1.0.0"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
@@ -711,6 +719,9 @@ mcpAddons:
   #     --from-literal=confluence-username=<YOUR_EMAIL> --from-literal=confluence-api-token=<YOUR_API_TOKEN> -n <NAMESPACE>
   confluenceMcp:
     enabled: false
+
+    # Custom annotations to add to the Deployment metadata
+    deploymentAnnotations: {}
 
     image: "mcp-atlassian:v0.21.2"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"


### PR DESCRIPTION
## Summary

Add custom annotations support to Deployment metadata for GitHub, Azure, Confluence, and Kubernetes Remediation MCP server templates.

## Problem

The MCP server Deployment templates do not support custom annotations on the Deployment metadata. This prevents adding annotations like `reloader.stakater.com/auto: "true"` needed to trigger automatic pod rolling restarts when referenced Secrets are updated by ESO (External Secrets Operator).

## Changes

- **4 MCP server templates** (github, azure, confluence-mcp, kubernetes-remediation): added `deploymentAnnotations` block to Deployment metadata
- **values.yaml**: added `deploymentAnnotations: {}` default to each server's config section

## Verification

- ✅ Render verified with annotations set → annotations appear correctly
- ✅ Render verified with annotations unset → no annotations in output (no-op)
- ✅ All 4 templates tested individually

Closes #1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom deployment-level annotations across multiple MCP servers. Azure MCP, Confluence MCP, GitHub MCP, and Kubernetes Remediation MCP deployments can now be configured with custom annotations through Helm values, enabling enhanced deployment customization, improved metadata management, and flexible Kubernetes resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->