### PR TITLE
Make test fixtures reentrant for parallel CI execution

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/183b_elasticsearch_index_discovery/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183b_elasticsearch_index_discovery/test_case.yaml
@@ -51,6 +51,13 @@ before_test: |
   # Small delay to ensure index is fully ready
   sleep 2
 
+  # One-shot stale-doc cleanup: drop any doc whose _id isn't in our known
+  # set. Safe under concurrency (parallel run's docs match the keep-list).
+  curl -s -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["doc-1","doc-2","doc-3","doc-4","doc-5"]}}]}}}' > /dev/null
+
   # Index 5 documents using bulk API. Stable _ids make this idempotent under
   # concurrent runs (overwrites instead of duplicates).
   BULK_DATA=""

--- a/tests/llm/fixtures/test_ask_holmes/183b_elasticsearch_index_discovery/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183b_elasticsearch_index_discovery/test_case.yaml
@@ -32,20 +32,18 @@ before_test: |
   export HOLMES_ES_TEST_INDEX="app-183b-data-xq7n4f2p"
   echo "Using test index: $HOLMES_ES_TEST_INDEX"
 
-  # Clean up any existing index first
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: index name is static and shared with parallel CI runs of this
+  # eval. Do NOT delete - that would wipe a parallel run's data. Create-or-
+  # reuse instead, and use stable doc _ids so concurrent runs converge on the
+  # same 5 documents (count check expects exactly 5).
+  echo "⏳ Creating (or reusing) test index with 5 documents..."
 
-  # Create the test index with 5 documents
-  echo "⏳ Creating test index with 5 documents..."
-
-  # Create the index with wait_for_active_shards to ensure it's ready
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"settings": {"number_of_shards": 1, "number_of_replicas": 0}}')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -53,10 +51,11 @@ before_test: |
   # Small delay to ensure index is fully ready
   sleep 2
 
-  # Index 5 documents using bulk API
+  # Index 5 documents using bulk API. Stable _ids make this idempotent under
+  # concurrent runs (overwrites instead of duplicates).
   BULK_DATA=""
   for i in 1 2 3 4 5; do
-    BULK_DATA="${BULK_DATA}{\"index\":{}}\n{\"message\":\"Test document $i for Holmes eval\",\"level\":\"INFO\",\"timestamp\":\"2025-01-01T12:00:0${i}Z\"}\n"
+    BULK_DATA="${BULK_DATA}{\"index\":{\"_id\":\"doc-$i\"}}\n{\"message\":\"Test document $i for Holmes eval\",\"level\":\"INFO\",\"timestamp\":\"2025-01-01T12:00:0${i}Z\"}\n"
   done
 
   BULK_RESPONSE=$(echo -e "$BULK_DATA" | curl -sf -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_bulk" \
@@ -85,8 +84,8 @@ before_test: |
   fi
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-183b-data-xq7n4f2p"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-183b-data-xq7n4f2p" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-183b-data-xq7n4f2p). Parallel
+  # CI runs share the same Elasticsearch cluster, so we skip deletion to
+  # avoid removing the index while another run still depends on it.
+  # before_test is idempotent (create-or-reuse + stable doc _ids).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/183c_elasticsearch_log_search/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183c_elasticsearch_log_search/test_case.yaml
@@ -31,19 +31,17 @@ before_test: |
 
   export HOLMES_ES_TEST_INDEX="app-183c-logs"
 
-  # Delete the index if it exists (clean slate)
-  echo "⏳ Cleaning up any existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create the test index with mapping (wait for shard to be active)
-  echo "⏳ Creating test index with log mapping..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
+  # Reentrancy: index name is static and shared with parallel CI runs of this
+  # eval. Do NOT delete - that would wipe a parallel run's data. Create-or-
+  # reuse instead, and use stable doc _ids so concurrent runs converge on
+  # the same documents (the verification expects exactly 3 ERROR rows).
+  echo "⏳ Creating (or reusing) test index with log mapping..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"timestamp":{"type":"date"},"level":{"type":"keyword"},"service":{"type":"keyword"},"error_code":{"type":"keyword"},"message":{"type":"text"}}}}')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -58,21 +56,23 @@ before_test: |
   # Create unique temp file
   BULK_FILE="/tmp/es_bulk_183c_$$.ndjson"
 
-  # Create bulk data file with mixed log levels and specific error codes
+  # Create bulk data file with mixed log levels and specific error codes.
+  # Stable _ids make this idempotent under concurrent runs (overwrite, not
+  # duplicate) so the ERROR-count check stays at exactly 3.
   cat > "$BULK_FILE" << BULK_EOF
-  {"index":{}}
+  {"index":{"_id":"log-1"}}
   {"timestamp":"2025-01-01T10:00:00Z","level":"INFO","service":"payment-api","message":"Service started successfully"}
-  {"index":{}}
+  {"index":{"_id":"log-2"}}
   {"timestamp":"2025-01-01T10:05:00Z","level":"ERROR","service":"payment-api","error_code":"${ERROR_CODE_1}","message":"Database connection timeout - ${ERROR_CODE_1}: Failed to connect to primary database after 30s"}
-  {"index":{}}
+  {"index":{"_id":"log-3"}}
   {"timestamp":"2025-01-01T10:06:00Z","level":"WARN","service":"payment-api","message":"Retrying database connection"}
-  {"index":{}}
+  {"index":{"_id":"log-4"}}
   {"timestamp":"2025-01-01T10:10:00Z","level":"ERROR","service":"order-service","error_code":"${ERROR_CODE_2}","message":"Payment validation failed - ${ERROR_CODE_2}: Invalid card number format"}
-  {"index":{}}
+  {"index":{"_id":"log-5"}}
   {"timestamp":"2025-01-01T10:15:00Z","level":"INFO","service":"order-service","message":"Processing order batch complete"}
-  {"index":{}}
+  {"index":{"_id":"log-6"}}
   {"timestamp":"2025-01-01T10:20:00Z","level":"ERROR","service":"inventory-api","error_code":"${ERROR_CODE_3}","message":"Stock sync failed - ${ERROR_CODE_3}: External inventory API returned 503"}
-  {"index":{}}
+  {"index":{"_id":"log-7"}}
   {"timestamp":"2025-01-01T10:25:00Z","level":"INFO","service":"inventory-api","message":"Recovered from temporary outage"}
   BULK_EOF
 
@@ -112,8 +112,8 @@ before_test: |
   fi
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-183c-logs"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-183c-logs" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-183c-logs). Parallel CI runs
+  # share the same Elasticsearch cluster, so we skip deletion to avoid
+  # removing the index while another run still depends on it.
+  # before_test is idempotent (create-or-reuse + stable doc _ids).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/183c_elasticsearch_log_search/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183c_elasticsearch_log_search/test_case.yaml
@@ -48,6 +48,13 @@ before_test: |
 
   sleep 2
 
+  # One-shot stale-doc cleanup: drop any doc whose _id isn't in our known
+  # set. Safe under concurrency (parallel run's docs match the keep-list).
+  curl -s -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["log-1","log-2","log-3","log-4","log-5","log-6","log-7"]}}]}}}' > /dev/null
+
   # Define the specific error codes for anti-hallucination testing
   ERROR_CODE_1="ERR-7291"
   ERROR_CODE_2="ERR-4058"

--- a/tests/llm/fixtures/test_ask_holmes/183d_elasticsearch_aggregation/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183d_elasticsearch_aggregation/test_case.yaml
@@ -49,6 +49,13 @@ before_test: |
     exit 1
   fi
 
+  # One-shot stale-doc cleanup: drop any doc whose _id isn't in our known
+  # set. Safe under concurrency (parallel run's docs match the keep-list).
+  curl -s -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["evt-1","evt-2","evt-3","evt-4","evt-5","evt-6","evt-7","evt-8","evt-9","evt-10"]}}]}}}' > /dev/null
+
   # Small delay to ensure index is fully ready for queries and bulk operations
   # (wait_for_active_shards only ensures shard allocation)
   sleep 2

--- a/tests/llm/fixtures/test_ask_holmes/183d_elasticsearch_aggregation/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183d_elasticsearch_aggregation/test_case.yaml
@@ -34,19 +34,17 @@ before_test: |
 
   export HOLMES_ES_TEST_INDEX="app-183d-events"
 
-  # Delete the index if it exists
-  echo "⏳ Cleaning up any existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create the test index
-  echo "⏳ Creating test index..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse instead, and use stable doc _ids so concurrent runs
+  # converge on the same 10 documents (count check expects exactly 10).
+  echo "⏳ Creating (or reusing) test index..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"timestamp":{"type":"date"},"service":{"type":"keyword"},"event_type":{"type":"keyword"},"duration_ms":{"type":"integer"}}}}')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -60,26 +58,28 @@ before_test: |
 
   # Create bulk data file with specific distribution:
   # payment-api: 5 events, order-service: 3 events, inventory-api: 2 events
+  # Stable _ids make this idempotent under concurrent runs (overwrite, not
+  # duplicate) so the 10-document count check stays exact.
   cat > "$BULK_FILE" << 'BULK_EOF'
-  {"index":{}}
+  {"index":{"_id":"evt-1"}}
   {"timestamp":"2025-01-01T10:01:00Z","service":"payment-api","event_type":"request","duration_ms":110}
-  {"index":{}}
+  {"index":{"_id":"evt-2"}}
   {"timestamp":"2025-01-01T10:02:00Z","service":"payment-api","event_type":"request","duration_ms":120}
-  {"index":{}}
+  {"index":{"_id":"evt-3"}}
   {"timestamp":"2025-01-01T10:03:00Z","service":"payment-api","event_type":"request","duration_ms":130}
-  {"index":{}}
+  {"index":{"_id":"evt-4"}}
   {"timestamp":"2025-01-01T10:04:00Z","service":"payment-api","event_type":"request","duration_ms":140}
-  {"index":{}}
+  {"index":{"_id":"evt-5"}}
   {"timestamp":"2025-01-01T10:05:00Z","service":"payment-api","event_type":"request","duration_ms":150}
-  {"index":{}}
+  {"index":{"_id":"evt-6"}}
   {"timestamp":"2025-01-01T11:01:00Z","service":"order-service","event_type":"request","duration_ms":210}
