### PR TITLE
Fix Alertmanager basic auth password forwarding

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -610,6 +610,7 @@ class Config(RobustaBaseConfig):
         return AlertManagerSource(
             url=self.alertmanager_url,  # type: ignore
             username=self.alertmanager_username,
+            password=self.alertmanager_password,
             alertname_filter=self.alertmanager_alertname,  # type: ignore
             label_filter=self.alertmanager_label,  # type: ignore
             filepath=self.alertmanager_file,

--- a/tests/config_class/test_alertmanager_source_factory.py
+++ b/tests/config_class/test_alertmanager_source_factory.py
@@ -1,0 +1,14 @@
+from holmes.config import Config
+
+
+def test_create_alertmanager_source_forwards_basic_auth_credentials() -> None:
+    config = Config(
+        alertmanager_url="https://alertmanager.example.com",
+        alertmanager_username="holmes",
+        alertmanager_password="secret-password",
+    )
+
+    source = config.create_alertmanager_source()
+
+    assert source.username == "holmes"
+    assert source.password == "secret-password"


### PR DESCRIPTION
## Summary

Fix Alertmanager Basic Auth by forwarding the configured password into `AlertManagerSource`.

## Problem

`holmes investigate alertmanager --alertmanager-password ...` accepted a password in config, but `Config.create_alertmanager_source()` only passed the username to the source. Alertmanager requests were therefore sent without the password and could fail with `401 Unauthorized` against Basic Auth-protected endpoints.

## Changes

- Pass `alertmanager_password` into `AlertManagerSource`.
- Add a regression test covering username and password forwarding.

## Test plan

- `uv run --with-editable . --with pytest --with pytest-xdist --with pytest-cov --with responses --with pytest-shared-session-scope --with braintrust --with autoevals pytest tests/config_class/test_alertmanager_source_factory.py --no-cov -q`
- `ruff check tests/config_class/test_alertmanager_source_factory.py`
- `git diff --check`

Closes #2022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AlertManager source configuration now properly handles password credentials during authentication setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2026)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->