### PR TITLE
Prevent OAuth token leakage via static Authorization headers

### DIFF
--- a/holmes/core/oauth_utils.py
+++ b/holmes/core/oauth_utils.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
-from holmes.common.env_vars import DEFAULT_CLI_USER
 from mcp.client.auth.oauth2 import PKCEParameters
 from mcp.client.auth.utils import (
     build_oauth_authorization_server_metadata_discovery_urls,
@@ -76,8 +75,7 @@ def eager_load_oauth_tools(executor: Any) -> None:
         if not ts._mcp_config.oauth.authorization_url:
             continue
         for user_id in token_mgr.get_cached_user_ids(ts._mcp_config.oauth):
-            request_ctx = {"user_id": user_id} if user_id != DEFAULT_CLI_USER else None
-            executor.oauth_connector.load_tools_for_user(user_id, ts, request_ctx)
+            executor.oauth_connector.load_tools_for_user(user_id, ts, {"user_id": user_id})
 
 
 # exchange_code_for_tokens is re-exported from oauth_config (imported above)

--- a/holmes/core/tools_utils/oauth_tool_connector.py
+++ b/holmes/core/tools_utils/oauth_tool_connector.py
@@ -150,9 +150,10 @@ class OAuthToolConnector:
 
     def resolve_tools(self, user_id: Optional[str]) -> Optional[Dict[str, List[Tool]]]:
         """Return per-user OAuth tools if available, or None."""
-        key = user_id or _get_token_manager().require_user_id(None)
+        if not user_id:
+            return None
         with self._lock:
-            user_tools = self._user_tools.get(key)
+            user_tools = self._user_tools.get(user_id)
             return dict(user_tools) if user_tools else None
 
     def apply_user_tools(
@@ -190,9 +191,10 @@ class OAuthToolConnector:
 
     def find_tool(self, name: str, user_id: Optional[str]) -> Optional[Tool]:
         """Look up a tool in the per-user OAuth tools store."""
-        key = user_id or _get_token_manager().require_user_id(None)
+        if not user_id:
+            return None
         with self._lock:
-            for toolset_tools in self._user_tools.get(key, {}).values():
+            for toolset_tools in self._user_tools.get(user_id, {}).values():
                 for tool in toolset_tools:
                     if tool.name == name:
                         return tool
@@ -200,8 +202,9 @@ class OAuthToolConnector:
 
     def get_toolset(self, tool_name: str, user_id: Optional[str]) -> Optional[Any]:
         """Return the toolset for a per-user OAuth tool, or None."""
-        key = user_id or _get_token_manager().require_user_id(None)
-        return self._user_tool_to_toolset.get(key, {}).get(tool_name)
+        if not user_id:
+            return None
+        return self._user_tool_to_toolset.get(user_id, {}).get(tool_name)
 
 
     # ── Error handling helpers ─────────────────────────────────────────

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -48,6 +48,7 @@ from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
+from holmes.common.env_vars import DEFAULT_CLI_USER
 from holmes.config import Config
 from holmes.core.config import config_path_dir
 from holmes.core.init_event import StatusEvent, StatusEventKind, ToolsetStatus
@@ -2638,6 +2639,7 @@ def run_interactive_loop(
                                 cancel_event=_cancel_event,
                                 tool_number_offset=_tool_number_offset,
                                 iteration_offset=_iteration_offset,
+                                request_context={"user_id": DEFAULT_CLI_USER},
                             )
                             tool_decisions = None
                             last_event = None

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -166,6 +166,9 @@ def _investigate_issue(
     config: Config,
 ) -> LLMResult:
     """Investigate an issue using the standard ask system prompt with investigation additions."""
+    # Enable disk-based OAuth token storage so MCP tokens previously
+    # authorized via `holmes ask` are reused here (idempotent).
+    enable_disk_token_store()
     investigation_additions = f"Provide a terse analysis of the following {issue.source_type} alert/issue and why it is firing."
     system_prompt = build_system_prompt(
         toolsets=ai.tool_executor.toolsets,
@@ -735,6 +738,9 @@ def ticket(
             model=model,
             tool_results_dir=tool_results_dir,
         )
+
+        # Enable disk-based OAuth token storage for CLI mode
+        enable_disk_token_store()
 
         # Render ticket-specific additions
         ticket_additions = load_and_render_prompt(

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -38,7 +38,13 @@ from holmes.core.resource_instruction import ResourceInstructionDocument
 from holmes.core.tool_calling_llm import LLMResult, ToolCallingLLM
 from holmes.core.tools import PrerequisiteCacheMode, ToolsetTag, pretty_print_toolset_status
 from holmes.core.tools_utils.filesystem_result_storage import tool_result_storage
+from holmes.common.env_vars import DEFAULT_CLI_USER
 from holmes.core.oauth_utils import enable_disk_token_store
+
+# CLI runs as a single local identity. Setting this explicitly on every LLM
+# invocation keeps the OAuth token manager mode-agnostic: it never has to
+# guess whether a missing user_id means "CLI" or "buggy server caller".
+_CLI_REQUEST_CONTEXT = {"user_id": DEFAULT_CLI_USER}
 from holmes.core.tracing import SpanType, TracingFactory
 from holmes.interactive import InitProgressRenderer, run_interactive_loop, silence_display_loggers
 from holmes.plugins.destinations import DestinationType
@@ -177,7 +183,7 @@ def _investigate_issue(
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": user_prompt},
     ]
-    return ai.call(messages)
+    return ai.call(messages, request_context=_CLI_REQUEST_CONTEXT)
 
 
 # TODO: add streaming output
@@ -400,7 +406,7 @@ def ask(
             f'holmes ask "{prompt}"', span_type=SpanType.TASK
         ) as trace_span:
             trace_span.log(input=prompt, metadata={"type": "user_question"})
-            response = ai.call(messages, trace_span=trace_span)
+            response = ai.call(messages, trace_span=trace_span, request_context=_CLI_REQUEST_CONTEXT)
             trace_span.log(
                 output=response.result,
             )
@@ -760,7 +766,7 @@ def ticket(
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": ticket_user_prompt},
         ]
-        result = ai.call(messages)
+        result = ai.call(messages, request_context=_CLI_REQUEST_CONTEXT)
 
         console.print(Rule())
         console.print(

--- a/holmes/plugins/toolsets/mcp/oauth_token_manager.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_manager.py
@@ -137,8 +137,16 @@ class OAuthTokenManager:
 
         Returns None if no token is available anywhere (caller should initiate OAuth flow).
         """
-        cache_key = self._get_cache_key(oauth_config, request_context)
         user_id = _get_user_id(request_context)
+
+        # In server mode, refuse to serve tokens without a user identity. The
+        # in-memory cache would otherwise collapse all such requests onto the
+        # DEFAULT_CLI_USER fallback key and could leak one caller's token to
+        # another. DalTokenStore.get_token applies the same guard.
+        if self._is_server_mode() and not user_id:
+            return None
+
+        cache_key = self._get_cache_key(oauth_config, request_context)
 
         # 1. Check in-memory cache
         cached = self._cache.get_valid_access_token(cache_key)
@@ -178,6 +186,8 @@ class OAuthTokenManager:
         request_context: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Check if any token (access or refreshable) is available in cache."""
+        if self._is_server_mode() and not _get_user_id(request_context):
+            return False
         cache_key = self._get_cache_key(oauth_config, request_context)
         return self._cache.has_token_or_refresh(cache_key)
 
@@ -190,8 +200,18 @@ class OAuthTokenManager:
         store_to_disk: bool = False,
     ) -> None:
         """Store a token to cache and persistent store."""
-        cache_key = self._get_cache_key(oauth_config, request_context)
         user_id = _get_user_id(request_context)
+
+        # In server mode, never persist a token under the DEFAULT_CLI_USER
+        # fallback — that would seed the in-memory cache with an entry that
+        # any subsequent user_id-less request could consume.
+        if self._is_server_mode() and not user_id:
+            logger.warning(
+                "OAuthTokenManager: refusing to store token in server mode without a user_id"
+            )
+            return
+
+        cache_key = self._get_cache_key(oauth_config, request_context)
         access_token = token_data.get("access_token")
         if not access_token:
             logger.warning("OAuthTokenManager: store_token called with no access_token")
@@ -244,6 +264,15 @@ class OAuthTokenManager:
         self._refresh_thread.join(timeout=5)
 
     # ── Cache / key helpers ────────────────────────────────────────────
+
+    def _is_server_mode(self) -> bool:
+        """True when running against the DB-backed token store (multi-user server).
+
+        In server mode the cache must not fall back to DEFAULT_CLI_USER because
+        the cache key would collide across callers. CLI mode legitimately uses
+        DEFAULT_CLI_USER as the single local identity.
+        """
+        return isinstance(self._store, DalTokenStore)
 
     @property
     def cache(self) -> OAuthTokenCache:

--- a/holmes/plugins/toolsets/mcp/oauth_token_manager.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_manager.py
@@ -240,14 +240,18 @@ class OAuthTokenManager:
             cache_key, expires_in, "refresh_token" in token_data,
         )
 
-    def require_user_id(self, request_context: Optional[Dict[str, Any]]) -> Optional[str]:
-        """Return the user_id from request_context, or None if absent.
+    def require_user_id(self, request_context: Optional[Dict[str, Any]]) -> str:
+        """Return the user_id from request_context, or raise if absent.
 
         Callers (CLI, server, conversation worker) are responsible for putting
         a real user_id on request_context — CLI uses DEFAULT_CLI_USER, server
-        uses the authenticated user. This method just surfaces it.
+        uses the authenticated user. Missing user_id is a programming error
+        (would silently corrupt downstream per-user storage), so we fail fast.
         """
-        return _get_user_id(request_context)
+        user_id = _get_user_id(request_context)
+        if not user_id:
+            raise ValueError("OAuthTokenManager: user_id is required in request_context")
+        return user_id
 
     def shutdown(self) -> None:
         """Stop the background refresh thread."""

--- a/holmes/plugins/toolsets/mcp/oauth_token_manager.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_manager.py
@@ -135,18 +135,18 @@ class OAuthTokenManager:
     ) -> Optional[str]:
         """Return a valid access token, checking cache → refresh → persistent store.
 
+        A user_id must be present on request_context. CLI callers must pass
+        DEFAULT_CLI_USER explicitly; the server must pass the authenticated
+        user. Without a user_id the cache cannot be safely keyed, so we
+        refuse to serve any token (mirrors DalTokenStore.get_token's guard).
+
         Returns None if no token is available anywhere (caller should initiate OAuth flow).
         """
         user_id = _get_user_id(request_context)
-
-        # In server mode, refuse to serve tokens without a user identity. The
-        # in-memory cache would otherwise collapse all such requests onto the
-        # DEFAULT_CLI_USER fallback key and could leak one caller's token to
-        # another. DalTokenStore.get_token applies the same guard.
-        if self._is_server_mode() and not user_id:
+        if not user_id:
             return None
 
-        cache_key = self._get_cache_key(oauth_config, request_context)
+        cache_key = self._build_cache_key(user_id, oauth_config.authorization_url)
 
         # 1. Check in-memory cache
         cached = self._cache.get_valid_access_token(cache_key)
@@ -186,9 +186,10 @@ class OAuthTokenManager:
         request_context: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Check if any token (access or refreshable) is available in cache."""
-        if self._is_server_mode() and not _get_user_id(request_context):
+        user_id = _get_user_id(request_context)
+        if not user_id:
             return False
-        cache_key = self._get_cache_key(oauth_config, request_context)
+        cache_key = self._build_cache_key(user_id, oauth_config.authorization_url)
         return self._cache.has_token_or_refresh(cache_key)
 
     def store_token(
@@ -201,17 +202,11 @@ class OAuthTokenManager:
     ) -> None:
         """Store a token to cache and persistent store."""
         user_id = _get_user_id(request_context)
-
-        # In server mode, never persist a token under the DEFAULT_CLI_USER
-        # fallback — that would seed the in-memory cache with an entry that
-        # any subsequent user_id-less request could consume.
-        if self._is_server_mode() and not user_id:
-            logger.warning(
-                "OAuthTokenManager: refusing to store token in server mode without a user_id"
-            )
+        if not user_id:
+            logger.warning("OAuthTokenManager: refusing to store token without a user_id")
             return
 
-        cache_key = self._get_cache_key(oauth_config, request_context)
+        cache_key = self._build_cache_key(user_id, oauth_config.authorization_url)
         access_token = token_data.get("access_token")
         if not access_token:
             logger.warning("OAuthTokenManager: store_token called with no access_token")
@@ -245,18 +240,14 @@ class OAuthTokenManager:
             cache_key, expires_in, "refresh_token" in token_data,
         )
 
-    def require_user_id(self, request_context: Optional[Dict[str, Any]]) -> str:
-        """Return a user_id, using DEFAULT_CLI_USER in CLI mode or raising in server mode.
+    def require_user_id(self, request_context: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Return the user_id from request_context, or None if absent.
 
-        CLI mode (DiskTokenStore / no store): returns DEFAULT_CLI_USER.
-        Server mode (DalTokenStore): raises ValueError if user_id is missing.
+        Callers (CLI, server, conversation worker) are responsible for putting
+        a real user_id on request_context — CLI uses DEFAULT_CLI_USER, server
+        uses the authenticated user. This method just surfaces it.
         """
-        user_id = _get_user_id(request_context)
-        if user_id:
-            return user_id
-        if isinstance(self._store, DalTokenStore):
-            return None
-        return DEFAULT_CLI_USER
+        return _get_user_id(request_context)
 
     def shutdown(self) -> None:
         """Stop the background refresh thread."""
@@ -264,15 +255,6 @@ class OAuthTokenManager:
         self._refresh_thread.join(timeout=5)
 
     # ── Cache / key helpers ────────────────────────────────────────────
-
-    def _is_server_mode(self) -> bool:
-        """True when running against the DB-backed token store (multi-user server).
-
-        In server mode the cache must not fall back to DEFAULT_CLI_USER because
-        the cache key would collide across callers. CLI mode legitimately uses
-        DEFAULT_CLI_USER as the single local identity.
-        """
-        return isinstance(self._store, DalTokenStore)
 
     @property
     def cache(self) -> OAuthTokenCache:
@@ -429,7 +411,12 @@ class OAuthTokenManager:
     # ── Key helpers ────────────────────────────────────────────────────
 
     def _get_cache_key(self, oauth_config: Any, request_context: Optional[Dict[str, Any]]) -> str:
-        user_id = _get_user_id(request_context) or DEFAULT_CLI_USER
+        """Build a cache key from request_context. Raises if user_id is missing —
+        callers must put a user_id on the context (DEFAULT_CLI_USER in CLI mode,
+        authenticated user in server mode)."""
+        user_id = _get_user_id(request_context)
+        if not user_id:
+            raise ValueError("OAuthTokenManager: user_id is required in request_context")
         return self._build_cache_key(user_id, oauth_config.authorization_url)
 
     @staticmethod

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -834,7 +834,24 @@ class RemoteMCPToolset(Toolset):
                 final_headers["Authorization"] = f"Bearer {cached_token}"
                 logger.debug("OAuth token injected for MCP server %s", self.name)
             else:
-                logger.warning("OAuth MCP server %s: no cached token — request will likely 401", self.name)
+                # OAuth is configured for this toolset but we have no user token
+                # (e.g. user_id is missing in server mode, or no one has authenticated).
+                # Strip any Authorization header coming from static `headers` /
+                # `extra_headers` so a shared service-account credential cannot
+                # silently substitute for the absent per-user OAuth token.
+                stripped = [k for k in list(final_headers.keys()) if k.lower() == "authorization"]
+                for k in stripped:
+                    del final_headers[k]
+                if stripped:
+                    logger.warning(
+                        "OAuth MCP server %s: no OAuth token available and static Authorization header suppressed — request will 401",
+                        self.name,
+                    )
+                else:
+                    logger.warning(
+                        "OAuth MCP server %s: no OAuth token available — request will 401",
+                        self.name,
+                    )
 
         return final_headers if final_headers else None
 

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1233,6 +1233,73 @@ class TestRenderHeadersOAuth:
         assert result is not None
         assert result["Authorization"] == "Bearer refreshed-tok"
 
+    def test_strips_static_authorization_when_oauth_enabled_but_no_token(self):
+        """When OAuth is configured but no user token is available (e.g. user_id
+        is null), a static Authorization header from `headers` must NOT be sent —
+        otherwise a shared service-account key would silently substitute for the
+        absent per-user OAuth token (privilege escalation)."""
+        oauth = MCPOAuthConfig(
+            enabled=True,
+            authorization_url="http://idp-strip/auth",
+            token_url="http://idp-strip/token",
+            client_id="strip-cid",
+        )
+        ts = RemoteMCPToolset(name="strip-test", enabled=True)
+        ts._mcp_config = MCPConfig(
+            url="http://mcp:8000",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=oauth,
+            headers={
+                "Authorization": "Bearer service-account-key",
+                "X-Custom": "keep-me",
+            },
+        )
+
+        # No token cached and request_context has no user_id
+        result = ts._render_headers(None) or {}
+
+        assert "Authorization" not in result
+        assert "authorization" not in result
+        assert result.get("X-Custom") == "keep-me"
+
+    def test_strips_static_authorization_case_insensitive(self):
+        """The strip must match Authorization headers regardless of case."""
+        oauth = MCPOAuthConfig(
+            enabled=True,
+            authorization_url="http://idp-strip-ci/auth",
+            token_url="http://idp-strip-ci/token",
+            client_id="strip-ci-cid",
+        )
+        ts = RemoteMCPToolset(name="strip-ci-test", enabled=True)
+        ts._mcp_config = MCPConfig(
+            url="http://mcp:8000",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=oauth,
+            headers={
+                "authorization": "Bearer lowercase-key",
+                "AUTHORIZATION": "Bearer upper-key",
+            },
+        )
+
+        result = ts._render_headers(None) or {}
+
+        assert not any(k.lower() == "authorization" for k in result)
+
+    def test_keeps_static_authorization_when_oauth_disabled(self):
+        """If OAuth is NOT configured for the toolset, the static Authorization
+        header is a deliberate config choice and must be passed through."""
+        ts = RemoteMCPToolset(name="no-oauth-test", enabled=True)
+        ts._mcp_config = MCPConfig(
+            url="http://mcp:8000",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=None,
+            headers={"Authorization": "Bearer static-key"},
+        )
+
+        result = ts._render_headers(None) or {}
+
+        assert result.get("Authorization") == "Bearer static-key"
+
 
 # ---------------------------------------------------------------------------
 # _discover_oauth_endpoints (mocked HTTP)

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -193,7 +193,7 @@ class TestRequiresApproval:
         ctx = MagicMock()
         ctx.user_approved = False
         ctx.tool_call_id = tool_call_id
-        ctx.request_context = {"headers": {"X-Conversation-Id": conv_id}}
+        ctx.request_context = {"user_id": "test-user", "headers": {"X-Conversation-Id": conv_id}}
         return ctx
 
     def test_requires_approval_with_oauth_metadata(self):
@@ -290,7 +290,7 @@ class TestExchangeCodeForToken:
         }
         mock_response.raise_for_status = MagicMock()
 
-        request_context = {"headers": {"X-Conversation-Id": conv_id}}
+        request_context = {"user_id": "test-user", "headers": {"X-Conversation-Id": conv_id}}
 
         with patch("holmes.core.oauth_utils.httpx.post", return_value=mock_response) as mock_post:
             _get_exchange_manager().complete_exchange(tool_call_id, oauth_code, request_context)
@@ -419,7 +419,7 @@ class TestOAuthCacheKeySharedIdP:
             token_url="http://internal-keycloak:8080/realms/mcp/protocol/openid-connect/token",  # different token_url
             client_id="holmes-client",
         )
-        ctx = {"headers": {"X-Conversation-Id": "conv-shared"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "conv-shared"}}
         key1 = _get_token_manager().get_cache_key(oauth1, ctx)
         key2 = _get_token_manager().get_cache_key(oauth2, ctx)
         assert key1 == key2, "Same authorization_url + client_id should produce same cache key"
@@ -438,7 +438,7 @@ class TestOAuthCacheKeySharedIdP:
             token_url="http://keycloak-b:8080/token",
             client_id="holmes-client",
         )
