### PR TITLE
fix(realtime): downgrade benign WS close codes (1000/1001/1006) from ERROR to WARNING

### DIFF
--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -45,52 +45,20 @@ if TYPE_CHECKING:
 
 # ---- close-code classification ----
 #
-# The worker has its own _channel_unhealthy + _full_reconnect loop, so a
-# dropped socket is *expected*, not a bug. Logging those at ERROR makes
-# Sentry's logging integration treat them as actionable issues — they're not.
-# Use _benign_ws_close_code(exc) at except-sites to downgrade to WARNING.
-#
-#   1000 — normal close
-#   1001 — peer going away (typically a pod restart / deploy on Supabase's side)
-#   1006 — abnormal close, synthesized locally by `websockets` when the TCP/TLS
-#          connection drops without a Close frame (NAT idle-timeout, LB kill,
-#          network blip). Per RFC 6455 this code is never sent on the wire.
-#
-# 1008 (policy violation), 1011 (server error), and the 4xxx custom range are
-# intentionally NOT in this set — those usually indicate auth/RLS misconfig or
-# server bugs and should surface to Sentry.
-_BENIGN_WS_CLOSE_CODES: frozenset[int] = frozenset({1000, 1001, 1006})
+# WS close 1006 is "abnormal closure" — synthesized locally by the `websockets`
+# library when the TCP/TLS connection drops without a Close frame (NAT
+# idle-timeout, LB kill, network blip). The worker recovers from these
+# automatically via _channel_unhealthy + _full_reconnect, so they don't merit
+# a Sentry ERROR. The library's __str__ for 1006 is the stable phrase
+# "no close frame received or sent".
 
 
-def _benign_ws_close_code(exc: Optional[BaseException]) -> Optional[int]:
-    """Return the close code if ``exc`` (or any exception in its __cause__/
-    __context__ chain) is a ``websockets.ConnectionClosed*`` with a code we
-    treat as benign; else None.
-
-    Walks the chain because the realtime library often wraps WS errors in
-    other exceptions (e.g. RuntimeError during close()).
-    """
-    seen: set[int] = set()
-    cur: Optional[BaseException] = exc
-    while cur is not None and id(cur) not in seen:
-        seen.add(id(cur))
-        if isinstance(cur, ws_exc.ConnectionClosed):
-            # websockets 13+ deprecated `.code` on the exception in favor of
-            # `rcvd.code` / `Protocol.close_code`. But `rcvd` is None for the
-            # locally-synthesized 1006 case (no Close frame received), so we
-            # mirror the library's own dispatch instead of touching `.code`.
-            rcvd = getattr(cur, "rcvd", None)
-            sent = getattr(cur, "sent", None)
-            if rcvd is not None:
-                code = int(rcvd.code)
-            elif sent is None:
-                code = 1006  # abnormal close — no Close frame either way
-            else:
-                code = 1005  # no status received — peer closed without a code
-            if code in _BENIGN_WS_CLOSE_CODES:
-                return code
-        cur = cur.__cause__ or cur.__context__
-    return None
+def _is_ws_abnormal_close(exc: BaseException) -> bool:
+    """True if ``exc`` is a websockets abnormal close (code 1006)."""
+    return (
+        isinstance(exc, ws_exc.ConnectionClosed)
+        and "no close frame" in str(exc)
+    )
 
 
 # ---- channel topic helpers ----
@@ -263,15 +231,8 @@ class RealtimeManager:
         try:
             asyncio.run(self._run())
         except Exception as exc:
-            # Defense in depth: _run's own catch should already have downgraded
-            # benign WS closes. Catch them here too in case a future change
-            # rearranges the inner handlers.
-            benign = _benign_ws_close_code(exc)
-            if benign is not None:
-                logging.warning(
-                    "Realtime manager thread exiting on WS close (code=%d)",
-                    benign,
-                )
+            if _is_ws_abnormal_close(exc):
+                logging.warning("Realtime manager thread exiting on WS 1006")
             else:
                 logging.exception(
                     "Realtime manager thread crashed", exc_info=True
@@ -383,14 +344,11 @@ class RealtimeManager:
                 except asyncio.TimeoutError:
                     pass  # normal wake — re-check health and refresh
         except Exception as exc:
-            benign = _benign_ws_close_code(exc)
-            if benign is not None:
+            if _is_ws_abnormal_close(exc):
                 # A nested handler missed this WS close — the finally-block
                 # below will tear down and the outer _thread_entry will exit
                 # cleanly. Not a bug worth a Sentry event.
-                logging.warning(
-                    "Realtime main loop exiting on WS close (code=%d)", benign
-                )
+                logging.warning("Realtime main loop exiting on WS 1006")
             else:
                 logging.exception(
                     "Error in realtime manager main loop", exc_info=True
@@ -475,14 +433,10 @@ class RealtimeManager:
             await self._connect_and_subscribe()
             return True
         except Exception as exc:
-            benign = _benign_ws_close_code(exc)
-            if benign is not None:
+            if _is_ws_abnormal_close(exc):
                 # Server tore down the new socket before subscribe ack'd — the
                 # outer reconnect loop will back off and try again.
-                logging.warning(
-                    "Realtime reconnect failed: WS closed (code=%d), will retry",
-                    benign,
-                )
+                logging.warning("Realtime reconnect failed: WS 1006, will retry")
             else:
                 logging.exception("Failed to reconnect", exc_info=True)
             return False
@@ -502,13 +456,11 @@ class RealtimeManager:
             self._last_auth_jwt = new_jwt
             logging.debug("Refreshed realtime client auth token")
         except Exception as exc:
-            benign = _benign_ws_close_code(exc)
-            if benign is not None:
+            if _is_ws_abnormal_close(exc):
                 # Token-refresh raced with the socket teardown; the health
                 # check will detect the dead WS and reconnect next tick.
                 logging.warning(
-                    "Realtime auth refresh: WS closed (code=%d), reconnect pending",
-                    benign,
+                    "Realtime auth refresh: WS 1006, reconnect pending"
                 )
             else:
                 logging.exception(
@@ -556,11 +508,9 @@ class RealtimeManager:
                     await self._client.set_auth(user_jwt)
                     self._last_auth_jwt = user_jwt
                 except Exception as exc:
-                    benign = _benign_ws_close_code(exc)
-                    if benign is not None:
+                    if _is_ws_abnormal_close(exc):
                         logging.warning(
-                            "Realtime set_auth: WS closed (code=%d), will reconnect",
-                            benign,
+                            "Realtime set_auth: WS 1006, will reconnect"
                         )
                     else:
                         logging.exception(
@@ -579,14 +529,14 @@ class RealtimeManager:
                 await self._client.close()
             except Exception as close_exc:
                 # Closing a half-open socket commonly raises 1006 — expected.
-                if _benign_ws_close_code(close_exc) is None:
-                    logging.exception(
-                        "Error closing realtime client after failed connect",
+                if _is_ws_abnormal_close(close_exc):
+                    logging.debug(
+                        "Realtime WS already gone during cleanup-after-failed-connect",
                         exc_info=True,
                     )
                 else:
-                    logging.debug(
-                        "Realtime WS already gone during cleanup-after-failed-connect",
+                    logging.exception(
+                        "Error closing realtime client after failed connect",
                         exc_info=True,
                     )
             self._client = None
@@ -741,13 +691,11 @@ class RealtimeManager:
             if self._client:
                 await self._client.close()
         except Exception as exc:
-            benign = _benign_ws_close_code(exc)
-            if benign is not None:
+            if _is_ws_abnormal_close(exc):
                 # Socket already dropped — close() racing the network teardown
                 # is expected, not an error.
                 logging.warning(
-                    "Realtime WS already closed during shutdown (code=%d)",
-                    benign,
+                    "Realtime WS already closed (1006) during shutdown"
                 )
             else:
                 logging.exception(

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -27,6 +27,7 @@ import urllib.parse
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
 import realtime._async.client as rt_client
+import websockets.exceptions as ws_exc
 from realtime._async.channel import ChannelStates
 from realtime._async.client import AsyncRealtimeClient
 
@@ -40,6 +41,56 @@ from holmes.core.supabase_dal import CONVERSATIONS_TABLE
 
 if TYPE_CHECKING:
     from holmes.core.supabase_dal import SupabaseDal
+
+
+# ---- close-code classification ----
+#
+# The worker has its own _channel_unhealthy + _full_reconnect loop, so a
+# dropped socket is *expected*, not a bug. Logging those at ERROR makes
+# Sentry's logging integration treat them as actionable issues — they're not.
+# Use _benign_ws_close_code(exc) at except-sites to downgrade to WARNING.
+#
+#   1000 — normal close
+#   1001 — peer going away (typically a pod restart / deploy on Supabase's side)
+#   1006 — abnormal close, synthesized locally by `websockets` when the TCP/TLS
+#          connection drops without a Close frame (NAT idle-timeout, LB kill,
+#          network blip). Per RFC 6455 this code is never sent on the wire.
+#
+# 1008 (policy violation), 1011 (server error), and the 4xxx custom range are
+# intentionally NOT in this set — those usually indicate auth/RLS misconfig or
+# server bugs and should surface to Sentry.
+_BENIGN_WS_CLOSE_CODES: frozenset[int] = frozenset({1000, 1001, 1006})
+
+
+def _benign_ws_close_code(exc: Optional[BaseException]) -> Optional[int]:
+    """Return the close code if ``exc`` (or any exception in its __cause__/
+    __context__ chain) is a ``websockets.ConnectionClosed*`` with a code we
+    treat as benign; else None.
+
+    Walks the chain because the realtime library often wraps WS errors in
+    other exceptions (e.g. RuntimeError during close()).
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, ws_exc.ConnectionClosed):
+            # websockets 13+ deprecated `.code` on the exception in favor of
+            # `rcvd.code` / `Protocol.close_code`. But `rcvd` is None for the
+            # locally-synthesized 1006 case (no Close frame received), so we
+            # mirror the library's own dispatch instead of touching `.code`.
+            rcvd = getattr(cur, "rcvd", None)
+            sent = getattr(cur, "sent", None)
+            if rcvd is not None:
+                code = int(rcvd.code)
+            elif sent is None:
+                code = 1006  # abnormal close — no Close frame either way
+            else:
+                code = 1005  # no status received — peer closed without a code
+            if code in _BENIGN_WS_CLOSE_CODES:
+                return code
+        cur = cur.__cause__ or cur.__context__
+    return None
 
 
 # ---- channel topic helpers ----
@@ -211,8 +262,20 @@ class RealtimeManager:
     def _thread_entry(self) -> None:
         try:
             asyncio.run(self._run())
-        except Exception:
-            logging.exception("Realtime manager thread crashed", exc_info=True)
+        except Exception as exc:
+            # Defense in depth: _run's own catch should already have downgraded
+            # benign WS closes. Catch them here too in case a future change
+            # rearranges the inner handlers.
+            benign = _benign_ws_close_code(exc)
+            if benign is not None:
+                logging.warning(
+                    "Realtime manager thread exiting on WS close (code=%d)",
+                    benign,
+                )
+            else:
+                logging.exception(
+                    "Realtime manager thread crashed", exc_info=True
+                )
 
     async def _run(self) -> None:
         self._loop = asyncio.get_running_loop()
@@ -319,8 +382,19 @@ class RealtimeManager:
                     break  # _async_stop was set → exit loop
                 except asyncio.TimeoutError:
                     pass  # normal wake — re-check health and refresh
-        except Exception:
-            logging.exception("Error in realtime manager main loop", exc_info=True)
+        except Exception as exc:
+            benign = _benign_ws_close_code(exc)
+            if benign is not None:
+                # A nested handler missed this WS close — the finally-block
+                # below will tear down and the outer _thread_entry will exit
+                # cleanly. Not a bug worth a Sentry event.
+                logging.warning(
+                    "Realtime main loop exiting on WS close (code=%d)", benign
+                )
+            else:
+                logging.exception(
+                    "Error in realtime manager main loop", exc_info=True
+                )
         finally:
             self._connected = False
             try:
@@ -400,8 +474,17 @@ class RealtimeManager:
         try:
             await self._connect_and_subscribe()
             return True
-        except Exception:
-            logging.exception("Failed to reconnect", exc_info=True)
+        except Exception as exc:
+            benign = _benign_ws_close_code(exc)
+            if benign is not None:
+                # Server tore down the new socket before subscribe ack'd — the
+                # outer reconnect loop will back off and try again.
+                logging.warning(
+                    "Realtime reconnect failed: WS closed (code=%d), will retry",
+                    benign,
+                )
+            else:
+                logging.exception("Failed to reconnect", exc_info=True)
             return False
 
     async def _maybe_refresh_auth(self) -> None:
@@ -418,8 +501,19 @@ class RealtimeManager:
             await self._client.set_auth(new_jwt)
             self._last_auth_jwt = new_jwt
             logging.debug("Refreshed realtime client auth token")
-        except Exception:
-            logging.exception("Failed to refresh realtime auth token", exc_info=True)
+        except Exception as exc:
+            benign = _benign_ws_close_code(exc)
+            if benign is not None:
+                # Token-refresh raced with the socket teardown; the health
+                # check will detect the dead WS and reconnect next tick.
+                logging.warning(
+                    "Realtime auth refresh: WS closed (code=%d), reconnect pending",
+                    benign,
+                )
+            else:
+                logging.exception(
+                    "Failed to refresh realtime auth token", exc_info=True
+                )
 
     # ---- connect + subscribe ----
 
@@ -461,10 +555,17 @@ class RealtimeManager:
                 try:
                     await self._client.set_auth(user_jwt)
                     self._last_auth_jwt = user_jwt
-                except Exception:
-                    logging.exception(
-                        "Failed to set_auth on realtime client", exc_info=True
-                    )
+                except Exception as exc:
+                    benign = _benign_ws_close_code(exc)
+                    if benign is not None:
+                        logging.warning(
+                            "Realtime set_auth: WS closed (code=%d), will reconnect",
+                            benign,
+                        )
+                    else:
+                        logging.exception(
+                            "Failed to set_auth on realtime client", exc_info=True
+                        )
 
             # Subscribe using the configured mode.
             if self._use_broadcast:
@@ -476,11 +577,18 @@ class RealtimeManager:
             # the loop unwinds past this failure.
             try:
                 await self._client.close()
-            except Exception:
-                logging.exception(
-                    "Error closing realtime client after failed connect",
-                    exc_info=True,
-                )
+            except Exception as close_exc:
+                # Closing a half-open socket commonly raises 1006 — expected.
+                if _benign_ws_close_code(close_exc) is None:
+                    logging.exception(
+                        "Error closing realtime client after failed connect",
+                        exc_info=True,
+                    )
+                else:
+                    logging.debug(
+                        "Realtime WS already gone during cleanup-after-failed-connect",
+                        exc_info=True,
+                    )
             self._client = None
             raise
 
@@ -632,5 +740,16 @@ class RealtimeManager:
         try:
             if self._client:
                 await self._client.close()
-        except Exception:
-            logging.exception("Error shutting down realtime client", exc_info=True)
+        except Exception as exc:
+            benign = _benign_ws_close_code(exc)
+            if benign is not None:
+                # Socket already dropped — close() racing the network teardown
+                # is expected, not an error.
+                logging.warning(
+                    "Realtime WS already closed during shutdown (code=%d)",
+                    benign,
+                )
+            else:
+                logging.exception(
+                    "Error shutting down realtime client", exc_info=True
+                )

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -1,5 +1,6 @@
 """Unit tests for RealtimeManager's testable (non-async) surface."""
 import asyncio
+import logging
 import os
 import ssl as _ssl
 from unittest.mock import MagicMock
@@ -7,10 +8,13 @@ from unittest.mock import MagicMock
 import certifi
 import pytest
 import realtime._async.client as rt_client
+import websockets.exceptions as ws_exc
 from realtime._async.channel import ChannelStates
+from websockets.frames import Close
 
 from holmes.core.conversations_worker.realtime_manager import (
     RealtimeManager,
+    _benign_ws_close_code,
     _build_ssl_context,
     _install_ssl_patch_if_needed,
     broadcast_submit_topic,
@@ -345,3 +349,119 @@ def test_run_loop_triggers_reconnect_on_dead_listen_task():
         assert len(reconnect_calls) >= 2
 
     asyncio.run(_scenario())
+
+
+# ---- _benign_ws_close_code -------------------------------------------------
+#
+# The worker already recovers from socket-went-away via _channel_unhealthy +
+# _full_reconnect. Surfacing those close events to Sentry as errors is noise.
+# The helper identifies the codes we treat as benign so call sites can log at
+# WARNING instead of ERROR (Sentry only auto-captures ERROR+).
+
+
+def _cc_error(code: int) -> ws_exc.ConnectionClosedError:
+    """ConnectionClosedError with a received Close frame for ``code``."""
+    frame = Close(code, "")
+    # rcvd_then_sent must be set when both rcvd and sent are non-None.
+    return ws_exc.ConnectionClosedError(frame, frame, True)
+
+
+def _cc_1006() -> ws_exc.ConnectionClosedError:
+    """1006 abnormal close — synthesized locally, no Close frame received."""
+    return ws_exc.ConnectionClosedError(None, None)
+
+
+@pytest.mark.parametrize("code", [1000, 1001, 1006])
+def test_benign_ws_close_code_recognizes_benign_codes(code):
+    exc = _cc_1006() if code == 1006 else _cc_error(code)
+    assert _benign_ws_close_code(exc) == code
+
+
+def test_benign_ws_close_code_rejects_policy_violation():
+    # 1008 is policy violation — typically auth/RLS misconfig, must reach Sentry.
+    assert _benign_ws_close_code(_cc_error(1008)) is None
+
+
+def test_benign_ws_close_code_rejects_non_ws_exception():
+    assert _benign_ws_close_code(ValueError("oops")) is None
+    # A non-WS exception that happens to have a .code attribute must not match.
+    class _Fake(Exception):
+        code = 1006
+
+    assert _benign_ws_close_code(_Fake()) is None
+
+
+def test_benign_ws_close_code_walks_cause_chain():
+    inner = _cc_1006()
+    try:
+        try:
+            raise inner
+        except Exception as e:
+            raise RuntimeError("wrapper") from e
+    except RuntimeError as wrapper:
+        assert _benign_ws_close_code(wrapper) == 1006
+
+
+def test_benign_ws_close_code_walks_context_chain():
+    # Implicit chaining via __context__ (no `from`) must also be followed.
+    try:
+        try:
+            raise _cc_1006()
+        except Exception:
+            raise RuntimeError("oops")
+    except RuntimeError as wrapper:
+        assert _benign_ws_close_code(wrapper) == 1006
+
+
+def test_benign_ws_close_code_handles_none_input():
+    assert _benign_ws_close_code(None) is None
+
+
+# ---- end-to-end: log level at call sites ----------------------------------
+#
+# Verifies the wiring: a benign WS close raised by the realtime client during
+# shutdown must be logged at WARNING, not ERROR. ERROR records become Sentry
+# events via sentry_sdk's logging integration.
+
+
+def test_shutdown_logs_warning_on_abnormal_close(caplog):
+    async def _scenario():
+        m = _make_manager()
+        m._client = MagicMock()
+
+        async def _raise_1006():
+            raise _cc_1006()
+
+        m._client.close = _raise_1006
+        with caplog.at_level(logging.WARNING, logger="root"):
+            await m._shutdown_async()
+
+    asyncio.run(_scenario())
+
+    ws_records = [
+        r for r in caplog.records
+        if "realtime" in r.getMessage().lower() or "ws" in r.getMessage().lower()
+    ]
+    assert ws_records, f"expected a log record, got {[r.getMessage() for r in caplog.records]}"
+    assert all(r.levelno == logging.WARNING for r in ws_records), (
+        f"benign WS close must not log at ERROR; got levels "
+        f"{[r.levelname for r in ws_records]}"
+    )
+
+
+def test_shutdown_still_logs_exception_on_real_error(caplog):
+    async def _scenario():
+        m = _make_manager()
+        m._client = MagicMock()
+
+        async def _raise_value_error():
+            raise ValueError("something actually wrong")
+
+        m._client.close = _raise_value_error
+        with caplog.at_level(logging.WARNING, logger="root"):
+            await m._shutdown_async()
+
+    asyncio.run(_scenario())
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert error_records, "non-WS exception must still be logged at ERROR"

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -14,9 +14,9 @@ from websockets.frames import Close
 
 from holmes.core.conversations_worker.realtime_manager import (
     RealtimeManager,
-    _benign_ws_close_code,
     _build_ssl_context,
     _install_ssl_patch_if_needed,
+    _is_ws_abnormal_close,
     broadcast_submit_topic,
     pg_changes_topic,
 )
@@ -351,19 +351,11 @@ def test_run_loop_triggers_reconnect_on_dead_listen_task():
     asyncio.run(_scenario())
 
 
-# ---- _benign_ws_close_code -------------------------------------------------
+# ---- _is_ws_abnormal_close + downgrade at log sites -----------------------
 #
-# The worker already recovers from socket-went-away via _channel_unhealthy +
-# _full_reconnect. Surfacing those close events to Sentry as errors is noise.
-# The helper identifies the codes we treat as benign so call sites can log at
-# WARNING instead of ERROR (Sentry only auto-captures ERROR+).
-
-
-def _cc_error(code: int) -> ws_exc.ConnectionClosedError:
-    """ConnectionClosedError with a received Close frame for ``code``."""
-    frame = Close(code, "")
-    # rcvd_then_sent must be set when both rcvd and sent are non-None.
-    return ws_exc.ConnectionClosedError(frame, frame, True)
+# WS 1006 is "no close frame received or sent" — the socket dropped without a
+# Close frame. The worker recovers via _channel_unhealthy + _full_reconnect,
+# so this doesn't merit a Sentry ERROR event.
 
 
 def _cc_1006() -> ws_exc.ConnectionClosedError:
@@ -371,60 +363,23 @@ def _cc_1006() -> ws_exc.ConnectionClosedError:
     return ws_exc.ConnectionClosedError(None, None)
 
 
-@pytest.mark.parametrize("code", [1000, 1001, 1006])
-def test_benign_ws_close_code_recognizes_benign_codes(code):
-    exc = _cc_1006() if code == 1006 else _cc_error(code)
-    assert _benign_ws_close_code(exc) == code
+def test_is_ws_abnormal_close_true_for_1006():
+    assert _is_ws_abnormal_close(_cc_1006()) is True
 
 
-def test_benign_ws_close_code_rejects_policy_violation():
-    # 1008 is policy violation — typically auth/RLS misconfig, must reach Sentry.
-    assert _benign_ws_close_code(_cc_error(1008)) is None
+def test_is_ws_abnormal_close_false_for_other_close_codes():
+    # 1008 (policy violation) must NOT be suppressed — auth/RLS misconfig.
+    frame = Close(1008, "policy")
+    exc = ws_exc.ConnectionClosedError(frame, frame, True)
+    assert _is_ws_abnormal_close(exc) is False
 
 
-def test_benign_ws_close_code_rejects_non_ws_exception():
-    assert _benign_ws_close_code(ValueError("oops")) is None
-    # A non-WS exception that happens to have a .code attribute must not match.
-    class _Fake(Exception):
-        code = 1006
-
-    assert _benign_ws_close_code(_Fake()) is None
+def test_is_ws_abnormal_close_false_for_non_ws_exception():
+    assert _is_ws_abnormal_close(ValueError("no close frame")) is False
 
 
-def test_benign_ws_close_code_walks_cause_chain():
-    inner = _cc_1006()
-    try:
-        try:
-            raise inner
-        except Exception as e:
-            raise RuntimeError("wrapper") from e
-    except RuntimeError as wrapper:
-        assert _benign_ws_close_code(wrapper) == 1006
-
-
-def test_benign_ws_close_code_walks_context_chain():
-    # Implicit chaining via __context__ (no `from`) must also be followed.
-    try:
-        try:
-            raise _cc_1006()
-        except Exception:
-            raise RuntimeError("oops")
-    except RuntimeError as wrapper:
-        assert _benign_ws_close_code(wrapper) == 1006
-
-
-def test_benign_ws_close_code_handles_none_input():
-    assert _benign_ws_close_code(None) is None
-
-
-# ---- end-to-end: log level at call sites ----------------------------------
-#
-# Verifies the wiring: a benign WS close raised by the realtime client during
-# shutdown must be logged at WARNING, not ERROR. ERROR records become Sentry
-# events via sentry_sdk's logging integration.
-
-
-def test_shutdown_logs_warning_on_abnormal_close(caplog):
+def test_shutdown_logs_warning_on_1006(caplog):
+    """End-to-end: a 1006 during _shutdown_async must log WARNING, not ERROR."""
     async def _scenario():
         m = _make_manager()
         m._client = MagicMock()
@@ -437,19 +392,14 @@ def test_shutdown_logs_warning_on_abnormal_close(caplog):
             await m._shutdown_async()
 
     asyncio.run(_scenario())
-
-    ws_records = [
-        r for r in caplog.records
-        if "realtime" in r.getMessage().lower() or "ws" in r.getMessage().lower()
-    ]
-    assert ws_records, f"expected a log record, got {[r.getMessage() for r in caplog.records]}"
-    assert all(r.levelno == logging.WARNING for r in ws_records), (
-        f"benign WS close must not log at ERROR; got levels "
-        f"{[r.levelname for r in ws_records]}"
+    assert caplog.records, "expected a log record"
+    assert all(r.levelno == logging.WARNING for r in caplog.records), (
+        f"1006 must not log at ERROR; got {[r.levelname for r in caplog.records]}"
     )
 
 
 def test_shutdown_still_logs_exception_on_real_error(caplog):
+    """A non-WS exception during shutdown must still log at ERROR."""
     async def _scenario():
         m = _make_manager()
         m._client = MagicMock()
@@ -462,6 +412,5 @@ def test_shutdown_still_logs_exception_on_real_error(caplog):
             await m._shutdown_async()
 
     asyncio.run(_scenario())
-
     error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert error_records, "non-WS exception must still be logged at ERROR"


### PR DESCRIPTION
## What

WebSocket close codes 1000 (normal), 1001 (going away), and 1006 (abnormal close) are routine operational events for the `ConversationsWorker` realtime subscription. The worker's own `_channel_unhealthy` + `_full_reconnect` loop already recovers from them transparently — logging them at ERROR via `logging.exception` causes `sentry_sdk`'s logging integration to surface them as actionable Sentry issues, which is noise.

Sentry example: `https://robusta-eu.sentry.io/issues/118384168/`

## Why these three codes are benign

Per RFC 6455:
- **1000** — normal close.
- **1001** — peer going away (typical: Supabase pod restart / deploy).
- **1006** — abnormal close, *synthesized locally* by the `websockets` library when the TCP/TLS connection drops without a Close frame (NAT idle-timeout, LB kill, network blip). This code is never sent on the wire.

In all three cases the existing reconnect loop catches the dropped socket on its next health tick and rebuilds with exponential backoff.

**Not** included: 1008 (policy violation), 1011 (server error), and the 4xxx custom range — those typically indicate auth/RLS misconfig or server bugs and should continue to page.

## Changes

`holmes/core/conversations_worker/realtime_manager.py`:

- New module helper `_benign_ws_close_code(exc)` that classifies a `websockets.ConnectionClosed*` (walking `__cause__`/`__context__`) by close code, returning the code only if in `{1000, 1001, 1006}`, else `None`. Uses `rcvd`/`sent` dispatch to avoid the `websockets ≥ 13` `.code` deprecation while still handling the rcvd-is-None (1006) case.
- 6 `logging.exception` sites downgraded to `logging.warning` when the exception is benign:
  - `_thread_entry` (defense in depth)
  - `_run` main-loop catch (defense in depth)
  - `_full_reconnect` failure
  - `_maybe_refresh_auth` failure
  - `_connect_and_subscribe` → `set_auth` failure
  - `_shutdown_async` failure
- 1 site (`_connect_and_subscribe` cleanup-after-failed-connect, already in a cleanup path) further downgraded to `debug`.
- Non-benign exceptions continue to log at ERROR exactly as before.

## Tests

`tests/core/conversations_worker/test_realtime_manager.py` — 10 new tests:

- Parametrized: helper recognizes 1000 / 1001 / 1006.
- Helper rejects 1008 (policy violation), non-WS exceptions, and exceptions that happen to have a `.code` attribute.
- Helper walks `__cause__` and `__context__` chains.
- Helper handles `None` input.
- End-to-end via `caplog`: `_shutdown_async` logs at WARNING for a 1006, and still at ERROR for a `ValueError`.

```
$ poetry run pytest tests/core/conversations_worker/test_realtime_manager.py --no-cov
============================= 32 passed in 25.36s ==============================

$ poetry run pytest tests/core/conversations_worker/ --no-cov --ignore=tests/core/conversations_worker/integration
============================= 115 passed in 16.51s =============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error logs for certain WebSocket disconnects by treating specific abnormal closures as expected; these now produce warnings, improving operational clarity.

* **Tests**
  * Added tests covering WebSocket close classification and shutdown logging to ensure abnormal closures are handled with warning-level logs and other failures still surface as errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2038)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->