### PR TITLE
fix(operator): forward HOLMES_API_KEY in HealthCheck requests (#2030)

### DIFF
--- a/helm/holmes/templates/operator-deployment.yaml
+++ b/helm/holmes/templates/operator-deployment.yaml
@@ -59,6 +59,16 @@ spec:
           value: {{ .Values.operator.cleanupCompletedChecks | default false | quote }}
         - name: COMPLETED_CHECK_TTL_HOURS
           value: {{ .Values.operator.completedCheckTTLHours | default 24 | quote }}
+        {{- if and .Values.operator.holmesApiKeyExistingSecret .Values.operator.holmesApiKeyExistingSecret.name .Values.operator.holmesApiKeyExistingSecret.key }}
+        - name: HOLMES_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.operator.holmesApiKeyExistingSecret.name | quote }}
+              key: {{ .Values.operator.holmesApiKeyExistingSecret.key | quote }}
+        {{- else if .Values.operator.holmesApiKey }}
+        - name: HOLMES_API_KEY
+          value: {{ .Values.operator.holmesApiKey | quote }}
+        {{- end }}
         {{- if .Values.operator.additionalEnvVars }}
         {{- toYaml .Values.operator.additionalEnvVars | nindent 8 }}
         {{- end }}

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -879,6 +879,18 @@ operator:
   holmesApiUrl: ""  # Defaults to "http://<release-name>-holmes:80"
   holmesApiTimeout: 300  # seconds
 
+  # Authenticate the operator's calls to the Holmes API server.
+  # Required when the API server has HOLMES_API_KEY set (otherwise HealthChecks
+  # fail with 401 Unauthorized from /api/checks/execute).
+  # Natural pattern: point both the server and the operator at the same Secret/key.
+  # Prefer holmesApiKeyExistingSecret for production deployments;
+  # holmesApiKey (plain value) is convenient for local testing only.
+  # If both are set, holmesApiKeyExistingSecret takes precedence.
+  holmesApiKey: ""
+  holmesApiKeyExistingSecret:
+    name: ""   # Name of an existing Secret containing the API key
+    key: ""    # Key within the Secret that holds the API key value
+
   # Logging
   logLevel: INFO
 

--- a/holmes_operator/client/holmes_api_client.py
+++ b/holmes_operator/client/holmes_api_client.py
@@ -22,21 +22,35 @@ class HolmesAPIClient:
     - Error handling and logging
     """
 
-    def __init__(self, base_url: str, timeout: int = 300):
+    def __init__(
+        self,
+        base_url: str,
+        timeout: int = 300,
+        api_key: Optional[str] = None,
+    ):
         """
         Initialize the Holmes API client.
 
         Args:
             base_url: Base URL of the Holmes API server (e.g., "http://holmes-api:80")
             timeout: Default timeout for requests in seconds
+            api_key: Optional API key. When set, sent as the X-API-Key header on
+                every request to authenticate against a Holmes API server that has
+                HOLMES_API_KEY configured. When None/empty, no auth header is sent.
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
+        self._api_key = api_key or None
+        headers = {"X-API-Key": self._api_key} if self._api_key else None
         self.client = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout=timeout, connect=10.0),
             limits=httpx.Limits(max_keepalive_connections=10, max_connections=20),
+            headers=headers,
         )
