### PR TITLE
Add documentation link to OOM memory limit guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,6 +559,17 @@ When asked about content from the HolmesGPT documentation website (https://holme
 
 The docs site uses the `awesome-nav` plugin. Navigation is controlled by `.nav.yml` files in each `docs/` subdirectory, **not** by the `nav:` section in `mkdocs.yml`. When adding a new docs page, you must add it to the `.nav.yml` file in the corresponding directory (e.g., `docs/reference/.nav.yml` for reference pages).
 
+## Updating References When Docs Pages Change
+
+When you rename or move a docs page, or change a section heading (which changes its anchor), the URL changes. Before committing, `grep -rn` across the entire repo for the old page path and old anchor slug and update every hit. References can appear in:
+
+- Other `docs/*.md` files (relative links like `[text](../path/page.md#anchor)`)
+- Python source (user-facing error messages and hints, e.g. `holmes/utils/memory_limit.py`)
+- `README.md` and top-level markdown
+- Code comments
+
+This applies to both `https://holmesgpt.dev/...` absolute URLs and repo-relative `.md` links.
+
 ## MkDocs Formatting Notes
 
 When writing documentation in the `docs/` directory:

--- a/holmes/utils/memory_limit.py
+++ b/holmes/utils/memory_limit.py
@@ -81,13 +81,15 @@ def check_oom_and_append_hint(output: str, return_code: int) -> str:
             f"[OOM] Command exceeded the memory limit ({TOOL_MEMORY_LIMIT_MB} MB). "
             f"This is normal and expected — Holmes enforces memory limits by design to stay within resource "
             f"budgets. This is NOT an error or bug.\n"
+            f"\n"
+            f"For guidance on when and how to raise the limit, see:\n"
+            f"https://holmesgpt.dev/data-sources/tool-execution-safety/#when-to-raise-the-limit\n"
+            f"\n"
             f"Note to agent: Retry the query with filters to reduce memory usage — for example, filter by "
             f"namespace, label selector, specific resource name, or use a smaller time range. "
             f"Do NOT tell the user that something is broken or that there is an operational concern. "
             f"If you are unable to get results even after narrowing your queries, you may suggest that the "
-            f"user increase the memory limit by setting the TOOL_MEMORY_LIMIT_MB environment variable. "
-            f"See https://holmesgpt.dev/data-sources/tool-execution-safety/#when-to-raise-the-limit "
-            f"for guidance on when and how to raise the limit."
+            f"user increase the memory limit by setting the TOOL_MEMORY_LIMIT_MB environment variable."
         )
         if output:
             return hint + "\n\n" + _truncate_oom_output(output)

--- a/holmes/utils/memory_limit.py
+++ b/holmes/utils/memory_limit.py
@@ -85,7 +85,9 @@ def check_oom_and_append_hint(output: str, return_code: int) -> str:
             f"namespace, label selector, specific resource name, or use a smaller time range. "
             f"Do NOT tell the user that something is broken or that there is an operational concern. "
             f"If you are unable to get results even after narrowing your queries, you may suggest that the "
-            f"user increase the memory limit by setting the TOOL_MEMORY_LIMIT_MB environment variable."
+            f"user increase the memory limit by setting the TOOL_MEMORY_LIMIT_MB environment variable. "
+            f"See https://holmesgpt.dev/data-sources/tool-execution-safety/#when-to-raise-the-limit "
+            f"for guidance on when and how to raise the limit."
         )
         if output:
             return hint + "\n\n" + _truncate_oom_output(output)

--- a/tests/core/test_tool_memory_limit.py
+++ b/tests/core/test_tool_memory_limit.py
@@ -60,6 +60,10 @@ class TestCheckOomAndAppendHint:
         assert str(TOOL_MEMORY_LIMIT_MB) in result  # Shows current limit
         assert result.startswith("[OOM]")  # Hint comes first
         assert "NOT an error" in result  # Emphasizes this is by design
+        assert (
+            "https://holmesgpt.dev/data-sources/tool-execution-safety/#when-to-raise-the-limit"
+            in result
+        )  # Includes docs link
 
     def test_hint_prepended_before_output(self):
         """Test that hint appears before the original output, not after."""


### PR DESCRIPTION
## Summary
Enhanced the out-of-memory (OOM) error hint message to include a link to the HolmesGPT documentation for guidance on when and how to raise the memory limit.

## Changes
- **holmes/utils/memory_limit.py**: Extended the OOM hint message to include a reference link to the tool execution safety documentation section about raising memory limits
- **tests/core/test_tool_memory_limit.py**: Added assertion to verify the documentation link is included in the OOM hint output

## Details
When users encounter OOM errors, they now receive not just the suggestion to increase `TOOL_MEMORY_LIMIT_MB`, but also a direct link to documentation that explains the decision-making process for when and how to adjust the limit. This improves the user experience by providing actionable guidance without requiring them to search for documentation separately.

https://claude.ai/code/session_01K2r1qdyK1ve8YoQxuBnEFg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory-limit error messages now include a direct link to guidance on when and how to raise the limit, improving troubleshooting for OOM/killed tool runs.

* **Documentation**
  * New guidance added about updating repo-wide references when documentation pages or anchors move.

* **Tests**
  * Tests updated to assert the presence of the new guidance link in memory-limit hints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->