### PR TITLE
docs: clarify built-in Kubernetes vs MCP toolset choice

### DIFF
--- a/docs/data-sources/builtin-toolsets/index.md
+++ b/docs/data-sources/builtin-toolsets/index.md
@@ -74,9 +74,20 @@ HolmesGPT includes pre-built integrations for popular monitoring and observabili
 
 ### Kubernetes & Containers
 
+**Core Kubernetes access** — pick one read-only toolset, plus the remediation MCP if you need write actions:
+
 <div class="grid cards" markdown>
 
--   [:simple-kubernetes:{ .lg .middle } **Kubernetes**](kubernetes.md)
+-   [:simple-kubernetes:{ .lg .middle } **Kubernetes**](kubernetes.md) — default, read-only via `kubectl`
+-   [:simple-kubernetes:{ .lg .middle } **Kubernetes (MCP)**](kubernetes-mcp.md) — read-only with OAuth/OIDC
+-   [:simple-kubernetes:{ .lg .middle } **Kubernetes Remediation (MCP)**](kubernetes-remediation-mcp.md) — write actions (restart, scale, drain)
+
+</div>
+
+**Other container & Kubernetes tooling:**
+
+<div class="grid cards" markdown>
+
 -   [:simple-docker:{ .lg .middle } **Docker**](docker.md)
 -   [:material-package:{ .lg .middle } **Helm**](helm.md)
 -   [:simple-redhatopenshift:{ .lg .middle } **OpenShift**](openshift.md)
@@ -88,8 +99,6 @@ HolmesGPT includes pre-built integrations for popular monitoring and observabili
 -   [:material-magnify:{ .lg .middle } **Inspektor Gadget**](inspektor-gadget.md)
 -   [:material-microsoft-azure:{ .lg .middle } **Azure Kubernetes Service**](aks.md)
 -   [:material-heart-pulse:{ .lg .middle } **AKS Node Health**](aks-node-health.md)
--   [:simple-kubernetes:{ .lg .middle } **Kubernetes (MCP)**](kubernetes-mcp.md)
--   [:simple-kubernetes:{ .lg .middle } **Kubernetes Remediation (MCP)**](kubernetes-remediation-mcp.md)
 
 </div>
 

--- a/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
@@ -1,11 +1,8 @@
 # Kubernetes (MCP)
 
-!!! note "Built-in Kubernetes toolsets are recommended for most users"
-    Holmes includes built-in Kubernetes toolsets ([`kubernetes/core`](kubernetes.md), `kubernetes/logs`) that provide comprehensive cluster access — it uses bash to run kubectl commands directly, no additional setup required when deployed in-cluster.
+--8<-- "snippets/kubernetes_toolset_picker.md"
 