-        ctx = {"headers": {"X-Conversation-Id": "conv-diff"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "conv-diff"}}
         key1 = _get_token_manager().get_cache_key(oauth1, ctx)
         key2 = _get_token_manager().get_cache_key(oauth2, ctx)
         assert key1 != key2, "Different authorization_urls should produce different cache keys"
@@ -461,7 +461,7 @@ class TestOAuthCacheKeySharedIdP:
             token_url="http://keycloak:8080/token",
             client_id="client-b",
         )
-        ctx = {"headers": {"X-Conversation-Id": "conv-cid"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "conv-cid"}}
         key1 = _get_token_manager().get_cache_key(oauth1, ctx)
         key2 = _get_token_manager().get_cache_key(oauth2, ctx)
         assert key1 == key2, "Same authorization_url should produce same cache key"
@@ -474,7 +474,7 @@ class TestOAuthCacheKeySharedIdP:
             token_url=None,
             client_id=None,
         )
-        ctx = {"headers": {"X-Conversation-Id": "conv-none"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "conv-none"}}
         # Should not raise — returns a valid key even with None authorization_url
         key = _get_token_manager().get_cache_key(oauth, ctx)
         assert isinstance(key, str)
@@ -497,7 +497,7 @@ class TestOAuthCacheKeySharedIdP:
             token_url="http://internal:8080/token",  # different token_url, same auth
             client_id="shared-client",
         )