-  {"index":{}}
+  {"index":{"_id":"evt-7"}}
   {"timestamp":"2025-01-01T11:02:00Z","service":"order-service","event_type":"request","duration_ms":220}
-  {"index":{}}
+  {"index":{"_id":"evt-8"}}
   {"timestamp":"2025-01-01T11:03:00Z","service":"order-service","event_type":"request","duration_ms":230}
-  {"index":{}}
+  {"index":{"_id":"evt-9"}}
   {"timestamp":"2025-01-01T12:01:00Z","service":"inventory-api","event_type":"request","duration_ms":310}
-  {"index":{}}
+  {"index":{"_id":"evt-10"}}
   {"timestamp":"2025-01-01T12:02:00Z","service":"inventory-api","event_type":"request","duration_ms":320}
   BULK_EOF
 
@@ -117,8 +117,8 @@ before_test: |
   fi
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-183d-events"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-183d-events" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-183d-events). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # removing the index while another run still depends on it.
+  # before_test is idempotent (create-or-reuse + stable doc _ids).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/183e_elasticsearch_field_mappings/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183e_elasticsearch_field_mappings/test_case.yaml
@@ -33,14 +33,12 @@ before_test: |
 
   export HOLMES_ES_TEST_INDEX="app-183e-transactions"
 
-  # Delete the index if it exists
-  echo "⏳ Cleaning up any existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create the test index with specific mappings including nested objects
-  echo "⏳ Creating test index with specific schema..."
-  RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse instead. The mapping is fixed at index creation, so
+  # reusing an existing index is safe.
+  echo "⏳ Creating (or reusing) test index with specific schema..."
+  RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -67,9 +65,8 @@ before_test: |
       }
     }')
 
-  # Verify index was created
-  if echo "$RESPONSE" | grep -q '"acknowledged":true'; then
-    echo "✅ Test index created with custom schema"
+  if echo "$RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
+    echo "✅ Test index ready with custom schema"
   else
     echo "❌ Failed to create test index: $RESPONSE"
     exit 1
@@ -77,8 +74,9 @@ before_test: |
 
   sleep 2
 
-  # Index a sample document to confirm mappings
-  curl -sf -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_doc" \
+  # Index a sample document with a stable _id so concurrent runs converge on
+  # the same document instead of stacking duplicates.
+  curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_doc/seed-1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -102,8 +100,8 @@ before_test: |
   echo "✅ Test index ready with mappings: transaction_id (keyword), amount (double), metadata.region (keyword), metadata.priority (integer), processed_at (date)"
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-183e-transactions"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-183e-transactions" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-183e-transactions). Parallel
+  # CI runs share the same Elasticsearch cluster, so we skip deletion to
+  # avoid removing the index while another run still depends on it.
+  # before_test is idempotent (create-or-reuse + stable doc _id).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/183f_elasticsearch_shard_filtering/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183f_elasticsearch_shard_filtering/test_case.yaml
@@ -33,14 +33,12 @@ before_test: |
 
   export HOLMES_ES_TEST_INDEX="app-183f-shards"
 
-  # Delete the index if it exists
-  echo "⏳ Cleaning up any existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create the test index with 3 shards and 0 replicas
-  echo "⏳ Creating test index with 3 shards..."
-  RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse instead. The shard count is fixed at index creation,
+  # so reusing an existing index keeps the test invariant intact.
+  echo "⏳ Creating (or reusing) test index with 3 shards..."
+  RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -50,8 +48,8 @@ before_test: |
       }
     }')
 
-  if echo "$RESPONSE" | grep -q '"acknowledged":true'; then
-    echo "✅ Test index created with 3 shards"
+  if echo "$RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
+    echo "✅ Test index ready with 3 shards"
   else
     echo "❌ Failed to create test index: $RESPONSE"
     exit 1
@@ -79,8 +77,8 @@ before_test: |
   done
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-183f-shards"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-183f-shards" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-183f-shards). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # removing the index while another run still depends on it.
+  # before_test is idempotent (create-or-reuse).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/183g_elasticsearch_index_stats/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183g_elasticsearch_index_stats/test_case.yaml
@@ -52,6 +52,14 @@ before_test: |
 
   sleep 2
 
+  # One-shot stale-doc cleanup: drop any doc whose _id isn't in our known
+  # set (doc-1..doc-50). Safe under concurrency.
+  KEEP_IDS=$(python3 -c "import json; print(json.dumps([f'doc-{i}' for i in range(1,51)]))")
+  curl -s -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d "{\"query\":{\"bool\":{\"must_not\":[{\"ids\":{\"values\":${KEEP_IDS}}}]}}}" > /dev/null
+
   # Create exactly 50 documents using bulk API. Stable _ids make this
   # idempotent under concurrent runs (overwrite, not duplicate).
   echo "⏳ Indexing 50 documents..."

--- a/tests/llm/fixtures/test_ask_holmes/183g_elasticsearch_index_stats/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/183g_elasticsearch_index_stats/test_case.yaml
@@ -30,14 +30,12 @@ before_test: |
 
   export HOLMES_ES_TEST_INDEX="app-183g-stats"
 
-  # Delete the index if it exists
-  echo "⏳ Cleaning up any existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create the test index
-  echo "⏳ Creating test index..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse instead, and use stable doc _ids so concurrent runs
+  # converge on the same 50 documents (count check expects exactly 50).
+  echo "⏳ Creating (or reusing) test index..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -47,20 +45,21 @@ before_test: |
       }
     }')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
 
   sleep 2
 
-  # Create exactly 50 documents using bulk API
+  # Create exactly 50 documents using bulk API. Stable _ids make this
+  # idempotent under concurrent runs (overwrite, not duplicate).
   echo "⏳ Indexing 50 documents..."
   BULK_FILE="/tmp/es_bulk_183g_$$.ndjson"
   > "$BULK_FILE"
 
   for i in $(seq 1 50); do
-    echo '{"index":{}}' >> "$BULK_FILE"
+    echo "{\"index\":{\"_id\":\"doc-$i\"}}" >> "$BULK_FILE"
     echo "{\"id\":$i,\"message\":\"Test document number $i\",\"value\":$((i * 10))}" >> "$BULK_FILE"
   done
 
@@ -93,8 +92,8 @@ before_test: |
   fi
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-183g-stats"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-183g-stats" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-183g-stats). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # removing the index while another run still depends on it.
+  # before_test is idempotent (create-or-reuse + stable doc _ids).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/184_elasticsearch_index_explosion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/184_elasticsearch_index_explosion/test_case.yaml
@@ -41,15 +41,13 @@ before_test: |
 
   echo "Creating 1800 test indexes (5 large, 1795 small)..."
 
-  # Clean up any existing test data first for idempotency
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-184-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/_index_template/app-184-template" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" 2>/dev/null || true
+  # Reentrancy: index pattern (app-184-*) and template (app-184-template) are
+  # static and shared with parallel CI runs of this eval. Do NOT delete -
+  # that would wipe a parallel run's data. Instead, PUT the template (it
+  # is overwritten in place, which is idempotent) and rely on stable doc
+  # _ids in the bulk inserts so concurrent runs converge on the same docs.
 
-  # Create index template with 0 replicas to fit within cluster shard limits
-  echo "Creating index template with 0 replicas..."
+  echo "Creating (or updating) index template with 0 replicas..."
   TEMPLATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/_index_template/app-184-template" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
@@ -83,7 +81,10 @@ before_test: |
     for service in $SERVICES; do
       for day in $(seq -w 1 36); do
         INDEX_NAME="app-184-${team}-${service}-2024.01.${day}"
-        echo "{\"index\": {\"_index\": \"${INDEX_NAME}\"}}" >> "$BULK_FILE"
+        # Stable _id so concurrent runs overwrite this seed doc instead of
+        # adding duplicates (the test asserts the 5 "large" indices have
+        # exactly 500 docs each, while the others have just 1).
+        echo "{\"index\": {\"_index\": \"${INDEX_NAME}\", \"_id\": \"seed-1\"}}" >> "$BULK_FILE"
         echo "{\"@timestamp\": \"2024-01-${day}T12:00:00Z\", \"level\": \"INFO\", \"service\": \"${service}\", \"team\": \"${team}\", \"message\": \"Health check passed\"}" >> "$BULK_FILE"
       done
     done
@@ -128,8 +129,11 @@ before_test: |
     LARGE_BULK="/tmp/es_large_184_$$.ndjson"
     > "$LARGE_BULK"
 
+    # Stable _ids ("large-1".."large-499") so concurrent runs overwrite these
+    # bulky docs instead of multiplying them - the test verifies each large
+    # index has EXACTLY 500 docs.
     for i in $(seq 1 499); do
-      echo '{"index":{}}' >> "$LARGE_BULK"
+      echo "{\"index\":{\"_id\":\"large-$i\"}}" >> "$LARGE_BULK"
       echo "{\"@timestamp\":\"2024-01-15T12:00:00Z\",\"level\":\"INFO\",\"message\":\"Log entry $i\"}" >> "$LARGE_BULK"
     done
 
@@ -194,14 +198,10 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-  echo "Cleaning up test indexes (app-184-*)..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-184-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  echo "Cleaning up index template..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/_index_template/app-184-template" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Indices and template use static test-ID-scoped names (app-184-*,
+  # app-184-template). Parallel CI runs share the same Elasticsearch cluster,
+  # so we skip deletion to avoid wiping resources that another in-flight run
+  # still depends on. before_test is idempotent (template PUT overwrites,
+  # bulk inserts use stable _ids).
   rm -f /tmp/es_bulk_184_*.ndjson /tmp/es_bulk_184_chunk_* /tmp/es_large_184_*.ndjson
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/184_elasticsearch_index_explosion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/184_elasticsearch_index_explosion/test_case.yaml
@@ -124,10 +124,22 @@ before_test: |
   # Now add extra docs to the 5 "large" indexes (499 more each to total 500)
   echo "Adding extra documents to 5 large indexes..."
 