-    The Kubernetes MCP addon is for **advanced scenarios**: enterprise environments requiring OAuth/OIDC authentication or centralized access control via identity providers.
-
-The [Kubernetes MCP server](https://github.com/containers/kubernetes-mcp-server) gives Holmes access to Kubernetes clusters via the MCP protocol, with support for OAuth/OIDC authentication.
+The [Kubernetes MCP server](https://github.com/containers/kubernetes-mcp-server) gives Holmes access to Kubernetes clusters via the MCP protocol, with support for OAuth/OIDC authentication. It is intended to **replace** the built-in `kubernetes/core` and `kubernetes/logs` toolsets — the Helm examples below disable those to avoid overlap.
 
 ## In-Cluster Setup (ServiceAccount)
 

--- a/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
@@ -1,6 +1,10 @@
 # Kubernetes Remediation (MCP)
 
+--8<-- "snippets/kubernetes_toolset_picker.md"
+
 The Kubernetes Remediation MCP server provides safe kubectl command execution with layered security controls. It enables Holmes to not only diagnose Kubernetes issues but also **remediate** them — restarting pods, scaling deployments, draining nodes, and more.
+
+This toolset is **additive**: keep your existing read-only Kubernetes toolset ([built-in](kubernetes.md) or [MCP](kubernetes-mcp.md)) enabled for diagnosis, and enable this one alongside it for write actions.
 
 !!! warning "Write operations"
     Unlike the built-in read-only Kubernetes toolset, this MCP server can execute write operations (edit, patch, delete, scale, drain, etc.). Configure the `allowedCommands` setting carefully to match your security requirements.

--- a/docs/data-sources/builtin-toolsets/kubernetes.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes.md
@@ -9,7 +9,7 @@
 !!! info "Enabled by Default"
     This toolset is enabled by default and should typically remain enabled.
 
-By enabling this toolset, HolmesGPT will be able to describe and find Kubernetes resources like nodes, deployments, pods, etc. It runs `kubectl` commands through the [bash toolset](bash.md), authenticated with the pod's ServiceAccount when deployed in-cluster or with your local kubeconfig for CLI usage.
+By enabling this toolset, HolmesGPT will be able to describe and find Kubernetes resources like nodes, deployments, pods, etc. The tools shell out to `kubectl`, authenticated with the pod's ServiceAccount when deployed in-cluster or with your local kubeconfig for CLI usage. Permissions are read-only by default — secrets and other sensitive resources are excluded.
 
 **Configuration:**
 

--- a/docs/data-sources/builtin-toolsets/kubernetes.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes.md
@@ -1,5 +1,7 @@
 # Kubernetes
 
+--8<-- "snippets/kubernetes_toolset_picker.md"
+
 ## Toolsets
 
 ### Core
@@ -7,7 +9,7 @@
 !!! info "Enabled by Default"
     This toolset is enabled by default and should typically remain enabled.
 
-By enabling this toolset, HolmesGPT will be able to describe and find Kubernetes resources like nodes, deployments, pods, etc.
+By enabling this toolset, HolmesGPT will be able to describe and find Kubernetes resources like nodes, deployments, pods, etc. It runs `kubectl` commands through the [bash toolset](bash.md), authenticated with the pod's ServiceAccount when deployed in-cluster or with your local kubeconfig for CLI usage.
 
 **Configuration:**
 

--- a/docs/snippets/kubernetes_toolset_picker.md
+++ b/docs/snippets/kubernetes_toolset_picker.md
@@ -1,6 +1,6 @@
 !!! tip "Which Kubernetes toolset should I use?"
     Holmes has three Kubernetes integrations. Most users only need the first:
 
-    - **[Kubernetes (built-in)](kubernetes.md)** — *default for most users.* Read-only access via `kubectl` running through the bash toolset, authenticated with the pod's ServiceAccount (or your local kubeconfig for CLI). No extra deployment.
+    - **[Kubernetes (built-in)](kubernetes.md)** — *default for most users.* Read-only access to cluster resources via `kubectl`, authenticated with the pod's ServiceAccount in-cluster or your local kubeconfig for CLI. No extra deployment.
     - **[Kubernetes (MCP)](kubernetes-mcp.md)** — *use when you need OAuth/OIDC authentication* (e.g. AKS with Microsoft Entra ID, or per-user RBAC enforced by your identity provider). Replaces the built-in toolset.
     - **[Kubernetes Remediation (MCP)](kubernetes-remediation-mcp.md)** — *add on top of either of the above when you want Holmes to perform write actions* (restart, scale, drain, patch, etc.). Complements the read-only toolsets rather than replacing them.

--- a/docs/snippets/kubernetes_toolset_picker.md
+++ b/docs/snippets/kubernetes_toolset_picker.md
@@ -1,0 +1,6 @@
+!!! tip "Which Kubernetes toolset should I use?"
+    Holmes has three Kubernetes integrations. Most users only need the first:
+
+    - **[Kubernetes (built-in)](kubernetes.md)** — *default for most users.* Read-only access via `kubectl` running through the bash toolset, authenticated with the pod's ServiceAccount (or your local kubeconfig for CLI). No extra deployment.
+    - **[Kubernetes (MCP)](kubernetes-mcp.md)** — *use when you need OAuth/OIDC authentication* (e.g. AKS with Microsoft Entra ID, or per-user RBAC enforced by your identity provider). Replaces the built-in toolset.
+    - **[Kubernetes Remediation (MCP)](kubernetes-remediation-mcp.md)** — *add on top of either of the above when you want Holmes to perform write actions* (restart, scale, drain, patch, etc.). Complements the read-only toolsets rather than replacing them.


### PR DESCRIPTION
Readers landing on kubernetes.md never learned that MCP alternatives
existed, and the MCP pages didn't crisply explain when to switch or
whether they replace vs. complement the built-in. Adds a shared
"which toolset should I use?" snippet included on all three pages,
names the built-in mechanism (kubectl via bash + ServiceAccount),
flags the remediation MCP as additive, and groups the three K8s
entries together on the toolsets index with one-line descriptors.

Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked Kubernetes toolset docs with a new "Core Kubernetes access" subsection and removed duplicate standalone entries
  * Added a reusable toolset selection snippet explaining built-in default, Kubernetes MCP (OAuth/OIDC replacement), and Kubernetes Remediation (add-on for write actions)
  * Clarified authentication and read-only behavior for kubectl-based resource discovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->