### PR TITLE
fix(bash): allow echo in default (core) allowlist

### DIFF
--- a/holmes/plugins/toolsets/bash/common/default_lists.py
+++ b/holmes/plugins/toolsets/bash/common/default_lists.py
@@ -53,6 +53,8 @@ CORE_ALLOW_LIST: List[str] = [
     "date",
     "which",
     "type",
+    # Prints arguments to stdout — does not read files
+    "echo",
 ]
 
 # Extended allow list - adds filesystem access commands
@@ -61,7 +63,6 @@ CORE_ALLOW_LIST: List[str] = [
 EXTENDED_ALLOW_LIST: List[str] = CORE_ALLOW_LIST + [
     # File reading
     "cat",
-    "echo",
     "base64",
     # Filesystem traversal
     "ls",


### PR DESCRIPTION
## Summary

`echo` was only in `EXTENDED_ALLOW_LIST`, not `CORE_ALLOW_LIST`. The CLI defaults to `builtin_allowlist=\"core\"`, so any command containing `echo` triggered an approval prompt under the default config.

## The bug

Reported command:

```
kubectl get cronjob -n infra-networking 2>&1; echo ---; kubectl get jobs -n infra-networking 2>&1; echo ---; kubectl get pods -n infra-networking 2>&1
```

Failed with:

```
Command requires approval. Segment(s) not in allow list: 'echo ---', 'echo ---'
```

`validate_command` splits on `;` into five segments. The three `kubectl get …` segments matched the `kubectl get` prefix in `CORE_ALLOW_LIST`, but the two `echo ---` segments matched nothing, so the whole command needed approval.

## Why `echo` belongs in core

`echo` was grouped under \"File reading\" next to `cat`/`base64` in `EXTENDED_ALLOW_LIST`, but `echo` does not read files — it only writes its arguments to stdout. It carries no more risk than `whoami`, `date`, or `hostname`, all of which are in `CORE_ALLOW_LIST`.

## Fix

Moved `echo` from `EXTENDED_ALLOW_LIST` into `CORE_ALLOW_LIST`. `EXTENDED_ALLOW_LIST` still includes core via concatenation, so users on the extended list are unaffected.

## Verification

- Reproduced the original `APPROVAL_REQUIRED` result with the user's exact command before the fix.
- After the fix, the same command returns `ALLOWED` and executes end-to-end through `RunBashCommand.requires_approval` → `_invoke` (the same path the CLI hits before invoking the LLM-approved command).
- All 103 tests in `tests/test_bash_toolset_validation.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `echo` command is now available in core mode, improving bash script compatibility and usability across different execution contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->