### PR TITLE
Add Claude Code bash prefix import command

### DIFF
--- a/docs/data-sources/builtin-toolsets/bash.md
+++ b/docs/data-sources/builtin-toolsets/bash.md
@@ -99,9 +99,7 @@ Do you want to proceed?
 
 If you already maintain allowed Bash commands in Claude Code, import them into Holmes:
 
-```bash
-holmes toolset bash import-from-claude-code
-```
+    holmes toolset bash import-from-claude-code
 
 The command reads `~/.claude/settings.json`, extracts `Bash(...)` entries from `permissions.allow`, and merges them into `~/.holmes/bash_approved_prefixes.yaml`.
 
@@ -112,6 +110,7 @@ Useful options:
 | `--input PATH` | Read a custom Claude Code settings file |
 | `--output PATH` | Write a custom Holmes approved-prefixes file |
 | `--replace` | Replace the Holmes file instead of merging |
+| `--merge` | Merge imported prefixes with the Holmes file (default) |
 | `--dry-run` | Print the resulting YAML without writing |
 
 ## Prefix Matching

--- a/docs/data-sources/builtin-toolsets/bash.md
+++ b/docs/data-sources/builtin-toolsets/bash.md
@@ -95,6 +95,25 @@ Do you want to proceed?
 - **Option 2**: Run and add the prefix to your allow list (saved to `~/.holmes/bash_approved_prefixes.yaml`)
 - **Option 3**: Reject and provide feedback to Holmes
 
+### Importing Claude Code Permissions
+
+If you already maintain allowed Bash commands in Claude Code, import them into Holmes:
+
+```bash
+holmes toolset bash import-from-claude-code
+```
+
+The command reads `~/.claude/settings.json`, extracts `Bash(...)` entries from `permissions.allow`, and merges them into `~/.holmes/bash_approved_prefixes.yaml`.
+
+Useful options:
+
+| Option | Description |
+|--------|-------------|
+| `--input PATH` | Read a custom Claude Code settings file |
+| `--output PATH` | Write a custom Holmes approved-prefixes file |
+| `--replace` | Replace the Holmes file instead of merging |
+| `--dry-run` | Print the resulting YAML without writing |
+
 ## Prefix Matching
 
 Commands are matched by prefix. For example, if `kubectl get` is in your allow list:

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -45,6 +45,14 @@ from holmes.plugins.destinations import DestinationType
 from holmes.plugins.interfaces import Issue
 from holmes.plugins.prompts import load_and_render_prompt
 from holmes.plugins.sources.opsgenie import OPSGENIE_TEAM_INTEGRATION_KEY_HELP
+from holmes.plugins.toolsets.bash.common.cli_prefixes import (
+    dump_approved_prefixes,
+    get_default_bash_approved_prefixes_file,
+    get_default_claude_code_settings_file,
+    load_approved_prefixes_file,
+    load_claude_code_bash_prefixes,
+    save_approved_prefixes_file,
+)
 from holmes.utils.console.logging import init_logging
 from holmes.utils.console.result import handle_result
 from holmes.utils.file_utils import write_json_file
@@ -82,6 +90,13 @@ toolset_app = typer.Typer(
     help="Toolset management commands",
 )
 app.add_typer(toolset_app, name="toolset")
+bash_toolset_app = typer.Typer(
+    add_completion=False,
+    name="bash",
+    no_args_is_help=True,
+    help="Bash toolset helper commands",
+)
+toolset_app.add_typer(bash_toolset_app, name="bash")
 
 app.add_typer(checks_app, name="checks")
 