+  # Build the stable _id keep-list (seed-1 + large-1..large-499) once. Used
+  # below for the one-shot stale-doc cleanup that removes leftovers from
+  # older revisions of this fixture (which inserted with auto-generated _ids).
+  LARGE_KEEP_IDS=$(python3 -c "import json; print(json.dumps(['seed-1'] + [f'large-{i}' for i in range(1,500)]))")
+
   for LARGE_INDEX in $LARGE_INDEXES; do
     echo "  Adding 499 docs to $LARGE_INDEX..."
     LARGE_BULK="/tmp/es_large_184_$$.ndjson"
     > "$LARGE_BULK"
+
+    # Stale-doc cleanup: drop any doc whose _id isn't in our known set. Safe
+    # under concurrency (parallel run's docs match the keep-list).
+    curl -s -X POST "${ELASTICSEARCH_URL}/${LARGE_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+      -d "{\"query\":{\"bool\":{\"must_not\":[{\"ids\":{\"values\":${LARGE_KEEP_IDS}}}]}}}" > /dev/null
 
     # Stable _ids ("large-1".."large-499") so concurrent runs overwrite these
     # bulky docs instead of multiplying them - the test verifies each large

--- a/tests/llm/fixtures/test_ask_holmes/185_elasticsearch_cross_region_search/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/185_elasticsearch_cross_region_search/test_case.yaml
@@ -40,15 +40,13 @@ before_test: |
 
   echo "Creating 1620 geo-distributed indexes..."
 
-  # Clean up any existing test data first for idempotency
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-185-geo-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/_index_template/app-185-geo-template" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" 2>/dev/null || true
+  # Reentrancy: index pattern (app-185-geo-*) and template are static and
+  # shared with parallel CI runs of this eval. Do NOT delete - that would
+  # wipe a parallel run's data. PUT the template (idempotent overwrite) and
+  # rely on stable doc _ids in the bulk inserts so concurrent runs converge
+  # on the same documents.
 
-  # Create index template with 0 replicas to fit within cluster shard limits
-  echo "Creating index template with 0 replicas..."
+  echo "Creating (or updating) index template with 0 replicas..."
   TEMPLATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/_index_template/app-185-geo-template" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
@@ -80,7 +78,8 @@ before_test: |
     for service in $SERVICES; do
       for day in $(seq -w 1 10); do
         INDEX_NAME="app-185-geo-${region}-${service}-2024.01.${day}"
-        echo "{\"index\": {\"_index\": \"${INDEX_NAME}\"}}" >> "$BULK_FILE"
+        # Stable _id keeps the bulk inserts idempotent under concurrent runs.
+        echo "{\"index\": {\"_index\": \"${INDEX_NAME}\", \"_id\": \"seed-1\"}}" >> "$BULK_FILE"
         echo "{\"@timestamp\": \"2024-01-${day}T12:00:00Z\", \"level\": \"INFO\", \"service\": \"${service}\", \"region\": \"${region}\", \"message\": \"Request completed successfully\", \"response_time_ms\": 150}" >> "$BULK_FILE"
       done
     done
@@ -115,7 +114,10 @@ before_test: |
   # Insert the needle - a slow request in EU auth service
   echo "Inserting needle (slow EU request) into app-185-geo-eu-west-auth-2024.01.05..."
 
-  NEEDLE_RESPONSE=$(curl -sf -X POST "${ELASTICSEARCH_URL}/app-185-geo-eu-west-auth-2024.01.05/_doc" \
+  # PUT with a stable needle _id so concurrent runs overwrite the same doc
+  # (rather than producing two copies of the needle, which would still pass
+  # but bloat the index).
+  NEEDLE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-185-geo-eu-west-auth-2024.01.05/_doc/needle-1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -161,15 +163,10 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test indexes (app-185-geo-*)..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-185-geo-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  echo "Cleaning up index template..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/_index_template/app-185-geo-template" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Indices and template use static test-ID-scoped names (app-185-geo-*,
+  # app-185-geo-template). Parallel CI runs share the same Elasticsearch
+  # cluster, so we skip deletion to avoid wiping resources that another
+  # in-flight run still depends on. before_test is idempotent (template PUT
+  # overwrites, bulk inserts and needle PUT use stable _ids).
   rm -f /tmp/es_geo_185_*.ndjson /tmp/es_geo_185_chunk_*
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/186_elasticsearch_shard_explosion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/186_elasticsearch_shard_explosion/test_case.yaml
@@ -38,15 +38,12 @@ before_test: |
 
   echo "Creating indexes with ~507 total shards..."
 
-  # Clean up any existing test data first
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-186-shard-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/_index_template/app-186-shard-template" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" 2>/dev/null || true
+  # Reentrancy: pattern (app-186-shard-*) and template are static and shared
+  # with parallel CI runs of this eval. Do NOT delete - that would wipe a
+  # parallel run's data. PUT the template (idempotent overwrite) and rely on
+  # stable doc _ids in the bulk inserts.
 
-  # Create an index template for the data indexes with 5 shards
-  echo "Creating index template with 5 shards..."
+  echo "Creating (or updating) index template with 5 shards..."
   TEMPLATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/_index_template/app-186-shard-template" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
@@ -61,7 +58,7 @@ before_test: |
     }')
 
   if echo "$TEMPLATE_RESPONSE" | grep -q '"acknowledged":true'; then
-    echo "✅ Index template created successfully"
+    echo "✅ Index template ready"
   else
     echo "❌ Failed to create template: $TEMPLATE_RESPONSE"
     exit 1
@@ -73,7 +70,8 @@ before_test: |
 
   for i in $(seq -w 1 100); do
     INDEX_NAME="app-186-shard-data-${i}"
-    echo "{\"index\": {\"_index\": \"${INDEX_NAME}\"}}" >> "$BULK_FILE"
+    # Stable _id keeps the bulk inserts idempotent under concurrent runs.
+    echo "{\"index\": {\"_index\": \"${INDEX_NAME}\", \"_id\": \"seed-1\"}}" >> "$BULK_FILE"
     echo "{\"@timestamp\": \"2024-01-15T12:00:00Z\", \"value\": ${i}}" >> "$BULK_FILE"
   done
 
@@ -91,13 +89,12 @@ before_test: |
     echo "⚠️ Some errors during bulk insert (may be expected if re-running)"
   fi
 
-  # Create the special analytics index with 7 shards and 0 replicas
-  echo "Creating special analytics index with 7 shards..."
+  # Create (or reuse) the special analytics index with 7 shards. Shard count
+  # is fixed at index creation, so reusing an existing index keeps the test
+  # invariant intact. Do NOT delete - parallel runs would lose their data.
+  echo "Creating (or reusing) special analytics index with 7 shards..."
 
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-186-shard-analytics" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" > /dev/null 2>&1 || true
-
-  ANALYTICS_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-186-shard-analytics?wait_for_active_shards=1" \
+  ANALYTICS_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-186-shard-analytics?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -114,15 +111,15 @@ before_test: |
       }
     }')
 
-  if echo "$ANALYTICS_RESPONSE" | grep -q '"acknowledged":true'; then
-    echo "✅ Analytics index created with 7 shards"
+  if echo "$ANALYTICS_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
+    echo "✅ Analytics index ready with 7 shards"
   else
     echo "❌ Failed to create analytics index: $ANALYTICS_RESPONSE"
     exit 1
   fi
 
-  # Insert some data
-  curl -sf -X POST "${ELASTICSEARCH_URL}/app-186-shard-analytics/_doc" \
+  # Insert some data with a stable _id so concurrent runs converge cleanly.
+  curl -sf -X PUT "${ELASTICSEARCH_URL}/app-186-shard-analytics/_doc/seed-1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"@timestamp": "2024-01-15T12:00:00Z", "metric": "page_views", "value": 12345}' > /dev/null
@@ -161,15 +158,10 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test indexes (app-186-shard-*)..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-186-shard-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  echo "Cleaning up index template..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/_index_template/app-186-shard-template" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Indices and template use static test-ID-scoped names (app-186-shard-*,
+  # app-186-shard-template). Parallel CI runs share the same Elasticsearch
+  # cluster, so we skip deletion to avoid wiping resources another in-flight
+  # run depends on. before_test is idempotent (template PUT overwrites,
+  # index PUT tolerates already-exists, bulk inserts use stable _ids).
   rm -f /tmp/es_shard_bulk_186_*.ndjson
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/187_elasticsearch_disk_space/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/187_elasticsearch_disk_space/test_case.yaml
@@ -36,12 +36,12 @@ before_test: |
 
   echo "Creating test indexes for disk space investigation..."
 
-  # Clean up any existing test data first
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-187-logs-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-187-metrics-analytics" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: indices use static test-ID-scoped names (app-187-logs-*,
+  # app-187-metrics-analytics) and the same names are shared with parallel
+  # CI runs. Do NOT delete - that would wipe a parallel run's data. PUT-with-
+  # already-exists tolerated, and bulk inserts use stable _ids so concurrent
+  # runs converge on the same docs (the test compares relative size between
+  # logs-* and metrics-analytics, which holds as long as both grow together).
 
   # Create 20 small indexes via bulk insert
   BULK_FILE="/tmp/es_disk_187_small_$$.ndjson"
@@ -50,7 +50,7 @@ before_test: |
   for i in $(seq -w 1 20); do
     INDEX_NAME="app-187-logs-${i}"
     for j in $(seq 1 10); do
-      printf '{"index": {"_index": "%s"}}\n' "$INDEX_NAME" >> "$BULK_FILE"
+      printf '{"index": {"_index": "%s", "_id": "small-%s"}}\n' "$INDEX_NAME" "$j" >> "$BULK_FILE"
       printf '{"@timestamp": "2024-01-15T12:00:00Z", "level": "INFO", "message": "Application started successfully", "service": "app-%s"}\n' "$i" >> "$BULK_FILE"
     done
   done
@@ -69,19 +69,21 @@ before_test: |
 
   rm -f "$BULK_FILE"
 
-  # Create the large analytics index
-  echo "Creating large analytics index (app-187-metrics-analytics)..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-187-metrics-analytics" \
+  # Create (or reuse) the large analytics index.
+  echo "Creating (or reusing) large analytics index (app-187-metrics-analytics)..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-187-metrics-analytics" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"settings": {"number_of_shards": 1, "number_of_replicas": 0}}')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create analytics index: $CREATE_RESPONSE"
     exit 1
   fi
 
