### PR TITLE
Keep eval test case names on a single row in the GitHub report

### DIFF
--- a/tests/llm/utils/reporting/github_reporter.py
+++ b/tests/llm/utils/reporting/github_reporter.py
@@ -40,6 +40,10 @@ def _get_eval_source_url(test_type: str, test_case_name: str) -> Optional[str]:
     fixture_dir = _TEST_TYPE_TO_FIXTURE_DIR.get(test_type)
     if not fixture_dir or not test_case_name:
         return None
+    # Strip pytest parametrize suffix (e.g. "227_count_configmaps_per_namespace[0]"
+    # → "227_count_configmaps_per_namespace"); the fixture directory on disk
+    # does not include the "[…]" portion.
+    fixture_name = test_case_name.split("[", 1)[0]
     ref = (
         os.environ.get("EVAL_BRANCH")
         or os.environ.get("GITHUB_HEAD_REF")
@@ -49,7 +53,7 @@ def _get_eval_source_url(test_type: str, test_case_name: str) -> Optional[str]:
     encoded_ref = quote(ref, safe="")
     return (
         f"https://github.com/HolmesGPT/holmesgpt/blob/{encoded_ref}"
-        f"/tests/llm/fixtures/{fixture_dir}/{test_case_name}/test_case.yaml"
+        f"/tests/llm/fixtures/{fixture_dir}/{fixture_name}/test_case.yaml"
     )
 
 

--- a/tests/llm/utils/reporting/github_reporter.py
+++ b/tests/llm/utils/reporting/github_reporter.py
@@ -350,8 +350,8 @@ def generate_markdown_report(
             markdown += f", {ask_holmes_mock_failures} mock failures"
         markdown += "\n"
     # Generate detailed table
-    markdown += "\n\n| Status | Test case | Time | Turns | Tools | Cost | Total tokens | Input | Max input | Output | Max output | Cached | Non-cached | Reasoning | Compactions |\n"
-    markdown += "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+    markdown += "\n\n| Status | Test case | Time | Turns | Tools | Cost | Total tokens | Input | Max input | Output | Max output | Cached | Non-cached | Reasoning | Compactions | Src |\n"
+    markdown += "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
 
     # Track totals for summary row
     total_time = 0.0
@@ -382,16 +382,12 @@ def generate_markdown_report(
         if braintrust_url:
             test_case_name = f"[{test_case_name}]({braintrust_url})"
 
-        # Add 📄 link to the eval's test_case.yaml on the branch this run ran from
+        # Link to the eval's test_case.yaml on the branch this run ran from
+        # (rendered as its own "Src" column at the end of the row).
         source_url = _get_eval_source_url(
             result.get("test_type", ""), result["test_case_name"]
         )
-        if source_url:
-            test_case_name = f"[📄]({source_url}) {test_case_name}"
-
-        # Prevent long test case names from wrapping across multiple lines in
-        # the GitHub-rendered table.
-        test_case_name = f"<nobr>{test_case_name}</nobr>"
+        source_str = f"[src]({source_url})" if source_url else "—"
 
         status = TestStatus(result)
 
@@ -472,7 +468,7 @@ def generate_markdown_report(
         max_prompt_str = _fmt_tokens(max_prompt)
         compactions_str = str(num_compactions) if num_compactions > 0 else "—"
 
-        markdown += f"| {status.markdown_symbol} | {test_case_name} | {time_str} | {turns_str} | {tools_str} | {cost_str} | {total_tokens_str} | {input_str} | {max_prompt_str} | {output_str} | {max_completion_str} | {cached_tokens_str} | {non_cached_tokens_str} | {reasoning_str} | {compactions_str} |\n"
+        markdown += f"| {status.markdown_symbol} | {test_case_name} | {time_str} | {turns_str} | {tools_str} | {cost_str} | {total_tokens_str} | {input_str} | {max_prompt_str} | {output_str} | {max_completion_str} | {cached_tokens_str} | {non_cached_tokens_str} | {reasoning_str} | {compactions_str} | {source_str} |\n"
 
     # Add summary row
     avg_time_str = f"{total_time / time_count:.1f}s" if time_count > 0 else "—"
@@ -488,7 +484,7 @@ def generate_markdown_report(
     max_completion_max_str = _fmt_tokens(max_completion_per_call_max)
     max_prompt_max_str = _fmt_tokens(max_prompt_per_call_max)
     total_compactions_str = str(total_compactions) if total_compactions > 0 else "—"
-    markdown += f"| | **Total** | **{avg_time_str}** avg | **{avg_turns_str}** avg | **{avg_tools_str}** avg | **{total_cost_str}** | **{total_tokens_total_str}** | **{total_prompt_str}** | **{max_prompt_max_str}** | **{total_completion_str}** | **{max_completion_max_str}** | **{total_cached_tokens_str}** | **{total_non_cached_tokens_str}** | **{total_reasoning_str}** | **{total_compactions_str}** |\n"
+    markdown += f"| | **Total** | **{avg_time_str}** avg | **{avg_turns_str}** avg | **{avg_tools_str}** avg | **{total_cost_str}** | **{total_tokens_total_str}** | **{total_prompt_str}** | **{max_prompt_max_str}** | **{total_completion_str}** | **{max_completion_max_str}** | **{total_cached_tokens_str}** | **{total_non_cached_tokens_str}** | **{total_reasoning_str}** | **{total_compactions_str}** | |\n"
 
     # Add footer explaining benchmark comparison status
     if not benchmark and historical_details and historical_details.status:

--- a/tests/llm/utils/reporting/github_reporter.py
+++ b/tests/llm/utils/reporting/github_reporter.py
@@ -389,6 +389,10 @@ def generate_markdown_report(
         if source_url:
             test_case_name = f"[📄]({source_url}) {test_case_name}"
 
+        # Prevent long test case names from wrapping across multiple lines in
+        # the GitHub-rendered table.
+        test_case_name = f"<nobr>{test_case_name}</nobr>"
+
         status = TestStatus(result)
 
         # Format time (plain, no inline comparison)


### PR DESCRIPTION
Wrap the test case name cell in <nobr> so GitHub's markdown renderer
does not break long names (e.g. 176_network_policy_blocking_traffic_no_skills)
across two lines in the eval results table.

Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test report gains a dedicated "Src" column showing a link (or "—") to each test's source on the run's branch.
* **Bug Fixes**
  * Improved per-row formatting and table layout for clearer test names and source links.
  * Totals/summary row adjusted to align with the new column structure.
  * Source links now reliably resolve for parameterized tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2050)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->