### PR TITLE
feat(toolsets/datadog): multi-account support for all four Datadog toolsets

### DIFF
--- a/docs/data-sources/builtin-toolsets/datadog.md
+++ b/docs/data-sources/builtin-toolsets/datadog.md
@@ -186,6 +186,41 @@ holmes ask "list Datadog monitors"
 
 That's it! You're now connected to Datadog with all toolsets enabled.
 
+## Multiple Datadog accounts
+
+Each Datadog toolset can be configured against several Datadog accounts
+(organizations) at once. This is useful when, for example, staging and
+production live in separate Datadog orgs. The LLM picks the target account
+on a per-tool-call basis via an `account` parameter.
+
+Replace the single-account `api_key`/`app_key`/`api_url` block with an
+`accounts:` list. The two forms are mutually exclusive — supply one or the
+other.
+
+```yaml
+toolsets:
+  datadog/metrics:
+    enabled: true
+    config:
+      accounts:
+        - name: staging
+          api_key: "{{ env.DATADOG_API_KEY_STG }}"
+          app_key: "{{ env.DATADOG_APP_KEY_STG }}"
+          api_url: https://api.datadoghq.eu
+          default: true            # optional — first account wins otherwise
+        - name: production
+          api_key: "{{ env.DATADOG_API_KEY_PRD }}"
+          app_key: "{{ env.DATADOG_APP_KEY_PRD }}"
+          api_url: https://api.datadoghq.eu
+```
+
+When two or more accounts are configured, every tool exposed by that
+toolset accepts an optional `account` parameter whose value matches one of
+the configured account names. Omitting it routes the call to the account
+marked `default: true` (or to the first one if no default is set). The list
+of available accounts is injected into the toolset's system prompt so the
+LLM can pick the right one for each call.
+
 ## Available Toolsets
 
 HolmesGPT provides four specialized Datadog toolsets:

--- a/holmes/plugins/toolsets/datadog/datadog_api.py
+++ b/holmes/plugins/toolsets/datadog/datadog_api.py
@@ -3,11 +3,11 @@ import logging
 import re
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import Any, ClassVar, Dict, Optional, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
 import requests  # type: ignore
-from pydantic import AnyUrl, Field
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, model_validator
 from requests.structures import CaseInsensitiveDict  # type: ignore
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_incrementing
 from tenacity.wait import wait_base
@@ -95,8 +95,74 @@ def convert_api_url_to_app_url(api_url: Union[str, AnyUrl]) -> str:
     return app_url
 
 
+class DatadogAccount(BaseModel):
+    """A single Datadog organization (account) the toolset can query.
+
+    Each account carries its own credentials and site URL so a single
+    Holmes deployment can target several Datadog organizations (e.g.
+    staging + production) from the same toolset.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(
+        min_length=1,
+        title="Account name",
+        description=(
+            "Identifier used by the LLM to target this account from a tool "
+            "call (for example `staging` or `production`). Must be unique "
+            "within a toolset."
+        ),
+        examples=["default", "staging", "production"],
+    )
+    api_key: str = Field(
+        title="API Key",
+        description="Datadog API key for authentication",
+        json_schema_extra={"format": "password"},
+    )
+    app_key: str = Field(
+        title="Application Key",
+        description="Datadog application key for authentication",
+        json_schema_extra={"format": "password"},
+    )
+    api_url: AnyUrl = Field(
+        title="API URL",
+        description=(
+            "Datadog site API base URL for this account. See "
+            "https://docs.datadoghq.com/getting_started/site/ for the full "
+            "list."
+        ),
+        examples=[
+            "https://api.datadoghq.com",
+            "https://api.datadoghq.eu",
+        ],
+    )
+    default: bool = Field(
+        default=False,
+        title="Default",
+        description=(
+            "When true, this account is used by tool calls that don't set "
+            "an explicit `account` parameter. At most one account may be "
+            "flagged default; if none is, the first account in the list "
+            "wins."
+        ),
+    )
+
+
 class DatadogBaseConfig(ToolsetConfig):
-    """Base configuration for all Datadog toolsets"""
+    """Base configuration for all Datadog toolsets.
+
+    Supports two interchangeable schemas:
+
+    - **Single-account shorthand** (legacy / common case): set `api_key`,
+      `app_key` and `api_url` directly on the config. Internally normalised
+      to a single :class:`DatadogAccount` named ``default``.
+    - **Multi-account**: populate the `accounts:` list to query several
+      Datadog organizations from the same toolset. Each tool call accepts
+      an optional `account` parameter to pick the target.
+
+    The two forms are mutually exclusive within one config block.
+    """
 
     _deprecated_mappings: ClassVar[Dict[str, Optional[str]]] = {
         "dd_api_key": "api_key",
@@ -104,24 +170,45 @@ class DatadogBaseConfig(ToolsetConfig):
         "site_api_url": "api_url",
         "request_timeout": "timeout_seconds",
     }
+    # The UI form guides users through the common single-account path, so mark
+    # the shorthand credential fields as required in the exported schema even
+    # though they are Optional at the Pydantic level (to allow the
+    # `accounts:` alternative).  The `accounts` list is hidden because nested
+    # complex objects don't render well in form UIs — advanced users supply it
+    # directly in their YAML/Helm values.
+    _ui_required_fields: ClassVar[List[str]] = ["api_key", "app_key", "api_url"]
+    _hidden_fields: ClassVar[List[str]] = ["accounts"]
 
-    api_key: str = Field(
+    # Single-account shorthand. When `accounts:` below is populated, these
+    # fields must be omitted.
+    api_key: Optional[str] = Field(
+        default=None,
         title="API Key",
-        description="Datadog API key for authentication",
+        description=(
+            "Datadog API key. Single-account shorthand; for multi-account "
+            "setups, populate the `accounts:` list instead."
+        ),
         examples=["{{ env.DATADOG_API_KEY }}"],
         json_schema_extra={"format": "password"},
     )
-    app_key: str = Field(
+    app_key: Optional[str] = Field(
+        default=None,
         title="Application Key",
-        description="Datadog application key for authentication",
+        description=(
+            "Datadog application key. Single-account shorthand; for "
+            "multi-account setups, populate `accounts:` instead."
+        ),
         examples=["{{ env.DATADOG_APP_KEY }}"],
         json_schema_extra={"format": "password"},
     )
-    api_url: AnyUrl = Field(
+    api_url: Optional[AnyUrl] = Field(
+        default=None,
         title="API URL",
         description=(
-            "Datadog site API base URL. Pick the URL matching your Datadog region — "
-            "see https://docs.datadoghq.com/getting_started/site/ for the full list."
+            "Datadog site API base URL. Single-account shorthand; for "
+            "multi-account setups, populate `accounts:` instead. See "
+            "https://docs.datadoghq.com/getting_started/site/ for the "
+            "full list."
         ),
         examples=[
             "https://api.datadoghq.com",
@@ -132,11 +219,104 @@ class DatadogBaseConfig(ToolsetConfig):
             "https://api.ddog-gov.com",
         ],
     )
+    accounts: List[DatadogAccount] = Field(
+        default_factory=list,
+        title="Datadog accounts",
+        description=(
+            "Datadog accounts (organizations) the toolset can query. Leave "
+            "empty to use the single-account shorthand above; populate with "
+            "two or more entries to enable multi-account routing via the "
+            "`account` tool parameter."
+        ),
+    )
     timeout_seconds: int = Field(
         default=60,
         title="Timeout",
         description="HTTP request timeout in seconds",
     )
+
+    @model_validator(mode="after")
+    def _normalize_accounts(self) -> "DatadogBaseConfig":
+        """Coalesce the legacy single-account fields into ``self.accounts``."""
+        legacy_set = any(
+            v is not None for v in (self.api_key, self.app_key, self.api_url)
+        )
+        if self.accounts and legacy_set:
+            raise ValueError(
+                "Datadog config: provide either the top-level "
+                "api_key/app_key/api_url shorthand OR the `accounts:` list, "
+                "not both."
+            )
+        if not self.accounts:
+            if not legacy_set:
+                raise ValueError(
+                    "Datadog config: missing credentials. Provide either "
+                    "top-level api_key/app_key/api_url or an `accounts:` "
+                    "list."
+                )
+            missing = [
+                name
+                for name, value in (
+                    ("api_key", self.api_key),
+                    ("app_key", self.app_key),
+                    ("api_url", self.api_url),
+                )
+                if value is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"Datadog config: missing required field(s) {missing}. "
+                    "All of api_key, app_key, api_url must be set when "
+                    "using the single-account shorthand."
+                )
+            self.accounts = [
+                DatadogAccount(
+                    name="default",
+                    api_key=self.api_key,  # type: ignore[arg-type]
+                    app_key=self.app_key,  # type: ignore[arg-type]
+                    api_url=self.api_url,  # type: ignore[arg-type]
+                    default=True,
+                )
+            ]
+        # `self.accounts` is now the source of truth. We keep the legacy
+        # top-level fields populated (when the shorthand was used) so that
+        # downstream code reading them stays backward-compatible — but new
+        # call sites should always read from `accounts` via `get_account()`.
+        names = [account.name for account in self.accounts]
+        duplicates = sorted({n for n in names if names.count(n) > 1})
+        if duplicates:
+            raise ValueError(
+                f"Datadog config: duplicate account name(s): {duplicates}."
+            )
+        defaults = [account for account in self.accounts if account.default]
+        if len(defaults) > 1:
+            raise ValueError(
+                "Datadog config: at most one account may be flagged "
+                f"`default: true` (got {[a.name for a in defaults]})."
+            )
+        if not defaults:
+            self.accounts[0].default = True
+        return self
+
+    def get_account(self, name: Optional[str] = None) -> DatadogAccount:
+        """Resolve the named Datadog account, or the default when omitted.
+
+        Raises :class:`KeyError` with the list of valid account names when
+        ``name`` is unknown so the LLM can self-correct on retry.
+        """
+        if name is None:
+            for account in self.accounts:
+                if account.default:
+                    return account
+            return self.accounts[0]
+        for account in self.accounts:
+            if account.name == name:
+                return account
+        available = ", ".join(repr(account.name) for account in self.accounts)
+        raise KeyError(
+            f"unknown Datadog account {name!r}; available accounts: "
+            f"[{available}]"
+        )
 
 
 class DataDogRequestError(Exception):
@@ -159,19 +339,29 @@ class DataDogRequestError(Exception):
         self.response_headers = response_headers
 
 
-def get_headers(dd_config: DatadogBaseConfig) -> Dict[str, str]:
-    """Get standard headers for Datadog API requests.
+#: Shared description for the per-tool ``account`` parameter exposed by every
+#: Datadog tool. The exact list of available accounts is injected into the
+#: toolset's system instructions via Jinja so the LLM knows what's valid.
+ACCOUNT_TOOL_PARAM_DESCRIPTION = (
+    "Datadog account to query. Optional. If omitted, the configured default "
+    "account is used. The list of available accounts is in the toolset's "
+    "system instructions."
+)
+
+
+def get_headers(account: DatadogAccount) -> Dict[str, str]:
+    """Get standard headers for Datadog API requests for a given account.
 
     Args:
-        dd_config: Datadog configuration object
+        account: The Datadog account whose credentials should be used.
 
     Returns:
-        Dictionary of headers for Datadog API requests
+        Dictionary of headers for Datadog API requests.
     """
     return {
         "Content-Type": "application/json",
-        "DD-API-KEY": dd_config.api_key,
-        "DD-APPLICATION-KEY": dd_config.app_key,
+        "DD-API-KEY": account.api_key,
+        "DD-APPLICATION-KEY": account.app_key,
     }
 
 