-        ctx = {"headers": {"X-Conversation-Id": "conv-share-test"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "conv-share-test"}}
 
         # Cache token via first MCP server's config
         cache_key1 = _get_token_manager().get_cache_key(oauth1, ctx)
@@ -866,7 +866,7 @@ class TestCLIOAuthFlow:
         authorization_url (stable across DCR), so it stays the same."""
 
         oauth = self._make_oauth_endpoints(client_id=None, registration_endpoint="http://idp.test/register")
-        ctx = {"headers": {"X-Conversation-Id": "cli-conv"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "cli-conv"}}
 
         # Cache key before DCR (client_id=None)
         key_before = _get_token_manager().get_cache_key(oauth, ctx)
@@ -1183,7 +1183,7 @@ class TestRenderHeadersOAuth:
             client_id="inject-cid",
         )
         ts = self._make_toolset(oauth)
-        ctx = {"headers": {"X-Conversation-Id": "inject-conv"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "inject-conv"}}
         cache_key = _get_token_manager().get_cache_key(oauth, ctx)
         _get_token_manager().cache.set(cache_key, "my-bearer-token", expires_in=300)
 
@@ -1203,7 +1203,7 @@ class TestRenderHeadersOAuth:
             client_id="no-cache-cid",
         )
         ts = self._make_toolset(oauth)
-        ctx = {"headers": {"X-Conversation-Id": "no-cache-conv"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "no-cache-conv"}}
 
         result = ts._render_headers(ctx)
 
@@ -1217,7 +1217,7 @@ class TestRenderHeadersOAuth:
             client_id="refresh-inject-cid",
         )
         ts = self._make_toolset(oauth)
-        ctx = {"headers": {"X-Conversation-Id": "refresh-inject-conv"}}
+        ctx = {"user_id": "test-user", "headers": {"X-Conversation-Id": "refresh-inject-conv"}}
         cache_key = _get_token_manager().get_cache_key(oauth, ctx)
 
         _get_token_manager().cache.set(cache_key, "old", expires_in=60, refresh_token="r", refresh_expires_in=3600)
@@ -2005,27 +2005,27 @@ class TestBackgroundSweep:
 
 
 # ---------------------------------------------------------------------------
-# Server-mode user_id guard (prevents __no_user__ cache-key reuse)
+# user_id guard: cache cannot be keyed without an explicit identity
 # ---------------------------------------------------------------------------
-class TestServerModeUserIdGuard:
-    """In server mode (DalTokenStore), the in-memory cache must not be readable
-    or writable without a user_id. This mirrors DalTokenStore.get_token's guard
-    and prevents one caller's token from being served to another via the
-    DEFAULT_CLI_USER fallback cache key.
+class TestUserIdGuard:
+    """The in-memory cache must not be readable or writable without a user_id,
+    regardless of mode. Callers (CLI, server, worker) are responsible for
+    putting a real user_id on request_context — CLI uses DEFAULT_CLI_USER,
+    server/worker use the authenticated user.
+
+    Without this guard, a missing user_id in server mode would collapse all
+    callers onto one DEFAULT_CLI_USER cache slot (privilege escalation), and
+    cache_key computation would be ambiguous in any mode.
     """
 
