### PR TITLE
Propagate inbound trace context

### DIFF
--- a/server.py
+++ b/server.py
@@ -22,6 +22,7 @@ import litellm
 from holmes.core.oauth_config import OAuthConfigLookupError, OAuthTokenExchangeError
 from holmes.core.oauth_server_callbacks import get_toolset_oauth_config, process_oauth_callback
 from holmes.core.oauth_utils import _get_token_manager
+from opentelemetry import context as otel_context, propagate
 import sentry_sdk
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
@@ -269,6 +270,21 @@ if ENABLE_TELEMETRY and SENTRY_DSN:
         )
 
 app = FastAPI()
+
+
+@app.middleware("http")
+async def propagate_trace_context(request: Request, call_next):
+    """Continue inbound distributed traces from standard HTTP trace headers."""
+    extracted_context = propagate.extract(
+        request.headers,
+        context=otel_context.Context(),
+    )
+    token = otel_context.attach(extracted_context)
+    try:
+        return await call_next(request)
+    finally:
+        otel_context.detach(token)
+
 
 HOLMES_API_KEY = os.environ.get("HOLMES_API_KEY", "").strip()
 

--- a/tests/test_server_trace_context.py
+++ b/tests/test_server_trace_context.py
@@ -1,0 +1,139 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from opentelemetry import context as otel_context, propagate, trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import server
+from holmes.core.otel_tracing import OTelSpan
+
+
+@pytest.fixture()
+def client():
+    return TestClient(server.app)
+
+
+class _TestServerTracer:
+    def __init__(self):
+        self._tracer = trace.get_tracer("test-server")
+
+    def start_trace(self, name: str, span_type=None):
+        span = self._tracer.start_span(name)
+        ctx = trace.set_span_in_context(span)
+        token = otel_context.attach(ctx)
+        return OTelSpan(span, self._tracer, token)
+
+
+@pytest.fixture()
+def in_memory_trace_exporter(monkeypatch):
+    exporter = InMemorySpanExporter()
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    trace.set_tracer_provider(provider)
+
+    monkeypatch.setattr(server, "server_tracer", _TestServerTracer())
+    monkeypatch.setattr(server.TracingFactory, "get_metrics", lambda: None)
+
+    yield exporter
+    provider.shutdown()
+
+
+def _mock_llm():
+    mock_ai = MagicMock()
+    mock_ai.call.return_value = MagicMock(
+        result="This is a traced response.",
+        tool_calls=[],
+        messages=[{"role": "assistant", "content": "This is a traced response."}],
+        metadata={},
+        num_llm_calls=1,
+    )
+    return mock_ai
+
+
+def _chat_payload():
+    return {
+        "ask": "What can you do?",
+        "conversation_history": [
+            {"role": "system", "content": "You are a helpful assistant."}
+        ],
+        "model": "gpt-4.1",
+    }
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+@patch("holmes.core.supabase_dal.SupabaseDal.get_global_instructions_for_account")
+def test_api_chat_uses_inbound_traceparent(
+    mock_get_global_instructions,
+    mock_create_toolcalling_llm,
+    client,
+    in_memory_trace_exporter,
+):
+    mock_create_toolcalling_llm.return_value = _mock_llm()
+    mock_get_global_instructions.return_value = []
+
+    headers = {}
+    caller_tracer = trace.get_tracer("test-caller")
+    with caller_tracer.start_as_current_span("upstream-request") as upstream_span:
+        propagate.inject(headers)
+        upstream_context = upstream_span.get_span_context()
+
+    response = client.post("/api/chat", json=_chat_payload(), headers=headers)
+
+    assert response.status_code == 200
+
+    investigation_span = next(
+        span
+        for span in in_memory_trace_exporter.get_finished_spans()
+        if span.name == "holmesgpt.investigation"
+    )
+    assert investigation_span.context.trace_id == upstream_context.trace_id
+    assert investigation_span.parent is not None
+    assert investigation_span.parent.is_remote
+    assert investigation_span.parent.span_id == upstream_context.span_id
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+@patch("holmes.core.supabase_dal.SupabaseDal.get_global_instructions_for_account")
+def test_api_chat_detaches_trace_context_after_request(
+    mock_get_global_instructions,
+    mock_create_toolcalling_llm,
+    client,
+    in_memory_trace_exporter,
+):
+    mock_create_toolcalling_llm.return_value = _mock_llm()
+    mock_get_global_instructions.return_value = []
+
+    headers = {}
+    caller_tracer = trace.get_tracer("test-caller")
+    with caller_tracer.start_as_current_span("upstream-request") as upstream_span:
+        propagate.inject(headers)
+        upstream_context = upstream_span.get_span_context()
+
+    response = client.post("/api/chat", json=_chat_payload(), headers=headers)
+    assert response.status_code == 200
+
+    first_investigation_span = next(
+        span
+        for span in in_memory_trace_exporter.get_finished_spans()
+        if span.name == "holmesgpt.investigation"
+    )
+    assert first_investigation_span.parent is not None
+    assert first_investigation_span.parent.span_id == upstream_context.span_id
+
+    in_memory_trace_exporter.clear()
+
+    response = client.post("/api/chat", json=_chat_payload())
+    assert response.status_code == 200
+
+    second_investigation_span = next(
+        span
+        for span in in_memory_trace_exporter.get_finished_spans()
+        if span.name == "holmesgpt.investigation"
+    )
+    assert second_investigation_span.parent is None


### PR DESCRIPTION
## Summary

Continue inbound distributed trace context for `/api/chat` so Holmes investigation spans join the caller's trace when a standard `traceparent` header is present.

## What changed

- added an HTTP middleware in `server.py` that:
  - extracts OpenTelemetry/W3C trace context from inbound request headers
  - attaches that context for the lifetime of the request
  - detaches the context in `finally` to avoid leaking it into later requests
- added `tests/test_server_trace_context.py` to verify that:
  - `holmesgpt.investigation` reuses the upstream trace ID and parent span when `traceparent` is provided
  - trace context is cleaned up after the request, so a later request without trace headers starts a fresh trace

## Why

Without this, Holmes always starts a new root trace for `/api/chat`, which breaks trace continuity between upstream callers and the Holmes investigation spans they trigger.

With this change, Holmes traces can be correlated with the originating request in OTel backends while keeping request-local context isolated.

## Testing

```bash
.venv/bin/python -m pytest tests/test_server_trace_context.py tests/test_server_endpoints.py --no-cov -n 0 -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed tracing support that automatically extracts and applies trace context from incoming requests, enabling better observability of API interactions across service boundaries.

* **Tests**
  * Added test coverage validating trace context propagation and ensuring proper context cleanup between requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2024)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->