--- a/holmes/plugins/toolsets/datadog/datadog_general_instructions.jinja2
+++ b/holmes/plugins/toolsets/datadog/datadog_general_instructions.jinja2
@@ -1,3 +1,15 @@
+{%- if dd_config and dd_config.accounts and dd_config.accounts | length > 1 %}
+## Datadog accounts
+
+This toolset is configured against multiple Datadog accounts:
+{%- for account in dd_config.accounts %}
+- `{{ account.name }}`{% if account.default %} (default){% endif %} — {{ account.api_url }}
+{%- endfor %}
+
+Pass the `account` parameter on each tool call to target a specific account.
+Omit it to use the default ({{ (dd_config.accounts | selectattr('default') | first).name }}).
+
+{% endif -%}
 ## Datadog General API Tools Usage Guide
 
 ### When to Use This Toolset

--- a/holmes/plugins/toolsets/datadog/datadog_logs_instructions.jinja2
+++ b/holmes/plugins/toolsets/datadog/datadog_logs_instructions.jinja2
@@ -1,3 +1,15 @@
+{%- if dd_config and dd_config.accounts and dd_config.accounts | length > 1 %}
+## Datadog accounts
+
+This toolset is configured against multiple Datadog accounts:
+{%- for account in dd_config.accounts %}
+- `{{ account.name }}`{% if account.default %} (default){% endif %} — {{ account.api_url }}
+{%- endfor %}
+
+Pass the `account` parameter on each tool call to target a specific account.
+Omit it to use the default ({{ (dd_config.accounts | selectattr('default') | first).name }}).
+
+{% endif -%}
 ## Datadog Logs Tools Usage Guide
 
 Before running logs queries:

--- a/holmes/plugins/toolsets/datadog/datadog_metrics_instructions.jinja2
+++ b/holmes/plugins/toolsets/datadog/datadog_metrics_instructions.jinja2
@@ -1,3 +1,15 @@
+{%- if dd_config and dd_config.accounts and dd_config.accounts | length > 1 %}
+## Datadog accounts
+
+This toolset is configured against multiple Datadog accounts:
+{%- for account in dd_config.accounts %}
+- `{{ account.name }}`{% if account.default %} (default){% endif %} — {{ account.api_url }}
+{%- endfor %}
+
+Pass the `account` parameter on each tool call to target a specific account.
+Omit it to use the default ({{ (dd_config.accounts | selectattr('default') | first).name }}).
+
+{% endif -%}
 ## Datadog Metrics Tools Usage Guide
 
 Before running metrics queries:

--- a/holmes/plugins/toolsets/datadog/datadog_url_utils.py
+++ b/holmes/plugins/toolsets/datadog/datadog_url_utils.py
@@ -1,23 +1,20 @@
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode, urlparse
 