-    def _make_server_manager(self) -> OAuthTokenManager:
-        from holmes.plugins.toolsets.mcp.oauth_token_store import DalTokenStore
-
+    def _make_manager(self, with_dal: bool = False) -> OAuthTokenManager:
         manager = OAuthTokenManager()
         manager._shutdown_event.set()
-        manager._store = DalTokenStore(dal=MagicMock())
-        return manager
-
-    def _make_cli_manager(self) -> OAuthTokenManager:
-        manager = OAuthTokenManager()
-        manager._shutdown_event.set()
-        manager._store = DiskTokenStore(enabled=False)
+        if with_dal:
+            from holmes.plugins.toolsets.mcp.oauth_token_store import DalTokenStore
+            manager._store = DalTokenStore(dal=MagicMock())
+        else:
+            manager._store = DiskTokenStore(enabled=False)
         return manager
 
     def _oauth(self) -> MCPOAuthConfig:
@@ -2036,14 +2036,9 @@ class TestServerModeUserIdGuard:
             client_id="cid",
         )
 
-    def test_get_access_token_returns_none_without_user_id_in_server_mode(self):
-        manager = self._make_server_manager()
+    def test_get_access_token_returns_none_without_user_id(self):
+        manager = self._make_manager(with_dal=True)
         oauth = self._oauth()
