### PR TITLE
ROB-3821: Add additional_env_froms support to Holmes Helm chart

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -134,6 +134,10 @@ spec:
           {{- if .Values.additional_env_vars -}}
           {{ toYaml .Values.additional_env_vars | nindent 10 }}
           {{- end }}
+        {{- if .Values.additional_env_froms }}
+        envFrom:
+        {{ toYaml .Values.additional_env_froms | nindent 8 }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -3,6 +3,11 @@ logLevel: INFO
 
 additionalEnvVars: []
 additional_env_vars: []
+# Mirrors runner.additional_env_froms: a list of envFrom entries (secretRef /
+# configMapRef) loaded onto the Holmes pod. Use to share a Secret between the
+# runner and Holmes (e.g. ROBUSTA_UI_TOKEN, SLACK_TOKEN) without declaring
+# each key twice.
+additional_env_froms: []
 imagePullSecrets: []
 podAnnotations: {}
 


### PR DESCRIPTION
## Summary
- Adds an `additional_env_froms` value to the Holmes Helm chart, rendered as `envFrom` on the Holmes container.
- Mirrors the existing `runner.additional_env_froms` field in the Robusta chart so the same Secret / ConfigMap can be projected into both pods.
- Lets users share credentials such as `ROBUSTA_UI_TOKEN` or `SLACK_TOKEN` between the Robusta runner and Holmes without restating each key under `additional_env_vars`.

Defaults to `[]`, so this is a no-op for existing installations.

### Example
\`\`\`yaml
additional_env_froms:
  - secretRef:
      name: holmes-secrets
\`\`\`

## Test plan
- [ ] \`helm template\` with \`additional_env_froms: []\` (default) renders no \`envFrom\` block on the Holmes container.
- [ ] \`helm template\` with a populated \`additional_env_froms\` list renders the entries under \`envFrom\` on the Holmes container.
- [ ] Deploy with a \`secretRef\` entry and verify the projected env vars appear inside the Holmes pod (\`kubectl exec ... -- env\`).

> Note: I couldn't find a pre-existing GitHub issue discussing this — happy to link one if there's an internal ticket beyond ROB-3821 that should be referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for injecting additional environment sources (ConfigMaps and Secrets) into Holmes pod deployments via new Helm configuration, enabling shared secrets/configs without duplicating individual entries.

* **Documentation**
  * Added configuration comments explaining the new `additional_env_froms` option and usage examples for envFrom entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2028)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->