@@ -1062,6 +1077,69 @@ def config_toolset(
     console = init_logging(verbose)
     config = Config.load_from_file(config_file)
     run_toolset_config_tui(config, config_file, console)
+
+
+@bash_toolset_app.command("import-from-claude-code")
+def import_bash_prefixes_from_claude_code(
+    input_path: Optional[Path] = typer.Option(
+        None,
+        "--input",
+        "-i",
+        help="Path to Claude Code settings.json. Defaults to ~/.claude/settings.json.",
+    ),
+    output_path: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Path to Holmes bash approved prefixes YAML. Defaults to ~/.holmes/bash_approved_prefixes.yaml.",
+    ),
+    replace: bool = typer.Option(
+        False,
+        "--replace/--merge",
+        help="Replace existing Holmes prefixes instead of merging with them.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the resulting YAML without writing it.",
+    ),
+):
+    """
+    Import approved Bash prefixes from Claude Code permissions.
+    """
+    input_file = (input_path or get_default_claude_code_settings_file()).expanduser()
+    output_file = (
+        output_path or get_default_bash_approved_prefixes_file()
+    ).expanduser()
+
+    try:
+        imported_prefixes, ignored_entries = load_claude_code_bash_prefixes(input_file)
+        existing_prefixes = [] if replace else load_approved_prefixes_file(output_file)
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    merged_prefixes = imported_prefixes + existing_prefixes
+
+    for entry in ignored_entries:
+        typer.echo(
+            f"Warning: ignored unsupported Claude Code permission: {entry}", err=True
+        )
+
+    if dry_run:
+        typer.echo(dump_approved_prefixes(merged_prefixes).rstrip())
+        return
+
+    try:
+        save_approved_prefixes_file(output_file, merged_prefixes)
+    except Exception as e:
+        typer.echo(f"Error: failed to write {output_file}: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    typer.echo(
+        f"Wrote {len(set(merged_prefixes))} approved bash prefixes to {output_file}"
+    )
+    typer.echo(f"Imported {len(imported_prefixes)} prefixes from {input_file}")
 
 
 @app.command()

--- a/holmes/plugins/toolsets/bash/common/cli_prefixes.py
+++ b/holmes/plugins/toolsets/bash/common/cli_prefixes.py
@@ -10,12 +10,18 @@ unnecessary file I/O in server mode.
 """
 
 import logging
-import os
-from typing import List
+import json
+import re
+from pathlib import Path
+from typing import Any, List, Optional
 
 import yaml
 
 from holmes.core.config import config_path_dir
+
+BASH_APPROVED_PREFIXES_FILENAME = "bash_approved_prefixes.yaml"
+DEFAULT_CLAUDE_CODE_SETTINGS_FILE = Path("~/.claude/settings.json")
+_CLAUDE_CODE_BASH_PERMISSION_RE = re.compile(r"^Bash\((.+)\)$")
 
 # CLI mode flag - only when enabled will we read from file
 _cli_mode_enabled = False
@@ -37,6 +43,112 @@ def is_cli_mode() -> bool:
     return _cli_mode_enabled
 
 
+def get_default_bash_approved_prefixes_file() -> Path:
+    """Return the default path for persisted CLI-approved bash prefixes."""
+    return Path(config_path_dir) / BASH_APPROVED_PREFIXES_FILENAME
+
+
+def get_default_claude_code_settings_file() -> Path:
+    """Return the default Claude Code settings path."""
+    return DEFAULT_CLAUDE_CODE_SETTINGS_FILE.expanduser()
+
+
+def load_approved_prefixes_file(path: Path) -> List[str]:
+    """Load approved prefixes from a Holmes bash approved-prefixes file."""
+    expanded_path = path.expanduser()
+    if not expanded_path.exists():
+        return []
+
+    with expanded_path.open("r") as f:
+        data = yaml.safe_load(f)
+
+    if not data:
+        return []
+    if not isinstance(data, dict):
+        raise ValueError(f"{expanded_path} must contain a YAML object")
+
+    approved_prefixes = data.get("approved_prefixes", [])
+    if approved_prefixes is None:
+        return []
+    if not isinstance(approved_prefixes, list):
+        raise ValueError("'approved_prefixes' must be a list")
+
+    return [prefix for prefix in approved_prefixes if isinstance(prefix, str)]
+
+
+def dump_approved_prefixes(prefixes: List[str]) -> str:
+    """Serialize approved prefixes using the Holmes YAML shape."""
+    deduped = sorted(set(prefixes))
+    return yaml.safe_dump({"approved_prefixes": deduped}, default_flow_style=False)
+
+
+def save_approved_prefixes_file(path: Path, prefixes: List[str]) -> None:
+    """Write approved prefixes to a Holmes bash approved-prefixes file."""
+    expanded_path = path.expanduser()
+    expanded_path.parent.mkdir(parents=True, exist_ok=True)
+    expanded_path.write_text(dump_approved_prefixes(prefixes), encoding="utf-8")
+
+
+def parse_claude_code_bash_permission(entry: str) -> Optional[str]:
+    """Extract a Holmes bash prefix from one Claude Code permission entry."""
+    match = _CLAUDE_CODE_BASH_PERMISSION_RE.match(entry)
+    if not match:
+        return None
+
+    prefix = match.group(1).strip()
+    if prefix.endswith(":*"):
+        prefix = prefix[:-2].strip()
+
+    return prefix or None
+
+
+def extract_claude_code_bash_prefixes(
+    settings: dict[str, Any],
+) -> tuple[List[str], List[str]]:
+    """Extract bash prefixes and ignored entries from Claude Code settings."""
+    permissions = settings.get("permissions", {})
+    if not isinstance(permissions, dict):
+        raise ValueError("'permissions' must be an object")
+
+    allow_entries = permissions.get("allow", [])
+    if allow_entries is None:
+        return [], []
+    if not isinstance(allow_entries, list):
+        raise ValueError("'permissions.allow' must be a list")
+
+    prefixes: List[str] = []
+    ignored_entries: List[str] = []
+    seen: set[str] = set()
+
+    for entry in allow_entries:
+        if not isinstance(entry, str):
+            ignored_entries.append(repr(entry))
+            continue
+
+        prefix = parse_claude_code_bash_permission(entry)
+        if prefix is None:
+            ignored_entries.append(entry)
+            continue
+
+        if prefix not in seen:
+            prefixes.append(prefix)
+            seen.add(prefix)
+
+    return prefixes, ignored_entries
+
+
+def load_claude_code_bash_prefixes(path: Path) -> tuple[List[str], List[str]]:
+    """Load Claude Code settings and extract bash prefixes."""
+    expanded_path = path.expanduser()
+    with expanded_path.open("r", encoding="utf-8") as f:
+        settings = json.load(f)
+
+    if not isinstance(settings, dict):
+        raise ValueError(f"{expanded_path} must contain a JSON object")
+
+    return extract_claude_code_bash_prefixes(settings)
+
+
 def load_cli_bash_tools_approved_prefixes() -> List[str]:
     """
     Load approved prefixes from ~/.holmes/bash_approved_prefixes.yaml.