-  # Generate bulk file with 5000 documents using bash
+  # Generate bulk file with 5000 documents using bash, with stable _ids so
+  # concurrent runs overwrite the same docs (preserves the index's relative
+  # size advantage over the small logs-* indices).
   LARGE_BULK="/tmp/es_disk_187_large_$$.ndjson"
   > "$LARGE_BULK"
 
@@ -91,7 +93,7 @@ before_test: |
   for i in $(seq 1 5000); do
     HOST_NUM=$(printf '%04d' $i)
     VAL=$((i % 100))
-    printf '{"index": {"_index": "app-187-metrics-analytics"}}\n' >> "$LARGE_BULK"
+    printf '{"index": {"_index": "app-187-metrics-analytics", "_id": "large-%s"}}\n' "$i" >> "$LARGE_BULK"
     printf '{"@timestamp": "2024-01-15T12:00:00Z", "metric_type": "cpu_usage", "host": "server-%s", "value": %d, "data": "%s"}\n' "$HOST_NUM" "$VAL" "$PAYLOAD" >> "$LARGE_BULK"
   done
 
@@ -128,13 +130,10 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test indexes..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-187-logs-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-187-metrics-analytics" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Indices use static test-ID-scoped names (app-187-logs-*, app-187-metrics-
+  # analytics). Parallel CI runs share the same Elasticsearch cluster, so
+  # we skip deletion to avoid wiping resources another in-flight run still
+  # depends on. before_test is idempotent (PUT tolerates already-exists,
+  # bulk inserts use stable _ids).
   rm -f /tmp/es_disk_187_*.ndjson /tmp/es_disk_187_batch_*
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/188_elasticsearch_mapping_explosion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/188_elasticsearch_mapping_explosion/test_case.yaml
@@ -37,17 +37,19 @@ before_test: |
 
   echo "Creating test indexes for mapping explosion scenario..."
 
-  # Clean up any existing test data first
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-188-index-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: indices use static test-ID-scoped names (app-188-index-*) and
+  # the same name space is shared with parallel CI runs of this eval. Do NOT
+  # delete the existing indices — that would wipe a parallel run's data.
+  # Instead, create-or-reuse: tolerate "resource_already_exists_exception"
+  # on PUT, and use a stable doc _id so re-running overwrites instead of
+  # duplicating.
 
   # Create indexes with standard field counts
   for suffix in a b c; do
     INDEX_NAME="app-188-index-${suffix}"
-    echo "Creating normal index: ${INDEX_NAME}..."
+    echo "Creating (or reusing) normal index: ${INDEX_NAME}..."
 
-    CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${INDEX_NAME}" \
+    CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${INDEX_NAME}" \
       -H "Content-Type: application/json" \
       -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
       -d '{
@@ -71,17 +73,18 @@ before_test: |
         }
       }')
 
-    if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
-      echo "⚠️ Warning creating ${INDEX_NAME}: $CREATE_RESPONSE"
+    if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
+      echo "❌ Failed to create ${INDEX_NAME}: $CREATE_RESPONSE"
+      exit 1
     fi
   done
 
-  echo "✅ Standard indexes created with ~10 fields each"
+  echo "✅ Standard indexes ready with ~10 fields each"
 
-  # Create index with 523 fields using dynamic mapping
-  echo "Creating index with 500+ fields..."
+  # Create (or reuse) index with 523 fields using dynamic mapping
+  echo "Creating (or reusing) index with 500+ fields..."
 
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-188-index-x" \
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-188-index-x" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -91,7 +94,7 @@ before_test: |
       }
     }')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -126,13 +129,14 @@ before_test: |
   FIELD_COUNT=$(grep -o '"[^"]*":' "$DOC_FILE" | wc -l)
   echo "Generated document with $FIELD_COUNT fields"
 
-  # Index the document
-  RESPONSE=$(curl -sf -X POST "${ELASTICSEARCH_URL}/app-188-index-x/_doc" \
+  # Index the document with a stable _id so concurrent runs converge to the
+  # same single document instead of stacking duplicates.
+  RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-188-index-x/_doc/seed-1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d @"$DOC_FILE")
 
-  if echo "$RESPONSE" | grep -q '"result":"created"'; then
+  if echo "$RESPONSE" | grep -qE '"result":"(created|updated)"'; then
     echo "✅ Document indexed successfully"
   else
     echo "❌ Failed to index document: $RESPONSE"
@@ -159,11 +163,10 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test indexes..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-188-index-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Indices use static test-ID-scoped names (app-188-index-*). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # removing indices that another in-flight run still depends on.
+  # before_test is idempotent (create-or-reuse + stable doc _id), so stale
+  # state is harmless.
   rm -f /tmp/es_mapping_188_*.json
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/189_elasticsearch_timeseries_gap/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/189_elasticsearch_timeseries_gap/test_case.yaml
@@ -40,13 +40,12 @@ before_test: |
 
   echo "Creating test index for time-series gap detection..."
 
-  # Clean up any existing test data first
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-189-metrics-timeseries" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse, and use stable doc _ids so concurrent runs converge on
+  # the same set of timestamped points (preserving the 6-hour gap).
 
-  # Create the index
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-189-metrics-timeseries" \
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-189-metrics-timeseries" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -65,7 +64,7 @@ before_test: |
       }
     }')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -103,7 +102,9 @@ before_test: |
     # Host rotation
     HOST_NUM=$((hour % 5 + 1))
 
-    echo "{\"index\": {\"_index\": \"app-189-metrics-timeseries\"}}" >> "$BULK_FILE"
+    # Stable _id keyed by hour so concurrent runs converge on the same 42
+    # data points (one per hour, with the 6-hour gap preserved).
+    echo "{\"index\": {\"_index\": \"app-189-metrics-timeseries\", \"_id\": \"hour-${hour}\"}}" >> "$BULK_FILE"
     echo "{\"@timestamp\": \"$TIMESTAMP\", \"request_id\": \"$REQUEST_ID\", \"metric_name\": \"cpu_usage\", \"value\": ${CPU_VALUE}.0, \"host\": \"server-${HOST_NUM}\"}" >> "$BULK_FILE"
   done
 
@@ -151,11 +152,10 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-189-metrics-timeseries" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Index uses a static test-ID-scoped name (app-189-metrics-timeseries).
+  # Parallel CI runs share the same Elasticsearch cluster, so we skip
+  # deletion to avoid wiping data another in-flight run depends on.
+  # before_test is idempotent (PUT tolerates already-exists, bulk inserts
+  # use stable hour-keyed _ids).
   rm -f /tmp/es_timeseries_189_*.ndjson
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/190_elasticsearch_cross_service_correlation/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/190_elasticsearch_cross_service_correlation/test_case.yaml
@@ -81,26 +81,28 @@ before_test: |
   BULK_FILE="/tmp/es_correlation_190_$$.ndjson"
   > "$BULK_FILE"
 
-  # Generate 50 normal traces (success)
+  # Generate 50 normal traces (success). Stable _ids and deterministic
+  # trace_ids so concurrent runs converge on the same docs instead of
+  # accumulating new copies in the shared cluster.
   for i in $(seq 1 50); do
-    TRACE_ID="TRACE-$((10000 + RANDOM % 90000))"
+    TRACE_ID=$(printf "TRACE-NORM-%03d" "$i")
     MIN=$(printf "%02d" $i)
 
     # Gateway log
-    echo "{\"index\": {\"_index\": \"app-190-service-gateway\"}}" >> "$BULK_FILE"
-    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-gw-${i}\", \"service\": \"gateway\", \"level\": \"INFO\", \"message\": \"Received request POST /api/orders\", \"duration_ms\": $((1 + RANDOM % 5))}" >> "$BULK_FILE"
+    echo "{\"index\": {\"_index\": \"app-190-service-gateway\", \"_id\": \"norm-gw-${i}\"}}" >> "$BULK_FILE"
+    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-gw-${i}\", \"service\": \"gateway\", \"level\": \"INFO\", \"message\": \"Received request POST /api/orders\", \"duration_ms\": $((1 + i % 5))}" >> "$BULK_FILE"
 
     # Auth log
-    echo "{\"index\": {\"_index\": \"app-190-service-auth\"}}" >> "$BULK_FILE"
-    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.010Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-auth-${i}\", \"service\": \"auth\", \"level\": \"INFO\", \"message\": \"User authenticated successfully\", \"duration_ms\": $((5 + RANDOM % 15))}" >> "$BULK_FILE"
+    echo "{\"index\": {\"_index\": \"app-190-service-auth\", \"_id\": \"norm-auth-${i}\"}}" >> "$BULK_FILE"
+    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.010Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-auth-${i}\", \"service\": \"auth\", \"level\": \"INFO\", \"message\": \"User authenticated successfully\", \"duration_ms\": $((5 + i % 15))}" >> "$BULK_FILE"
 
     # Orders log
-    echo "{\"index\": {\"_index\": \"app-190-service-orders\"}}" >> "$BULK_FILE"
-    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.030Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-orders-${i}\", \"service\": \"orders\", \"level\": \"INFO\", \"message\": \"Order created, checking inventory\", \"duration_ms\": $((10 + RANDOM % 40))}" >> "$BULK_FILE"
+    echo "{\"index\": {\"_index\": \"app-190-service-orders\", \"_id\": \"norm-orders-${i}\"}}" >> "$BULK_FILE"
+    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.030Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-orders-${i}\", \"service\": \"orders\", \"level\": \"INFO\", \"message\": \"Order created, checking inventory\", \"duration_ms\": $((10 + i % 40))}" >> "$BULK_FILE"
 
     # Inventory log
-    echo "{\"index\": {\"_index\": \"app-190-service-inventory\"}}" >> "$BULK_FILE"
-    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.080Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-inv-${i}\", \"service\": \"inventory\", \"level\": \"INFO\", \"message\": \"Stock reserved successfully\", \"duration_ms\": $((20 + RANDOM % 80))}" >> "$BULK_FILE"
+    echo "{\"index\": {\"_index\": \"app-190-service-inventory\", \"_id\": \"norm-inv-${i}\"}}" >> "$BULK_FILE"
+    echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.080Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-inv-${i}\", \"service\": \"inventory\", \"level\": \"INFO\", \"message\": \"Stock reserved successfully\", \"duration_ms\": $((20 + i % 80))}" >> "$BULK_FILE"
   done
 
   # Generate THE error trace - TRACE-X7K9M2-ERR. The needle docs use stable
