### PR TITLE
Add multi-region support for Robusta platform endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -650,3 +650,40 @@ When writing documentation in the `docs/` directory:
   ```
 
 - **Common Use Cases format**: Just example prompts, one per code block, no sub-headers, no explanations.
+
+## Robusta Platform/API URLs in Docs
+
+Whenever you reference `api.robusta.dev` or `platform.robusta.dev` in a docs page, use the `robusta-region` custom fence so readers can pick US/EU/AP. **Never hardcode a single region** — the Robusta platform is hosted in multiple regions and a bare `api.robusta.dev` link silently breaks for EU/AP users.
+
+The fence (defined in `docs/custom_fences.py`, registered in `mkdocs.yml`) takes a US URL as input and emits a three-tab picker with the domain rewritten per region. Pick the input shape that matches your context:
+
+- **Plain URL or text** (renders as a code block per tab):
+
+    ````markdown
+    ```robusta-region
+    https://api.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
+    ````
+
+- **Markdown link** (renders as a clickable link per tab — use for "go to platform.robusta.dev" style prose):
+
+    ````markdown
+    ```robusta-region
+    [platform.robusta.dev](https://platform.robusta.dev/)
+    ```
+    ````
+
+- **YAML or other code with `{lang=<name>}`** (applies the `language-<name>` class for syntax highlighting):
+
+    `````markdown
+    ```robusta-region {lang=yaml}
+    holmes:
+      additionalEnvVars:
+        - name: ROBUSTA_API_ENDPOINT
+          value: "https://api.robusta.dev"
+    ```
+    `````
+
+Author the URL once using the US domain (`api.robusta.dev` / `platform.robusta.dev`); the fence handles the `.eu` / `.ap` rewrites. If you add a new region or rename one, update `ROBUSTA_REGIONS` in `docs/custom_fences.py` — that single change propagates to every page.
+
+Existing usages (greppable starting points): `docs/ai-providers/robusta-ai.md`, `docs/installation/ui-installation.md`, `docs/reference/environment-variables.md`, `docs/data-sources/builtin-toolsets/coralogix-logs.md`, `docs/data-sources/builtin-toolsets/kubernetes-mcp.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -675,14 +675,14 @@ The fence (defined in `docs/custom_fences.py`, registered in `mkdocs.yml`) takes
 
 - **YAML or other code with `{lang=<name>}`** (applies the `language-<name>` class for syntax highlighting):
 
-    `````markdown
+    ````markdown
     ```robusta-region {lang=yaml}
     holmes:
       additionalEnvVars:
         - name: ROBUSTA_API_ENDPOINT
           value: "https://api.robusta.dev"
     ```
-    `````
+    ````
 
 Author the URL once using the US domain (`api.robusta.dev` / `platform.robusta.dev`); the fence handles the `.eu` / `.ap` rewrites. If you add a new region or rename one, update `ROBUSTA_REGIONS` in `docs/custom_fences.py` — that single change propagates to every page.
 

--- a/docs/ai-providers/robusta-ai.md
+++ b/docs/ai-providers/robusta-ai.md
@@ -96,12 +96,34 @@ holmes:
       value: "false"
 ```
 
+### Selecting a Region
+
+The Robusta platform is hosted in multiple regions. HolmesGPT defaults to the US endpoint. If your Robusta account lives in the EU or AP region, set `ROBUSTA_API_ENDPOINT` to the matching API URL:
+
+| Region | API endpoint |
+|--------|--------------|
+| US (default) | `https://api.robusta.dev` |
+| EU | `https://api.eu.robusta.dev` |
+| AP | `https://api.ap.robusta.dev` |
+
+```yaml
+# Add to generated_values.yaml
+holmes:
+  additionalEnvVars:
+    - name: ROBUSTA_AI
+      value: "true"
+    - name: ROBUSTA_API_ENDPOINT
+      value: "https://api.eu.robusta.dev"  # change to match your region
+```
+
+The endpoint must match the region your cluster is connected to in the Robusta platform — using the wrong endpoint will cause authentication and model-discovery failures.
+
 ## How It Works
 
 1. **Authentication**: HolmesGPT reads your Robusta token from the cluster configuration
 2. **Session creation**: A session token is created with the Robusta platform