-
-        # Pre-seed the cache under DEFAULT_CLI_USER to simulate a stale/poisoned
-        # entry. A user_id-less request must NOT receive this token.
-        poisoned_key = manager._get_cache_key(oauth, None)
-        manager._cache.set(poisoned_key, "leaked-token", expires_in=3600)
 
         assert manager.get_access_token(oauth, request_context=None) is None
         assert manager.get_access_token(oauth, request_context={"user_id": None}) is None
@@ -2051,20 +2046,17 @@ class TestServerModeUserIdGuard:
 
         manager.shutdown()
 
-    def test_has_token_returns_false_without_user_id_in_server_mode(self):
-        manager = self._make_server_manager()
+    def test_has_token_returns_false_without_user_id(self):
+        manager = self._make_manager(with_dal=True)
         oauth = self._oauth()
-
-        poisoned_key = manager._get_cache_key(oauth, None)
-        manager._cache.set(poisoned_key, "leaked-token", expires_in=3600)
 
         assert manager.has_token(oauth, request_context=None) is False
         assert manager.has_token(oauth, request_context={"user_id": None}) is False
 
         manager.shutdown()
 
-    def test_store_token_refused_without_user_id_in_server_mode(self):
-        manager = self._make_server_manager()
+    def test_store_token_refused_without_user_id(self):
+        manager = self._make_manager(with_dal=True)
         oauth = self._oauth()
 
         with patch.object(manager._store, "store_token") as mock_store:
