### PR TITLE
ROB-3921 - Accept user_email on chat requests and persist to HolmesUsageEvents

### DIFF
--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -636,6 +636,13 @@ class ConversationWorker:
         # Per-event data still wins so the FE can override per-turn (e.g.
         # an alert-investigation chat that pivots to a freeform question).
         resolved_user_id = data.get("user_id") or task.user_id
+        # user_email lives under Conversations.metadata (same shape as
+        # request_source). Per-event value wins; fall back to the row-level
+        # metadata so follow-up turns still get the email when the FE
+        # didn't repeat it in the user_message event.
+        resolved_user_email = data.get("user_email") or (
+            task.metadata.get("user_email") if task.metadata else None
+        )
         resolved_request_source = data.get("request_source") or (
             task.metadata.get("request_source") if task.metadata else None
         )
@@ -659,6 +666,7 @@ class ConversationWorker:
             # state. user_id / request_source fall back to the Conversations
             # row when the FE didn't repeat them in the event.
             user_id=resolved_user_id,
+            user_email=resolved_user_email,
             # request_type: pass through whatever the FE sent (None if absent)
             # rather than hard-coding 'user_chat' here. The recorder helper
             # (build_chat_recorder_state) handles the default and runs Slack

--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -646,6 +646,13 @@ class ConversationWorker:
         resolved_request_source = data.get("request_source") or (
             task.metadata.get("request_source") if task.metadata else None
         )