-3. **Model discovery**: Available models are fetched from `https://api.robusta.dev/api/llm/models/v2`
-4. **Proxy access**: Models are accessed through Robusta's proxy endpoint at `https://api.robusta.dev/llm/{model_name}`
+3. **Model discovery**: Available models are fetched from `${ROBUSTA_API_ENDPOINT}/api/llm/models/v2` (default: `https://api.robusta.dev/api/llm/models/v2`)
+4. **Proxy access**: Models are accessed through Robusta's proxy endpoint at `${ROBUSTA_API_ENDPOINT}/llm/{model_name}` (default: `https://api.robusta.dev/llm/{model_name}`)
 5. **Automatic refresh**: Authentication tokens are automatically refreshed when they expire
 
 ## Available Models
@@ -124,16 +146,17 @@ When Robusta AI is enabled, models appear in the model selector dropdown in the 
 Check that:
 
 1. Your Robusta token is valid and not expired
-2. HolmesGPT can reach `api.robusta.dev`
-3. `ROBUSTA_AI` is set to `true`
-4. Check logs for authentication errors
+2. HolmesGPT can reach the Robusta API endpoint for your region (`api.robusta.dev`, `api.eu.robusta.dev`, or `api.ap.robusta.dev`)
+3. `ROBUSTA_API_ENDPOINT` matches the region your Robusta account is in (see [Selecting a Region](#selecting-a-region))
+4. `ROBUSTA_AI` is set to `true`
+5. Check logs for authentication errors
 
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|------------|---------|
 | `ROBUSTA_AI` | Enable/disable Robusta AI | Auto-detected |
-| `ROBUSTA_API_ENDPOINT` | Robusta API endpoint (different for on-premise users) | `https://api.robusta.dev` |
+| `ROBUSTA_API_ENDPOINT` | Robusta API endpoint. Set per region (`https://api.robusta.dev`, `https://api.eu.robusta.dev`, `https://api.ap.robusta.dev`) or to your on-premise URL. See [Selecting a Region](#selecting-a-region). | `https://api.robusta.dev` |
 
 ## See Also
 

--- a/docs/ai-providers/robusta-ai.md
+++ b/docs/ai-providers/robusta-ai.md
@@ -98,23 +98,43 @@ holmes:
 
 ### Selecting a Region
 
-The Robusta platform is hosted in multiple regions. HolmesGPT defaults to the US endpoint. If your Robusta account lives in the EU or AP region, set `ROBUSTA_API_ENDPOINT` to the matching API URL:
+The Robusta platform is hosted in multiple regions. HolmesGPT defaults to the US endpoint. If your Robusta account lives in the EU or AP region, set `ROBUSTA_API_ENDPOINT` to the matching API URL — pick your region below:
 
-| Region | API endpoint |
-|--------|--------------|
-| US (default) | `https://api.robusta.dev` |
-| EU | `https://api.eu.robusta.dev` |
-| AP | `https://api.ap.robusta.dev` |
+=== "US"
 
-```yaml
-# Add to generated_values.yaml
-holmes:
-  additionalEnvVars:
-    - name: ROBUSTA_AI
-      value: "true"
-    - name: ROBUSTA_API_ENDPOINT
-      value: "https://api.eu.robusta.dev"  # change to match your region
-```
+    ```yaml
+    # Add to generated_values.yaml
+    holmes:
+      additionalEnvVars:
+        - name: ROBUSTA_AI
+          value: "true"
+        - name: ROBUSTA_API_ENDPOINT
+          value: "https://api.robusta.dev"
+    ```
+
+=== "EU"
+
+    ```yaml
+    # Add to generated_values.yaml
+    holmes:
+      additionalEnvVars:
+        - name: ROBUSTA_AI
+          value: "true"
+        - name: ROBUSTA_API_ENDPOINT
+          value: "https://api.eu.robusta.dev"
+    ```
+
+=== "AP"
+
+    ```yaml
+    # Add to generated_values.yaml
+    holmes:
+      additionalEnvVars:
+        - name: ROBUSTA_AI
+          value: "true"
+        - name: ROBUSTA_API_ENDPOINT
+          value: "https://api.ap.robusta.dev"
+    ```
 
 The endpoint must match the region your cluster is connected to in the Robusta platform — using the wrong endpoint will cause authentication and model-discovery failures.
 

--- a/docs/ai-providers/robusta-ai.md
+++ b/docs/ai-providers/robusta-ai.md
@@ -100,41 +100,15 @@ holmes:
 
 The Robusta platform is hosted in multiple regions. HolmesGPT defaults to the US endpoint. If your Robusta account lives in the EU or AP region, set `ROBUSTA_API_ENDPOINT` to the matching API URL — pick your region below:
 
-=== "US"
-
-    ```yaml
-    # Add to generated_values.yaml
-    holmes:
-      additionalEnvVars:
-        - name: ROBUSTA_AI
-          value: "true"
-        - name: ROBUSTA_API_ENDPOINT
-          value: "https://api.robusta.dev"
-    ```
-
-=== "EU"
-
-    ```yaml
-    # Add to generated_values.yaml
-    holmes:
-      additionalEnvVars:
-        - name: ROBUSTA_AI
-          value: "true"
-        - name: ROBUSTA_API_ENDPOINT
-          value: "https://api.eu.robusta.dev"
-    ```
-
-=== "AP"
-
-    ```yaml
-    # Add to generated_values.yaml
-    holmes:
-      additionalEnvVars:
-        - name: ROBUSTA_AI
-          value: "true"
-        - name: ROBUSTA_API_ENDPOINT
-          value: "https://api.ap.robusta.dev"
-    ```
+```robusta-region {lang=yaml}
+# Add to generated_values.yaml
+holmes:
+  additionalEnvVars:
+    - name: ROBUSTA_AI
+      value: "true"
+    - name: ROBUSTA_API_ENDPOINT
+      value: "https://api.robusta.dev"
+```
 
 The endpoint must match the region your cluster is connected to in the Robusta platform — using the wrong endpoint will cause authentication and model-discovery failures.
 

--- a/docs/custom_fences.py
+++ b/docs/custom_fences.py
@@ -4,10 +4,24 @@ Custom fence processors for MkDocs documentation.
 Fences available:
 - yaml-toolset-config: Creates 3 tabs (Holmes CLI, Holmes Helm Chart, Robusta Helm Chart) for toolset configurations
 - yaml-helm-values: Creates 2 tabs (Holmes Helm Chart, Robusta Helm Chart) for Helm-only configurations like permissions
+- robusta-region: Creates 3 tabs (US, EU, AP) for any text containing api.robusta.dev or platform.robusta.dev. Plain
+  URLs render as code blocks; markdown links `[text](url)` render as clickable links.
 """
 
 import html
+import re
 import uuid
+
+ROBUSTA_REGIONS = (("US", ""), ("EU", "eu"), ("AP", "ap"))
+ROBUSTA_DOMAIN_RE = re.compile(r"\b(api|platform)\.robusta\.dev\b")
+MARKDOWN_LINK_RE = re.compile(r"^\[([^\]]+)\]\(([^)\s]+)\)(\{[^}]*\})?$")
+
+
+def _rewrite_robusta_domain(text: str, region_infix: str) -> str:
+    """Rewrite api.robusta.dev / platform.robusta.dev to the regional variant."""
+    if not region_infix:
+        return text
+    return ROBUSTA_DOMAIN_RE.sub(rf"\1.{region_infix}.robusta.dev", text)
 
 
 def toolset_config_fence_format(source, language, css_class, options, md, **kwargs):
@@ -120,3 +134,84 @@ holmes:
 </div>"""
 
     return tabs_html
+
+
+def robusta_region_fence_format(source, language, css_class, options, md, **kwargs):
+    """
+    Render the source as three tabs (US, EU, AP), rewriting `api.robusta.dev`
+    and `platform.robusta.dev` to the regional subdomain in each tab.
+
+    Auto-detects two input shapes:
+
+    1. A markdown link `[text](url)` (with optional `{...}` attribute list) →
+       renders as a clickable link per region.
+    2. Anything else → renders as a code block per region. Pass `lang=<name>`
+       in the fence options to set syntax highlighting (e.g. `lang=yaml`).
+
+    Usage:
+
+        ```robusta-region
+        https://api.robusta.dev/litellm/model_prices_and_context_window.json
+        ```
+
+        ```robusta-region
+        [platform.robusta.dev](https://platform.robusta.dev/)
+        ```
+
+        ````robusta-region lang=yaml
+        holmes:
+          additionalEnvVars:
+            - name: ROBUSTA_API_ENDPOINT
+              value: "https://api.robusta.dev"
+        ````
+    """
+    inner = source.strip()
+    # Inline `{lang=yaml}` attrs arrive via kwargs['attrs']; config-level options
+    # come from mkdocs.yml (currently unused).
+    attrs = kwargs.get("attrs") or {}
+    inner_lang = attrs.get("lang") or (options or {}).get("lang") or ""
+    lang_class_attr = (
+        f' class="language-{html.escape(inner_lang)}"' if inner_lang else ""
+    )
+
+    link_match = MARKDOWN_LINK_RE.match(inner)
+
+    tab_group_id = str(uuid.uuid4()).replace("-", "_")
+    group_name = f"__tabbed_{tab_group_id}"
+
+    inputs_html = ""
+    labels_html = ""
+    blocks_html = ""
+
+    for index, (region_name, region_infix) in enumerate(ROBUSTA_REGIONS, start=1):
+        tab_id = f"{group_name}_{index}"
+        checked_attr = ' checked="checked"' if index == 1 else ""
+        inputs_html += (
+            f'<input{checked_attr} id="{tab_id}" name="{group_name}" type="radio">\n'
+        )
+        labels_html += f'<label for="{tab_id}">{region_name}</label>\n'
+
+        if link_match:
+            link_text, link_url, _attrs = link_match.groups()
+            regional_text = _rewrite_robusta_domain(link_text, region_infix)
+            regional_url = _rewrite_robusta_domain(link_url, region_infix)
+            inner_html = (
+                f'<p><a href="{html.escape(regional_url)}">'
+                f"{html.escape(regional_text)}</a></p>"
+            )
+        else:
+            regional_content = _rewrite_robusta_domain(inner, region_infix)
+            inner_html = (
+                f"<pre><code{lang_class_attr}>{html.escape(regional_content)}"
+                "</code></pre>"
+            )
+
+        blocks_html += f'<div class="tabbed-block">{inner_html}</div>\n'
+
+    return (
+        '<div class="tabbed-set" data-tabs="1:3">\n'
+        f"{inputs_html}"
+        f'<div class="tabbed-labels">\n{labels_html}</div>\n'
+        f'<div class="tabbed-content">\n{blocks_html}</div>\n'
+        "</div>"
+    )

--- a/docs/data-sources/builtin-toolsets/coralogix-logs.md
+++ b/docs/data-sources/builtin-toolsets/coralogix-logs.md
@@ -128,7 +128,14 @@ By specifying details about your Coralogix metrics, logs, and traces, you can si
 
 To configure this:
 
-1. Go to [platform.robusta.dev](https://platform.robusta.dev/)
+1. Go to the Robusta platform for your region:
+
+    | Region | Platform URL |
+    |--------|--------------|
+    | US (default) | [platform.robusta.dev](https://platform.robusta.dev/) |
+    | EU | [platform.eu.robusta.dev](https://platform.eu.robusta.dev/) |
+    | AP | [platform.ap.robusta.dev](https://platform.ap.robusta.dev/) |
+
 2. Navigate to **Settings → AI Assistant → AI Customization**
 3. Add your labels and metric details
 4. Save your changes

--- a/docs/data-sources/builtin-toolsets/coralogix-logs.md
+++ b/docs/data-sources/builtin-toolsets/coralogix-logs.md
@@ -130,17 +130,9 @@ To configure this:
 
 1. Open the Robusta platform — pick your region:
 
-    === "US"
-
-        [platform.robusta.dev](https://platform.robusta.dev/)
-
-    === "EU"
-
-        [platform.eu.robusta.dev](https://platform.eu.robusta.dev/)
-
-    === "AP"
-
-        [platform.ap.robusta.dev](https://platform.ap.robusta.dev/)
+    ```robusta-region
+    [platform.robusta.dev](https://platform.robusta.dev/)
+    ```
 
 2. Navigate to **Settings → AI Assistant → AI Customization**
 3. Add your labels and metric details

--- a/docs/data-sources/builtin-toolsets/coralogix-logs.md
+++ b/docs/data-sources/builtin-toolsets/coralogix-logs.md
@@ -128,13 +128,19 @@ By specifying details about your Coralogix metrics, logs, and traces, you can si
 
 To configure this:
 
-1. Go to the Robusta platform for your region:
+1. Open the Robusta platform — pick your region:
 
-    | Region | Platform URL |
-    |--------|--------------|
-    | US (default) | [platform.robusta.dev](https://platform.robusta.dev/) |
-    | EU | [platform.eu.robusta.dev](https://platform.eu.robusta.dev/) |
-    | AP | [platform.ap.robusta.dev](https://platform.ap.robusta.dev/) |
+    === "US"
+
+        [platform.robusta.dev](https://platform.robusta.dev/)
+
+    === "EU"
+
+        [platform.eu.robusta.dev](https://platform.eu.robusta.dev/)
+
+    === "AP"
+
+        [platform.ap.robusta.dev](https://platform.ap.robusta.dev/)
 
 2. Navigate to **Settings → AI Assistant → AI Customization**
 3. Add your labels and metric details

--- a/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
@@ -102,11 +102,23 @@ Your AKS cluster must be configured for Azure AD authentication. Follow the [Mic
 2. Enter a name (e.g., `holmes-k8s-mcp`), select **Accounts in this organizational directory only**, and click **Register**
 3. Under **Authentication > Platform configurations**, add a **Web** platform with the redirect URI matching your Robusta region:
 
-    | Region | Redirect URI |
-    |--------|--------------|
-    | US (default) | `https://platform.robusta.dev/oauth/callback.html` |
-    | EU | `https://platform.eu.robusta.dev/oauth/callback.html` |
-    | AP | `https://platform.ap.robusta.dev/oauth/callback.html` |
+    === "US"
+
+        ```
+        https://platform.robusta.dev/oauth/callback.html
+        ```
+
+    === "EU"
+
+        ```
+        https://platform.eu.robusta.dev/oauth/callback.html
+        ```
+
+    === "AP"
+
+        ```
+        https://platform.ap.robusta.dev/oauth/callback.html
+        ```
 
 4. Under **API Permissions**, add the following delegated permissions:
       - **Azure Kubernetes Service AAD Server** (`6dae42f8-4368-4678-94ff-3960e28e3630`): `user.read`

--- a/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
@@ -100,7 +100,14 @@ Your AKS cluster must be configured for Azure AD authentication. Follow the [Mic
 
 1. In the Azure portal, go to **Microsoft Entra ID > App Registrations > New Registration**
 2. Enter a name (e.g., `holmes-k8s-mcp`), select **Accounts in this organizational directory only**, and click **Register**
-3. Under **Authentication > Platform configurations**, add a **Web** platform with redirect URI: `https://platform.robusta.dev/oauth/callback.html`
+3. Under **Authentication > Platform configurations**, add a **Web** platform with the redirect URI matching your Robusta region:
+
+    | Region | Redirect URI |
+    |--------|--------------|
+    | US (default) | `https://platform.robusta.dev/oauth/callback.html` |
+    | EU | `https://platform.eu.robusta.dev/oauth/callback.html` |
+    | AP | `https://platform.ap.robusta.dev/oauth/callback.html` |
+
 4. Under **API Permissions**, add the following delegated permissions:
       - **Azure Kubernetes Service AAD Server** (`6dae42f8-4368-4678-94ff-3960e28e3630`): `user.read`
       - **Microsoft Graph**: `email`, `openid`, `profile`

--- a/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
@@ -102,23 +102,9 @@ Your AKS cluster must be configured for Azure AD authentication. Follow the [Mic
 2. Enter a name (e.g., `holmes-k8s-mcp`), select **Accounts in this organizational directory only**, and click **Register**
 3. Under **Authentication > Platform configurations**, add a **Web** platform with the redirect URI matching your Robusta region:
 
-    === "US"
-
-        ```
-        https://platform.robusta.dev/oauth/callback.html
-        ```
-
-    === "EU"
-
-        ```
-        https://platform.eu.robusta.dev/oauth/callback.html
-        ```
-
-    === "AP"
-
-        ```
-        https://platform.ap.robusta.dev/oauth/callback.html
-        ```
+    ```robusta-region
+    https://platform.robusta.dev/oauth/callback.html
+    ```
 
 4. Under **API Permissions**, add the following delegated permissions:
       - **Azure Kubernetes Service AAD Server** (`6dae42f8-4368-4678-94ff-3960e28e3630`): `user.read`

--- a/docs/installation/ui-installation.md
+++ b/docs/installation/ui-installation.md
@@ -32,13 +32,19 @@ The fastest way to use HolmesGPT is via the Robusta platform, which can be used 
 
 ### Get Started
 
-1. **Sign up:** pick the region closest to your clusters:
+1. **Sign up** — pick the region closest to your clusters:
 
-    | Region | Sign-up URL |
-    |--------|-------------|
-    | US (default) | [platform.robusta.dev](https://platform.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"} |
-    | EU | [platform.eu.robusta.dev](https://platform.eu.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"} |
-    | AP | [platform.ap.robusta.dev](https://platform.ap.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"} |
+    === "US"
+
+        [platform.robusta.dev](https://platform.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
+
+    === "EU"
+
+        [platform.eu.robusta.dev](https://platform.eu.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
+
+    === "AP"
+
+        [platform.ap.robusta.dev](https://platform.ap.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
 
 2. **Connect your cluster:** Follow the in-app wizard
 3. **Ask Holmes:** Analyze alerts or troubleshoot issues

--- a/docs/installation/ui-installation.md
+++ b/docs/installation/ui-installation.md
@@ -32,7 +32,14 @@ The fastest way to use HolmesGPT is via the Robusta platform, which can be used 
 
 ### Get Started
 
-1. **Sign up:** [platform.robusta.dev](https://platform.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
+1. **Sign up:** pick the region closest to your clusters:
+
+    | Region | Sign-up URL |
+    |--------|-------------|
+    | US (default) | [platform.robusta.dev](https://platform.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"} |
+    | EU | [platform.eu.robusta.dev](https://platform.eu.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"} |
+    | AP | [platform.ap.robusta.dev](https://platform.ap.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"} |
+
 2. **Connect your cluster:** Follow the in-app wizard
 3. **Ask Holmes:** Analyze alerts or troubleshoot issues
 

--- a/docs/installation/ui-installation.md
+++ b/docs/installation/ui-installation.md
@@ -34,17 +34,9 @@ The fastest way to use HolmesGPT is via the Robusta platform, which can be used 
 
 1. **Sign up** — pick the region closest to your clusters:
 
-    === "US"
-
-        [platform.robusta.dev](https://platform.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
-
-    === "EU"
-
-        [platform.eu.robusta.dev](https://platform.eu.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
-
-    === "AP"
-
-        [platform.ap.robusta.dev](https://platform.ap.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section){:target="\_blank"}
+    ```robusta-region
+    [platform.robusta.dev](https://platform.robusta.dev/signup/?utm_source=docs&utm_medium=holmesgpt-docs&utm_content=ui_installation_section)
+    ```
 
 2. **Connect your cluster:** Follow the in-app wizard
 3. **Ask Holmes:** Analyze alerts or troubleshoot issues

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -199,11 +199,13 @@ See [Using Multiple Providers](../ai-providers/using-multiple-providers.md) for 
 ### LITELLM_MODEL_COST_MAP_URL
 Overrides the URL LiteLLM fetches the model catalog (`model_prices_and_context_window.json`) from. LiteLLM uses that catalog to know each model's context window, max output tokens, and pricing. By default LiteLLM pulls it from `raw.githubusercontent.com`, which is unreachable from networks that block GitHub egress.
 
-Robusta hosts a mirror of the same file at:
+Robusta hosts a mirror of the same file in each region. Pick the URL matching the region your Robusta account is in:
 
-```
-https://api.robusta.dev/litellm/model_prices_and_context_window.json
-```
+| Region | Mirror URL |
+|--------|------------|
+| US (default) | `https://api.robusta.dev/litellm/model_prices_and_context_window.json` |
+| EU | `https://api.eu.robusta.dev/litellm/model_prices_and_context_window.json` |
+| AP | `https://api.ap.robusta.dev/litellm/model_prices_and_context_window.json` |
 
 The mirror is cached and falls back to its last-known-good copy if the upstream is temporarily unreachable, so pointing at it gives the same freshness as the default URL without requiring egress to `raw.githubusercontent.com`.
 
@@ -211,7 +213,7 @@ The mirror is cached and falls back to its last-known-good copy if the upstream 
 ```yaml
 additionalEnvVars:
   - name: LITELLM_MODEL_COST_MAP_URL
-    value: https://api.robusta.dev/litellm/model_prices_and_context_window.json
+    value: https://api.robusta.dev/litellm/model_prices_and_context_window.json  # change to match your region
 ```
 
 ### HOLMES_CONFIG_PATH

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -201,51 +201,19 @@ Overrides the URL LiteLLM fetches the model catalog (`model_prices_and_context_w
 
 Robusta hosts a mirror of the same file in each region. Pick the URL matching your Robusta region:
 
-=== "US"
-
-    ```
-    https://api.robusta.dev/litellm/model_prices_and_context_window.json
-    ```
-
-=== "EU"
-
-    ```
-    https://api.eu.robusta.dev/litellm/model_prices_and_context_window.json
-    ```
-
-=== "AP"
-
-    ```
-    https://api.ap.robusta.dev/litellm/model_prices_and_context_window.json
-    ```
+```robusta-region
+https://api.robusta.dev/litellm/model_prices_and_context_window.json
+```
 
 The mirror is cached and falls back to its last-known-good copy if the upstream is temporarily unreachable, so pointing at it gives the same freshness as the default URL without requiring egress to `raw.githubusercontent.com`.
 
 **Helm example:**
 
-=== "US"
-
-    ```yaml
-    additionalEnvVars:
-      - name: LITELLM_MODEL_COST_MAP_URL
-        value: https://api.robusta.dev/litellm/model_prices_and_context_window.json
-    ```
-
-=== "EU"
-
-    ```yaml
-    additionalEnvVars:
-      - name: LITELLM_MODEL_COST_MAP_URL
-        value: https://api.eu.robusta.dev/litellm/model_prices_and_context_window.json
-    ```
-
-=== "AP"
-
-    ```yaml
-    additionalEnvVars:
-      - name: LITELLM_MODEL_COST_MAP_URL
-        value: https://api.ap.robusta.dev/litellm/model_prices_and_context_window.json
-    ```
+```robusta-region {lang=yaml}
+additionalEnvVars:
+  - name: LITELLM_MODEL_COST_MAP_URL
+    value: https://api.robusta.dev/litellm/model_prices_and_context_window.json
+```
 
 ### HOLMES_CONFIG_PATH
 Path to a custom HolmesGPT configuration file. If not set, defaults to `~/.holmes/config.yaml`.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -199,22 +199,53 @@ See [Using Multiple Providers](../ai-providers/using-multiple-providers.md) for 
 ### LITELLM_MODEL_COST_MAP_URL
 Overrides the URL LiteLLM fetches the model catalog (`model_prices_and_context_window.json`) from. LiteLLM uses that catalog to know each model's context window, max output tokens, and pricing. By default LiteLLM pulls it from `raw.githubusercontent.com`, which is unreachable from networks that block GitHub egress.
 
-Robusta hosts a mirror of the same file in each region. Pick the URL matching the region your Robusta account is in:
+Robusta hosts a mirror of the same file in each region. Pick the URL matching your Robusta region:
 
-| Region | Mirror URL |
-|--------|------------|
-| US (default) | `https://api.robusta.dev/litellm/model_prices_and_context_window.json` |
-| EU | `https://api.eu.robusta.dev/litellm/model_prices_and_context_window.json` |
-| AP | `https://api.ap.robusta.dev/litellm/model_prices_and_context_window.json` |
+=== "US"
+
+    ```
+    https://api.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
+
+=== "EU"
+
+    ```
+    https://api.eu.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
+
+=== "AP"
+
+    ```
+    https://api.ap.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
 
 The mirror is cached and falls back to its last-known-good copy if the upstream is temporarily unreachable, so pointing at it gives the same freshness as the default URL without requiring egress to `raw.githubusercontent.com`.
 
 **Helm example:**
-```yaml
-additionalEnvVars:
-  - name: LITELLM_MODEL_COST_MAP_URL
-    value: https://api.robusta.dev/litellm/model_prices_and_context_window.json  # change to match your region
-```
+
+=== "US"
+
+    ```yaml
+    additionalEnvVars:
+      - name: LITELLM_MODEL_COST_MAP_URL
+        value: https://api.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
+
+=== "EU"
+
+    ```yaml
+    additionalEnvVars:
+      - name: LITELLM_MODEL_COST_MAP_URL
+        value: https://api.eu.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
+
+=== "AP"
+
+    ```yaml
+    additionalEnvVars:
+      - name: LITELLM_MODEL_COST_MAP_URL
+        value: https://api.ap.robusta.dev/litellm/model_prices_and_context_window.json
+    ```
 
 ### HOLMES_CONFIG_PATH
 Path to a custom HolmesGPT configuration file. If not set, defaults to `~/.holmes/config.yaml`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -245,6 +245,9 @@ markdown_extensions:
               - name: yaml-toolset-config
                 class: yaml
                 format: !!python/name:docs.custom_fences.toolset_config_fence_format
+              - name: robusta-region
+                class: robusta-region
+                format: !!python/name:docs.custom_fences.robusta_region_fence_format
     - pymdownx.tabbed:
           alternate_style: true
           combine_header_slug: true


### PR DESCRIPTION
## Summary

This PR adds comprehensive multi-region support for the Robusta platform, allowing users to configure HolmesGPT for US, EU, and AP regions. The changes include new configuration guidance, updated environment variable documentation, and region-specific endpoint URLs across all relevant documentation.

## Key Changes

- **New "Selecting a Region" section** in Robusta AI provider docs with tabbed configuration examples for US, EU, and AP regions
- **Updated "How It Works" section** to document that model discovery and proxy access endpoints now use the configurable `ROBUSTA_API_ENDPOINT` variable
- **Enhanced troubleshooting guidance** to include region-specific endpoint validation and the importance of matching `ROBUSTA_API_ENDPOINT` to the user's account region
- **Expanded environment variables documentation** with clearer description of `ROBUSTA_API_ENDPOINT` and region-specific values
- **Multi-region support in LiteLLM configuration** (`LITELLM_MODEL_COST_MAP_URL`) with tabbed examples for each region
- **Region-specific OAuth redirect URIs** for Azure AD authentication in Kubernetes MCP toolset
- **Region-specific platform URLs** for:
  - Coralogix logs configuration (platform setup)
  - UI installation signup flow

## Implementation Details

- All region-specific URLs follow the pattern: `https://api[.region].robusta.dev` for API endpoints and `https://platform[.region].robusta.dev` for UI
- Documentation uses MkDocs tabbed interface (`=== "Region"`) for clean, organized presentation of region options
- Default behavior remains unchanged (US region) for backwards compatibility
- Added clear warnings about endpoint/region mismatch causing authentication and model-discovery failures

https://claude.ai/code/session_01RueKk3pFhbXqTqyM8EKKjZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added region-specific API endpoint guidance (US/EU/AP) for Robusta configuration
  * Updated signup and installation flows with region selectors for easier onboarding
  * Enhanced integration setup with region-matching callback URLs
  * Improved troubleshooting and environment-variable guidance for regional deployments
  * Introduced a region-tabs rendering block for US/EU/AP links/examples and guidance for authors to use it

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->