-from holmes.plugins.toolsets.datadog.datadog_api import convert_api_url_to_app_url
-from holmes.plugins.toolsets.datadog.datadog_models import (
-    DatadogGeneralConfig,
-    DatadogLogsConfig,
-    DatadogMetricsConfig,
-    DatadogTracesConfig,
+from holmes.plugins.toolsets.datadog.datadog_api import (
+    DatadogAccount,
+    convert_api_url_to_app_url,
 )
 
 
 def generate_datadog_metrics_explorer_url(
-    dd_config: DatadogMetricsConfig,
+    account: DatadogAccount,
     query: str,
     from_time: int,
     to_time: int,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
 
     params = {
         "query": query,
@@ -30,13 +27,13 @@ def generate_datadog_metrics_explorer_url(
 
 
 def generate_datadog_metrics_list_url(
-    dd_config: DatadogMetricsConfig,
+    account: DatadogAccount,
     from_time: int,
     host: Optional[str] = None,
     tag_filter: Optional[str] = None,
     metric_filter: Optional[str] = None,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
 
     params = {}
     if metric_filter:
@@ -52,30 +49,30 @@ def generate_datadog_metrics_list_url(
 
 
 def generate_datadog_metric_metadata_url(
-    dd_config: DatadogMetricsConfig,
+    account: DatadogAccount,
     metric_name: str,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
     params = {"metric": metric_name}
     return f"{base_url}/metric/summary?{urlencode(params)}"
 
 
 def generate_datadog_metric_tags_url(
-    dd_config: DatadogMetricsConfig,
+    account: DatadogAccount,
     metric_name: str,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
     params = {"metric": metric_name}
     return f"{base_url}/metric/summary?{urlencode(params)}"
 
 
 def generate_datadog_spans_url(
-    dd_config: DatadogTracesConfig,
+    account: DatadogAccount,
     query: str,
     from_time_ms: int,
     to_time_ms: int,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
 
     url_params = {
         "query": query,
@@ -88,12 +85,12 @@ def generate_datadog_spans_url(
 
 
 def generate_datadog_spans_analytics_url(
-    dd_config: DatadogTracesConfig,
+    account: DatadogAccount,
     query: str,
     from_time_ms: int,
     to_time_ms: int,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
 
     url_params = {
         "query": query,
@@ -106,10 +103,11 @@ def generate_datadog_spans_analytics_url(
 
 
 def generate_datadog_logs_url(
-    dd_config: DatadogLogsConfig,
+    account: DatadogAccount,
+    indexes: List[str],
     params: dict,
 ) -> str:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
     url_params = {
         "query": params["filter"]["query"],
         "from_ts": params["filter"]["from"],
@@ -118,8 +116,8 @@ def generate_datadog_logs_url(
         "storage": params["filter"]["storage_tier"],
     }
 
-    if dd_config.indexes != ["*"]:
-        url_params["index"] = ",".join(dd_config.indexes)
+    if indexes != ["*"]:
+        url_params["index"] = ",".join(indexes)
 
     # Construct the full URL
     return f"{base_url}/logs?{urlencode(url_params)}"
@@ -157,11 +155,11 @@ def _build_qs(
 
 
 def generate_datadog_general_url(
-    dd_config: DatadogGeneralConfig,
+    account: DatadogAccount,
     endpoint: str,
     query_params: Optional[Dict[str, Any]] = None,
 ) -> Optional[str]:
-    base_url = convert_api_url_to_app_url(dd_config.api_url)
+    base_url = convert_api_url_to_app_url(account.api_url)
     path = urlparse(endpoint).path
 
     if "/logs" in path:

--- a/holmes/plugins/toolsets/datadog/instructions_datadog_traces.jinja2
+++ b/holmes/plugins/toolsets/datadog/instructions_datadog_traces.jinja2
@@ -1,3 +1,15 @@
+{%- if dd_config and dd_config.accounts and dd_config.accounts | length > 1 %}
+## Datadog accounts
+
+This toolset is configured against multiple Datadog accounts:
+{%- for account in dd_config.accounts %}
+- `{{ account.name }}`{% if account.default %} (default){% endif %} — {{ account.api_url }}
+{%- endfor %}
+
+Pass the `account` parameter on each tool call to target a specific account.
+Omit it to use the default ({{ (dd_config.accounts | selectattr('default') | first).name }}).
+
+{% endif -%}
 ## Datadog Traces Toolset
 
 Tools to search and analyze distributed traces from Datadog APM.

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_general.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_general.py
@@ -21,7 +21,9 @@ from holmes.core.tools import (
 )
 from holmes.plugins.toolsets.consts import TOOLSET_CONFIG_MISSING_ERROR
 from holmes.plugins.toolsets.datadog.datadog_api import (
+    ACCOUNT_TOOL_PARAM_DESCRIPTION,
     MAX_RETRY_COUNT_ON_RATE_LIMIT,
+    DatadogAccount,
     DataDogRequestError,
     enhance_error_message,
     execute_datadog_http_request,
@@ -225,12 +227,7 @@ class DatadogGeneralToolset(Toolset):
             ],
             tags=[ToolsetTag.CORE],
         )
-        template_file_path = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__), "datadog_general_instructions.jinja2"
-            )
-        )
-        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")
+        self._reload_instructions()
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         """Check prerequisites with configuration."""
@@ -256,19 +253,28 @@ class DatadogGeneralToolset(Toolset):
                     "Could not fetch OpenAPI spec; enhanced error messages will be limited"
                 )
 
-            success, error_msg = self._perform_healthcheck(dd_config)
-            return success, error_msg
+            for account in dd_config.accounts:
+                success, error_msg = self._perform_healthcheck(account, dd_config)
+                if not success:
+                    return False, error_msg
+            self._reload_instructions()
+            return True, ""
         except Exception as e:
             logging.exception("Failed to set up Datadog general toolset")
             return False, f"Invalid Datadog General configuration: {e}"
 
-    def _perform_healthcheck(self, dd_config: DatadogGeneralConfig) -> Tuple[bool, str]:
-        """Perform health check on Datadog API."""
+    def _perform_healthcheck(
+        self, account: DatadogAccount, dd_config: DatadogGeneralConfig
+    ) -> Tuple[bool, str]:
+        """Perform health check on Datadog API for one account."""
         try:
-            logging.info("Performing Datadog general API configuration healthcheck...")
-            base_url = str(dd_config.api_url).rstrip("/")
+            logging.info(
+                "Performing Datadog general API healthcheck for account %r...",
+                account.name,
+            )
+            base_url = str(account.api_url).rstrip("/")
             url = f"{base_url}/api/v1/validate"
-            headers = get_headers(dd_config)
+            headers = get_headers(account)
 
             data = execute_datadog_http_request(
                 url=url,
@@ -279,16 +285,47 @@ class DatadogGeneralToolset(Toolset):
             )
 
             if data.get("valid", False):
-                logging.debug("Datadog general API health check completed successfully")
+                logging.debug(
+                    "Datadog general API healthcheck succeeded for account %r",
+                    account.name,
+                )
                 return True, ""
-            else:
-                error_msg = "Datadog API key validation failed"
-                logging.error(f"Datadog General health check failed: {error_msg}")
-                return False, f"Datadog General health check failed: {error_msg}"
+            error_msg = (
+                f"Datadog General healthcheck failed for account {account.name!r}: "
+                "API key validation returned valid=false."
+            )
+            logging.error(error_msg)
+            return False, error_msg
 
         except Exception as e:
-            logging.exception("Failed during Datadog general API health check")
-            return False, f"Datadog General health check failed: {e}"
+            logging.exception(
+                "Datadog general API healthcheck failed for account %r", account.name
+            )
+            return False, (
+                f"Datadog General healthcheck failed for account "
+                f"{account.name!r}: {e}"
+            )
+
+    def _reload_instructions(self):
+        """Load Datadog general specific troubleshooting instructions.
+
+        Passes the validated ``dd_config`` (with its accounts list) to the
+        Jinja context so the template can surface the available accounts.
+        """
+        from holmes.plugins.prompts import load_and_render_prompt
+
+        template_file_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "datadog_general_instructions.jinja2"
+            )
+        )
+        self.llm_instructions = load_and_render_prompt(
+            prompt=f"file://{template_file_path}",
+            context={
+                "tool_names": [t.name for t in self.tools],
+                "dd_config": self.dd_config,
+            },
+        )
 
 
 def is_endpoint_allowed(
@@ -385,6 +422,11 @@ class DatadogAPIGet(BaseDatadogGeneralTool):
                     type="string",
                     required=True,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -413,6 +455,14 @@ class DatadogAPIGet(BaseDatadogGeneralTool):
                 error=TOOLSET_CONFIG_MISSING_ERROR,
                 params=params_return,
             )
+        try:
+            account = self.toolset.dd_config.get_account(params.get("account"))
+        except KeyError as exc:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=str(exc),
+                params=params_return,
+            )
 
         endpoint = params.get("endpoint", "")
         query_params = params.get("query_params", {})
@@ -434,10 +484,10 @@ class DatadogAPIGet(BaseDatadogGeneralTool):
         url = None
         try:
             # Build full URL (ensure no double slashes)
-            base_url = str(self.toolset.dd_config.api_url).rstrip("/")
+            base_url = str(account.api_url).rstrip("/")
             endpoint = endpoint.lstrip("/")
             url = f"{base_url}/{endpoint}"
-            headers = get_headers(self.toolset.dd_config)
+            headers = get_headers(account)
 
             logging.info(f"Full API URL: {url}")
 
@@ -466,7 +516,7 @@ class DatadogAPIGet(BaseDatadogGeneralTool):
                 )
 
             web_url = generate_datadog_general_url(
-                self.toolset.dd_config,
+                account,
                 endpoint,
                 query_params,
             )
@@ -492,7 +542,7 @@ class DatadogAPIGet(BaseDatadogGeneralTool):
             elif e.status_code == 400:
                 # Use enhanced error message for 400 errors
                 error_msg = enhance_error_message(
-                    e, endpoint, "GET", str(self.toolset.dd_config.api_url)
+                    e, endpoint, "GET", str(account.api_url)
                 )
             else:
                 error_msg = f"API error {e.status_code}: {str(e)}"
@@ -560,6 +610,11 @@ class DatadogAPIPostSearch(BaseDatadogGeneralTool):
                     type="string",
                     required=True,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -609,6 +664,14 @@ class DatadogAPIPostSearch(BaseDatadogGeneralTool):
                 error=TOOLSET_CONFIG_MISSING_ERROR,
                 params=params,
             )
+        try:
+            account = self.toolset.dd_config.get_account(params.get("account"))
+        except KeyError as exc:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=str(exc),
+                params=params,
+            )
 
         endpoint = params.get("endpoint", "")
         body = params.get("body", {})
@@ -630,10 +693,10 @@ class DatadogAPIPostSearch(BaseDatadogGeneralTool):
         url = None
         try:
             # Build full URL (ensure no double slashes)
-            base_url = str(self.toolset.dd_config.api_url).rstrip("/")
+            base_url = str(account.api_url).rstrip("/")
             endpoint = endpoint.lstrip("/")
             url = f"{base_url}/{endpoint}"
-            headers = get_headers(self.toolset.dd_config)
+            headers = get_headers(account)
 
             logging.info(f"Full API URL: {url}")
 
@@ -663,7 +726,7 @@ class DatadogAPIPostSearch(BaseDatadogGeneralTool):
 
             body_query_params = self._body_to_query_params(body)
             web_url = generate_datadog_general_url(
-                self.toolset.dd_config,
+                account,
                 endpoint,
                 body_query_params,
             )
@@ -689,7 +752,7 @@ class DatadogAPIPostSearch(BaseDatadogGeneralTool):
             elif e.status_code == 400:
                 # Use enhanced error message for 400 errors
                 error_msg = enhance_error_message(
-                    e, endpoint, "POST", str(self.toolset.dd_config.api_url)
+                    e, endpoint, "POST", str(account.api_url)
                 )
             else:
                 error_msg = f"API error {e.status_code}: {str(e)}"

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
@@ -16,7 +16,9 @@ from holmes.core.tools import (
 )
 from holmes.plugins.toolsets.consts import STANDARD_END_DATETIME_TOOL_PARAM_DESCRIPTION
 from holmes.plugins.toolsets.datadog.datadog_api import (
+    ACCOUNT_TOOL_PARAM_DESCRIPTION,
     MAX_RETRY_COUNT_ON_RATE_LIMIT,
+    DatadogAccount,
     DataDogRequestError,
     execute_datadog_http_request,
     get_headers,
@@ -79,13 +81,15 @@ class DatadogLogsToolset(Toolset):
         self.tools = [GetLogs(toolset=self)]
         self._reload_instructions()
 
-    def _perform_healthcheck(self) -> Tuple[bool, str]:
-        """Perform health check on Datadog logs API."""
+    def _perform_healthcheck(self, account: DatadogAccount) -> Tuple[bool, str]:
+        """Perform health check on Datadog logs API for one account."""
         if not self.dd_config:
             return False, "Internal error: Datadog configuration not initialized"
         try:
-            logging.info("Performing Datadog logs configuration healthcheck...")
-            headers = get_headers(self.dd_config)
+            logging.info(
+                "Performing Datadog logs healthcheck for account %r...", account.name
+            )
+            headers = get_headers(account)
             payload = {
                 "filter": {
                     "from": "now-1m",
@@ -96,7 +100,7 @@ class DatadogLogsToolset(Toolset):
                 "page": {"limit": 1},
             }
 
-            search_url = f"{self.dd_config.api_url}/api/v2/logs/events/search"
+            search_url = f"{account.api_url}/api/v2/logs/events/search"
             execute_datadog_http_request(
                 url=search_url,
                 headers=headers,
@@ -109,18 +113,30 @@ class DatadogLogsToolset(Toolset):
 
         except DataDogRequestError as e:
             logging.error(
-                f"Datadog API error during healthcheck: {e.status_code} - {e.response_text}"
+                "Datadog logs healthcheck failed for account %r: %s - %s",
+                account.name,
+                e.status_code,
+                e.response_text,
             )
             if e.status_code == 403:
                 return (
                     False,
-                    "API key lacks required permissions. Make sure your API key has 'apm_read' scope.",
+                    f"Datadog Logs healthcheck failed for account "
+                    f"{account.name!r}: API key lacks required permissions. "
+                    "Make sure your API key has 'apm_read' scope.",
                 )
-            else:
-                return False, f"Datadog API error: {e.status_code} - {e.response_text}"
+            return (
+                False,
+                f"Datadog Logs healthcheck failed for account "
+                f"{account.name!r}: API error {e.status_code} - {e.response_text}",
+            )
         except Exception as e:
-            logging.exception("Failed during Datadog logs health check")
-            return False, f"Datadog Logs health check failed: {e}"
+            logging.exception(
+                "Datadog logs healthcheck failed for account %r", account.name
+            )
+            return False, (
+                f"Datadog Logs healthcheck failed for account {account.name!r}: {e}"
+            )
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         if not config:
@@ -133,19 +149,35 @@ class DatadogLogsToolset(Toolset):
             dd_config = DatadogLogsConfig(**config)
             self.dd_config = dd_config
 
-            success, error_msg = self._perform_healthcheck()
-            return success, error_msg
+            for account in dd_config.accounts:
+                success, error_msg = self._perform_healthcheck(account)
+                if not success:
+                    return False, error_msg
+            self._reload_instructions()
+            return True, ""
 
         except Exception as e:
             logging.exception("Failed to set up Datadog Logs toolset")
             return (False, f"Invalid Datadog Logs configuration: {e}")
 
     def _reload_instructions(self):
-        """Load Datadog logs specific troubleshooting instructions."""
+        """Load Datadog logs specific troubleshooting instructions.
+
+        Passes the validated ``dd_config`` (with its accounts list) to the
+        Jinja context so the template can surface the available accounts.
+        """
+        from holmes.plugins.prompts import load_and_render_prompt
+
         template_file_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "datadog_logs_instructions.jinja2")
         )
-        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")
+        self.llm_instructions = load_and_render_prompt(
+            prompt=f"file://{template_file_path}",
+            context={
+                "tool_names": [t.name for t in self.tools],
+                "dd_config": self.dd_config,
+            },
+        )
 
 
 class GetLogs(Tool):
@@ -188,6 +220,11 @@ class GetLogs(Tool):
             type="boolean",
             required=False,
         ),
+        "account": ToolParameter(
+            description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+            type="string",
+            required=False,
+        ),
     }
 
     def get_parameterized_one_liner(self, params: dict) -> str:
@@ -202,6 +239,15 @@ class GetLogs(Tool):
                 error="Datadog configuration not initialized",
                 params=params,
             )
+        try:
+            account = self.toolset.dd_config.get_account(params.get("account"))
+        except KeyError as exc:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=str(exc),
+                params=params,
+            )
+
         url = None
         payload: Optional[Dict[str, Any]] = None
         try:
@@ -221,8 +267,8 @@ class GetLogs(Tool):
             params["limit"] = limit
             sort = "timestamp" if params.get("sort_desc", False) else "-timestamp"
 
-            url = f"{self.toolset.dd_config.api_url}/api/v2/logs/events/search"
-            headers = get_headers(self.toolset.dd_config)
+            url = f"{account.api_url}/api/v2/logs/events/search"
+            headers = get_headers(account)
 
             storage = self.toolset.dd_config.storage_tier
             payload = {
@@ -257,7 +303,9 @@ class GetLogs(Tool):
                 status=StructuredToolResultStatus.SUCCESS,
                 data=response,
                 params=params,
-                url=generate_datadog_logs_url(self.toolset.dd_config, payload),
+                url=generate_datadog_logs_url(
+                    account, self.toolset.dd_config.indexes, payload
+                ),
             )
 
         except DataDogRequestError as e:

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_metrics.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_metrics.py
@@ -23,7 +23,9 @@ from holmes.plugins.toolsets.consts import (
     TOOLSET_CONFIG_MISSING_ERROR,
 )
 from holmes.plugins.toolsets.datadog.datadog_api import (
+    ACCOUNT_TOOL_PARAM_DESCRIPTION,
     MAX_RETRY_COUNT_ON_RATE_LIMIT,
+    DatadogAccount,
     DataDogRequestError,
     execute_datadog_http_request,
     get_headers,
@@ -48,6 +50,24 @@ from holmes.plugins.toolsets.utils import (
 
 class BaseDatadogMetricsTool(Tool):
     toolset: "DatadogMetricsToolset"
+
+    def _resolve_account(
+        self, params: dict
+    ) -> Tuple[Optional[DatadogAccount], Optional[StructuredToolResult]]:
+        """Resolve the target Datadog account from the ``account`` parameter.
+
+        Returns either (account, None) on success or (None, error_result)
+        when the account is unknown so the caller can short-circuit.
+        """
+        assert self.toolset.dd_config is not None
+        try:
+            return self.toolset.dd_config.get_account(params.get("account")), None
+        except KeyError as exc:
+            return None, StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=str(exc),
+                params=params,
+            )
 
 
 ACTIVE_METRICS_DEFAULT_LOOK_BACK_HOURS = 24
@@ -86,6 +106,11 @@ class ListActiveMetrics(BaseDatadogMetricsTool):
                     type="integer",
                     required=False,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -97,6 +122,11 @@ class ListActiveMetrics(BaseDatadogMetricsTool):
                 error=TOOLSET_CONFIG_MISSING_ERROR,
                 params=params,
             )
+
+        account, error = self._resolve_account(params)
+        if error is not None:
+            return error
+        assert account is not None
 
         url = None
         query_params = None
@@ -110,8 +140,8 @@ class ListActiveMetrics(BaseDatadogMetricsTool):
                 default_time_span_seconds=ACTIVE_METRICS_DEFAULT_TIME_SPAN_SECONDS,
             )
 
-            url = f"{self.toolset.dd_config.api_url}/api/v1/metrics"
-            headers = get_headers(self.toolset.dd_config)
+            url = f"{account.api_url}/api/v1/metrics"
+            headers = get_headers(account)
 
             query_params = {
                 "from": from_time,
@@ -182,7 +212,7 @@ class ListActiveMetrics(BaseDatadogMetricsTool):
                 )
 
             url = generate_datadog_metrics_list_url(
-                self.toolset.dd_config,
+                account,
                 from_time,
                 params.get("host"),
                 params.get("tag_filter"),
@@ -293,6 +323,11 @@ class QueryMetrics(BaseDatadogMetricsTool):
                     type="string",
                     required=False,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -304,6 +339,11 @@ class QueryMetrics(BaseDatadogMetricsTool):
                 error=TOOLSET_CONFIG_MISSING_ERROR,
                 params=params,
             )
+
+        account, error = self._resolve_account(params)
+        if error is not None:
+            return error
+        assert account is not None
 
         url = None
         query_params = None
@@ -317,8 +357,8 @@ class QueryMetrics(BaseDatadogMetricsTool):
                 default_time_span_seconds=DEFAULT_TIME_SPAN_SECONDS,
             )
 
