### PR TITLE
Add Naomi Caren to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@
 | Tomer Keshet        | [Sheeproid](https://github.com/Sheeproid)         | [Robusta](https://github.com/robusta-dev)           |
 | Roi Glinik          | [RoiGlinik](https://github.com/RoiGlinik)         | [Robusta](https://github.com/robusta-dev)           |
 | Moshe Morad         | [moshemorad](https://github.com/moshemorad)       | [Robusta](https://github.com/robusta-dev)           |
+| Naomi Caren         | [naomi-robusta](https://github.com/naomi-robusta) | [Robusta](https://github.com/robusta-dev)           |
 | Qingchuan Hao       | [mainred](https://github.com/mainred)             | [Microsoft](https://github.com/microsoft)           |
 
 ## Emeritus


### PR DESCRIPTION
## Summary

Adds **Naomi Caren** ([@naomi-robusta](https://github.com/naomi-robusta), Robusta) to the active maintainers list in `MAINTAINERS.md`.

## Status

🚧 **Draft — do not merge until the maintainer nomination vote passes.**

Tracking issue: #2092

Per `GOVERNANCE.md`:
- New maintainers are approved by simple majority vote at a quarterly Maintainer Meeting.
- This PR will be marked ready-for-review once the vote in #2092 concludes successfully.

## Eligibility (summary)

- **13 merged PRs in the last 12 months** (≥ 5-PR threshold) — full list in #2092.
- Cross-cutting ownership of the realtime / conversation-worker subsystem (Supabase Realtime, WebSocket TLS, retry logic, event flushing, health checks).

## Test plan

- [ ] `MAINTAINERS.md` renders correctly on GitHub
- [ ] Tracking issue #2092 vote passes


---
_Generated by [Claude Code](https://claude.ai/code/session_017QaRxLsTqG3NpfEipfarzC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the maintainers list with an additional team member.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2093?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->