### PR TITLE
Add per-conversation OAuth opt-out support

### DIFF
--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -636,6 +636,16 @@ class ConversationWorker:
         # Per-event data still wins so the FE can override per-turn (e.g.
         # an alert-investigation chat that pivots to a freeform question).
         resolved_user_id = data.get("user_id") or task.user_id
+        # Per-conversation OAuth opt-out. When a Conversations row carries
+        # `metadata.oauth_enabled = false` (e.g. triggered workflows that
+        # don't want Holmes acting under the workflow creator's per-user
+        # OAuth tokens), drop user_id before it reaches ChatRequest so the
+        # OAuth resolver in tool_calling_llm has no user to key on.
+        oauth_enabled = (
+            task.metadata.get("oauth_enabled", True) if task.metadata else True
+        )
+        if not oauth_enabled:
+            resolved_user_id = None
         # Per-event presence wins, not truthiness — so an explicit empty
         # value from the FE (e.g. "" to deliberately clear a field) keeps
         # priority over the row-level metadata fallback and we don't


### PR DESCRIPTION
## Summary
Add support for disabling OAuth token usage on a per-conversation basis by checking a `metadata.oauth_enabled` flag in the ConversationTask. When OAuth is disabled for a conversation, the resolved user ID is cleared before reaching the ChatRequest, preventing the OAuth resolver from using per-user tokens.

## Changes
- Added logic to check `task.metadata.oauth_enabled` (defaults to `True` for backwards compatibility)
- When `oauth_enabled` is `False`, set `resolved_user_id` to `None` to prevent OAuth token resolution
- This allows triggered workflows and other use cases to opt out of using the workflow creator's OAuth tokens

## Implementation Details
- The check is placed after the per-event user ID resolution, ensuring metadata-level settings can override the default behavior
- Safely handles missing metadata with a fallback to `True` (OAuth enabled by default)
- Includes detailed comments explaining the use case (e.g., triggered workflows that shouldn't act under the creator's OAuth tokens)

https://claude.ai/code/session_01TFRPoBApwPveqX6TEgfNDh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-conversation OAuth opt-out capability, allowing conversations to disable OAuth token usage when needed. When disabled for a conversation, OAuth-dependent operations will not have access to user credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->