-            url = f"{self.toolset.dd_config.api_url}/api/v1/query"
-            headers = get_headers(self.toolset.dd_config)
+            url = f"{account.api_url}/api/v1/query"
+            headers = get_headers(account)
 
             query_params = {
                 "query": query,
@@ -413,7 +453,7 @@ class QueryMetrics(BaseDatadogMetricsTool):
             }
 
             url = generate_datadog_metrics_explorer_url(
-                self.toolset.dd_config,
+                account,
                 query,
                 from_time,
                 to_time,
@@ -493,6 +533,11 @@ class QueryMetricsMetadata(BaseDatadogMetricsTool):
                     type="string",
                     required=True,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -504,6 +549,11 @@ class QueryMetricsMetadata(BaseDatadogMetricsTool):
                 error=TOOLSET_CONFIG_MISSING_ERROR,
                 params=params,
             )
+
+        account, error = self._resolve_account(params)
+        if error is not None:
+            return error
+        assert account is not None
 
         try:
             metric_names_str = get_param_or_raise(params, "metric_names")
@@ -521,14 +571,14 @@ class QueryMetricsMetadata(BaseDatadogMetricsTool):
                     params=params,
                 )
 
-            headers = get_headers(self.toolset.dd_config)
+            headers = get_headers(account)
 
             results = {}
             errors = {}
 
             for metric_name in metric_names:
                 try:
