### PR TITLE
Move MANDATORY Task Management block back to its pre-#1970 position

### DIFF
--- a/holmes/plugins/prompts/generic_ask.jinja2
+++ b/holmes/plugins/prompts/generic_ask.jinja2
@@ -232,21 +232,6 @@ If the answer to any of those questions is 'yes' - The investigation is INCOMPLE
   - Proceed to verification (investigation complete)
 
   Never guess - if unsure whether investigation is complete, create another phase.
-
-# MANDATORY Task Management
-
-* You MUST use the TodoWrite tool for ANY investigation requiring multiple steps
-* Your FIRST tool call MUST be TodoWrite to create your investigation plan
-* Break down ALL complex problems into smaller, manageable tasks
-* You MUST update task status (pending → in_progress → completed) as you work through your investigation
-* The TodoWrite tool will show you a formatted task list - reference this throughout your investigation
-* Mark tasks as 'in_progress' when you start them, 'completed' when finished
-* Follow ALL tasks in your plan - don't skip any tasks
-* Use task management to ensure you don't miss important investigation steps
-* If you discover additional steps during investigation, add them to your task list using TodoWrite
-* When calling TodoWrite, you may ALSO call other tools in parallel to speed things up for your users and make them happy!
-* On the first TodoWrite call, mark at least one task as in_progress, and start working on it in parallel.
-* When calling TodoWrite for the first time, mark the tasks you started working on with 'in_progress' status.
 {% endif %}
 
 {% if general_instructions_enabled %}
@@ -309,6 +294,23 @@ If during the investigation you encounter a permissions error (e.g., `Error from
 * That is different than - for example - fetching a pod's logs and seeing that the pod itself has permission errors. in that case, you explain say that permission errors are the cause of the problem and give details
 * Issues are a subset of findings. When asked about an issue or a finding and you have an id, use the tool `fetch_finding_by_id`.
 * For any question, try to make the answer specific to the user's environment.
+{% endif %}
+
+{% if todowrite_enabled %}
+# MANDATORY Task Management
+
+* You MUST use the TodoWrite tool for ANY investigation requiring multiple steps
+* Your FIRST tool call MUST be TodoWrite to create your investigation plan
+* Break down ALL complex problems into smaller, manageable tasks
+* You MUST update task status (pending → in_progress → completed) as you work through your investigation
+* The TodoWrite tool will show you a formatted task list - reference this throughout your investigation
+* Mark tasks as 'in_progress' when you start them, 'completed' when finished
+* Follow ALL tasks in your plan - don't skip any tasks
+* Use task management to ensure you don't miss important investigation steps
+* If you discover additional steps during investigation, add them to your task list using TodoWrite
+* When calling TodoWrite, you may ALSO call other tools in parallel to speed things up for your users and make them happy!
+* On the first TodoWrite call, mark at least one task as in_progress, and start working on it in parallel.
+* When calling TodoWrite for the first time, mark the tasks you started working on with 'in_progress' status.
 {% endif %}
 
 {% if general_instructions_enabled %}


### PR DESCRIPTION
PR #1970 inlined investigation_procedure.jinja2 into generic_ask.jinja2 and, in doing so, repositioned the `# MANDATORY Task Management` block from its old slot (between `# Special cases and how to reply` and `# Tool/function calls`, near the end of the prompt) to immediately after `# INVESTIGATION PHASE TRANSITION EXAMPLES`, in the middle of the prompt.

The block content is byte-identical; only its position changed. But that single positional move turns out to drive the residual ~10% eval-perf regression that survived PR #2051's revert of PR #2040.

Local n=10 sweep against the docker-loki regression eval (#259) on opus-4.6:

  condition                       time    turns  total_tk   compl_tk
  baseline (cf6ddb7)              78.6s    7.8   193,919     5,097
  PR-merged (fix-AD only)         83.0s    8.6   202,756     4,834   <- residual
  Restore deleted intro lines     76.0s    9.0   208,022     4,647
  THIS PATCH (just block move)    71.1s    7.6   182,068     4,421
  Block move + intro lines        76.1s    7.6   185,765     4,829
  Full baseline prompt            75.1s    7.2   182,008     4,914

Every z vs baseline for this patch is ≤ 0: time z=-1.91, turns z=-0.46, completion z=-2.14, total tokens z=-0.92. The block-move alone is strictly better than restoring the two deleted intro lines, and matches the full baseline-prompt restoration on aggregate metrics. No text added or removed; just position.

Hypothesis on the mechanism: with the task-management rules sandwiched inside the multi-phase investigation doctrine, the model reads "If you discover additional steps during investigation, add them to your task list using TodoWrite" while it is still planning phases and acts on it more aggressively (extra TodoWrite mid-investigation, extra turns). When the same rules sit at the end of the prompt as a quiet reminder (post-Special-Cases, pre-Tool/function-calls), they don't compound with the phase-planning instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized task management prompt instructions for improved template structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->