@@ -2074,20 +2066,29 @@ class TestServerModeUserIdGuard:
                 request_context=None,
             )
 
-        # Neither cache nor persistent store should have been touched.
         assert mock_store.call_count == 0
-        cache_key = manager._get_cache_key(oauth, None)
-        assert manager._cache.get_valid_access_token(cache_key) is None
 
         manager.shutdown()
 
-    def test_get_access_token_still_works_with_user_id_in_server_mode(self):
+    def test_get_cache_key_raises_without_user_id(self):
+        """Cache-key computation must refuse to silently substitute a default."""
+        manager = self._make_manager(with_dal=True)
+        oauth = self._oauth()
+
+        with pytest.raises(ValueError):
+            manager.get_cache_key(oauth, None)
+        with pytest.raises(ValueError):
+            manager.get_cache_key(oauth, {"user_id": None})
+
+        manager.shutdown()
+
+    def test_explicit_user_id_works(self):
         """Regression: the guard must not break the legitimate per-user path."""
-        manager = self._make_server_manager()
+        manager = self._make_manager(with_dal=True)
         oauth = self._oauth()
         ctx = {"user_id": "alice"}
 
-        cache_key = manager._get_cache_key(oauth, ctx)
+        cache_key = manager.get_cache_key(oauth, ctx)
         manager._cache.set(cache_key, "alice-token", expires_in=3600)
 
         assert manager.get_access_token(oauth, request_context=ctx) == "alice-token"
