### PR TITLE
ROB-3942 Hardwire cluster and conversation context into platform-mcp headers

### DIFF
--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -880,10 +880,19 @@ class ConversationWorker:
 
             # Build request_context with user_id so per-user OAuth tools resolve
             # correctly inside call_stream (matches the regular /api/chat flow
-            # in server.py).
+            # in server.py). Also surface conversation_id and cluster_name so
+            # the platform-mcp toolset can hardwire them onto its outbound
+            # requests (as X-Robusta-* headers) — keeping them out of the
+            # LLM-visible tool schema.
             request_context: Optional[Dict[str, Any]] = None
             if chat_request.user_id:
                 request_context = {"user_id": chat_request.user_id}
+            if task.conversation_id:
+                request_context = request_context or {}
+                request_context["conversation_id"] = task.conversation_id
+            if self.config.cluster_name:
+                request_context = request_context or {}
+                request_context["cluster_name"] = self.config.cluster_name
 
             try:
                 # Wrap the raw stream with the usage recorder BEFORE the

--- a/holmes/plugins/toolsets/robusta_platform_mcp/robusta_platform_mcp.py
+++ b/holmes/plugins/toolsets/robusta_platform_mcp/robusta_platform_mcp.py
@@ -64,6 +64,19 @@ class RobustaPlatformMCPToolset(RemoteMCPToolset):
         # headers via config if they need to.
         headers: Dict[str, str] = super()._render_headers(request_context) or {}
 
+        # Hardwire cluster_name and conversation_id into every request as
+        # transport headers. The relay reads these off the request and
+        # passes them into the tool handler's MCPCallContext — keeping
+        # them out of the LLM-visible tool schema so the model can't
+        # forge or omit them.
+        if request_context:
+            cluster_name = request_context.get("cluster_name")
+            if cluster_name:
+                headers["X-Robusta-Cluster"] = str(cluster_name)
+            conversation_id = request_context.get("conversation_id")
+            if conversation_id:
+                headers["X-Robusta-Conversation-Id"] = str(conversation_id)
+
         dal = self._dal
         if dal is None or not dal.enabled:
             # Should not happen since we only construct the toolset when DAL

--- a/server.py
+++ b/server.py
@@ -451,6 +451,14 @@ def chat(chat_request: ChatRequest, http_request: Request):
         if chat_request.user_id:
             request_context.setdefault("headers", {})
             request_context["user_id"] = chat_request.user_id
+        # Surface conversation_id and cluster_name to toolsets that need
+        # to hardwire them into outbound requests (e.g. platform-mcp adds
+        # them as X-Robusta-* headers so tool handlers don't have to trust
+        # the LLM-supplied arguments).
+        if chat_request.conversation_id:
+            request_context["conversation_id"] = chat_request.conversation_id
+        if config.cluster_name:
+            request_context["cluster_name"] = config.cluster_name
 
         storage = tool_result_storage()
         tool_results_dir = storage.__enter__()

--- a/tests/plugins/toolsets/test_robusta_platform_mcp.py
+++ b/tests/plugins/toolsets/test_robusta_platform_mcp.py
@@ -103,6 +103,45 @@ def test_render_headers_returns_none_when_only_stale_auth_on_error():
     assert headers is None
 
 
+def test_render_headers_injects_cluster_and_conversation_headers():
+    """cluster_name and conversation_id from request_context are hardwired
+    onto every MCP request as X-Robusta-* headers so the relay can pass
+    them into the tool handler without trusting LLM-supplied arguments."""
+    dal = MagicMock()
+    dal.enabled = True
+    dal.get_ai_credentials.return_value = ("acct-1", "tok-abc")
+    toolset = make_robusta_platform_mcp_toolset(dal)
+    assert toolset is not None
+
+    headers = toolset._render_headers(
+        {"cluster_name": "prod-eu", "conversation_id": "conv-42"}
+    )
+    assert headers is not None
+    assert headers["X-Robusta-Cluster"] == "prod-eu"
+    assert headers["X-Robusta-Conversation-Id"] == "conv-42"
+    assert headers["Authorization"] == "Bearer acct-1 tok-abc"
+
+
+def test_render_headers_omits_robusta_headers_when_context_missing():
+    """When cluster_name / conversation_id aren't in the request context
+    (e.g. CLI mode), don't emit empty X-Robusta-* headers."""
+    dal = MagicMock()
+    dal.enabled = True
+    dal.get_ai_credentials.return_value = ("acct-1", "tok-abc")
+    toolset = make_robusta_platform_mcp_toolset(dal)
+    assert toolset is not None
+
+    headers = toolset._render_headers(None)
+    assert headers is not None
+    assert "X-Robusta-Cluster" not in headers
+    assert "X-Robusta-Conversation-Id" not in headers
+
+    headers_empty_ctx = toolset._render_headers({})
+    assert headers_empty_ctx is not None
+    assert "X-Robusta-Cluster" not in headers_empty_ctx
+    assert "X-Robusta-Conversation-Id" not in headers_empty_ctx
+
+
 def test_render_headers_strips_authorization_case_insensitively():
     """HTTP headers are case-insensitive; a user-supplied lowercase
     'authorization' in extra_headers must not leak through the sanitiser."""


### PR DESCRIPTION
## Summary

This change ensures that `cluster_name` and `conversation_id` from the request context are automatically injected into outbound platform-mcp requests as `X-Robusta-*` headers. This allows the relay to pass these values to tool handlers without relying on LLM-supplied arguments, improving security and reliability.

## Key Changes

- **Platform MCP Toolset** (`robusta_platform_mcp.py`):
  - Modified `_render_headers()` to extract `cluster_name` and `conversation_id` from `request_context` and inject them as `X-Robusta-Cluster` and `X-Robusta-Conversation-Id` headers
  - Headers are only added when the values are present in the context (handles CLI mode where context may be missing)

- **Conversations Worker** (`conversations_worker/worker.py`):
  - Updated `_run_chat_and_publish()` to populate `request_context` with `conversation_id` from the task and `cluster_name` from the worker config
  - These values are now passed through to toolsets that need them

- **Server Chat Endpoint** (`server.py`):
  - Updated the `/chat` endpoint to surface `conversation_id` and `cluster_name` in the `request_context` dictionary
  - Ensures consistency with the conversations worker flow

- **Test Coverage** (`test_robusta_platform_mcp.py`):
  - Added `test_render_headers_injects_cluster_and_conversation_headers()` to verify headers are correctly injected when context is present
  - Added `test_render_headers_omits_robusta_headers_when_context_missing()` to verify headers are omitted when context is `None` or empty (CLI mode)

## Implementation Details

- The headers are injected at the transport layer, keeping them out of the LLM-visible tool schema
- This prevents the LLM from forging or omitting these critical context values
- The implementation gracefully handles missing context (e.g., CLI mode) by only adding headers when values are present
- Values are converted to strings to ensure header compatibility

https://claude.ai/code/session_01Xn4NwkWqt2J8NBhMjmCwcB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat conversations and cluster information are now properly propagated throughout external service requests, improving context tracking and routing across the system.

* **Tests**
  * Added verification to ensure conversation and cluster identifiers are correctly transmitted in outbound service calls when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HolmesGPT/holmesgpt/pull/2098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->