@@ -178,6 +180,6 @@ after_test: |
   # Indices use static test-ID-scoped names (app-190-service-*). Parallel CI
   # runs share the same Elasticsearch cluster, so we skip deletion to avoid
   # removing indices that another in-flight run still depends on.
-  # before_test is idempotent (create-or-reuse + stable _ids on needle docs).
+  # before_test is idempotent (create-or-reuse + stable _ids on every doc).
   rm -f /tmp/es_correlation_190_*.ndjson
   echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/190_elasticsearch_cross_service_correlation/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/190_elasticsearch_cross_service_correlation/test_case.yaml
@@ -41,14 +41,14 @@ before_test: |
 
   echo "Creating test indexes for cross-service correlation..."
 
-  # Clean up any existing test data first
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-190-service-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: indices use static test-ID-scoped names (app-190-service-*)
+  # and the same names are shared with parallel CI runs of this eval.
+  # Do NOT delete existing indices - that would wipe a parallel run's data.
+  # Instead, create-or-reuse: tolerate "resource_already_exists_exception".
 
   # Create indexes for each service
   for service in gateway auth orders inventory; do
-    CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-190-service-${service}" \
+    CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-190-service-${service}" \
       -H "Content-Type: application/json" \
       -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
       -d '{
@@ -70,8 +70,9 @@ before_test: |
         }
       }')
 
-    if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
-      echo "⚠️ Warning creating app-190-service-${service}: $CREATE_RESPONSE"
+    if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
+      echo "❌ Failed to create app-190-service-${service}: $CREATE_RESPONSE"
+      exit 1
     fi
   done
 
@@ -102,31 +103,33 @@ before_test: |
     echo "{\"@timestamp\": \"2024-01-15T10:${MIN}:00.080Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-inv-${i}\", \"service\": \"inventory\", \"level\": \"INFO\", \"message\": \"Stock reserved successfully\", \"duration_ms\": $((20 + RANDOM % 80))}" >> "$BULK_FILE"
   done
 
-  # Generate THE error trace - TRACE-X7K9M2-ERR
+  # Generate THE error trace - TRACE-X7K9M2-ERR. The needle docs use stable
+  # _ids so concurrent runs converge on the same documents instead of
+  # stacking duplicates that could skew the search.
   ERROR_TRACE="TRACE-X7K9M2-ERR"
 
   # Gateway - received request
-  echo "{\"index\": {\"_index\": \"app-190-service-gateway\"}}" >> "$BULK_FILE"
+  echo "{\"index\": {\"_index\": \"app-190-service-gateway\", \"_id\": \"err-gw-1\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:25:00Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-gw-err\", \"service\": \"gateway\", \"level\": \"INFO\", \"message\": \"Received request POST /api/orders for user_12847\", \"duration_ms\": 2}" >> "$BULK_FILE"
 
   # Auth - success
-  echo "{\"index\": {\"_index\": \"app-190-service-auth\"}}" >> "$BULK_FILE"
+  echo "{\"index\": {\"_index\": \"app-190-service-auth\", \"_id\": \"err-auth-1\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:25:00.010Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-auth-err\", \"service\": \"auth\", \"level\": \"INFO\", \"message\": \"User user_12847 authenticated via JWT token\", \"duration_ms\": 15}" >> "$BULK_FILE"
 
   # Orders - processing
-  echo "{\"index\": {\"_index\": \"app-190-service-orders\"}}" >> "$BULK_FILE"
+  echo "{\"index\": {\"_index\": \"app-190-service-orders\", \"_id\": \"err-orders-1\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:25:00.030Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-orders-err\", \"service\": \"orders\", \"level\": \"INFO\", \"message\": \"Processing order for product SKU-78234, quantity: 500\", \"duration_ms\": 25}" >> "$BULK_FILE"
 
   # Inventory - THE ERROR
-  echo "{\"index\": {\"_index\": \"app-190-service-inventory\"}}" >> "$BULK_FILE"
+  echo "{\"index\": {\"_index\": \"app-190-service-inventory\", \"_id\": \"err-inv-1\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:25:00.080Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-inv-err\", \"service\": \"inventory\", \"level\": \"ERROR\", \"message\": \"Failed to reserve stock for SKU-78234: insufficient inventory. Requested: 500, Available: 23\", \"error_code\": \"INV-ERR-4082\", \"duration_ms\": 45}" >> "$BULK_FILE"
 
   # Orders - propagated error
-  echo "{\"index\": {\"_index\": \"app-190-service-orders\"}}" >> "$BULK_FILE"
+  echo "{\"index\": {\"_index\": \"app-190-service-orders\", \"_id\": \"err-orders-2\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:25:00.130Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-orders-err-2\", \"service\": \"orders\", \"level\": \"ERROR\", \"message\": \"Order failed: inventory service returned error INV-ERR-4082\", \"error_code\": \"ORD-ERR-1001\", \"duration_ms\": 130}" >> "$BULK_FILE"
 
   # Gateway - error response
-  echo "{\"index\": {\"_index\": \"app-190-service-gateway\"}}" >> "$BULK_FILE"
+  echo "{\"index\": {\"_index\": \"app-190-service-gateway\", \"_id\": \"err-gw-2\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:25:00.140Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-gw-err-2\", \"service\": \"gateway\", \"level\": \"ERROR\", \"message\": \"Request failed with 400 Bad Request: Order could not be fulfilled\", \"error_code\": \"GW-ERR-400\", \"duration_ms\": 145}" >> "$BULK_FILE"
 
   DOC_COUNT=$(grep -c '"index"' "$BULK_FILE")
@@ -172,11 +175,9 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test indexes..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-190-service-*" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Indices use static test-ID-scoped names (app-190-service-*). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # removing indices that another in-flight run still depends on.
+  # before_test is idempotent (create-or-reuse + stable _ids on needle docs).
   rm -f /tmp/es_correlation_190_*.ndjson
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/191_elasticsearch_query_profile/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/191_elasticsearch_query_profile/test_case.yaml
@@ -31,19 +31,17 @@ before_test: |
 
   export HOLMES_ES_TEST_INDEX="app-191-profile"
 
-  # Delete the index if it exists (clean slate)
-  echo "⏳ Cleaning up any existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create the test index with mapping
-  echo "⏳ Creating test index..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse, and use stable doc _ids so concurrent runs converge on
+  # the same 6 documents (count check expects exactly 6).
+  echo "⏳ Creating (or reusing) test index..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"timestamp":{"type":"date"},"message":{"type":"text"},"status":{"type":"keyword"}}}}')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -51,19 +49,20 @@ before_test: |
   # Create unique temp file
   BULK_FILE="/tmp/es_bulk_191_$$.ndjson"
 
-  # Create bulk data file with logs including timeout messages
+  # Stable _ids make this idempotent under concurrent runs (overwrite, not
+  # duplicate) so the 6-doc count stays exact.
   cat > "$BULK_FILE" << 'BULK_EOF'
-  {"index":{}}
+  {"index":{"_id":"log-1"}}
   {"timestamp":"2025-01-01T10:00:00Z","message":"Connection established successfully","status":"success"}
-  {"index":{}}
+  {"index":{"_id":"log-2"}}
   {"timestamp":"2025-01-01T10:01:00Z","message":"Request timeout after 30 seconds","status":"error"}
-  {"index":{}}
+  {"index":{"_id":"log-3"}}
   {"timestamp":"2025-01-01T10:02:00Z","message":"Processing completed","status":"success"}
-  {"index":{}}
+  {"index":{"_id":"log-4"}}
   {"timestamp":"2025-01-01T10:03:00Z","message":"Database query timeout exceeded limit","status":"error"}
-  {"index":{}}
+  {"index":{"_id":"log-5"}}
   {"timestamp":"2025-01-01T10:04:00Z","message":"API response received","status":"success"}
-  {"index":{}}
+  {"index":{"_id":"log-6"}}
   {"timestamp":"2025-01-01T10:05:00Z","message":"Socket timeout during file upload","status":"error"}
   BULK_EOF
 
@@ -100,8 +99,8 @@ before_test: |
   fi
 
 after_test: |
-
-  echo "⏳ Cleaning up test index: app-191-profile"
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-191-profile" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  echo "✅ Cleanup complete"
+  # Index uses a static test-ID-scoped name (app-191-profile). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # wiping data another in-flight run depends on. before_test is idempotent
+  # (PUT tolerates already-exists, bulk inserts use stable _ids).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/191_elasticsearch_query_profile/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/191_elasticsearch_query_profile/test_case.yaml
@@ -46,6 +46,13 @@ before_test: |
     exit 1
   fi
 
+  # One-shot stale-doc cleanup: drop any doc whose _id isn't in our known
+  # set. Safe under concurrency (parallel run's docs match the keep-list).
+  curl -s -X POST "${ELASTICSEARCH_URL}/${HOLMES_ES_TEST_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["log-1","log-2","log-3","log-4","log-5","log-6"]}}]}}}' > /dev/null
+
   # Create unique temp file
   BULK_FILE="/tmp/es_bulk_191_$$.ndjson"
 

--- a/tests/llm/fixtures/test_ask_holmes/193_elasticsearch_large_mapping_search/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/193_elasticsearch_large_mapping_search/test_case.yaml
@@ -34,13 +34,12 @@ before_test: |
 
   echo "Creating index with 10,000+ fields for large mapping test..."
 
-  # Clean up any existing test data first
-  echo "Cleaning up any existing test data..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-193-telemetry" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse, and seed the document with a stable _id so concurrent
+  # runs converge.
 
-  # Create the index
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-193-telemetry" \
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-193-telemetry" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -51,7 +50,7 @@ before_test: |
       }
     }')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "Failed to create index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -88,10 +87,11 @@ before_test: |
   FIELD_COUNT=$(grep -o '"[^"]*":' "$DOC_FILE" | wc -l)
   echo "Generated document with $FIELD_COUNT fields"
 