-        logger.info(f"Initialized Holmes API client for {self.base_url}")
+        logger.info(
+            f"Initialized Holmes API client for {self.base_url} "
+            f"(api_key_set={bool(self._api_key)})"
+        )
 
     @retry(
         stop=stop_after_attempt(3),

--- a/holmes_operator/config.py
+++ b/holmes_operator/config.py
@@ -16,6 +16,7 @@ def load_bool(env_var, default: Optional[bool]) -> Optional[bool]:
 
 HOLMES_API_URL = os.getenv("HOLMES_API_URL", "http://holmes-api:80")
 HOLMES_API_TIMEOUT = int(os.getenv("HOLMES_API_TIMEOUT", "300"))
+HOLMES_API_KEY = os.environ.get("HOLMES_API_KEY", "").strip() or None
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 MAX_HISTORY_ITEMS = int(os.getenv("MAX_HISTORY_ITEMS", "10"))
 CLEANUP_COMPLETED_CHECKS = load_bool("CLEANUP_COMPLETED_CHECKS", False)
@@ -38,12 +39,17 @@ class OperatorConfig:
     cleanup_completed_checks: bool
     completed_check_ttl_hours: int
 
+    # Optional API key forwarded to the Holmes API server (issue #2030).
+    # Default None preserves prior behavior when HOLMES_API_KEY is unset.
+    holmes_api_key: Optional[str] = None
+
     @classmethod
     def load(cls) -> "OperatorConfig":
         """Load configuration from environment variables."""
         return cls(
             holmes_api_url=HOLMES_API_URL,
             holmes_api_timeout=HOLMES_API_TIMEOUT,
+            holmes_api_key=HOLMES_API_KEY,
             log_level=LOG_LEVEL,
             max_history_items=MAX_HISTORY_ITEMS,
             cleanup_completed_checks=CLEANUP_COMPLETED_CHECKS,

--- a/holmes_operator/context.py
+++ b/holmes_operator/context.py
@@ -61,6 +61,7 @@ async def initialize() -> OperatorConfig:
     api_client = HolmesAPIClient(
         base_url=config.holmes_api_url,
         timeout=config.holmes_api_timeout,
+        api_key=config.holmes_api_key,
     )
 
     # Initialize and start scheduler manager

--- a/tests/holmes_operator/test_holmes_api_client_auth.py
+++ b/tests/holmes_operator/test_holmes_api_client_auth.py
@@ -1,0 +1,127 @@
+"""Unit tests for HolmesAPIClient authentication header behavior.
+
+Covers the contract between the operator and the Holmes API server when
+HOLMES_API_KEY is configured (issue #2030):
+- without an API key, no auth header is sent (current behavior preserved);
+- with an API key, the X-API-Key header is sent on /api/checks/execute
+  (the request path that previously failed with 401 Unauthorized);
+- with an API key, the X-API-Key header is sent on every endpoint the client
+  exposes, so a future endpoint can't silently regress.
+"""
+
+import pytest
+import respx
+from httpx import Response
+
+from holmes_operator.client.holmes_api_client import HolmesAPIClient
+
+
+SAMPLE_CHECK_RESPONSE = {
+    "status": "pass",
+    "message": "ok",
+    "rationale": "ok",
+    "duration": 0.1,
+    "model_used": "test-model",
+    "notifications": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_no_api_key_sends_no_auth_header(respx_mock):
+    """Without an API key, the client must not send X-API-Key or Authorization."""
+    route = respx_mock.post(
+        "http://mock-holmes-api:80/api/checks/execute"
+    ).mock(return_value=Response(200, json=SAMPLE_CHECK_RESPONSE))
+
+    client = HolmesAPIClient(base_url="http://mock-holmes-api:80")
+    try:
+        await client.execute_check(
+            check_name="t",
+            query="q",
+            timeout=10,
+            mode="monitor",
+            destinations=[],
+        )
+    finally:
+        await client.close()
+
+    assert route.called
+    sent = route.calls.last.request
+    assert "X-API-Key" not in sent.headers
+    assert "Authorization" not in sent.headers
+
+
+@pytest.mark.asyncio
+async def test_api_key_sent_on_execute_check(respx_mock):
+    """With an API key, X-API-Key must reach /api/checks/execute exactly."""
+    route = respx_mock.post(
+        "http://mock-holmes-api:80/api/checks/execute"
+    ).mock(return_value=Response(200, json=SAMPLE_CHECK_RESPONSE))
+
+    client = HolmesAPIClient(base_url="http://mock-holmes-api:80", api_key="secret")
+    try:
+        await client.execute_check(
+            check_name="t",
+            query="q",
+            timeout=10,
+            mode="monitor",
+            destinations=[],
+        )
+    finally:
+        await client.close()
+
+    assert route.called
+    sent = route.calls.last.request
+    assert sent.headers.get("X-API-Key") == "secret"
+    assert sent.url.path == "/api/checks/execute"
+
+
+@pytest.mark.asyncio
+async def test_api_key_sent_on_every_endpoint(respx_mock):
+    """The auth header must apply to every endpoint, not just execute_check."""
+    public_methods = [
+        name
+        for name in dir(HolmesAPIClient)
+        if not name.startswith("_") and callable(getattr(HolmesAPIClient, name))
+    ]
+    # Sanity check: if a new endpoint is added without updating this test, the
+    # author should at least see the list grow.
+    assert "execute_check" in public_methods
+
+    route = respx_mock.route(host="mock-holmes-api").mock(
+        return_value=Response(200, json=SAMPLE_CHECK_RESPONSE)
+    )
+
+    client = HolmesAPIClient(base_url="http://mock-holmes-api:80", api_key="secret")
+    try:
+        # Drive every HTTP-bound endpoint the client exposes today.
+        await client.execute_check(
+            check_name="t",
+            query="q",
+            timeout=10,
+            mode="monitor",
+            destinations=[],
+        )
+        # Exercise the underlying httpx.AsyncClient directly to assert the header
+        # is attached by construction — any future endpoint built on self.client
+        # inherits the header automatically.
+        await client.client.get("http://mock-holmes-api:80/some/future/endpoint")
+    finally:
+        await client.close()
+
+    assert route.call_count >= 2
+    for call in route.calls:
+        assert call.request.headers.get("X-API-Key") == "secret"
+
+
+@pytest.mark.asyncio
+async def test_api_key_value_not_logged(caplog):
+    """The API key value must never appear in log output."""
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    client = HolmesAPIClient(base_url="http://mock-holmes-api:80", api_key="super-secret-value")
+    try:
+        assert "super-secret-value" not in caplog.text
+    finally:
+        await client.close()


### PR DESCRIPTION
Fixes #2030.

## Problem

When `HOLMES_API_KEY` is set on the Holmes API server via the Helm chart, the Holmes operator cannot authenticate against the API server and every `HealthCheck` CR fails with `401 Unauthorized` from `/api/checks/execute`. The operator never had a code path that forwarded an API key, so users who enable auth on the server effectively break the operator.

## Server-side auth contract (confirmed before coding)

- Header: `X-API-Key` (checked first), with `Authorization: Bearer <key>` as a fallback (`holmes/utils/auth.py`).
- Scope: global FastAPI middleware in `server.py:278`, applied to every path except `/healthz` and `/readyz`. `/api/checks/execute` is gated.
- Comparison: plain `==`, not `hmac.compare_digest`. Out of scope for this PR — see "Follow-ups" below.

The operator now sends the same `X-API-Key` header the server already accepts. No new convention introduced; no server-side changes.

## What changed

**Operator config (`holmes_operator/config.py`)**
- New `HOLMES_API_KEY` env var, exposed as `OperatorConfig.holmes_api_key` (`Optional[str]`, default `None`). Default `None` preserves prior behavior byte-for-byte when the env var is unset.

**Operator HTTP client (`holmes_operator/client/holmes_api_client.py`)**
- `HolmesAPIClient.__init__` accepts an optional `api_key` argument. When non-empty, `X-API-Key` is attached to the underlying `httpx.AsyncClient` **once at construction**, so it applies to every current and future endpoint automatically (no per-call risk of forgetting on a new endpoint).
- Only `bool(self._api_key)` is logged — the key value never appears in logs, error messages, or `__repr__`.

**Operator context (`holmes_operator/context.py`)**
- `initialize()` passes `config.holmes_api_key` to the client.

**Helm chart (`helm/holmes/values.yaml`, `helm/holmes/templates/operator-deployment.yaml`)**
- Two mutually-exclusive operator-side options:
  - `operator.holmesApiKey` — plain value (convenient for local testing).
  - `operator.holmesApiKeyExistingSecret.{name,key}` — `secretKeyRef`, recommended for production. Takes precedence when both are set.
- If neither is set, no `HOLMES_API_KEY` env var is rendered into the operator Deployment — current behavior, no regression for users who don't run with auth.
- `values.yaml` notes that the natural pattern is to point both the server and the operator at the same Secret/key. Not enforced.

**Tests (`tests/holmes_operator/test_holmes_api_client_auth.py`)**
- `HolmesAPIClient(api_key=None)` → outgoing request has no auth header.
- `HolmesAPIClient(api_key="secret")` → outgoing request to `/api/checks/execute` carries `X-API-Key: secret`.
- `HolmesAPIClient(api_key="secret")` → header is present on every endpoint, asserted at the `httpx.AsyncClient` level so future endpoints inherit it automatically.
- Constructing the client never logs the key value.
- Uses `respx` and pytest-asyncio to match the existing operator test idiom — no new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key configuration for Holmes API integration in operator deployments.
  * Helm values support either a direct API key or a reference to an existing Kubernetes Secret (secret reference takes precedence).
  * Operator deployment now exposes the API key to the runtime container when configured.

* **Tests**
  * Added tests validating authentication header behavior, request handling, and that API keys are not leaked in logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->