@@ -47,16 +159,11 @@ def load_cli_bash_tools_approved_prefixes() -> List[str]:
     if not _cli_mode_enabled:
         return []
 
-    prefixes_file = os.path.join(config_path_dir, "bash_approved_prefixes.yaml")
-    if os.path.exists(prefixes_file):
-        try:
-            with open(prefixes_file, "r") as f:
-                data = yaml.safe_load(f)
-                if isinstance(data, dict) and "approved_prefixes" in data:
-                    return data["approved_prefixes"]
-        except Exception as e:
-            logging.warning(f"Failed to load approved prefixes: {e}")
-    return []
+    try:
+        return load_approved_prefixes_file(get_default_bash_approved_prefixes_file())
+    except Exception as e:
+        logging.warning(f"Failed to load approved prefixes: {e}")
+        return []
 
 
 def save_cli_bash_tools_approved_prefixes(prefixes: List[str]) -> None:
@@ -66,24 +173,15 @@ def save_cli_bash_tools_approved_prefixes(prefixes: List[str]) -> None:
     Note: This function works regardless of CLI mode, as saving is only
     called from interactive approval flow which is inherently CLI.
     """
-    prefixes_file = os.path.join(config_path_dir, "bash_approved_prefixes.yaml")
-    os.makedirs(config_path_dir, exist_ok=True)
+    prefixes_file = get_default_bash_approved_prefixes_file()
 
     # Load existing prefixes and merge (bypass CLI mode check for internal use)
-    existing: set[str] = set()
-    if os.path.exists(prefixes_file):
-        try:
-            with open(prefixes_file, "r") as f:
-                data = yaml.safe_load(f)
-                if isinstance(data, dict) and "approved_prefixes" in data:
-                    existing = set(data["approved_prefixes"])
-        except Exception:
-            pass
-
-    updated = sorted(set(prefixes) | existing)
+    try:
+        existing = load_approved_prefixes_file(prefixes_file)
+    except Exception:
+        existing = []
 
     try:
-        with open(prefixes_file, "w") as f:
-            yaml.safe_dump({"approved_prefixes": updated}, f, default_flow_style=False)
+        save_approved_prefixes_file(prefixes_file, prefixes + existing)
     except Exception as e:
         logging.error(f"Failed to save approved prefixes: {e}")

--- a/holmes/plugins/toolsets/bash/common/cli_prefixes.py
+++ b/holmes/plugins/toolsets/bash/common/cli_prefixes.py
@@ -203,8 +203,11 @@ def save_cli_bash_tools_approved_prefixes(prefixes: List[str]) -> None:
     # Load existing prefixes and merge (bypass CLI mode check for internal use)
     try:
         existing = load_approved_prefixes_file(prefixes_file)
-    except Exception:
-        existing = []
+    except Exception as e:
+        logging.error(
+            f"Failed to load existing approved prefixes from {prefixes_file}: {e}"
+        )
+        return
 
     try:
         save_approved_prefixes_file(prefixes_file, prefixes + existing)

--- a/holmes/plugins/toolsets/bash/common/cli_prefixes.py
+++ b/holmes/plugins/toolsets/bash/common/cli_prefixes.py
@@ -98,8 +98,15 @@ def parse_claude_code_bash_permission(entry: str) -> Optional[str]:
     prefix = match.group(1).strip()
     if prefix.endswith(":*"):
         prefix = prefix[:-2].strip()
+    elif prefix.endswith(" *"):
+        prefix = prefix[:-2].strip()
 
     return prefix or None
+
+
+def _prefixes_overlap(left: str, right: str) -> bool:
+    """Return True when two command prefixes can match the same command."""
+    return left == right or left.startswith(f"{right} ") or right.startswith(f"{left} ")
 
 
 def extract_claude_code_bash_prefixes(
@@ -116,6 +123,20 @@ def extract_claude_code_bash_prefixes(
     if not isinstance(allow_entries, list):
         raise ValueError("'permissions.allow' must be a list")
 
+    deny_entries = permissions.get("deny", [])
+    if deny_entries is None:
+        deny_entries = []
+    if not isinstance(deny_entries, list):
+        raise ValueError("'permissions.deny' must be a list")
+
+    deny_prefixes = [
+        prefix
+        for entry in deny_entries
+        if isinstance(entry, str)
+        for prefix in [parse_claude_code_bash_permission(entry)]
+        if prefix is not None
+    ]
+
     prefixes: List[str] = []
     ignored_entries: List[str] = []
     seen: set[str] = set()
@@ -127,6 +148,10 @@ def extract_claude_code_bash_prefixes(
 
         prefix = parse_claude_code_bash_permission(entry)
         if prefix is None:
+            ignored_entries.append(entry)
+            continue
+
+        if any(_prefixes_overlap(prefix, deny_prefix) for deny_prefix in deny_prefixes):
             ignored_entries.append(entry)
             continue
 

--- a/tests/test_bash_claude_code_import.py
+++ b/tests/test_bash_claude_code_import.py
@@ -1,0 +1,153 @@
+import json
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from holmes.main import app
+from holmes.plugins.toolsets.bash.common.cli_prefixes import (
+    extract_claude_code_bash_prefixes,
+    parse_claude_code_bash_permission,
+)
+
+
+runner = CliRunner()
+
+
+def test_parse_claude_code_bash_permission_strips_trailing_wildcard_only():
+    entry = "Bash(aws sts assume-role --role-arn arn:aws:iam::123:role/Admin:*)"
+
+    assert (
+        parse_claude_code_bash_permission(entry)
+        == "aws sts assume-role --role-arn arn:aws:iam::123:role/Admin"
+    )
+
+
+def test_extract_claude_code_bash_prefixes_warns_on_unsupported_entries():
+    prefixes, ignored = extract_claude_code_bash_prefixes(
+        {
+            "permissions": {
+                "allow": [
+                    "Bash(kubectl get:*)",
+                    "Bash(kubectl get:*)",
+                    "Read(**)",
+                    "Bahs(ls:*)",
+                    5,
+                ]
+            }
+        }
+    )
+
+    assert prefixes == ["kubectl get"]
+    assert ignored == ["Read(**)", "Bahs(ls:*)", "5"]
+
+
+def test_extract_claude_code_bash_prefixes_requires_allow_list():
+    with pytest.raises(ValueError, match="'permissions.allow' must be a list"):
+        extract_claude_code_bash_prefixes({"permissions": {"allow": "Bash(ls:*)"}})
+
+
+def test_import_from_claude_code_merges_with_existing_prefixes(tmp_path):
+    settings_file = tmp_path / "settings.json"
+    output_file = tmp_path / "bash_approved_prefixes.yaml"
+
+    settings_file.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "Bash(aws elbv2 describe-load-balancers:*)",
+                        "Bash(kubectl get pods)",
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_file.write_text(
+        yaml.safe_dump({"approved_prefixes": ["kubectl get"]}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "toolset",
+            "bash",
+            "import-from-claude-code",
+            "--input",
+            str(settings_file),
+            "--output",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert yaml.safe_load(output_file.read_text(encoding="utf-8")) == {
+        "approved_prefixes": [
+            "aws elbv2 describe-load-balancers",
+            "kubectl get",
+            "kubectl get pods",
+        ]
+    }
+
+
+def test_import_from_claude_code_replace_ignores_existing_prefixes(tmp_path):
+    settings_file = tmp_path / "settings.json"
+    output_file = tmp_path / "bash_approved_prefixes.yaml"
+
+    settings_file.write_text(
+        json.dumps({"permissions": {"allow": ["Bash(kubectl logs:*)"]}}),
+        encoding="utf-8",
+    )
+    output_file.write_text(
+        yaml.safe_dump({"approved_prefixes": ["kubectl get"]}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "toolset",
+            "bash",
+            "import-from-claude-code",
+            "--input",
+            str(settings_file),
+            "--output",
+            str(output_file),
+            "--replace",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert yaml.safe_load(output_file.read_text(encoding="utf-8")) == {
+        "approved_prefixes": ["kubectl logs"]
+    }
+
+
+def test_import_from_claude_code_dry_run_does_not_write(tmp_path):
+    settings_file = tmp_path / "settings.json"
+    output_file = tmp_path / "bash_approved_prefixes.yaml"
+
+    settings_file.write_text(
+        json.dumps({"permissions": {"allow": ["Bash(helm list:*)"]}}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "toolset",
+            "bash",
+            "import-from-claude-code",
+            "--input",
+            str(settings_file),
+            "--output",
+            str(output_file),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not output_file.exists()
+    assert yaml.safe_load(result.output) == {"approved_prefixes": ["helm list"]}

--- a/tests/test_bash_claude_code_import.py
+++ b/tests/test_bash_claude_code_import.py
@@ -1,10 +1,12 @@
 import json
+import logging
 
 import pytest
 import yaml
 from typer.testing import CliRunner
 
 from holmes.main import app
+from holmes.plugins.toolsets.bash.common import cli_prefixes
 from holmes.plugins.toolsets.bash.common.cli_prefixes import (
     extract_claude_code_bash_prefixes,
     parse_claude_code_bash_permission,
@@ -176,3 +178,26 @@ def test_import_from_claude_code_dry_run_does_not_write(tmp_path):
     assert result.exit_code == 0, result.output
     assert not output_file.exists()
     assert yaml.safe_load(result.output) == {"approved_prefixes": ["helm list"]}
+
+
+def test_save_cli_bash_tools_approved_prefixes_does_not_clobber_load_errors(
+    tmp_path, monkeypatch, caplog
+):
+    prefixes_file = tmp_path / "bash_approved_prefixes.yaml"
+    original_content = "approved_prefixes: kubectl get\n"
+    prefixes_file.write_text(original_content, encoding="utf-8")
+
+    monkeypatch.setattr(
+        cli_prefixes,
+        "get_default_bash_approved_prefixes_file",
+        lambda: prefixes_file,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        cli_prefixes.save_cli_bash_tools_approved_prefixes(["kubectl logs"])
+
+    assert prefixes_file.read_text(encoding="utf-8") == original_content
+    assert (
+        f"Failed to load existing approved prefixes from {prefixes_file}" in caplog.text
+    )
+    assert "'approved_prefixes' must be a list" in caplog.text

--- a/tests/test_bash_claude_code_import.py
+++ b/tests/test_bash_claude_code_import.py
@@ -23,6 +23,10 @@ def test_parse_claude_code_bash_permission_strips_trailing_wildcard_only():
     )
 
 
+def test_parse_claude_code_bash_permission_strips_space_star_wildcard():
+    assert parse_claude_code_bash_permission("Bash(kubectl get *)") == "kubectl get"
+
+
 def test_extract_claude_code_bash_prefixes_warns_on_unsupported_entries():
     prefixes, ignored = extract_claude_code_bash_prefixes(
         {
@@ -43,8 +47,29 @@ def test_extract_claude_code_bash_prefixes_warns_on_unsupported_entries():
 
 
 def test_extract_claude_code_bash_prefixes_requires_allow_list():
-    with pytest.raises(ValueError, match="'permissions.allow' must be a list"):
+    with pytest.raises(ValueError, match=r"'permissions\.allow' must be a list"):
         extract_claude_code_bash_prefixes({"permissions": {"allow": "Bash(ls:*)"}})
+
+
+def test_extract_claude_code_bash_prefixes_ignores_allows_overlapping_denies():
+    prefixes, ignored = extract_claude_code_bash_prefixes(
+        {
+            "permissions": {
+                "allow": [
+                    "Bash(kubectl:*)",
+                    "Bash(helm list:*)",
+                    "Bash(git status)",
+                ],
+                "deny": [
+                    "Bash(kubectl delete:*)",
+                    "Bash(helm:*)",
+                ],
+            }
+        }
+    )
+
+    assert prefixes == ["git status"]
+    assert ignored == ["Bash(kubectl:*)", "Bash(helm list:*)"]
 
 
 def test_import_from_claude_code_merges_with_existing_prefixes(tmp_path):


### PR DESCRIPTION
## Summary

Add a `holmes toolset bash import-from-claude-code` helper for importing Claude Code Bash permissions into Holmes' persisted bash allow list.

## Problem

Users who already maintain `permissions.allow` entries in `~/.claude/settings.json` had to manually translate entries like `Bash(aws elbv2 describe-load-balancers:*)` into `~/.holmes/bash_approved_prefixes.yaml`.

## Changes

- Add reusable helpers for loading/saving Holmes approved-prefix files.
- Parse Claude Code `Bash(...)` permissions, including trailing `:*` wildcard entries, without truncating command arguments that contain other colons.
- Add the nested CLI command with `--input`, `--output`, `--replace/--merge`, and `--dry-run` options.
- Document the import flow in the bash toolset docs.
- Add focused tests for parsing, merge, replace, dry-run, and CLI behavior.

## Test plan

- `uv run --with-editable . --with pytest --with pytest-xdist --with pytest-cov --with responses --with pytest-shared-session-scope --with braintrust --with autoevals pytest tests/test_bash_claude_code_import.py --no-cov -q`
- `ruff check holmes/plugins/toolsets/bash/common/cli_prefixes.py holmes/main.py tests/test_bash_claude_code_import.py`
- `git diff --check`

Closes #1897


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI command to import previously approved Bash permissions from Claude Code, with input/output path options, merge/replace modes, and a dry-run preview; reports counts and warns about ignored entries.

* **Documentation**
  * New guide documenting the Bash permission import workflow and CLI options.

* **Tests**
  * Added comprehensive unit and integration tests covering import behavior, merging/replacing, dry-run, and robustness when existing data is malformed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2027)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->