-  # Index the document (large payload needs longer timeout and binary mode)
+  # Index the document with a stable _id so concurrent runs converge on the
+  # same single document (rather than stacking duplicates).
   DOC_SIZE=$(wc -c < "$DOC_FILE")
   echo "Indexing document ($DOC_SIZE bytes, this may take a moment)..."
-  RESPONSE=$(curl -s --max-time 120 -X POST "${ELASTICSEARCH_URL}/app-193-telemetry/_doc" \
+  RESPONSE=$(curl -s --max-time 120 -X PUT "${ELASTICSEARCH_URL}/app-193-telemetry/_doc/seed-1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     --data-binary @"$DOC_FILE" 2>&1)
@@ -103,7 +103,7 @@ before_test: |
     exit 1
   fi
 
-  if echo "$RESPONSE" | grep -q '"result":"created"'; then
+  if echo "$RESPONSE" | grep -qE '"result":"(created|updated)"'; then
     echo "✅ Document indexed successfully"
   else
     echo "❌ Failed to index document: $RESPONSE"
@@ -141,11 +141,9 @@ before_test: |
   echo "Setup complete!"
 
 after_test: |
-
-  echo "Cleaning up test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-193-telemetry" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Index uses a static test-ID-scoped name (app-193-telemetry). Parallel CI
+  # runs share the same Elasticsearch cluster, so we skip deletion to avoid
+  # wiping data another in-flight run depends on. before_test is idempotent
+  # (PUT tolerates already-exists, doc seeded with a stable _id).
   rm -f /tmp/es_large_mapping_193_*.json
-
-  echo "Cleanup complete"
+  echo "Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/214_confluence_page_content/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/214_confluence_page_content/test_case.yaml
@@ -109,17 +109,9 @@ before_test: |
   echo "Setup complete"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES214"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES214 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the page
+  # and break the in-flight run. before_test is idempotent (creates-or-reuses
+  # the space and page), so we skip cleanup. The space accumulates across
+  # runs, which is the intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/215_confluence_cql_search/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/215_confluence_cql_search/test_case.yaml
@@ -116,17 +116,9 @@ before_test: |
   echo "Warning: Search verification timed out, but continuing with test"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES215"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES215 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the page
+  # and break the in-flight run. before_test is idempotent (creates-or-reuses
+  # the space and page), so we skip cleanup. The space accumulates across
+  # runs, which is the intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/216_confluence_page_hierarchy/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/216_confluence_page_hierarchy/test_case.yaml
@@ -161,17 +161,9 @@ before_test: |
   echo "Setup complete"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES216"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES216 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the parent
+  # and child pages and break the in-flight run. before_test is idempotent
+  # (creates-or-reuses), so we skip cleanup. The space accumulates across
+  # runs, which is the intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/220_confluence_table_with_macros/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/220_confluence_table_with_macros/test_case.yaml
@@ -216,17 +216,9 @@ before_test: |
   echo "Setup complete"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES220"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES220 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the page
+  # and break the in-flight run. before_test is idempotent (creates-or-reuses),
+  # so we skip cleanup. The space accumulates across runs, which is the
+  # intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/221_confluence_expand_macro/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/221_confluence_expand_macro/test_case.yaml
@@ -203,17 +203,9 @@ before_test: |
   echo "Setup complete"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES221"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES221 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the page
+  # and break the in-flight run. before_test is idempotent (creates-or-reuses),
+  # so we skip cleanup. The space accumulates across runs, which is the
+  # intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/224_confluence_page_content_apikey/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/224_confluence_page_content_apikey/test_case.yaml
@@ -119,17 +119,9 @@ before_test: |
   echo "Setup complete"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES224"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES224 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the page
+  # and break the in-flight run. before_test is idempotent (creates-or-reuses),
+  # so we skip cleanup. The space accumulates across runs, which is the
+  # intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/235_elasticsearch_cluster_mismatch/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/235_elasticsearch_cluster_mismatch/test_case.yaml
@@ -85,19 +85,18 @@ before_test: |
   T_7D=$(ts "days=7")
   T_45D=$(ts "days=45")
 
-  # Clean up any existing test indices
-  echo "⏳ Cleaning up existing test indices..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${INVENTORY_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${CHANGES_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: indices use static test-ID-scoped names (app-235-*) shared
+  # with parallel CI runs. Do NOT delete - that would wipe a parallel run's
+  # data. Create-or-reuse, and below we use stable _ids on the bulk inserts
+  # so concurrent runs converge on the same documents (counts must stay at
+  # 6 inventory + 4 changes).
 
   # --- Index 1: Cluster Inventory ---
   # Only contains what's visible from the ci-cd cluster.
   # The alert's app (lambda-dashboard-monitoring) is NOT here.
   # An empty "us-prod-eks" namespace exists as a red herring.
-  echo "⏳ Creating cluster inventory index..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${INVENTORY_INDEX}?wait_for_active_shards=1" \
+  echo "⏳ Creating (or reusing) cluster inventory index..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${INVENTORY_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -113,25 +112,27 @@ before_test: |
         "last_updated": {"type": "date"}
       }}
     }')
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create inventory index: $CREATE_RESPONSE"
     exit 1
   fi
   sleep 2
 
+  # Stable _ids ("inv-1".."inv-6") keep this idempotent under concurrent
+  # runs (overwrite, not duplicate), so the count check stays at exactly 6.
   BULK_FILE=$(es_temp_file "inventory" "235")
   cat > "$BULK_FILE" << BULK_EOF
-  {"index":{}}
+  {"index":{"_id":"inv-1"}}
   {"cluster":"ci-cd","namespace":"ci","app_name":"jenkins","kind":"Deployment","status":"Running","replicas":1,"image":"jenkins/jenkins:2.426.3-lts","last_updated":"${T_6H}"}
-  {"index":{}}
+  {"index":{"_id":"inv-2"}}
   {"cluster":"ci-cd","namespace":"ci","app_name":"argocd-server","kind":"Deployment","status":"Running","replicas":2,"image":"quay.io/argoproj/argocd:v2.9.3","last_updated":"${T_6H}"}
-  {"index":{}}
+  {"index":{"_id":"inv-3"}}
   {"cluster":"ci-cd","namespace":"ci","app_name":"gitlab-runner","kind":"Deployment","status":"Running","replicas":3,"image":"gitlab/gitlab-runner:v16.7.0","last_updated":"${T_2H}"}
-  {"index":{}}
+  {"index":{"_id":"inv-4"}}
   {"cluster":"ci-cd","namespace":"cd","app_name":"flux-controller","kind":"Deployment","status":"Running","replicas":1,"image":"fluxcd/flux:v2.2.1","last_updated":"${T_7D}"}
-  {"index":{}}
+  {"index":{"_id":"inv-5"}}
   {"cluster":"ci-cd","namespace":"cd","app_name":"tekton-pipelines","kind":"Deployment","status":"Running","replicas":1,"image":"gcr.io/tekton-releases/pipeline:v0.54.0","last_updated":"${T_5D}"}
-  {"index":{}}
+  {"index":{"_id":"inv-6"}}
   {"cluster":"ci-cd","namespace":"us-prod-eks","app_name":"","kind":"Namespace","status":"Active","replicas":0,"image":"","last_updated":"${T_45D}"}
   BULK_EOF
   sed 's/^  //' "$BULK_FILE" > "${BULK_FILE}.tmp" && mv "${BULK_FILE}.tmp" "$BULK_FILE"
@@ -151,8 +152,8 @@ before_test: |
   # Only CI/CD tool changes. Nothing related to lambda-dashboard-monitoring,
   # clientorg-alpha, or the us-prod-eks namespace. Mirrors the real scenario
   # where Robusta's fetch_configuration_changes_metadata returned 0 changes.
-  echo "⏳ Creating change history index..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${CHANGES_INDEX}?wait_for_active_shards=1" \
+  echo "⏳ Creating (or reusing) change history index..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${CHANGES_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -170,21 +171,23 @@ before_test: |
         "description": {"type": "text"}
       }}
     }')
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "❌ Failed to create change history index: $CREATE_RESPONSE"
     exit 1
   fi
   sleep 2
 
+  # Stable _ids ("chg-1".."chg-4") keep this idempotent under concurrent
+  # runs (overwrite, not duplicate), so the count check stays at exactly 4.
   BULK_FILE=$(es_temp_file "changes" "235")
   cat > "$BULK_FILE" << BULK_EOF
-  {"index":{}}
+  {"index":{"_id":"chg-1"}}
   {"cluster":"ci-cd","namespace":"ci","app_name":"jenkins","change_type":"deployment","change_id":"BUILD-7X4Q9M","version":"2.426.3-lts","previous_version":"2.426.2-lts","changed_by":"infra-team","timestamp":"${T_6H}","description":"Jenkins LTS version bump to 2.426.3"}
-  {"index":{}}
+  {"index":{"_id":"chg-2"}}
   {"cluster":"ci-cd","namespace":"ci","app_name":"argocd-server","change_type":"deployment","change_id":"BUILD-3NR8Y1","version":"v2.9.3","previous_version":"v2.9.2","changed_by":"infra-team","timestamp":"${T_5H}","description":"ArgoCD security patch update"}
-  {"index":{}}
+  {"index":{"_id":"chg-3"}}
   {"cluster":"ci-cd","namespace":"ci","app_name":"gitlab-runner","change_type":"scale","change_id":"BUILD-5PW2K6","version":"v16.7.0","previous_version":"v16.7.0","changed_by":"infra-team","timestamp":"${T_2H}","description":"Scaled gitlab-runner from 2 to 3 replicas for faster pipeline throughput"}
-  {"index":{}}
+  {"index":{"_id":"chg-4"}}
   {"cluster":"ci-cd","namespace":"cd","app_name":"flux-controller","change_type":"config-update","change_id":"BUILD-9TL6V3","version":"v2.2.1","previous_version":"v2.2.1","changed_by":"platform-team","timestamp":"${T_7D}","description":"Updated flux sync interval from 5m to 3m"}
   BULK_EOF
   sed 's/^  //' "$BULK_FILE" > "${BULK_FILE}.tmp" && mv "${BULK_FILE}.tmp" "$BULK_FILE"