-                    api_url = f"{self.toolset.dd_config.api_url}/api/v1/metrics/{metric_name}"
+                    api_url = f"{account.api_url}/api/v1/metrics/{metric_name}"
 
                     data = execute_datadog_http_request(
                         url=api_url,
@@ -563,7 +613,7 @@ class QueryMetricsMetadata(BaseDatadogMetricsTool):
             # Generate URL for the first metric (or a general metrics page if multiple)
             if metric_names:
                 url = generate_datadog_metric_metadata_url(
-                    self.toolset.dd_config,
+                    account,
                     metric_names[0],
                 )
             else:
@@ -618,6 +668,11 @@ class ListMetricTags(BaseDatadogMetricsTool):
                     type="string",
                     required=True,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -630,14 +685,19 @@ class ListMetricTags(BaseDatadogMetricsTool):
                 params=params,
             )
 
+        account, error = self._resolve_account(params)
+        if error is not None:
+            return error
+        assert account is not None
+
         api_url = None
         query_params = None
 
         try:
             metric_name = get_param_or_raise(params, "metric_name")
 
-            api_url = f"{self.toolset.dd_config.api_url}/api/v2/metrics/{metric_name}/active-configurations"
-            headers = get_headers(self.toolset.dd_config)
+            api_url = f"{account.api_url}/api/v2/metrics/{metric_name}/active-configurations"
+            headers = get_headers(account)
 
             data = execute_datadog_http_request(
                 url=api_url,
@@ -648,7 +708,7 @@ class ListMetricTags(BaseDatadogMetricsTool):
             )
 
             web_url = generate_datadog_metric_tags_url(
-                self.toolset.dd_config,
+                account,
                 metric_name,
             )
 
@@ -728,12 +788,17 @@ class DatadogMetricsToolset(Toolset):
         )
         self._reload_instructions()
 
-    def _perform_healthcheck(self, dd_config: DatadogMetricsConfig) -> Tuple[bool, str]:
+    def _perform_healthcheck(
+        self, account: DatadogAccount, dd_config: DatadogMetricsConfig
+    ) -> Tuple[bool, str]:
         try:
-            logging.debug("Performing Datadog metrics configuration healthcheck...")
+            logging.debug(
+                "Performing Datadog metrics healthcheck for account %r...",
+                account.name,
+            )
 
-            url = f"{dd_config.api_url}/api/v1/validate"
-            headers = get_headers(dd_config)
+            url = f"{account.api_url}/api/v1/validate"
+            headers = get_headers(account)
 
             data = execute_datadog_http_request(
                 url=url,
@@ -744,16 +809,26 @@ class DatadogMetricsToolset(Toolset):
             )
 
             if data.get("valid", False):
-                logging.info("Datadog metrics health check completed successfully")
+                logging.info(
+                    "Datadog metrics healthcheck succeeded for account %r",
+                    account.name,
+                )
                 return True, ""
-            else:
-                error_msg = "Datadog API key validation failed"
-                logging.error(f"Datadog Metrics health check failed: {error_msg}")
-                return False, f"Datadog Metrics health check failed: {error_msg}"
+            error_msg = (
+                f"Datadog Metrics healthcheck failed for account {account.name!r}: "
+                "API key validation returned valid=false."
+            )
+            logging.error(error_msg)
+            return False, error_msg
 
         except Exception as e:
-            logging.exception("Failed during Datadog metrics health check")
-            return False, f"Datadog Metrics health check failed: {e}"
+            logging.exception(
+                "Datadog metrics healthcheck failed for account %r", account.name
+            )
+            return False, (
+                f"Datadog Metrics healthcheck failed for account "
+                f"{account.name!r}: {e}"
+            )
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         if not config:
@@ -766,18 +841,40 @@ class DatadogMetricsToolset(Toolset):
             dd_config = DatadogMetricsConfig(**config)
             self.dd_config = dd_config
 
-            success, error_msg = self._perform_healthcheck(dd_config)
-            return success, error_msg
+            for account in dd_config.accounts:
+                success, error_msg = self._perform_healthcheck(account, dd_config)
+                if not success:
+                    return False, error_msg
+
+            # Re-render the LLM instructions now that the validated config
+            # (with its account list) is bound on the toolset, so the LLM
+            # sees the available account names.
+            self._reload_instructions()
+            return True, ""
 
         except Exception as e:
             logging.exception("Failed to set up Datadog Metrics toolset")
             return (False, f"Invalid Datadog Metrics configuration: {e}")
 
     def _reload_instructions(self):
-        """Load Datadog metrics specific troubleshooting instructions."""
+        """Load Datadog metrics specific troubleshooting instructions.
+
+        Passes the validated ``dd_config`` (with its accounts list) to the
+        Jinja context so the template can surface the available account
+        names to the LLM. ``dd_config`` is None on first render (called
+        from ``__init__``) and the template guards against that.
+        """
+        from holmes.plugins.prompts import load_and_render_prompt
+
         template_file_path = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__), "datadog_metrics_instructions.jinja2"
             )
         )
-        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")
+        self.llm_instructions = load_and_render_prompt(
+            prompt=f"file://{template_file_path}",
+            context={
+                "tool_names": [t.name for t in self.tools],
+                "dd_config": self.dd_config,
+            },
+        )

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_traces.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_traces.py
@@ -22,7 +22,9 @@ from holmes.core.tools import (
 )
 from holmes.plugins.toolsets.consts import STANDARD_END_DATETIME_TOOL_PARAM_DESCRIPTION
 from holmes.plugins.toolsets.datadog.datadog_api import (
+    ACCOUNT_TOOL_PARAM_DESCRIPTION,
     MAX_RETRY_COUNT_ON_RATE_LIMIT,
+    DatadogAccount,
     DataDogRequestError,
     execute_datadog_http_request,
     get_headers,
@@ -65,9 +67,7 @@ class DatadogTracesToolset(Toolset):
             ],
             tags=[ToolsetTag.CORE],
         )
-        self._load_llm_instructions_from_file(
-            os.path.dirname(__file__), "instructions_datadog_traces.jinja2"
-        )
+        self._reload_instructions()
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         """Check prerequisites with configuration."""
@@ -77,17 +77,25 @@ class DatadogTracesToolset(Toolset):
         try:
             dd_config = DatadogTracesConfig(**config)
             self.dd_config = dd_config
-            success, error_msg = self._perform_healthcheck(dd_config)
-            return success, error_msg
+            for account in dd_config.accounts:
+                success, error_msg = self._perform_healthcheck(account, dd_config)
+                if not success:
+                    return False, error_msg
+            self._reload_instructions()
+            return True, ""
         except Exception as e:
             logging.exception("Failed to set up Datadog traces toolset")
             return False, f"Invalid Datadog Traces configuration: {e}"
 
-    def _perform_healthcheck(self, dd_config: DatadogTracesConfig) -> Tuple[bool, str]:
-        """Perform health check on Datadog traces API."""
+    def _perform_healthcheck(
+        self, account: DatadogAccount, dd_config: DatadogTracesConfig
+    ) -> Tuple[bool, str]:
+        """Perform health check on Datadog traces API for one account."""
         try:
-            logging.info("Performing Datadog traces configuration healthcheck...")
-            headers = get_headers(dd_config)
+            logging.info(
+                "Performing Datadog traces healthcheck for account %r...", account.name
+            )
+            headers = get_headers(account)
 
             # The spans API uses POST, not GET
             payload = {
@@ -105,8 +113,7 @@ class DatadogTracesToolset(Toolset):
                 }
             }
 