@@ -2095,20 +2096,23 @@ class TestServerModeUserIdGuard:
 
         manager.shutdown()
 
-    def test_cli_mode_still_allows_default_user(self):
-        """In CLI mode the guard must NOT trigger — DEFAULT_CLI_USER is the
-        legitimate single-user identity for the local process."""
-        manager = self._make_cli_manager()
+    def test_cli_caller_passes_default_user_explicitly(self):
+        """CLI callers must put DEFAULT_CLI_USER on request_context themselves.
+        With it set, the guard does not trigger and tokens flow normally."""
+        from holmes.common.env_vars import DEFAULT_CLI_USER
+
+        manager = self._make_manager(with_dal=False)
         oauth = self._oauth()
+        cli_ctx = {"user_id": DEFAULT_CLI_USER}
 
         manager.store_token(
             oauth,
             {"access_token": "cli-token", "expires_in": 3600},
-            request_context=None,
+            request_context=cli_ctx,
         )
 
-        assert manager.get_access_token(oauth, request_context=None) == "cli-token"
-        assert manager.has_token(oauth, request_context=None) is True
+        assert manager.get_access_token(oauth, request_context=cli_ctx) == "cli-token"
+        assert manager.has_token(oauth, request_context=cli_ctx) is True
 
         manager.shutdown()
 

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -2082,6 +2082,22 @@ class TestUserIdGuard:
 
         manager.shutdown()
 
+    def test_require_user_id_raises_when_missing(self):
+        """require_user_id must fail-fast so callers like OAuthToolConnector
+        never receive None and silently pass it into per-user storage."""
+        manager = self._make_manager(with_dal=True)
+
+        with pytest.raises(ValueError):
+            manager.require_user_id(None)
+        with pytest.raises(ValueError):
+            manager.require_user_id({"user_id": None})
+        with pytest.raises(ValueError):
+            manager.require_user_id({"user_id": ""})
+
+        assert manager.require_user_id({"user_id": "alice"}) == "alice"
+
+        manager.shutdown()
+
     def test_explicit_user_id_works(self):
         """Regression: the guard must not break the legitimate per-user path."""
         manager = self._make_manager(with_dal=True)

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1938,3 +1938,112 @@ class TestBackgroundSweep:
 
 
 # ---------------------------------------------------------------------------
