### PR TITLE
feat: add generic webhook destination for health checks

### DIFF
--- a/docs/operator/destinations.md
+++ b/docs/operator/destinations.md
@@ -15,10 +15,11 @@ Destinations are used when a HealthCheck or ScheduledHealthCheck has `mode: aler
 
 ## Supported Destinations
 
-Holmes Operator currently supports two alert destination types:
+Holmes Operator currently supports three alert destination types:
 
 - **Slack** - Send formatted messages to Slack channels
 - **PagerDuty** - Create incidents in PagerDuty
+- **Webhook** - POST a JSON payload to any HTTP endpoint
 
 ## Slack Destination
 
@@ -220,6 +221,152 @@ PagerDuty incidents created by Holmes include:
 **Links:**
 - If the check has an associated URL, it's included as a link in the incident
 
+
+## Webhook Destination
+
+Send a JSON notification to any HTTP endpoint when a health check fails. The payload structure is fully defined by you, making it compatible with any system that accepts HTTP POST requests.
+
+### Configuration
+
+**Option 1: WEBHOOK_URL environment variable (Recommended)**
+
+Store the full webhook URL in a Kubernetes secret and mount it as `WEBHOOK_URL`:
+
+```yaml
+# values.yaml
+additionalEnvVars:
+  - name: WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: holmes-webhook
+        key: url
+```
+
+Create the secret:
+
+```bash
+kubectl create secret generic holmes-webhook \
+  --from-literal=url="https://your-system.example.com/webhook/endpoint/secret-token" \
+  -n <holmes-namespace>
+```
+
+Checks omit the URL entirely — it resolves from the environment:
+
+```yaml
+apiVersion: holmesgpt.dev/v1alpha1
+kind: HealthCheck
+metadata:
+  name: production-check
+spec:
+  query: "Is production healthy?"
+  mode: alert
+  destinations:
+    - type: webhook
+      config:
+        payload:
+          event_type: "health_check_failure"
+          message: "{{analysis}}"
+          event_source: "holmesgpt"
+          metadata: "{{check_name}}"
+```
+
+**Option 2: Named environment variable (Multiple webhooks)**
+
+Use `url_env` to name a specific environment variable, allowing different checks to send to different endpoints:
+
+```yaml
+# values.yaml
+additionalEnvVars:
+  - name: SERVICENOW_WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: servicenow-webhook
+        key: url
+  - name: TEAMS_WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: teams-webhook
+        key: url
+```
+
+```yaml
+# HealthCheck 1 → Sample1 Webhook
+destinations:
+  - type: webhook
+    config:
+      url_env: "SAMPLE1_WEBHOOK_URL"
+      payload:
+        message: "{{analysis}}"
+
+# HealthCheck 2 → Sample2 Webhook
+destinations:
+  - type: webhook
+    config:
+      url_env: "SAMPLE2_WEBHOOK_URL"
+      payload:
+        message: "{{analysis}}"
+```
+
+**Option 3: URL directly in config**
+
+```yaml
+destinations:
+  - type: webhook
+    config:
+      url: "https://your-system.example.com/webhook/endpoint"
+      payload:
+        message: "{{analysis}}"
+```
+
+!!! warning "Security Best Practice"
+
+    Avoid putting URLs that contain secret tokens directly in check resources — they are stored unencrypted in etcd and visible to anyone with `kubectl` access. Use environment variables loaded from Kubernetes secrets instead.
+
+### Configuration Fields
+
+**url** (string, optional)
+
+Literal webhook URL. Takes priority over `url_env` and `WEBHOOK_URL`.
+
+**url_env** (string, optional)
+
+Name of an environment variable containing the webhook URL. Useful when multiple checks send to different endpoints.
+
+**payload** (object, optional)
+
+JSON object to POST. Supports `{{variable}}` placeholders substituted at send time. If omitted, a default payload is sent.
+
+**headers** (object, optional)
+
+Additional HTTP headers to include in the request. Useful for authentication headers.
+
+- Example: `Authorization: "Bearer token"`
+
+### Payload Variables
+
+Use these placeholders in any string value within `payload`:
+
+| Placeholder | Value |
+|---|---|
+| `{{check_name}}` | Name of the health check |
+| `{{analysis}}` | Full LLM analysis text |
+| `{{status}}` | Issue status (`open` or `unknown`) |
+| `{{source_type}}` | Source type (e.g. `HealthCheck`) |
+| `{{url}}` | Issue URL if available, otherwise empty |
+
+### Default Payload
+
+When `payload` is not specified, Holmes sends:
+
+```json
+{
+  "check_name": "...",
+  "status": "open",
+  "analysis": "...",
+  "source_type": "HealthCheck",
+  "url": "..."
+}
+```
 
 ## Notification Status
 

--- a/docs/operator/destinations.md
+++ b/docs/operator/destinations.md
@@ -277,15 +277,15 @@ Use `url_env` to name a specific environment variable, allowing different checks
 ```yaml
 # values.yaml
 additionalEnvVars:
-  - name: SERVICENOW_WEBHOOK_URL
+  - name: SAMPLE1_WEBHOOK_URL
     valueFrom:
       secretKeyRef:
-        name: servicenow-webhook
+        name: sample1-webhook
         key: url
-  - name: TEAMS_WEBHOOK_URL
+  - name: SAMPLE2_WEBHOOK_URL
     valueFrom:
       secretKeyRef:
-        name: teams-webhook
+        name: sample2-webhook
         key: url
 ```
 

--- a/holmes/checks/checks_api.py
+++ b/holmes/checks/checks_api.py
@@ -14,6 +14,7 @@ from holmes.core.issue import Issue, IssueStatus
 from holmes.core.tool_calling_llm import LLMResult, ToolCallingLLM
 from holmes.core.tools import PrerequisiteCacheMode, ToolsetTag
 from holmes.plugins.destinations.slack.plugin import SlackDestination
+from holmes.plugins.destinations.webhook.plugin import WebhookDestination
 
 checks_app = FastAPI()
 
@@ -192,6 +193,37 @@ def execute_health_check(
                                 f"Failed to send Slack notification: {e}", exc_info=True
                             )
 
+                        notifications.append(notification)
+                    elif dest_type == "webhook":
+                        notification = NotificationStatus(type="webhook", status="pending")
+                        try:
+                            webhook_url = (
+                                dest_config.get("url")
+                                or os.environ.get(dest_config.get("url_env", ""))
+                                or os.environ.get("WEBHOOK_URL")
+                            )
+                            if not webhook_url:
+                                notification.status = "skipped"
+                                notification.error = "webhook url not configured"
+                                logging.warning(
+                                    "Webhook destination missing url (set 'url' in config, 'url_env' pointing to an env var, or WEBHOOK_URL env var), skipping"
+                                )
+                            else:
+                                webhook_headers = dest_config.get("headers")
+                                webhook_payload = dest_config.get("payload")
+                                webhook_dest = WebhookDestination(
+                                    url=webhook_url,
+                                    headers=webhook_headers,
+                                    payload_template=webhook_payload,
+                                )
+                                webhook_dest.send_issue(issue, llm_result)
+                                notification.status = "sent"
+                        except Exception as e:
+                            notification.status = "failed"
+                            notification.error = str(e)
+                            logging.error(
+                                f"Failed to send webhook notification: {e}", exc_info=True
+                            )
                         notifications.append(notification)
                     # Add other destination types here (pagerduty, etc.) as needed
 

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -33,6 +33,7 @@ from holmes.plugins.skills.skill_loader import (
 if TYPE_CHECKING:
     from holmes.core.tool_calling_llm import ToolCallingLLM
     from holmes.plugins.destinations.slack import SlackDestination
+    from holmes.plugins.destinations.webhook import WebhookDestination
     from holmes.plugins.sources.github import GitHubSource
     from holmes.plugins.sources.jira import JiraServiceManagementSource, JiraSource
     from holmes.plugins.sources.opsgenie import OpsGenieSource
@@ -97,6 +98,10 @@ class Config(RobustaBaseConfig):
     opsgenie_query: Optional[str] = None
 
     custom_skill_paths: List[Union[str, FilePath]] = []
+
+    webhook_url: Optional[SecretStr] = None
+    webhook_headers: Optional[dict] = None
+    webhook_payload: Optional[dict] = None
 
     # custom_toolsets is passed from config file, and be used to override built-in toolsets, provides 'stable' customized toolset.
     # The status of custom toolsets can be cached.
@@ -246,6 +251,7 @@ class Config(RobustaBaseConfig):
             "github_repository",
             "github_pat",
             "github_query",
+            "webhook_url",
         ]:
             val = os.getenv(field_name.upper(), None)
             if val is not None:
@@ -623,6 +629,18 @@ class Config(RobustaBaseConfig):
         if self.slack_channel is None:
             raise ValueError("--slack-channel must be specified")
         return SlackDestination(self.slack_token.get_secret_value(), self.slack_channel)
+    
+    def create_webhook_destination(self) -> "WebhookDestination":
+        from holmes.plugins.destinations.webhook import WebhookDestination
+
+        if self.webhook_url is None:
+            raise ValueError("--webhook-url must be specified")
+        
+        return WebhookDestination(
+            url=self.webhook_url.get_secret_value(),
+            headers=self.webhook_headers,
+            payload_template=self.webhook_payload,
+        )
 
     @staticmethod
     def _format_token_count(n: int) -> str:

--- a/holmes/plugins/destinations/__init__.py
+++ b/holmes/plugins/destinations/__init__.py
@@ -4,3 +4,4 @@ from strenum import StrEnum
 class DestinationType(StrEnum):
     SLACK = "slack"
     CLI = "cli"
+    WEBHOOK = "webhook"

--- a/holmes/plugins/destinations/webhook/__init__.py
+++ b/holmes/plugins/destinations/webhook/__init__.py
@@ -1,0 +1,2 @@
+# ruff: noqa: F401
+from .plugin import WebhookDestination

--- a/holmes/plugins/destinations/webhook/plugin.py
+++ b/holmes/plugins/destinations/webhook/plugin.py
@@ -15,7 +15,7 @@ def _substitute(value: Any, context: dict) -> Any:
     """Recursively replace {{key}} placeholders in strings within a dict/list/str."""
     if isinstance(value, str):
         for k, v in context.items():
-            value = re.sub(r"\{\{" + re.escape(k) + r"\}\}", str(v), value)
+            value = re.sub(r"\{\{" + re.escape(k) + r"\}\}", lambda _m, _v=str(v): _v, value)
         return value
     elif isinstance(value, dict):
         return {k: _substitute(v, context) for k, v in value.items()}

--- a/holmes/plugins/destinations/webhook/plugin.py
+++ b/holmes/plugins/destinations/webhook/plugin.py
@@ -1,0 +1,84 @@
+import copy
+import logging
+import re
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from holmes.core.issue import Issue
+from holmes.core.tool_calling_llm import LLMResult
+from holmes.plugins.interfaces import DestinationPlugin
+
+
+def _substitute(value: Any, context: dict) -> Any:
+    """Recursively replace {{key}} placeholders in strings within a dict/list/str."""
+    if isinstance(value, str):
+        for k, v in context.items():
+            value = re.sub(r"\{\{" + re.escape(k) + r"\}\}", str(v), value)
+        return value
+    elif isinstance(value, dict):
+        return {k: _substitute(v, context) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [_substitute(item, context) for item in value]
+    return value
+
+
+def _host(url: str) -> str:
+    """Return just the scheme+host of a URL, omitting path (which may contain secrets)."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+class WebhookDestination(DestinationPlugin):
+    def __init__(
+        self,
+        url: str,
+        headers: Optional[dict] = None,
+        payload_template: Optional[dict] = None,
+    ):
+        self.url = url
+        self.headers = headers or {}
+        self.payload_template = payload_template
+
+    def send_issue(self, issue: Issue, result: LLMResult) -> None:
+        status = (
+            issue.presentation_status.value
+            if issue.presentation_status
+            else "unknown"
+        )
+
+        context = {
+            "check_name": issue.name,
+            "analysis": result.result or "",
+            "status": status,
+            "source_type": issue.source_type,
+            "url": issue.url or "",
+        }
+
+        if self.payload_template is not None:
+            payload = _substitute(copy.deepcopy(self.payload_template), context)
+        else:
+            payload = {
+                "check_name": issue.name,
+                "status": status,
+                "analysis": result.result or "",
+                "source_type": issue.source_type,
+                "url": issue.url or "",
+            }
+
+        http_headers = {"Content-Type": "application/json"}
+        http_headers.update(self.headers)
+
+        try:
+            response = requests.post(self.url, json=payload, headers=http_headers, timeout=30)
+            response.raise_for_status()
+            logging.info(f"Webhook notification sent to {_host(self.url)} (status {response.status_code})")
+        except requests.exceptions.HTTPError as e:
+            logging.error(
+                f"Webhook POST to {_host(self.url)} failed with HTTP {e.response.status_code}: {e.response.text}"
+            )
+            raise
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Webhook POST to {_host(self.url)} failed: {e}")
+            raise

--- a/holmes/utils/console/result.py
+++ b/holmes/utils/console/result.py
@@ -46,3 +46,7 @@ def handle_result(
     elif destination == DestinationType.SLACK:
         slack = config.create_slack_destination()
         slack.send_issue(issue, result)
+
+    elif destination == DestinationType.WEBHOOK:
+        webhook = config.create_webhook_destination()
+        webhook.send_issue(issue, result)

--- a/tests/test_webhook_destination.py
+++ b/tests/test_webhook_destination.py
@@ -1,0 +1,170 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.core.issue import Issue, IssueStatus
+from holmes.core.tool_calling_llm import LLMResult
+from holmes.plugins.destinations.webhook.plugin import WebhookDestination, _substitute
+
+
+def make_issue(**kwargs):
+    defaults = dict(
+        id="test-1",
+        name="Health Check Failed: production-check",
+        source_instance_id="my-cluster",
+        source_type="HealthCheck",
+        presentation_status=IssueStatus.OPEN,
+        url="https://example.com/check/1",
+    )
+    defaults.update(kwargs)
+    return Issue(**defaults)
+
+
+def make_result(**kwargs):
+    defaults = dict(result="Something is broken in the cluster.", tool_calls=[], messages=[])
+    defaults.update(kwargs)
+    return LLMResult(**defaults)
+
+
+class TestSubstitute:
+    def test_replaces_string_variable(self):
+        assert _substitute("{{foo}}", {"foo": "bar"}) == "bar"
+
+    def test_replaces_multiple_variables(self):
+        assert _substitute("{{a}} and {{b}}", {"a": "X", "b": "Y"}) == "X and Y"
+
+    def test_leaves_unknown_variables(self):
+        assert _substitute("{{unknown}}", {"foo": "bar"}) == "{{unknown}}"
+
+    def test_recurses_into_dict(self):
+        result = _substitute({"key": "{{foo}}"}, {"foo": "baz"})
+        assert result == {"key": "baz"}
+
+    def test_recurses_into_list(self):
+        result = _substitute(["{{foo}}", "static"], {"foo": "bar"})
+        assert result == ["bar", "static"]
+
+    def test_non_string_passthrough(self):
+        assert _substitute(42, {}) == 42
+
+
+class TestWebhookDestination:
+    @patch("holmes.plugins.destinations.webhook.plugin.requests.post")
+    def test_default_payload(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200, raise_for_status=lambda: None)
+        dest = WebhookDestination(url="https://hook.example.com/endpoint")
+        issue = make_issue()
+        result = make_result()
+
+        dest.send_issue(issue, result)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+        assert payload["check_name"] == issue.name
+        assert payload["status"] == "open"
+        assert payload["analysis"] == result.result
+        assert payload["source_type"] == "HealthCheck"
+        assert payload["url"] == issue.url
+
+    @patch("holmes.plugins.destinations.webhook.plugin.requests.post")
+    def test_custom_payload_template(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200, raise_for_status=lambda: None)
+        template = {
+            "incident_key": "{{check_name}}",
+            "description": "{{analysis}}",
+            "severity": "critical",
+        }
+        dest = WebhookDestination(url="https://hook.example.com/endpoint", payload_template=template)
+        issue = make_issue()
+        result = make_result()
+
+        dest.send_issue(issue, result)
+
+        _, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+        assert payload["incident_key"] == issue.name
+        assert payload["description"] == result.result
+        assert payload["severity"] == "critical"  # static value unchanged
+
+    @patch("holmes.plugins.destinations.webhook.plugin.requests.post")
+    def test_custom_headers_merged(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200, raise_for_status=lambda: None)
+        dest = WebhookDestination(
+            url="https://hook.example.com/endpoint",
+            headers={"Authorization": "Bearer secret"},
+        )
+        dest.send_issue(make_issue(), make_result())
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+
+    @patch("holmes.plugins.destinations.webhook.plugin.requests.post")
+    def test_template_not_mutated(self, mock_post):
+        """Ensure the original payload_template dict is not modified."""
+        mock_post.return_value = MagicMock(status_code=200, raise_for_status=lambda: None)
+        template = {"key": "{{check_name}}"}
+        dest = WebhookDestination(url="https://hook.example.com/endpoint", payload_template=template)
+        dest.send_issue(make_issue(), make_result())
+
+        assert template["key"] == "{{check_name}}"  # original unchanged
+
+    @patch("holmes.plugins.destinations.webhook.plugin.requests.post")
+    def test_http_error_raises(self, mock_post):
+        import requests as req
+        mock_response = MagicMock(status_code=500, text="Internal Server Error")
+        mock_post.return_value = mock_response
+        mock_response.raise_for_status.side_effect = req.exceptions.HTTPError(
+            response=mock_response
+        )
+        dest = WebhookDestination(url="https://hook.example.com/endpoint")
+
+        # Should raise so checks_api can set notification.status = "failed"
+        with pytest.raises(req.exceptions.HTTPError):
+            dest.send_issue(make_issue(), make_result())
+
+
+class TestWebhookUrlResolution:
+    """Tests for url / url_env / WEBHOOK_URL resolution logic in checks_api."""
+
+    def _resolve_url(self, dest_config: dict) -> str:
+        """Mirrors the resolution logic in checks_api.py."""
+        return (
+            dest_config.get("url")
+            or os.environ.get(dest_config.get("url_env", ""))
+            or os.environ.get("WEBHOOK_URL")
+            or ""
+        )
+
+    def test_literal_url_takes_priority(self):
+        url = self._resolve_url({"url": "https://example.com/hook"})
+        assert url == "https://example.com/hook"
+
+    def test_url_env_resolves_named_env_var(self, monkeypatch):
+        monkeypatch.setenv("MY_SYSTEM_WEBHOOK", "https://my-system.com/hook")
+        url = self._resolve_url({"url_env": "MY_SYSTEM_WEBHOOK"})
+        assert url == "https://my-system.com/hook"
+
+    def test_webhook_url_fallback(self, monkeypatch):
+        monkeypatch.setenv("WEBHOOK_URL", "https://fallback.com/hook")
+        url = self._resolve_url({})
+        assert url == "https://fallback.com/hook"
+
+    def test_literal_url_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("WEBHOOK_URL", "https://should-not-use.com")
+        url = self._resolve_url({"url": "https://explicit.com/hook"})
+        assert url == "https://explicit.com/hook"
+
+    def test_url_env_overrides_webhook_url_fallback(self, monkeypatch):
+        monkeypatch.setenv("MY_SYSTEM_WEBHOOK", "https://named.com/hook")
+        monkeypatch.setenv("WEBHOOK_URL", "https://should-not-use.com")
+        url = self._resolve_url({"url_env": "MY_SYSTEM_WEBHOOK"})
+        assert url == "https://named.com/hook"
+
+    def test_missing_url_env_var_falls_through(self, monkeypatch):
+        monkeypatch.setenv("WEBHOOK_URL", "https://fallback.com/hook")
+        # url_env points to a var that doesn't exist — should fall through to WEBHOOK_URL
+        url = self._resolve_url({"url_env": "NONEXISTENT_VAR"})
+        assert url == "https://fallback.com/hook"


### PR DESCRIPTION
  ## Summary                                                                                                                          
                                                                                                                                                                  
  Adds a `webhook` destination type that POSTs a JSON payload to any HTTP endpoint when a health check fires. This makes it easy to integrate Holmes alerts with  
  arbitrary systems (ServiceNow, PagerDuty, Teams, custom APIs, etc.) without needing a dedicated plugin.                                                                
                                                                                                                                                                  
  - New `WebhookDestination` plugin with `{{variable}}` template substitution in payloads                                                                       
  - Three URL resolution methods: literal `url`, named env var via `url_env`, or `WEBHOOK_URL` fallback (recommended for secrets)                                 
  - Optional custom headers (e.g. `Authorization`)                                                                                                                
  - Sensible default payload when no template is specified                                                                                                        
  - Full unit test coverage for substitution logic, URL resolution, headers, and error handling                                                                   
                  
  ## Example                                                                                                                                                      
   
  ```yaml                                                                                                                                                         
  destinations:   
    - type: webhook
      config:
        url_env: "CUSTOM_WEBHOOK_URL"
        payload:
          event_type: "health_check_failure"
          message: "{{analysis}}"
          source: "holmesgpt"
  ```                                                                                                                                                             
   
  ## Test plan                                                                                                                                                    
                  
  - [x] `make test-without-llm` passes
  - [x] Verified webhook fires against a local endpoint with default and custom payloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook added as a supported alert destination with configurable URL, headers, and payload templates using placeholders.

* **Documentation**
  * Added guide explaining webhook destination setup, URL resolution options, payload customization, and default JSON payload.

* **Tests**
  * New test suite covering webhook payload templating, header merging, URL resolution precedence, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->