-            # Use search endpoint instead
-            search_url = f"{dd_config.api_url}/api/v2/spans/events/search"
+            search_url = f"{account.api_url}/api/v2/spans/events/search"
 
             execute_datadog_http_request(
                 url=search_url,
@@ -120,18 +127,49 @@ class DatadogTracesToolset(Toolset):
 
         except DataDogRequestError as e:
             logging.error(
-                f"Datadog API error during healthcheck: {e.status_code} - {e.response_text}"
+                "Datadog traces healthcheck failed for account %r: %s - %s",
+                account.name,
+                e.status_code,
+                e.response_text,
             )
             if e.status_code == 403:
                 return (
                     False,
-                    "API key lacks required permissions. Make sure your API key has 'apm_read' scope.",
+                    f"Datadog Traces healthcheck failed for account "
+                    f"{account.name!r}: API key lacks required permissions. "
+                    "Make sure your API key has 'apm_read' scope.",
                 )
-            else:
-                return False, f"Datadog API error: {e.status_code} - {e.response_text}"
+            return (
+                False,
+                f"Datadog Traces healthcheck failed for account "
+                f"{account.name!r}: API error {e.status_code} - {e.response_text}",
+            )
         except Exception as e:
-            logging.exception("Failed during Datadog traces health check")
-            return False, f"Datadog Traces health check failed: {e}"
+            logging.exception(
+                "Datadog traces healthcheck failed for account %r", account.name
+            )
+            return False, (
+                f"Datadog Traces healthcheck failed for account {account.name!r}: {e}"
+            )
+
+    def _reload_instructions(self):
+        """Load Datadog traces specific troubleshooting instructions.
+
+        Passes the validated ``dd_config`` (with its accounts list) to the
+        Jinja context so the template can surface the available accounts.
+        """
+        from holmes.plugins.prompts import load_and_render_prompt
+
+        template_file_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "instructions_datadog_traces.jinja2")
+        )
+        self.llm_instructions = load_and_render_prompt(
+            prompt=f"file://{template_file_path}",
+            context={
+                "tool_names": [t.name for t in self.tools],
+                "dd_config": self.dd_config,
+            },
+        )
 
 
 class BaseDatadogTracesTool(Tool):
@@ -212,6 +250,11 @@ class GetSpans(BaseDatadogTracesTool):
                     type="boolean",
                     required=True,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -226,6 +269,14 @@ class GetSpans(BaseDatadogTracesTool):
             return StructuredToolResult(
                 status=StructuredToolResultStatus.ERROR,
                 error="Datadog configuration not initialized",
+                params=params,
+            )
+        try:
+            account = self.toolset.dd_config.get_account(params.get("account"))
+        except KeyError as exc:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=str(exc),
                 params=params,
             )
 
@@ -252,8 +303,8 @@ class GetSpans(BaseDatadogTracesTool):
                 sort = "-timestamp"
 
             # Use POST endpoint for more complex searches
-            url = f"{self.toolset.dd_config.api_url}/api/v2/spans/events/search"
-            headers = get_headers(self.toolset.dd_config)
+            url = f"{account.api_url}/api/v2/spans/events/search"
+            headers = get_headers(account)
 
             payload = {
                 "data": {
@@ -291,7 +342,7 @@ class GetSpans(BaseDatadogTracesTool):
                 ]
 
             web_url = generate_datadog_spans_url(
-                self.toolset.dd_config,
+                account,
                 query,
                 from_time_ms,
                 to_time_ms,
@@ -548,6 +599,11 @@ class AggregateSpans(BaseDatadogTracesTool):
                     type="string",
                     required=False,
                 ),
+                "account": ToolParameter(
+                    description=ACCOUNT_TOOL_PARAM_DESCRIPTION,
+                    type="string",
+                    required=False,
+                ),
             },
             toolset=toolset,
         )
@@ -594,6 +650,14 @@ class AggregateSpans(BaseDatadogTracesTool):
                 error="Datadog configuration not initialized",
                 params=params,
             )
+        try:
+            account = self.toolset.dd_config.get_account(params.get("account"))
+        except KeyError as exc:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=str(exc),
+                params=params,
+            )
 
         url = None
         payload = None
@@ -613,8 +677,8 @@ class AggregateSpans(BaseDatadogTracesTool):
             query = params.get("query", "*")
 
             # Build the request payload
-            url = f"{self.toolset.dd_config.api_url}/api/v2/spans/analytics/aggregate"
-            headers = get_headers(self.toolset.dd_config)
+            url = f"{account.api_url}/api/v2/spans/analytics/aggregate"
+            headers = get_headers(account)
 
             # Build payload attributes first
             # Process compute parameter to fix common p95->pc95 style mistakes