@@ -240,7 +243,6 @@ before_test: |
 after_test: |
   # Indices use static test-ID-prefixed names (app-235-*). Parallel CI runs
   # share the same ES cluster, so we skip deletion to avoid removing indices
-  # that another run's before_test just created (reentrancy-safe).
-  # before_test is idempotent (delete-then-create), so stale indices are
-  # cleaned up on the next run automatically.
-  echo "✅ Skipping index cleanup (reentrant — before_test handles idempotent setup)"
+  # that another in-flight run still depends on. before_test is idempotent
+  # (PUT tolerates already-exists, bulk inserts use stable _ids).
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/235_elasticsearch_cluster_mismatch/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/235_elasticsearch_cluster_mismatch/test_case.yaml
@@ -118,6 +118,16 @@ before_test: |
   fi
   sleep 2
 
+  # One-shot stale-doc cleanup. Deletes any doc whose _id is NOT in our
+  # known stable-_id set (inv-1..inv-6). Safe under concurrency: a parallel
+  # run's docs all match the keep-list and are preserved. Removes leftovers
+  # from older revisions of this fixture (which used auto-generated _ids)
+  # and any future ad-hoc inserts.
+  curl -s -X POST "${ELASTICSEARCH_URL}/${INVENTORY_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["inv-1","inv-2","inv-3","inv-4","inv-5","inv-6"]}}]}}}' > /dev/null
+
   # Stable _ids ("inv-1".."inv-6") keep this idempotent under concurrent
   # runs (overwrite, not duplicate), so the count check stays at exactly 6.
   BULK_FILE=$(es_temp_file "inventory" "235")
@@ -176,6 +186,12 @@ before_test: |
     exit 1
   fi
   sleep 2
+
+  # Stale-doc cleanup (see comment on inventory above).
+  curl -s -X POST "${ELASTICSEARCH_URL}/${CHANGES_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["chg-1","chg-2","chg-3","chg-4"]}}]}}}' > /dev/null
 
   # Stable _ids ("chg-1".."chg-4") keep this idempotent under concurrent
   # runs (overwrite, not duplicate), so the count check stays at exactly 4.

--- a/tests/llm/fixtures/test_ask_holmes/245_elasticsearch_trace_large_fields/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/245_elasticsearch_trace_large_fields/test_case.yaml
@@ -46,18 +46,19 @@ before_test: |
 
   echo "Creating APM traces index with large payload fields..."
 
-  # Clean up any existing test data
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-245-apm-traces" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
+  # Reentrancy: index name is static and shared with parallel CI runs of
+  # this eval. Do NOT delete - that would wipe a parallel run's data.
+  # Create-or-reuse, with stable _ids on both the noise traces and the
+  # error needle so concurrent runs converge on the same document set.
 
-  # Create index with APM trace mapping
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/app-245-apm-traces" \
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/app-245-apm-traces" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"@timestamp":{"type":"date"},"trace_id":{"type":"keyword"},"span_id":{"type":"keyword"},"parent_span_id":{"type":"keyword"},"service":{"type":"keyword"},"operation":{"type":"keyword"},"duration_ms":{"type":"integer"},"http.method":{"type":"keyword"},"http.status_code":{"type":"integer"},"http.request.body":{"type":"text"},"http.response.body":{"type":"text"},"error.type":{"type":"keyword"},"error.message":{"type":"text"},"error.stack_trace":{"type":"text"}}}}')
 
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
-    echo "⚠️ Warning creating index: $CREATE_RESPONSE"
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
+    echo "❌ Failed to create index: $CREATE_RESPONSE"
+    exit 1
   fi
 
   echo "✅ Index created, generating trace data..."
@@ -65,17 +66,18 @@ before_test: |
   BULK_FILE="/tmp/es_trace_195_$$.ndjson"
   > "$BULK_FILE"
 
-  # Generate 10 normal successful traces (small data)
+  # Generate 10 normal successful traces (small data). Stable _ids (one per
+  # span index) keep this idempotent under concurrent runs.
   for i in $(seq 1 10); do
     PADDED_MIN=$(printf "%02d" $i)
     TRACE_ID="TRACE-OK-$((10000 + RANDOM % 90000))"
 
     # API Gateway span
-    echo "{\"index\": {\"_index\": \"app-245-apm-traces\"}}" >> "$BULK_FILE"
+    echo "{\"index\": {\"_index\": \"app-245-apm-traces\", \"_id\": \"ok-gw-${i}\"}}" >> "$BULK_FILE"
     echo "{\"@timestamp\": \"2024-01-15T10:${PADDED_MIN}:00Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-gw-${i}\", \"service\": \"api-gateway\", \"operation\": \"POST /api/payment\", \"duration_ms\": 245, \"http.method\": \"POST\", \"http.status_code\": 200}" >> "$BULK_FILE"
 
     # Payment service span
-    echo "{\"index\": {\"_index\": \"app-245-apm-traces\"}}" >> "$BULK_FILE"
+    echo "{\"index\": {\"_index\": \"app-245-apm-traces\", \"_id\": \"ok-pay-${i}\"}}" >> "$BULK_FILE"
     echo "{\"@timestamp\": \"2024-01-15T10:${PADDED_MIN}:00.050Z\", \"trace_id\": \"${TRACE_ID}\", \"span_id\": \"span-pay-${i}\", \"parent_span_id\": \"span-gw-${i}\", \"service\": \"payment-service\", \"operation\": \"process_payment\", \"duration_ms\": 180, \"http.status_code\": 200}" >> "$BULK_FILE"
   done
 
@@ -112,12 +114,12 @@ before_test: |
   done
   STACK_TRACE="${STACK_TRACE}\\nConnectionTimeout: Authentication service did not respond within 5.0 seconds"
 
-  # API Gateway - received request (NO large fields here)
-  echo "{\"index\": {\"_index\": \"app-245-apm-traces\"}}" >> "$BULK_FILE"
+  # API Gateway - received request (NO large fields here). Stable _id.
+  echo "{\"index\": {\"_index\": \"app-245-apm-traces\", \"_id\": \"err-gw-1\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:15:00Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-gw-err\", \"service\": \"api-gateway\", \"operation\": \"POST /api/payment\", \"duration_ms\": 5234, \"http.method\": \"POST\", \"http.status_code\": 503}" >> "$BULK_FILE"
 
-  # Payment Gateway - THE ERROR with HUGE fields
-  echo "{\"index\": {\"_index\": \"app-245-apm-traces\"}}" >> "$BULK_FILE"
+  # Payment Gateway - THE ERROR with HUGE fields. Stable _id.
+  echo "{\"index\": {\"_index\": \"app-245-apm-traces\", \"_id\": \"err-pay-1\"}}" >> "$BULK_FILE"
   echo "{\"@timestamp\": \"2024-01-15T10:15:00.050Z\", \"trace_id\": \"${ERROR_TRACE}\", \"span_id\": \"span-pay-err\", \"parent_span_id\": \"span-gw-err\", \"service\": \"payment-gateway\", \"operation\": \"authenticate_payment\", \"duration_ms\": 5180, \"http.status_code\": 503, \"http.request.body\": \"${REQUEST_BODY}\", \"http.response.body\": \"${RESPONSE_BODY}\", \"error.type\": \"ConnectionTimeout\", \"error.message\": \"Authentication service timeout - error code AUTH-4729\", \"error.stack_trace\": \"${STACK_TRACE}\"}" >> "$BULK_FILE"
 
   DOC_COUNT=$(grep -c '\"index\"' "$BULK_FILE")
@@ -168,10 +170,9 @@ before_test: |
   echo "✅ Setup complete!"
 
 after_test: |
-  echo "Cleaning up test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/app-245-apm-traces" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
+  # Index uses a static test-ID-scoped name (app-245-apm-traces). Parallel
+  # CI runs share the same Elasticsearch cluster, so we skip deletion to
+  # avoid wiping data another in-flight run depends on. before_test is
+  # idempotent (PUT tolerates already-exists, bulk inserts use stable _ids).
   rm -f /tmp/es_trace_195_*.ndjson
-
-  echo "✅ Cleanup complete"
+  echo "✅ Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/245_elasticsearch_trace_large_fields/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/245_elasticsearch_trace_large_fields/test_case.yaml
@@ -66,11 +66,12 @@ before_test: |
   BULK_FILE="/tmp/es_trace_195_$$.ndjson"
   > "$BULK_FILE"
 
-  # Generate 10 normal successful traces (small data). Stable _ids (one per
-  # span index) keep this idempotent under concurrent runs.
+  # Generate 10 normal successful traces (small data). Stable _ids and
+  # deterministic trace_ids (derived from the loop index) keep this fully
+  # idempotent under concurrent runs.
   for i in $(seq 1 10); do
     PADDED_MIN=$(printf "%02d" $i)
-    TRACE_ID="TRACE-OK-$((10000 + RANDOM % 90000))"
+    TRACE_ID=$(printf "TRACE-OK-%05d" $((10000 + i)))
 
     # API Gateway span
     echo "{\"index\": {\"_index\": \"app-245-apm-traces\", \"_id\": \"ok-gw-${i}\"}}" >> "$BULK_FILE"

--- a/tests/llm/fixtures/test_ask_holmes/248_confluence_space_info/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/248_confluence_space_info/test_case.yaml
@@ -58,17 +58,9 @@ before_test: |
   echo "Setup complete"
 
 after_test: |
