### PR TITLE
Warn when OTLP endpoint is set but OTEL packages are missing

### DIFF
--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -342,7 +342,7 @@ class TracingFactory:
                     TracingFactory._active_tracer = tracer
                     return tracer
                 except ImportError:
-                    logging.debug(
+                    logging.warning(
                         "OTEL_EXPORTER_OTLP_ENDPOINT set but otel packages not installed, using DummyTracer"
                     )
             return DummyTracer()


### PR DESCRIPTION
Surface misconfiguration at warning level instead of debug so operators notice when tracing falls back to DummyTracer.

Partly Fixes #2077 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced visibility of configuration issues by promoting log level from debug to warning when OpenTelemetry packages are missing during auto-detection, ensuring users are properly notified of potential setup problems before the system falls back to default tracing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->