### PR TITLE
Enable private channels and add auth for realtime subscriptions

### DIFF
--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -488,7 +488,7 @@ class RealtimeManager:
         topic = pg_changes_topic(self.dal.account_id)
         self._channel = self._client.channel(
             topic,
-            {"config": {"private": False}},
+            {"config": {"private": True}},
         )
 
         def _on_pg_change(payload: Dict[str, Any]) -> None:
@@ -565,7 +565,7 @@ class RealtimeManager:
         topic = broadcast_submit_topic(self.dal.account_id, self.dal.cluster)
         self._channel = self._client.channel(
             topic,
-            {"config": {"private": False}},
+            {"config": {"private": True}},
         )
 
         def _on_broadcast(payload: Dict[str, Any]) -> None:

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -488,7 +488,7 @@ class RealtimeManager:
         topic = pg_changes_topic(self.dal.account_id)
         self._channel = self._client.channel(
             topic,
-            {"config": {"private": True}},
+            {"config": {"private": True, "presence": {"enabled": False}}},
         )
 
         def _on_pg_change(payload: Dict[str, Any]) -> None:
@@ -565,7 +565,7 @@ class RealtimeManager:
         topic = broadcast_submit_topic(self.dal.account_id, self.dal.cluster)
         self._channel = self._client.channel(
             topic,
-            {"config": {"private": True}},
+            {"config": {"private": True, "presence": {"enabled": False}}},
         )
 
         def _on_broadcast(payload: Dict[str, Any]) -> None:

--- a/tests/core/conversations_worker/integration/__init__.py
+++ b/tests/core/conversations_worker/integration/__init__.py
@@ -145,7 +145,7 @@ class SupabaseFixture:
                     url=ws_url, token=self._api_key, auto_reconnect=True
                 )
                 await rt.connect()
-                ch = rt.channel(topic, {"config": {"private": False}})
+                ch = rt.channel(topic, {"config": {"private": True}})
                 subscribed = asyncio.Event()
 
                 def _on_sub(status: Any, err: Any = None) -> None:

--- a/tests/core/conversations_worker/integration/__init__.py
+++ b/tests/core/conversations_worker/integration/__init__.py
@@ -145,6 +145,13 @@ class SupabaseFixture:
                     url=ws_url, token=self._api_key, auto_reconnect=True
                 )
                 await rt.connect()
+                # Authenticate as the logged-in test user so the realtime.messages
+                # RLS policies (which gate on is_account_user_role / cluster perms)
+                # can resolve. Without this, the channel runs as anon and the join
+                # is rejected — Supabase drops the WS with code 1006.
+                session = self.client.auth.get_session()
+                if session and session.access_token:
+                    await rt.set_auth(session.access_token)
                 ch = rt.channel(
                     topic,
                     {"config": {"private": True, "presence": {"enabled": False}}},

--- a/tests/core/conversations_worker/integration/__init__.py
+++ b/tests/core/conversations_worker/integration/__init__.py
@@ -145,7 +145,10 @@ class SupabaseFixture:
                     url=ws_url, token=self._api_key, auto_reconnect=True
                 )
                 await rt.connect()
-                ch = rt.channel(topic, {"config": {"private": True}})
+                ch = rt.channel(
+                    topic,
+                    {"config": {"private": True, "presence": {"enabled": False}}},
+                )
                 subscribed = asyncio.Event()
 
                 def _on_sub(status: Any, err: Any = None) -> None:

--- a/tests/core/conversations_worker/integration/broadcast_health_check.py
+++ b/tests/core/conversations_worker/integration/broadcast_health_check.py
@@ -84,7 +84,10 @@ def _setup_broadcast():
         topic = broadcast_submit_topic(account_id, cluster_id)
         rt = AsyncRealtimeClient(url=ws_url, token=decoded["api_key"], auto_reconnect=True)
         await rt.connect()
-        ch = rt.channel(topic, {"config": {"private": True}})
+        ch = rt.channel(
+            topic,
+            {"config": {"private": True, "presence": {"enabled": False}}},
+        )
         subscribed = asyncio.Event()
 
         def _on_sub(status, err=None):

--- a/tests/core/conversations_worker/integration/broadcast_health_check.py
+++ b/tests/core/conversations_worker/integration/broadcast_health_check.py
@@ -84,7 +84,7 @@ def _setup_broadcast():
         topic = broadcast_submit_topic(account_id, cluster_id)
         rt = AsyncRealtimeClient(url=ws_url, token=decoded["api_key"], auto_reconnect=True)
         await rt.connect()
-        ch = rt.channel(topic, {"config": {"private": False}})
+        ch = rt.channel(topic, {"config": {"private": True}})
         subscribed = asyncio.Event()
 
         def _on_sub(status, err=None):

--- a/tests/core/conversations_worker/integration/broadcast_health_check.py
+++ b/tests/core/conversations_worker/integration/broadcast_health_check.py
@@ -84,6 +84,10 @@ def _setup_broadcast():
         topic = broadcast_submit_topic(account_id, cluster_id)
         rt = AsyncRealtimeClient(url=ws_url, token=decoded["api_key"], auto_reconnect=True)
         await rt.connect()
+        # Authenticate as the signed-in user so the realtime.messages RLS
+        # policies on the private channel resolve. Without this the join
+        # runs as anon and Supabase rejects it (WS close 1006).
+        await rt.set_auth(res.session.access_token)
         ch = rt.channel(
             topic,
             {"config": {"private": True, "presence": {"enabled": False}}},


### PR DESCRIPTION
## Summary
Updated realtime channel configurations to use private channels with authentication and disabled presence, improving security for conversations worker subscriptions.

## Key Changes
- **Authentication for realtime connections**: Added explicit authentication using the logged-in test user's access token in integration tests before subscribing to channels. This ensures RLS policies that gate on `is_account_user_role` and cluster permissions can properly resolve.
- **Private channel configuration**: Changed all realtime channel subscriptions from public (`private: False`) to private (`private: True`) across:
  - `realtime_manager.py` - both pgchanges and broadcast subscriptions
  - Integration tests - conversations worker and broadcast health check tests
- **Disabled presence tracking**: Added `"presence": {"enabled": False}` to all channel configurations to reduce unnecessary overhead.

## Implementation Details
- The authentication fix addresses an issue where channels running as anonymous users were being rejected by Supabase with WebSocket code 1006
- Channel configuration is now consistent across all realtime subscriptions in the codebase
- Private channels require proper authentication, which is now explicitly handled in test setup

https://claude.ai/code/session_01BgVPhmz6YvnNvs13GqJq1L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Real-time channels now use private-mode configuration with presence disabled for all subscription types.
  * Real-time connections are authenticated using the current user session token before channel join.

* **Tests**
  * Integration tests updated to authenticate WebSocket realtime connections and subscribe to private broadcast channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->