-  set -e
-
-  SPACE_KEY="HOLMES213"
-
-  echo "Deleting space ${SPACE_KEY}..."
-  HTTP_CODE=$(curl -L -s -w "%{http_code}" -o /dev/null -X DELETE \
-    "${CONFLUENCE_SA_BASE_URL}/wiki/rest/api/space/${SPACE_KEY}" \
-    -H "Authorization: Bearer ${CONFLUENCE_SA_API_KEY}")
-
-  if [ "$HTTP_CODE" -eq 204 ] || [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
-    echo "Cleanup complete"
-  else
-    echo "Warning: Cleanup returned HTTP ${HTTP_CODE}"
-  fi
+  # Confluence space HOLMES213 has a static, test-ID-scoped key that another
+  # parallel CI run may currently be using. Deleting it would wipe the space
+  # and break the in-flight run. before_test is idempotent (creates-or-reuses),
+  # so we skip cleanup. The space accumulates across runs, which is the
+  # intended reentrant behaviour.
+  echo "Skipping space cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
@@ -55,14 +55,13 @@ before_test: |
   T_5H=$(ts "hours=5")
   T_6H=$(ts "hours=6")
 
-  # Clean up existing test index
-  echo "Cleaning up existing test index..."
-  curl -sf -X DELETE "${ELASTICSEARCH_URL}/${LOGS_INDEX}" \
-    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" || true
-
-  # Create logs index
-  echo "Creating prod logs index..."
-  CREATE_RESPONSE=$(curl -sf -X PUT "${ELASTICSEARCH_URL}/${LOGS_INDEX}?wait_for_active_shards=1" \
+  # Reentrancy: index uses a static test-ID-scoped name and is shared with
+  # parallel CI runs of this eval. Do NOT delete the index - that would
+  # wipe a parallel run's data. Create-or-reuse, and below we use stable
+  # _ids on the bulk insert so concurrent runs converge on the same 12
+  # documents (the count check expects exactly 12).
+  echo "Creating (or reusing) prod logs index..."
+  CREATE_RESPONSE=$(curl -s -X PUT "${ELASTICSEARCH_URL}/${LOGS_INDEX}?wait_for_active_shards=1" \
     -H "Content-Type: application/json" \
     -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
     -d '{
@@ -77,7 +76,7 @@ before_test: |
         "host": {"type": "keyword"}
       }}
     }')
-  if ! echo "$CREATE_RESPONSE" | grep -q '"acknowledged":true'; then
+  if ! echo "$CREATE_RESPONSE" | grep -qE '"acknowledged":true|resource_already_exists_exception'; then
     echo "Failed to create logs index: $CREATE_RESPONSE"
     exit 1
   fi
@@ -85,31 +84,33 @@ before_test: |
 
   # Insert log data for Company.Ops (main platform service) and Company.Ops.Radar.WebJob
   # Both have job processing failures but NEITHER is companyopswebjob
+  # Stable _ids ("log-1".."log-12") make this idempotent under concurrent
+  # runs (overwrite, not duplicate), so the count check stays at exactly 12.
   BULK_FILE=$(es_temp_file "logs" "254")
   cat > "$BULK_FILE" << BULK_EOF
-  {"index":{}}
+  {"index":{"_id":"log-1"}}
   {"timestamp":"${T_6H}","service":"Company.Ops","level":"INFO","message":"DR test initiated - switching to failover database","environment":"production","correlation_id":"dr-test-001","host":"ops-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-2"}}
   {"timestamp":"${T_5H}","service":"Company.Ops","level":"ERROR","message":"Job scheduler failed to process batch: connection timeout to failover DB after 30s","environment":"production","correlation_id":"dr-test-001","host":"ops-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-3"}}
   {"timestamp":"${T_5H}","service":"Company.Ops","level":"ERROR","message":"Scheduled job execution failed with status 500: unable to acquire database lock during failover","environment":"production","correlation_id":"job-8827","host":"ops-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-4"}}
   {"timestamp":"${T_4H}","service":"Company.Ops","level":"WARN","message":"Job creation endpoint returning 503 - database failover in progress","environment":"production","correlation_id":"dr-test-001","host":"ops-prod-02"}
-  {"index":{}}
+  {"index":{"_id":"log-5"}}
   {"timestamp":"${T_3H}","service":"Company.Ops","level":"ERROR","message":"Failed to create new scheduled job: HTTP 500 - transaction deadlock detected on jobs table","environment":"production","correlation_id":"job-8831","host":"ops-prod-02"}
-  {"index":{}}
+  {"index":{"_id":"log-6"}}
   {"timestamp":"${T_2H}","service":"Company.Ops","level":"INFO","message":"DR test failover completed - primary database restored","environment":"production","correlation_id":"dr-test-001","host":"ops-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-7"}}
   {"timestamp":"${T_1H}","service":"Company.Ops","level":"INFO","message":"Job scheduler resumed normal operation","environment":"production","correlation_id":"dr-test-001","host":"ops-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-8"}}
   {"timestamp":"${T_6H}","service":"Company.Ops.Radar.WebJob","level":"INFO","message":"Radar data collection job starting cycle","environment":"production","correlation_id":"radar-cycle-445","host":"radar-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-9"}}
   {"timestamp":"${T_5H}","service":"Company.Ops.Radar.WebJob","level":"ERROR","message":"Radar batch processing failed: upstream dependency Company.Ops unavailable during failover","environment":"production","correlation_id":"radar-cycle-445","host":"radar-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-10"}}
   {"timestamp":"${T_4H}","service":"Company.Ops.Radar.WebJob","level":"ERROR","message":"Job execution error: HTTP 500 from internal API - database connection pool exhausted","environment":"production","correlation_id":"radar-cycle-446","host":"radar-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-11"}}
   {"timestamp":"${T_3H}","service":"Company.Ops.Radar.WebJob","level":"WARN","message":"Retrying failed radar collection job after backoff","environment":"production","correlation_id":"radar-cycle-446","host":"radar-prod-01"}
-  {"index":{}}
+  {"index":{"_id":"log-12"}}
   {"timestamp":"${T_2H}","service":"Company.Ops.Radar.WebJob","level":"INFO","message":"Radar data collection resumed successfully after failover recovery","environment":"production","correlation_id":"radar-cycle-447","host":"radar-prod-01"}
   BULK_EOF
   sed 's/^  //' "$BULK_FILE" > "${BULK_FILE}.tmp" && mv "${BULK_FILE}.tmp" "$BULK_FILE"
@@ -156,5 +157,6 @@ before_test: |
 after_test: |
   # Indices use static test-ID-prefixed names (app-254-*). Parallel CI runs
   # share the same ES cluster, so we skip deletion to avoid removing indices
-  # that another run's before_test just created (reentrancy-safe).
+  # that another in-flight run still depends on. before_test is idempotent
+  # (PUT tolerates already-exists, bulk inserts use stable _ids).
   echo "Skipping index cleanup (reentrant - before_test handles idempotent setup)"

--- a/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
@@ -82,6 +82,15 @@ before_test: |
   fi
   sleep 2
 
+  # One-shot stale-doc cleanup. Deletes any doc whose _id is NOT in our
+  # known stable-_id set (log-1..log-12). Safe under concurrency: a parallel
+  # run's docs all match the keep-list and are preserved. Removes leftovers
+  # from older revisions of this fixture (which used auto-generated _ids).
+  curl -s -X POST "${ELASTICSEARCH_URL}/${LOGS_INDEX}/_delete_by_query?refresh=true&conflicts=proceed" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ApiKey ${ELASTICSEARCH_API_KEY}" \
+    -d '{"query":{"bool":{"must_not":[{"ids":{"values":["log-1","log-2","log-3","log-4","log-5","log-6","log-7","log-8","log-9","log-10","log-11","log-12"]}}]}}}' > /dev/null
+
   # Insert log data for Company.Ops (main platform service) and Company.Ops.Radar.WebJob
   # Both have job processing failures but NEITHER is companyopswebjob
   # Stable _ids ("log-1".."log-12") make this idempotent under concurrent


### PR DESCRIPTION
## Summary

Refactor test fixtures to support parallel execution in CI by eliminating destructive cleanup operations and making setup idempotent. Tests now create-or-reuse shared resources (Elasticsearch indices, Confluence spaces) and use stable document IDs to ensure concurrent runs converge on the same data rather than duplicating or conflicting.

## Key Changes

**Elasticsearch Test Fixtures** (186, 183d, 188, 235, 254, 183c, 187, 190, 184, 185, 191, 245, 183e, 193, 183b, 183g, 189, 183f):
- Removed all `DELETE` operations on indices and templates that would wipe parallel runs' data
- Changed index creation from `curl -sf` (fail-fast) to `curl -s` to tolerate `resource_already_exists_exception`
- Updated response validation to accept both `"acknowledged":true` and `resource_already_exists_exception` patterns
- Added stable `_id` fields to all bulk insert operations (e.g., `"_id": "seed-1"`, `"_id": "evt-1"`) so concurrent runs overwrite instead of duplicate
- Updated log messages from "Creating" to "Creating (or reusing)" to reflect idempotent behavior
- Added detailed comments explaining reentrancy constraints and why deletion is unsafe

**Confluence Test Fixtures** (214, 215, 216, 220, 221, 224, 248):
- Removed `after_test` cleanup blocks that deleted spaces
- Replaced with comments explaining that spaces are static, test-ID-scoped resources shared with parallel runs
- `before_test` remains idempotent (creates-or-reuses spaces and pages)

## Implementation Details

- **Stable Document IDs**: Each test now assigns deterministic `_id` values (e.g., `"inv-1"` through `"inv-6"` for inventory docs, `"evt-1"` through `"evt-10"` for events). This ensures that when multiple CI runs execute in parallel, they converge on the same documents rather than accumulating duplicates.

- **Idempotent Index Creation**: Index creation now tolerates the `resource_already_exists_exception` response, allowing tests to safely reuse existing indices. Shard counts and mappings are fixed at index creation time, so reusing an existing index preserves test invariants.

- **Template Reuse**: Index templates are PUT (not deleted and recreated), which is an idempotent overwrite operation. This allows parallel runs to safely share the same template namespace.

- **Count Assertions**: Tests that verify exact document counts (e.g., "exactly 10 documents", "exactly 6 inventory items") now rely on stable `_id` values to ensure concurrent runs don't inflate counts through duplication.

These changes enable safe parallel execution of test suites in CI without resource contention or data loss.

https://claude.ai/code/session_01FyVB4GpVDV92rqMr59eK3o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test fixtures made safe for parallel CI: setups now create-or-reuse shared resources idempotently, use deterministic document IDs to preserve expected counts, and skip destructive teardown. These updates improve stability and consistency of test data across concurrent runs, boosting CI reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2039)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->