+# Server-mode user_id guard (prevents __no_user__ cache-key reuse)
+# ---------------------------------------------------------------------------
+class TestServerModeUserIdGuard:
+    """In server mode (DalTokenStore), the in-memory cache must not be readable
+    or writable without a user_id. This mirrors DalTokenStore.get_token's guard
+    and prevents one caller's token from being served to another via the
+    DEFAULT_CLI_USER fallback cache key.
+    """
+
+    def _make_server_manager(self) -> OAuthTokenManager:
+        from holmes.plugins.toolsets.mcp.oauth_token_store import DalTokenStore
+
+        manager = OAuthTokenManager()
+        manager._shutdown_event.set()
+        manager._store = DalTokenStore(dal=MagicMock())
+        return manager
+
+    def _make_cli_manager(self) -> OAuthTokenManager:
+        manager = OAuthTokenManager()
+        manager._shutdown_event.set()
+        manager._store = DiskTokenStore(enabled=False)
+        return manager
+
+    def _oauth(self) -> MCPOAuthConfig:
+        return MCPOAuthConfig(
+            enabled=True,
+            authorization_url="http://idp/auth",
+            token_url="http://idp/token",
+            client_id="cid",
+        )
+
+    def test_get_access_token_returns_none_without_user_id_in_server_mode(self):
+        manager = self._make_server_manager()
+        oauth = self._oauth()
+
+        # Pre-seed the cache under DEFAULT_CLI_USER to simulate a stale/poisoned
+        # entry. A user_id-less request must NOT receive this token.
+        poisoned_key = manager._get_cache_key(oauth, None)
+        manager._cache.set(poisoned_key, "leaked-token", expires_in=3600)
+
+        assert manager.get_access_token(oauth, request_context=None) is None
+        assert manager.get_access_token(oauth, request_context={"user_id": None}) is None
+        assert manager.get_access_token(oauth, request_context={"user_id": ""}) is None
+
+        manager.shutdown()
+
+    def test_has_token_returns_false_without_user_id_in_server_mode(self):
+        manager = self._make_server_manager()
+        oauth = self._oauth()
+
+        poisoned_key = manager._get_cache_key(oauth, None)
+        manager._cache.set(poisoned_key, "leaked-token", expires_in=3600)
+
+        assert manager.has_token(oauth, request_context=None) is False
+        assert manager.has_token(oauth, request_context={"user_id": None}) is False
+
+        manager.shutdown()
+
+    def test_store_token_refused_without_user_id_in_server_mode(self):
+        manager = self._make_server_manager()
+        oauth = self._oauth()
+
+        with patch.object(manager._store, "store_token") as mock_store:
+            manager.store_token(
+                oauth,
+                {"access_token": "should-not-persist", "expires_in": 3600},
+                request_context=None,
+            )
+
+        # Neither cache nor persistent store should have been touched.
+        assert mock_store.call_count == 0
+        cache_key = manager._get_cache_key(oauth, None)
+        assert manager._cache.get_valid_access_token(cache_key) is None
+
+        manager.shutdown()
+
+    def test_get_access_token_still_works_with_user_id_in_server_mode(self):
+        """Regression: the guard must not break the legitimate per-user path."""
+        manager = self._make_server_manager()
+        oauth = self._oauth()
+        ctx = {"user_id": "alice"}
+
+        cache_key = manager._get_cache_key(oauth, ctx)
+        manager._cache.set(cache_key, "alice-token", expires_in=3600)
+
+        assert manager.get_access_token(oauth, request_context=ctx) == "alice-token"
+        assert manager.has_token(oauth, request_context=ctx) is True
+
+        manager.shutdown()
+
+    def test_cli_mode_still_allows_default_user(self):
+        """In CLI mode the guard must NOT trigger — DEFAULT_CLI_USER is the
+        legitimate single-user identity for the local process."""
+        manager = self._make_cli_manager()
+        oauth = self._oauth()
+
+        manager.store_token(
+            oauth,
+            {"access_token": "cli-token", "expires_in": 3600},
+            request_context=None,
+        )
+
+        assert manager.get_access_token(oauth, request_context=None) == "cli-token"
+        assert manager.has_token(oauth, request_context=None) is True
+
+        manager.shutdown()
+
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds security guards to prevent privilege escalation when OAuth is configured but no user token is available. It ensures that static Authorization headers from configuration cannot silently substitute for missing per-user OAuth tokens, which could leak shared service-account credentials.

## Key Changes

### 1. Server-Mode User ID Guard in OAuthTokenManager
- Added `_is_server_mode()` method to detect when running against the DB-backed token store (multi-user server)
- Added guards in `get_access_token()`, `has_token()`, and `store_token()` to refuse cache operations without a valid user_id in server mode
- Prevents cache key collisions where one caller's token could be served to another via the DEFAULT_CLI_USER fallback
- CLI mode (DiskTokenStore) continues to work normally with DEFAULT_CLI_USER as the legitimate single-user identity

### 2. Static Authorization Header Stripping in RemoteMCPToolset
- Modified `_render_headers()` to strip any Authorization header (case-insensitive) when OAuth is configured but no token is available
- Only strips headers when OAuth is enabled AND no cached token exists
- Preserves other headers and only strips Authorization to prevent service-account credential substitution
- Logs appropriate warnings distinguishing between "no token" and "no token + header stripped" cases

### 3. Comprehensive Test Coverage
- Added `TestServerModeUserIdGuard` class with 5 tests covering:
  - Token retrieval/storage refusal without user_id in server mode
  - Legitimate per-user token access still works
  - CLI mode continues to allow DEFAULT_CLI_USER
- Added 3 tests for Authorization header stripping:
  - Strips static Authorization when OAuth enabled but no token
  - Case-insensitive matching (handles "Authorization", "authorization", "AUTHORIZATION")
  - Preserves static Authorization when OAuth is disabled

## Implementation Details

- The server-mode guard mirrors the existing guard in `DalTokenStore.get_token()` to maintain consistency
- Authorization header stripping uses case-insensitive key matching to handle all header case variations
- Logging distinguishes between scenarios to aid debugging (token missing vs. token missing + header stripped)
- No changes to the OAuth flow itself—only prevents unsafe fallback behavior

https://claude.ai/code/session_01AAECGd71rhfPJfqgDWHtmp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cross-user token use; token checks and stores now fail safely when no user ID is present.
  * Static Authorization headers are suppressed when per-user OAuth tokens are required, with clearer warnings for likely 401s.

* **Chores**
  * CLI and interactive flows now consistently supply a default user ID in request contexts.

* **Tests**
  * Expanded coverage for per-user token behavior, header suppression, and CLI/interactive flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->