@@ -658,7 +722,7 @@ class AggregateSpans(BaseDatadogTracesTool):
             )
 
             web_url = generate_datadog_spans_analytics_url(
-                self.toolset.dd_config,
+                account,
                 query,
                 from_time_ms,
                 to_time_ms,

--- a/tests/plugins/toolsets/datadog/logs/test_check_prerequisites.py
+++ b/tests/plugins/toolsets/datadog/logs/test_check_prerequisites.py
@@ -4,10 +4,12 @@ from holmes.core.tools import StructuredToolResultStatus, ToolsetStatusEnum
 from holmes.plugins.toolsets.datadog.datadog_models import (
     DEFAULT_STORAGE_TIER,
     DataDogStorageTier,
+    DatadogLogsConfig,
 )
 from holmes.plugins.toolsets.datadog.toolset_datadog_logs import (
     DatadogLogsToolset,
 )
+from tests.conftest import create_mock_tool_invoke_context
 
 
 class TestDatadogToolsetCheckPrerequisites:
@@ -111,7 +113,10 @@ class TestDatadogToolsetCheckPrerequisites:
         toolset.check_prerequisites()
 
         assert toolset.status == ToolsetStatusEnum.FAILED
-        assert toolset.error == 'Datadog API error: 401 - {"errors":["Unauthorized"]}'
+        assert (
+            toolset.error
+            == 'Datadog Logs healthcheck failed for account \'default\': API error 401 - {"errors":["Unauthorized"]}'
+        )
 
     @patch(
         "holmes.plugins.toolsets.datadog.toolset_datadog_logs.execute_datadog_http_request"
@@ -130,7 +135,10 @@ class TestDatadogToolsetCheckPrerequisites:
         toolset.check_prerequisites()
 
         assert toolset.status == ToolsetStatusEnum.FAILED
-        assert "Datadog Logs health check failed: Network error" in toolset.error
+        assert (
+            "Datadog Logs healthcheck failed for account 'default': Network error"
+            in toolset.error
+        )
 
     @patch(
         "holmes.plugins.toolsets.datadog.toolset_datadog_logs.execute_datadog_http_request"
@@ -217,3 +225,65 @@ class TestDatadogToolsetCheckPrerequisites:
         prerequisite = toolset.prerequisites[0]
         assert hasattr(prerequisite, "callable")
         assert prerequisite.callable == toolset.prerequisites_callable
+
+
+class TestDatadogLogsAccountRouting:
+    """Verify the `account` parameter routes log queries to the right account."""
+
+    def setup_method(self):
+        self.toolset = DatadogLogsToolset()
+        self.toolset.dd_config = DatadogLogsConfig(
+            accounts=[
+                {
+                    "name": "staging",
+                    "api_key": "stg-key",
+                    "app_key": "stg-app",
+                    "api_url": "https://api.stg.datadoghq.eu",
+                },
+                {
+                    "name": "production",
+                    "api_key": "prd-key",
+                    "app_key": "prd-app",
+                    "api_url": "https://api.datadoghq.eu",
+                    "default": True,
+                },
+            ],
+            timeout_seconds=60,
+        )
+
+    @patch(
+        "holmes.plugins.toolsets.datadog.toolset_datadog_logs.execute_datadog_http_request"
+    )
+    def test_account_param_routes_to_target(self, mock_execute):
+        mock_execute.return_value = {"data": [], "meta": {}}
+        tool = self.toolset.tools[0]
+        result = tool._invoke(
+            {"account": "staging"}, context=create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["url"].startswith("https://api.stg.datadoghq.eu")
+        assert call_kwargs["headers"]["DD-API-KEY"] == "stg-key"
+
+    @patch(
+        "holmes.plugins.toolsets.datadog.toolset_datadog_logs.execute_datadog_http_request"
+    )
+    def test_omitted_account_uses_default(self, mock_execute):
+        mock_execute.return_value = {"data": [], "meta": {}}
+        tool = self.toolset.tools[0]
+        tool._invoke({}, context=create_mock_tool_invoke_context())
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["url"].startswith("https://api.datadoghq.eu")
+        assert call_kwargs["headers"]["DD-API-KEY"] == "prd-key"
+
+    def test_unknown_account_returns_structured_error(self):
+        tool = self.toolset.tools[0]
+        result = tool._invoke(
+            {"account": "nope"}, context=create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "'staging'" in result.error
+        assert "'production'" in result.error

--- a/tests/plugins/toolsets/datadog/metrics/test_datadog_metrics.py
+++ b/tests/plugins/toolsets/datadog/metrics/test_datadog_metrics.py
@@ -262,7 +262,9 @@ class TestDatadogMetricsToolset:
         response.json.return_value = {"valid": True}
         mock_get.return_value = response
 
-        success, error_msg = self.toolset._perform_healthcheck(self.config)
+        success, error_msg = self.toolset._perform_healthcheck(
+            self.config.accounts[0], self.config
+        )
 
         assert success is True
         assert error_msg == ""
@@ -277,10 +279,12 @@ class TestDatadogMetricsToolset:
         response.json.return_value = {"valid": False}
         mock_get.return_value = response
 
-        success, error_msg = self.toolset._perform_healthcheck(self.config)
+        success, error_msg = self.toolset._perform_healthcheck(
+            self.config.accounts[0], self.config
+        )
 
         assert success is False
-        assert "validation failed" in error_msg.lower()
+        assert "valid=false" in error_msg.lower()
 
     @patch("holmes.plugins.toolsets.datadog.datadog_api.requests.get")
     def test_prerequisites_callable_success(self, mock_get):
@@ -319,3 +323,72 @@ class TestDatadogMetricsToolset:
 
         assert success is False
         assert "Invalid Datadog Metrics configuration" in error_msg
+
+
+class TestDatadogMetricsAccountRouting:
+    """Verify the LLM-provided ``account`` parameter routes calls correctly."""
+
+    def setup_method(self):
+        self.toolset = DatadogMetricsToolset()
+        self.toolset.dd_config = DatadogMetricsConfig(
+            accounts=[
+                {
+                    "name": "staging",
+                    "api_key": "stg-key",
+                    "app_key": "stg-app",
+                    "api_url": "https://api.stg.datadoghq.eu",
+                },
+                {
+                    "name": "production",
+                    "api_key": "prd-key",
+                    "app_key": "prd-app",
+                    "api_url": "https://api.datadoghq.eu",
+                    "default": True,
+                },
+            ],
+            default_limit=1000,
+            timeout_seconds=60,
+        )
+
+    @patch("holmes.plugins.toolsets.datadog.datadog_api.requests.get")
+    def test_account_param_routes_to_target_url_and_keys(self, mock_get):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"metrics": ["system.cpu.user"]}
+        mock_get.return_value = response
+
+        # tools[0] is ListActiveMetrics
+        tool = self.toolset.tools[0]
+        result = tool._invoke(
+            {"account": "staging"}, context=create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        call_args = mock_get.call_args
+        assert call_args[0][0].startswith("https://api.stg.datadoghq.eu")
+        assert call_args[1]["headers"]["DD-API-KEY"] == "stg-key"
+        assert call_args[1]["headers"]["DD-APPLICATION-KEY"] == "stg-app"
+
+    @patch("holmes.plugins.toolsets.datadog.datadog_api.requests.get")
+    def test_omitted_account_uses_default(self, mock_get):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"metrics": []}
+        mock_get.return_value = response
+
+        tool = self.toolset.tools[0]
+        tool._invoke({}, context=create_mock_tool_invoke_context())
+
+        call_args = mock_get.call_args
+        assert call_args[0][0].startswith("https://api.datadoghq.eu")
+        assert call_args[1]["headers"]["DD-API-KEY"] == "prd-key"
+
+    def test_unknown_account_returns_structured_error(self):
+        tool = self.toolset.tools[0]
+        result = tool._invoke(
+            {"account": "nope"}, context=create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "'staging'" in result.error
+        assert "'production'" in result.error

--- a/tests/plugins/toolsets/datadog/test_datadog_accounts.py
+++ b/tests/plugins/toolsets/datadog/test_datadog_accounts.py
@@ -1,0 +1,174 @@
+"""Tests for the multi-account Datadog config plumbing.
+
+Covers the backward-compatible single-account shorthand, the new
+``accounts:`` list form, and the ``get_account()`` resolver used by every
+Datadog tool to route a call to the right account.
+"""
+
+import pytest
+
+from holmes.plugins.toolsets.datadog.datadog_api import (
+    DatadogAccount,
+    DatadogBaseConfig,
+)
+
+
+def _base_config(**kwargs):
+    return DatadogBaseConfig(**kwargs)
+
+
+class TestLegacyShorthand:
+    """The single-account shorthand must keep working unchanged."""
+
+    def test_shorthand_synthesizes_default_account(self):
+        cfg = _base_config(
+            api_key="k", app_key="a", api_url="https://api.datadoghq.com"
+        )
+        assert len(cfg.accounts) == 1
+        account = cfg.accounts[0]
+        assert account.name == "default"
+        assert account.default is True
+        assert account.api_key == "k"
+        assert account.app_key == "a"
+        assert str(account.api_url).rstrip("/") == "https://api.datadoghq.com"
+
+    def test_shorthand_missing_field_raises(self):
+        with pytest.raises(ValueError, match="missing required field"):
+            _base_config(api_key="k", api_url="https://api.datadoghq.com")
+
+    def test_no_credentials_raises(self):
+        with pytest.raises(ValueError, match="missing credentials"):
+            _base_config()
+
+
+class TestAccountsList:
+    """The new ``accounts:`` form supports N accounts."""
+
+    def test_accounts_list_preserves_names(self):
+        cfg = _base_config(
+            accounts=[
+                DatadogAccount(
+                    name="staging",
+                    api_key="ks",
+                    app_key="as",
+                    api_url="https://api.datadoghq.eu",
+                ),
+                DatadogAccount(
+                    name="production",
+                    api_key="kp",
+                    app_key="ap",
+                    api_url="https://api.datadoghq.eu",
+                    default=True,
+                ),
+            ]
+        )
+        assert [a.name for a in cfg.accounts] == ["staging", "production"]
+        assert cfg.accounts[1].default is True
+
+    def test_first_account_becomes_default_when_unset(self):
+        cfg = _base_config(
+            accounts=[
+                DatadogAccount(
+                    name="a", api_key="k", app_key="a", api_url="https://x.example"
+                ),
+                DatadogAccount(
+                    name="b", api_key="k", app_key="a", api_url="https://x.example"
+                ),
+            ]
+        )
+        assert cfg.accounts[0].default is True
+        assert cfg.accounts[1].default is False
+
+    def test_both_forms_together_is_rejected(self):
+        with pytest.raises(ValueError, match="either the top-level"):
+            _base_config(
+                api_key="k",
+                app_key="a",
+                api_url="https://api.datadoghq.com",
+                accounts=[
+                    DatadogAccount(
+                        name="x",
+                        api_key="k",
+                        app_key="a",
+                        api_url="https://api.datadoghq.com",
+                    )
+                ],
+            )
+
+    def test_duplicate_names_rejected(self):
+        with pytest.raises(ValueError, match="duplicate account name"):
+            _base_config(
+                accounts=[
+                    DatadogAccount(
+                        name="dup",
+                        api_key="k",
+                        app_key="a",
+                        api_url="https://x.example",
+                    ),
+                    DatadogAccount(
+                        name="dup",
+                        api_key="k",
+                        app_key="a",
+                        api_url="https://x.example",
+                    ),
+                ]
+            )
+
+    def test_multiple_defaults_rejected(self):
+        with pytest.raises(ValueError, match="at most one account"):
+            _base_config(
+                accounts=[
+                    DatadogAccount(
+                        name="a",
+                        api_key="k",
+                        app_key="a",
+                        api_url="https://x.example",
+                        default=True,
+                    ),
+                    DatadogAccount(
+                        name="b",
+                        api_key="k",
+                        app_key="a",
+                        api_url="https://x.example",
+                        default=True,
+                    ),
+                ]
+            )
+
+
+class TestGetAccount:
+    """`get_account` is what every tool calls to resolve the target account."""
+
+    @pytest.fixture
+    def cfg(self):
+        return _base_config(
+            accounts=[
+                DatadogAccount(
+                    name="staging",
+                    api_key="ks",
+                    app_key="as",
+                    api_url="https://api.datadoghq.eu",
+                ),
+                DatadogAccount(
+                    name="production",
+                    api_key="kp",
+                    app_key="ap",
+                    api_url="https://api.datadoghq.eu",
+                    default=True,
+                ),
+            ]
+        )
+
+    def test_none_returns_default(self, cfg):
+        assert cfg.get_account(None).name == "production"
+
+    def test_by_name(self, cfg):
+        assert cfg.get_account("staging").name == "staging"
+
+    def test_unknown_lists_available(self, cfg):
+        with pytest.raises(KeyError) as exc:
+            cfg.get_account("nope")
+        msg = str(exc.value)
+        assert "'staging'" in msg
+        assert "'production'" in msg
+        assert "'nope'" in msg

--- a/tests/plugins/toolsets/datadog/test_toolset_datadog_general.py
+++ b/tests/plugins/toolsets/datadog/test_toolset_datadog_general.py
@@ -173,3 +173,75 @@ class TestDatadogGeneralToolset:
 
         assert result.status == StructuredToolResultStatus.ERROR
         assert "blacklisted operation" in result.error
+
+
+class TestDatadogGeneralAccountRouting:
+    """Verify the `account` parameter routes API calls to the right account."""
+
+    def setup_method(self):
+        from holmes.plugins.toolsets.datadog.datadog_models import DatadogGeneralConfig
+        from holmes.plugins.toolsets.datadog.toolset_datadog_general import (
+            DatadogGeneralToolset,
+        )
+
+        self.toolset = DatadogGeneralToolset()
+        self.toolset.dd_config = DatadogGeneralConfig(
+            accounts=[
+                {
+                    "name": "staging",
+                    "api_key": "stg-key",
+                    "app_key": "stg-app",
+                    "api_url": "https://api.stg.datadoghq.eu",
+                },
+                {
+                    "name": "production",
+                    "api_key": "prd-key",
+                    "app_key": "prd-app",
+                    "api_url": "https://api.datadoghq.eu",
+                    "default": True,
+                },
+            ],
+            timeout_seconds=60,
+        )
+
+    @patch("holmes.plugins.toolsets.datadog.datadog_api.requests.get")
+    def test_account_param_routes_to_target(self, mock_get):
+        mock_get.return_value = Mock(
+            status_code=200, json=Mock(return_value={"data": []})
+        )
+        get_tool = self.toolset.tools[0]  # DatadogAPIGet
+        result = get_tool._invoke(
+            {"endpoint": "/api/v1/monitor", "account": "staging"},
+            context=create_mock_tool_invoke_context(),
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        call_args = mock_get.call_args
+        assert call_args[0][0].startswith("https://api.stg.datadoghq.eu")
+        assert call_args[1]["headers"]["DD-API-KEY"] == "stg-key"
+
+    @patch("holmes.plugins.toolsets.datadog.datadog_api.requests.get")
+    def test_omitted_account_uses_default(self, mock_get):
+        mock_get.return_value = Mock(
+            status_code=200, json=Mock(return_value={"data": []})
+        )
+        get_tool = self.toolset.tools[0]
+        get_tool._invoke(
+            {"endpoint": "/api/v1/monitor"},
+            context=create_mock_tool_invoke_context(),
+        )
+
+        call_args = mock_get.call_args
+        assert call_args[0][0].startswith("https://api.datadoghq.eu")
+        assert call_args[1]["headers"]["DD-API-KEY"] == "prd-key"
+
+    def test_unknown_account_returns_structured_error(self):
+        get_tool = self.toolset.tools[0]
+        result = get_tool._invoke(
+            {"endpoint": "/api/v1/monitor", "account": "nope"},
+            context=create_mock_tool_invoke_context(),
+        )
+
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "'staging'" in result.error
+        assert "'production'" in result.error

--- a/tests/plugins/toolsets/datadog/traces/test_datadog_traces.py
+++ b/tests/plugins/toolsets/datadog/traces/test_datadog_traces.py
@@ -158,3 +158,68 @@ class TestFetchDatadogSpansByFilter:
         # When no data is found, the tool still returns success with empty data
         assert result.data == mock_execute.return_value
         assert len(result.data["data"]) == 0
+
+
+class TestDatadogTracesAccountRouting:
+    """Verify the `account` parameter routes span queries to the right account."""
+
+    def setup_method(self):
+        from holmes.plugins.toolsets.datadog.datadog_api import DatadogAccount
+        from holmes.plugins.toolsets.datadog.datadog_models import DatadogTracesConfig
+
+        self.toolset = DatadogTracesToolset()
+        self.toolset.dd_config = DatadogTracesConfig(
+            accounts=[
+                {
+                    "name": "staging",
+                    "api_key": "stg-key",
+                    "app_key": "stg-app",
+                    "api_url": "https://api.stg.datadoghq.eu",
+                },
+                {
+                    "name": "production",
+                    "api_key": "prd-key",
+                    "app_key": "prd-app",
+                    "api_url": "https://api.datadoghq.eu",
+                    "default": True,
+                },
+            ],
+            timeout_seconds=60,
+        )
+
+    @patch(
+        "holmes.plugins.toolsets.datadog.toolset_datadog_traces.execute_datadog_http_request"
+    )
+    def test_account_param_routes_to_target(self, mock_execute):
+        mock_execute.return_value = {"data": [], "meta": {"page": {}}}
+        tool = self.toolset.tools[0]  # GetSpans
+        result = tool._invoke(
+            {"account": "staging"}, context=create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["url"].startswith("https://api.stg.datadoghq.eu")
+        assert call_kwargs["headers"]["DD-API-KEY"] == "stg-key"
+
+    @patch(
+        "holmes.plugins.toolsets.datadog.toolset_datadog_traces.execute_datadog_http_request"
+    )
+    def test_omitted_account_uses_default(self, mock_execute):
+        mock_execute.return_value = {"data": [], "meta": {"page": {}}}
+        tool = self.toolset.tools[0]
+        tool._invoke({}, context=create_mock_tool_invoke_context())
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["url"].startswith("https://api.datadoghq.eu")
+        assert call_kwargs["headers"]["DD-API-KEY"] == "prd-key"
+
+    def test_unknown_account_returns_structured_error(self):
+        tool = self.toolset.tools[0]
+        result = tool._invoke(
+            {"account": "nope"}, context=create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "'staging'" in result.error
+        assert "'production'" in result.error


### PR DESCRIPTION
## Problem

Many organizations run separate Datadog organizations for staging and production. Until now a single Holmes instance could only query **one** Datadog org per toolset, which meant either running two Holmes deployments or writing brittle custom-toolset YAML. This PR adds first-class multi-account support to all four Datadog toolsets while keeping the existing single-account configuration entirely unchanged.

## Solution

A new `accounts:` list on each toolset config lets users declare N Datadog accounts. The LLM picks the target account on every tool call via a new optional `account` parameter. When only one account is configured (including all existing deployments), the parameter is a no-op — behavior is identical to today.

### Before (unchanged, still works)

```yaml
toolsets:
  datadog/metrics:
    enabled: true
    config:
      api_key: "{{ env.DD_API_KEY }}"
      app_key: "{{ env.DD_APP_KEY }}"
      api_url: https://api.datadoghq.com
```

### After (new multi-account form)

```yaml
toolsets:
  datadog/metrics:
    enabled: true
    config:
      accounts:
        - name: staging
          api_key: "{{ env.DD_API_KEY_STG }}"
          app_key: "{{ env.DD_APP_KEY_STG }}"
          api_url: https://api.datadoghq.eu
          default: true
        - name: production
          api_key: "{{ env.DD_API_KEY_PRD }}"
          app_key: "{{ env.DD_APP_KEY_PRD }}"
          api_url: https://api.datadoghq.eu
```

## Changes

### `datadog_api.py`
- New `DatadogAccount` model holds per-account credentials (`name`, `api_key`, `app_key`, `api_url`, `default`).
- `DatadogBaseConfig` gains `accounts: List[DatadogAccount]`. A `@model_validator` normalises the single-account shorthand into a one-element `[DatadogAccount(name="default", ...)]`, so zero migration is required.
- `_ui_required_fields = ["api_key", "app_key", "api_url"]` keeps the UI form marking credentials as required for the common path; `_hidden_fields = ["accounts"]` hides the complex nested field from the form UI (advanced users configure it via YAML).
- `get_account(name)` resolves the per-call account name, or returns the default; raises `KeyError` listing available names so the LLM can self-correct on retry.
- `get_headers(account)` now takes a `DatadogAccount` instead of the full config.

### Four toolsets (logs, metrics, traces, general)
- Every tool gains an optional `account` string parameter.
- `_invoke` resolves the account via `get_account()` and passes it to `get_headers()` and all URL constructors.
- `_perform_healthcheck` takes a `DatadogAccount`; `prerequisites_callable` iterates all accounts and fails fast on the first unhealthy one, embedding the account name in the error message.
- `_reload_instructions()` passes the validated `dd_config` to the Jinja context so the system prompt lists available accounts and the default.

### Jinja instruction templates (all four)
Added a guard block listing configured accounts only when more than one is present. Single-account users see no change in their system prompt.

### `datadog_url_utils.py`
URL generators accept `DatadogAccount` instead of the full typed config, decoupling URL building from toolset config.

### Tests (67 pass, 16 skipped/slow)
- `tests/plugins/toolsets/datadog/test_datadog_accounts.py` (new, 11 tests): config parsing for both schemas, validation edge cases (`duplicate names`, `multiple defaults`, `both forms together`), and `get_account()` resolution.
- Account-routing tests added to all four toolset test files: verifies `account` routes to the correct API URL and credentials, that omitting it uses the default, and that an unknown name returns a structured error.
- Updated assertions in existing tests to match the new account-scoped healthcheck error messages.

### Docs
Added a "Multiple Datadog accounts" section to `docs/data-sources/builtin-toolsets/datadog.md` with the `accounts:` YAML schema and a staging/production example.

## Backward compatibility

| Scenario | Status |
|---|---|
| Existing `api_key`/`app_key`/`api_url` config | ✅ unchanged |
| Deprecated aliases (`dd_api_key`, `site_api_url`, …) | ✅ still work |
| Single toolset YAML, no `accounts:` key | ✅ auto-normalised |
| Multi-account `accounts:` list | ✅ new path |
| Both forms supplied together | ❌ `ValueError` (intentional) |

## Pending question

Should we had a deprecation warning if we go with this implementation?

## Note on `llm_instructions` timing

`_reload_instructions()` is called from both `__init__` (renders with `dd_config=None`, template guard emits nothing) and from `prerequisites_callable` (renders with the validated config including the account list). Because `check_prerequisites` runs before the first LLM conversation in all deployment paths, the account list is always present in the system prompt when it matters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring multiple Datadog accounts within a single toolset.
  * All Datadog tools now accept an optional `account` parameter to target a specific account; requests without this parameter automatically use the default account.
  * Legacy single-account configuration remains fully supported.

* **Documentation**
  * Updated Datadog toolset documentation with guidance on multi-account configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->