### PR TITLE
fix log level env var on the docs

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -188,7 +188,7 @@ Path to a custom HolmesGPT configuration file. If not set, defaults to `~/.holme
 export HOLMES_CONFIG_PATH="/path/to/custom/config.yaml"
 ```
 
-### HOLMES_LOG_LEVEL
+### LOG_LEVEL
 Controls the logging verbosity of HolmesGPT.
 
 **Values:** `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
@@ -196,7 +196,7 @@ Controls the logging verbosity of HolmesGPT.
 
 **Example:**
 ```bash
-export HOLMES_LOG_LEVEL="DEBUG"
+export LOG_LEVEL="DEBUG"
 ```
 
 ### TRACE_TOKEN_USAGE

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -382,7 +382,7 @@ export OPENAI_API_KEY="your-openai-key"
 
 # Optional
 export HOLMES_CONFIG_PATH="/path/to/config.yaml"
-export HOLMES_LOG_LEVEL="INFO"
+export LOG_LEVEL="INFO"
 ```
 
 See the [Environment Variables Reference](environment-variables.md) for complete documentation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logging environment variable name from `HOLMES_LOG_LEVEL` to `LOG_LEVEL` across documentation references. The new variable maintains the same configuration options (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->