### PR TITLE
Add k3s-in-Docker setup script for sandbox Kubernetes evals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,67 @@ HolmesGPT is an AI-powered troubleshooting agent that connects to observability 
 poetry install
 ```
 
+### Running Evals in the Claude Code Sandbox (k8s setup)
+
+Claude Code on the web runs in a managed Linux container where Docker works but
+KIND fails (nested systemd cannot mount the systemd cgroup hierarchy under
+cgroup v1). The supported path is **k3s-in-Docker**, set up by
+`scripts/setup-sandbox-k8s.sh`. The script is idempotent; run it once per session
+before invoking pytest.
+
+```bash
+./scripts/setup-sandbox-k8s.sh
+export KUBECONFIG=/tmp/k3s-output/kubeconfig.yaml
+
+# Use OpenRouter (the API key already exists in the sandbox env)
+# CLASSIFIER_MODEL is required when MODEL points at OpenRouter
+export MODEL="openrouter/openai/gpt-4.1-mini"
+export CLASSIFIER_MODEL="openrouter/openai/gpt-4.1"
+
+# Run a single eval end-to-end (~30-60s including pod setup)
+poetry run pytest -k "01_how_many_pods" --no-cov
+```
+
+**What the setup script handles (and why):**
+
+- Starts `dockerd` (the sandbox doesn't auto-start it).
+- Installs `kubectl`, `helm`, and a static `jq`. `helm` is needed by toolset
+  prerequisite checks — without it many `test_ask_holmes` evals fail at setup
+  with `helm: not found`.
+- Runs k3s v1.31 in a privileged Docker container with `--cgroupns=host` and
+  unconfined seccomp/apparmor. KIND is installed but **not** used — it can't
+  boot a control-plane container here.
+- Mounts the sandbox CA bundle (`/etc/ssl/certs/ca-certificates.crt`) into the
+  k3s container at the OS trust-store paths. The egress proxy MITMs HTTPS, so
+  without this containerd's image pulls fail with `x509: certificate signed by
+  unknown authority`.
+- **Replaces `/bin/runc` inside the k3s container with a wrapper that strips
+  `.process.oomScoreAdj` from each container's `config.json` before invoking
+  the real runc.** Without this, every pod sandbox creation fails with
+  `nsexec: failed to update /proc/self/oom_score_adj: Permission denied` →
+  `runc create failed: ... can't get final child's PID from pipe: EOF`. The
+  sandbox revokes `CAP_SYS_RESOURCE`, so processes cannot lower their
+  oom_score_adj, and kubelet sets `oomScoreAdj=-998` on every pause container.
+  Stripping the field lets runc inherit the parent's value.
+
+**Fastest eval to run as a smoke test:** `01_how_many_pods` — minimal manifest
+(14 busybox pods), straightforward question, completes in ~30s including k8s
+setup. Use it as the canonical "did I break anything" check.
+
+**Skipping setup on repeat runs:** Once `before_test` resources exist (e.g.,
+namespace `app-01`), `poetry run pytest -k "01_how_many_pods" --skip-setup --no-cov`
+runs the eval in ~25s.
+
+**Limitations of the sandbox cluster (don't waste time trying to fix):**
+
+- `kind`, `minikube`, and bare `k3s` outside the wrapper all fail.
+- Pods that explicitly require setting `oomScoreAdj` to a fixed value in the
+  spec may still fail; the wrapper only strips the kubelet-injected default.
+- Only a single-node cluster; no real load-balancer (`servicelb` is disabled);
+  no metrics-server, no traefik.
+- Cgroup v1 only. Anything that requires cgroup v2 (e.g., memory.swap.max
+  workloads, some eBPF tools) won't work.
+
 ### Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,29 @@ next run sees `0 pods` and fails. Run the full cycle each time.
 
 **Other env-var gotchas:**
 
-- `BRAINTRUST_API_KEY`: not set in this sandbox (only `BRAINTRUST_SERVICE_TOKEN`
-  is, which the eval framework ignores). Leave it alone. If you ever export
-  `BRAINTRUST_API_KEY=$BRAINTRUST_SERVICE_TOKEN`, expect tests to crash —
-  service tokens are read-only and `braintrust.init(... update=True)` 401s.
+- **Braintrust** — two different env vars and two different token types, easy to
+  confuse:
+  - `BRAINTRUST_API_KEY` is the only one the eval framework reads
+    (`tests/llm/utils/test_env_vars.py`); setting it flips `braintrust_enabled`
+    to true, which makes test setup call `braintrust.init_dataset()` and
+    `braintrust.init(... update=True)` (both **write** operations).
+  - `BRAINTRUST_SERVICE_TOKEN` is ignored by the eval framework (only
+    `braintrust_history.py` falls back to it, for read-only history fetches).
+  - Token-type rule of thumb: tokens that start with `bt-st-` are **service
+    tokens** — read-only by default. Anything else (typically a user API key
+    copied from your Braintrust profile) is writable.
+  - **How to check what you have in this shell:**
+    ```bash
+    env | grep -i braintrust
+    # BRAINTRUST_API_KEY     starting with bt-st-  → read-only,  WILL crash writes
+    # BRAINTRUST_API_KEY     anything else         → writable,   safe
+    # BRAINTRUST_SERVICE_TOKEN only                → framework ignores it, safe
+    # nothing                                      → braintrust disabled, safe
+    ```
+  - **This sandbox** ships with only `BRAINTRUST_SERVICE_TOKEN` (a `bt-st-…`
+    service token). Leave it alone. **Do not** copy it into
+    `BRAINTRUST_API_KEY` — tests will hit a 401 from `braintrust.init(...
+    update=True)` and fail.
 - `OPENAI_API_KEY`: not required when `MODEL` is an `openrouter/...` string;
   LiteLLM routes by the `openrouter/` prefix and reads `OPENROUTER_API_KEY`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,21 +19,32 @@ poetry install
 Claude Code on the web runs in a managed Linux container where Docker works but
 KIND fails (nested systemd cannot mount the systemd cgroup hierarchy under
 cgroup v1). The supported path is **k3s-in-Docker**, set up by
-`scripts/setup-sandbox-k8s.sh`. The script is idempotent; run it once per session
-before invoking pytest.
+`scripts/setup-sandbox-k8s.sh`. The script is idempotent; run it once per
+session before invoking pytest.
+
+**Complete steps (verified end-to-end):**
 
 ```bash