+        # source_ref is conversation-level for alert investigations (the
+        # whole chat is about one alert id), so the FE puts it on the
+        # Conversations row's metadata, not in each per-turn event. Same
+        # caller-wins / metadata-fallback pattern as request_source.
+        resolved_source_ref = data.get("source_ref") or (
+            task.metadata.get("source_ref") if task.metadata else None
+        )
 
         chat_request = ChatRequest(
             ask=ask,
@@ -660,11 +667,11 @@ class ConversationWorker:
             frontend_tool_results=data.get("frontend_tool_results"),  # type: ignore[arg-type]
             response_format=data.get("response_format"),
             behavior_controls=data.get("behavior_controls"),
-            # source_ref / meta / is_internal still come from the per-event
-            # blob only — they're per-turn signals (which alert this
-            # follow-up question was about, etc.), not Conversation-level
-            # state. user_id / request_source fall back to the Conversations
-            # row when the FE didn't repeat them in the event.
+            # meta / is_internal still come from the per-event blob only —
+            # they're per-turn signals, not Conversation-level state.
+            # user_id / user_email / request_source / source_ref fall back
+            # to the Conversations row when the FE didn't repeat them in
+            # the per-turn event.
             user_id=resolved_user_id,
             user_email=resolved_user_email,
             # request_type: pass through whatever the FE sent (None if absent)
@@ -677,7 +684,7 @@ class ConversationWorker:
             # at any time without a code change here.
             request_type=data.get("request_type"),
             request_source=resolved_request_source,
-            source_ref=data.get("source_ref"),
+            source_ref=resolved_source_ref,
             conversation_id=task.conversation_id,
             conversation_source="conversations",
             meta=data.get("meta"),

--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -636,22 +636,28 @@ class ConversationWorker:
         # Per-event data still wins so the FE can override per-turn (e.g.
         # an alert-investigation chat that pivots to a freeform question).
         resolved_user_id = data.get("user_id") or task.user_id
-        # user_email lives under Conversations.metadata (same shape as
-        # request_source). Per-event value wins; fall back to the row-level
-        # metadata so follow-up turns still get the email when the FE
-        # didn't repeat it in the user_message event.
-        resolved_user_email = data.get("user_email") or (
-            task.metadata.get("user_email") if task.metadata else None
+        # Per-event presence wins, not truthiness — so an explicit empty
+        # value from the FE (e.g. "" to deliberately clear a field) keeps
+        # priority over the row-level metadata fallback and we don't
+        # reintroduce stale Conversation-row values. Only fall back to
+        # task.metadata when the per-turn event omits the key entirely.
+        resolved_user_email = (
+            data["user_email"]
+            if "user_email" in data
+            else (task.metadata.get("user_email") if task.metadata else None)
         )
-        resolved_request_source = data.get("request_source") or (
-            task.metadata.get("request_source") if task.metadata else None
+        resolved_request_source = (
+            data["request_source"]
+            if "request_source" in data
+            else (task.metadata.get("request_source") if task.metadata else None)
         )
         # source_ref is conversation-level for alert investigations (the
         # whole chat is about one alert id), so the FE puts it on the
-        # Conversations row's metadata, not in each per-turn event. Same
-        # caller-wins / metadata-fallback pattern as request_source.
-        resolved_source_ref = data.get("source_ref") or (
-            task.metadata.get("source_ref") if task.metadata else None
+        # Conversations row's metadata, not in each per-turn event.
+        resolved_source_ref = (
+            data["source_ref"]
+            if "source_ref" in data
+            else (task.metadata.get("source_ref") if task.metadata else None)
         )
 
         chat_request = ChatRequest(

--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -659,6 +659,16 @@ class ConversationWorker:
             if "source_ref" in data
             else (task.metadata.get("source_ref") if task.metadata else None)
         )
+        # request_type may also live under Conversations.metadata when the
+        # FE classifies a whole chat once at creation time. Same key-presence
+        # semantics — leaving the resolved value None when neither source
+        # supplies it preserves build_chat_recorder_state's auto-detection
+        # (Slack-prefix → 'slack_chat', fallback → 'user_chat').
+        resolved_request_type = (
+            data["request_type"]
+            if "request_type" in data
+            else (task.metadata.get("request_type") if task.metadata else None)
+        )
 
         chat_request = ChatRequest(
             ask=ask,
@@ -675,20 +685,14 @@ class ConversationWorker:
             behavior_controls=data.get("behavior_controls"),
             # meta / is_internal still come from the per-event blob only —
             # they're per-turn signals, not Conversation-level state.
-            # user_id / user_email / request_source / source_ref fall back
-            # to the Conversations row when the FE didn't repeat them in
-            # the per-turn event.
+            # user_id / user_email / request_type / request_source /
+            # source_ref fall back to the Conversations row when the FE
+            # didn't repeat them in the per-turn event. None for
+            # request_type still lets build_chat_recorder_state's Slack
+            # auto-detection and 'user_chat' default run.
             user_id=resolved_user_id,
             user_email=resolved_user_email,
-            # request_type: pass through whatever the FE sent (None if absent)
-            # rather than hard-coding 'user_chat' here. The recorder helper
-            # (build_chat_recorder_state) handles the default and runs Slack
-            # auto-detection — hard-coding 'user_chat' would defeat the
-            # auto-detection because the helper bails out if request_type is
-            # already truthy. Today only /api/chat hits the Slack-prefix
-            # path, but the runner could route Slack through Conversations
-            # at any time without a code change here.
-            request_type=data.get("request_type"),
+            request_type=resolved_request_type,
             request_source=resolved_request_source,
             source_ref=resolved_source_ref,
             conversation_id=task.conversation_id,

--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -213,6 +213,7 @@ class ChatRequestBaseModel(BaseModel):
         None  # Optional span for tracing and heartbeat callbacks
     )
     user_id: Optional[str] = None  # User ID from relay session token validation
+    user_email: Optional[str] = None  # User email supplied by the frontend (source of truth for usage analytics)
 
     # ── AI usage tracking fields (HolmesUsageEvents). All optional / additive;
     # old clients that don't supply them keep working unchanged. ──

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -847,6 +847,7 @@ class SupabaseDal:
                 "account_id": self.account_id,
                 "cluster_id": state.cluster_id or self.cluster,
                 "user_id": state.user_id,
+                "user_email": state.user_email,
                 "conversation_id": state.conversation_id,
                 "conversation_source": state.conversation_source,
                 "request_id": state.request_id,

--- a/holmes/core/usage_recorder.py
+++ b/holmes/core/usage_recorder.py
@@ -156,6 +156,7 @@ def build_chat_recorder_state(
         conversation_id=chat_request.conversation_id,
         conversation_source=conversation_source,
         user_id=chat_request.user_id,
+        user_email=chat_request.user_email,
         is_streaming=is_streaming,
         is_internal=is_internal,
         model=model_name,
@@ -287,6 +288,12 @@ class UsageRecorderState:
     # is no human user. Used for per-user analytics and (today) by the
     # feedback RPC's auth.uid() check.
     user_id: Optional[str] = None
+
+    # Email of the human who started the chat. Supplied by the frontend
+    # on every chat-bound payload (FE is the source of truth — for SSO
+    # users it's not joinable from auth.users / account_users). NULL for
+    # system / scheduled flows or any client that didn't send it.
+    user_email: Optional[str] = None
 
     # Holmes' cluster id (env-var string, e.g. 'production-east'). Falls
     # back to dal.cluster inside record_usage_event when left at None


### PR DESCRIPTION
## Summary

- `HolmesUsageEvents.user_id` stores Supabase `auth.uid()`, which doesn't resolve to an email for SSO users (they aren't in `account_users`), so usage analytics can't join on email today.
- A new `user_email` column has been added to `HolmesUsageEvents`. The FE is being updated to send `user_email` on every chat-bound payload as the source of truth. This change wires Holmes to accept it and persist it.
- No server-side email resolution (no `auth.users` lookup, no admin client calls) — FE is authoritative, per spec.

## What changed

- `holmes/core/models.py` — Added `user_email: Optional[str] = None` on `ChatRequestBaseModel` next to `user_id`.
- `holmes/core/usage_recorder.py` — Added `user_email` field to `UsageRecorderState`; `build_chat_recorder_state` copies it from `chat_request.user_email`. Mirrors the `user_id` plumbing exactly.
- `holmes/core/supabase_dal.py` — `record_usage_event` writes `user_email=state.user_email` next to `user_id`. `None` passes through unchanged (no coercion); `meta` untouched.
- `holmes/core/conversations_worker/worker.py` — Per-turn `data.get(\"user_email\")` wins; falls back to `task.metadata[\"user_email\"]` so follow-up turns still get the email when the FE doesn't repeat it in the `user_message` event. Mirrors the existing `request_source` resolution pattern.

## Test plan

- [ ] Send a chat request with `user_email` in the payload; verify the row written to `HolmesUsageEvents` has the column populated.
- [ ] Send a chat request without `user_email`; verify the request succeeds and the column is `NULL`.
- [ ] Send a follow-up turn through the Conversations worker with `user_email` only on the original Conversations row (under `metadata`) and not on the per-turn event; verify the row's `user_email` is still populated via the metadata fallback.
- [ ] Verify other entry points that pass `user_id=None` (scheduled prompts, health checks, AG-UI) still write `user_email=NULL` without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend-supplied user email can now be included with chat requests and is captured for analytics.
  * Per-event fields (email, request type, request source, source reference) are resolved by key-presence and override conversation-level values when present.
  * Resolved email, request type, and source reference persist across follow-up turns and are recorded with usage events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->