+# 1. One-time per session: start dockerd, install kubectl/helm/jq,
+#    bring up k3s, install the runc oomScoreAdj-stripping wrapper.
 ./scripts/setup-sandbox-k8s.sh
+
+# 2. Point kubectl + the eval framework at the cluster.
 export KUBECONFIG=/tmp/k3s-output/kubeconfig.yaml
 
-# Use OpenRouter (the API key already exists in the sandbox env)
-# CLASSIFIER_MODEL is required when MODEL points at OpenRouter
+# 3. Use OpenRouter — the only LLM provider with creds in this env
+#    (OPENROUTER_API_KEY is pre-populated). CLASSIFIER_MODEL must also
+#    point at OpenRouter, otherwise the classifier default fails.
 export MODEL="openrouter/openai/gpt-4.1-mini"
 export CLASSIFIER_MODEL="openrouter/openai/gpt-4.1"
 
-# Run a single eval end-to-end (~30-60s including pod setup)
+# 4. Run an eval. Smoke test: ~45s end-to-end (setup + 14 pods + LLM call).
 poetry run pytest -k "01_how_many_pods" --no-cov
 ```
+
+Verified on this branch:
+- `setup-sandbox-k8s.sh` from scratch: ~15s.
+- `01_how_many_pods` full cycle (setup → eval → cleanup): ~45s wall time, PASS.
 
 **What the setup script handles (and why):**
 
@@ -58,12 +69,21 @@ poetry run pytest -k "01_how_many_pods" --no-cov
   Stripping the field lets runc inherit the parent's value.
 
 **Fastest eval to run as a smoke test:** `01_how_many_pods` — minimal manifest
-(14 busybox pods), straightforward question, completes in ~30s including k8s
-setup. Use it as the canonical "did I break anything" check.
+(14 busybox pods), straightforward question, completes in ~45s including k8s
+namespace setup. Use it as the canonical "did I break anything" check.
 
-**Skipping setup on repeat runs:** Once `before_test` resources exist (e.g.,
-namespace `app-01`), `poetry run pytest -k "01_how_many_pods" --skip-setup --no-cov`
-runs the eval in ~25s.
+**Don't use `--skip-setup` in this sandbox.** It skips `before_test` but the
+test framework still runs `after_test` (which deletes the namespace), so the
+next run sees `0 pods` and fails. Run the full cycle each time.
+
+**Other env-var gotchas:**
+
+- `BRAINTRUST_API_KEY`: not set in this sandbox (only `BRAINTRUST_SERVICE_TOKEN`
+  is, which the eval framework ignores). Leave it alone. If you ever export
+  `BRAINTRUST_API_KEY=$BRAINTRUST_SERVICE_TOKEN`, expect tests to crash —
+  service tokens are read-only and `braintrust.init(... update=True)` 401s.
+- `OPENAI_API_KEY`: not required when `MODEL` is an `openrouter/...` string;
+  LiteLLM routes by the `openrouter/` prefix and reads `OPENROUTER_API_KEY`.
 
 **Limitations of the sandbox cluster (don't waste time trying to fix):**
 

--- a/scripts/setup-sandbox-k8s.sh
+++ b/scripts/setup-sandbox-k8s.sh
@@ -135,4 +135,8 @@ kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=120s || t
 log "Cluster ready."
 kubectl get nodes
 echo
-echo "export KUBECONFIG=$KUBECONFIG"
+echo "Run evals with:"
+echo "  export KUBECONFIG=$KUBECONFIG"
+echo "  export MODEL=openrouter/openai/gpt-4.1-mini"
+echo "  export CLASSIFIER_MODEL=openrouter/openai/gpt-4.1"
+echo "  poetry run pytest -k '01_how_many_pods' --no-cov"

--- a/scripts/setup-sandbox-k8s.sh
+++ b/scripts/setup-sandbox-k8s.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Set up a working k3s-in-docker cluster + helm + kubectl for running HolmesGPT evals
+# inside this sandbox environment. Idempotent: safe to re-run.
+#
+# Workaround: the sandbox blocks setting oom_score_adj below 0, so the kubelet's
+# pause-container oomScoreAdj=-998 makes runc exit with
+#   "nsexec: failed to update /proc/self/oom_score_adj: Permission denied"
+# We replace /bin/runc inside k3s with a wrapper that strips .process.oomScoreAdj
+# from each container's config.json before invoking the real runc.
+
+set -euo pipefail
+
+K3S_IMAGE="${K3S_IMAGE:-rancher/k3s:v1.31.4-k3s1}"
+K3S_OUTPUT_DIR="${K3S_OUTPUT_DIR:-/tmp/k3s-output}"
+export KUBECONFIG="${K3S_OUTPUT_DIR}/kubeconfig.yaml"
+
+log() { echo "[setup-k8s] $*"; }
+
+# 1. Docker daemon
+if ! docker info >/dev/null 2>&1; then
+  log "Starting dockerd..."
+  dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 20); do
+    docker info >/dev/null 2>&1 && break
+    sleep 1
+  done
+  docker info >/dev/null 2>&1 || { log "dockerd failed to start"; tail /tmp/dockerd.log; exit 1; }
+fi
+
+# 2. kubectl + kind (kind only used for parity; not used for cluster here)
+if ! command -v kubectl >/dev/null; then
+  log "Installing kubectl..."
+  KUBECTL_VER=$(curl -sL https://dl.k8s.io/release/stable.txt)
+  curl -sLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VER}/bin/linux/amd64/kubectl"
+  chmod +x /usr/local/bin/kubectl
+fi
+
+# 3. helm (required for many toolset prerequisite checks)
+if ! command -v helm >/dev/null; then
+  log "Installing helm..."
+  curl -sL https://get.helm.sh/helm-v3.17.0-linux-amd64.tar.gz | tar xz -C /tmp/
+  mv /tmp/linux-amd64/helm /usr/local/bin/helm
+  chmod +x /usr/local/bin/helm
+  rm -rf /tmp/linux-amd64
+fi
+
+# 4. jq on host so we can copy it into the k3s container for the runc wrapper
+if [ ! -x /tmp/jq ]; then
+  log "Downloading jq..."
+  curl -sL -o /tmp/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+  chmod +x /tmp/jq
+fi
+
+mkdir -p "$K3S_OUTPUT_DIR"
+# 5. Sandbox CA bundle: containerd inside k3s must trust the proxy CA
+cp /etc/ssl/certs/ca-certificates.crt "$K3S_OUTPUT_DIR/ca-certs.crt"
+
+# 6. (Re)start k3s container
+if docker ps --format '{{.Names}}' | grep -q '^k3s-server$'; then
+  log "k3s-server already running"
+else
+  log "Starting k3s-server container..."
+  docker rm -f k3s-server >/dev/null 2>&1 || true
+  for attempt in 1 2 3 4; do
+    if docker image inspect "$K3S_IMAGE" >/dev/null 2>&1; then
+      break
+    fi
+    docker pull "$K3S_IMAGE" && break
+    log "pull attempt $attempt failed, retrying..."
+    sleep $((attempt*2))
+  done
+
+  docker run -d --privileged --name k3s-server \
+    --cgroupns=host \
+    --security-opt seccomp=unconfined \
+    --security-opt apparmor=unconfined \
+    -p 6443:6443 \
+    -e K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml \
+    -e K3S_KUBECONFIG_MODE=666 \
+    -v "$K3S_OUTPUT_DIR:/output" \
+    -v "$K3S_OUTPUT_DIR/ca-certs.crt:/etc/ssl/certs/ca-certificates.crt:ro" \
+    -v "$K3S_OUTPUT_DIR/ca-certs.crt:/etc/pki/tls/certs/ca-bundle.crt:ro" \
+    "$K3S_IMAGE" server \
+      --disable=traefik --disable=metrics-server --disable=servicelb >/dev/null
+fi
+
+# 7. Patch runc inside the container (idempotent)
+if ! docker exec k3s-server test -f /bin/runc.real; then
+  log "Installing oom_score_adj runc wrapper inside k3s-server..."
+  docker cp /tmp/jq k3s-server:/bin/jq
+  docker exec k3s-server sh -c '
+    mv /bin/runc /bin/runc.real
+    cat > /bin/runc <<EOF
+#!/bin/sh
+case "\$*" in
+  *create*)
+    BUNDLE=\$(echo "\$@" | grep -oE -- "--bundle [^ ]+" | awk "{print \\\$2}")
+    if [ -n "\$BUNDLE" ] && [ -f "\$BUNDLE/config.json" ]; then
+      /bin/jq "del(.process.oomScoreAdj)" "\$BUNDLE/config.json" > "\$BUNDLE/config.json.tmp" && mv "\$BUNDLE/config.json.tmp" "\$BUNDLE/config.json"
+    fi
+    ;;
+esac
+exec /bin/runc.real "\$@"
+EOF
+    chmod +x /bin/runc
+  '
+fi
+
+# 8. Wait for API server and node ready
+log "Waiting for cluster to be ready..."
+for _ in $(seq 1 60); do
+  if [ -f "$KUBECONFIG" ] && kubectl get nodes 2>/dev/null | grep -q ' Ready '; then
+    break
+  fi
+  sleep 2
+done
+
+kubectl wait --for=condition=Ready node --all --timeout=120s
+# Wait for kube-system pods to be created by the bootstrap controllers
+for _ in $(seq 1 30); do
+  COUNT=$(kubectl get pods -n kube-system --no-headers 2>/dev/null | wc -l)
+  [ "$COUNT" -ge 2 ] && break
+  sleep 1
+done
+# Force-recreate any kube-system pods that came up before the runc wrapper was installed
+BAD=$(kubectl get pods -n kube-system --no-headers 2>/dev/null | awk '$3 != "Running" && $3 != "Completed" {print $1}')
+if [ -n "$BAD" ]; then
+  log "Recreating stuck system pods: $BAD"
+  for name in $BAD; do
+    kubectl delete pod -n kube-system "$name" --grace-period=0 --force >/dev/null 2>&1 || true
+  done
+fi
+kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=120s || true
+
+log "Cluster ready."
+kubectl get nodes
+echo
+echo "export KUBECONFIG=$KUBECONFIG"


### PR DESCRIPTION
## Summary

Adds a complete Kubernetes evaluation environment setup for Claude Code sandbox, including a new `scripts/setup-sandbox-k8s.sh` script and comprehensive documentation in `CLAUDE.md`.

## Key Changes

- **New script `scripts/setup-sandbox-k8s.sh`**: Idempotent setup script that:
  - Starts `dockerd` (not auto-started in sandbox)
  - Installs `kubectl`, `helm`, and `jq` binaries
  - Launches k3s v1.31 in a privileged Docker container with proper cgroup/seccomp/apparmor settings
  - Mounts sandbox CA bundle for HTTPS proxy compatibility
  - **Patches `/bin/runc` inside k3s with a wrapper that strips `.process.oomScoreAdj`** from container configs to work around sandbox permission restrictions on `CAP_SYS_RESOURCE`
  - Waits for cluster readiness and recreates any stuck system pods

- **Updated `CLAUDE.md`**: Added comprehensive "Running Evals in the Claude Code Sandbox (k8s setup)" section covering:
  - Step-by-step instructions for running evals (verified end-to-end)
  - Performance baseline: ~15s setup, ~45s full eval cycle for smoke test
  - Detailed explanation of what the setup script handles and why (especially the runc wrapper workaround)
  - Recommended smoke test: `01_how_many_pods` eval
  - Important gotchas: `--skip-setup` behavior, Braintrust token types, OpenRouter configuration
  - Sandbox limitations (KIND/minikube don't work, cgroup v1 only, single-node cluster)

## Implementation Details

The runc wrapper is the critical piece: the sandbox blocks setting `oom_score_adj` below 0 (no `CAP_SYS_RESOURCE`), but kubelet sets `oomScoreAdj=-998` on every pause container. The wrapper intercepts runc's `create` command, uses `jq` to strip `.process.oomScoreAdj` from the container config, then invokes the real runc. This allows the pause container to inherit the parent's oom_score_adj instead of failing with "Permission denied".

The setup is fully idempotent and safe to re-run within a session.

https://claude.ai/code/session_01LyY7iHs3fRJ5LTFX11NP8R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for running evaluations in a Kubernetes sandbox environment, documenting the complete setup process, expected performance metrics, required environment variables, and sandbox-specific constraints and limitations.

* **New Features**
  * Added an automated setup script to provision and configure a local Kubernetes-on-Docker environment, including dependency management, CA bundle setup, and cluster readiness verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->