### PR TITLE
fix: allow omitting temperature for models that reject it (e.g. Opus 4.7+)

### DIFF
--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -63,7 +63,21 @@ SENTRY_TRACES_SAMPLE_RATE = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0
 EXTRA_HEADERS = os.environ.get("EXTRA_HEADERS", "")
 THINKING = os.environ.get("THINKING", "")
 REASONING_EFFORT = os.environ.get("REASONING_EFFORT", "").strip().lower()
-TEMPERATURE = float(os.environ.get("TEMPERATURE", "0.00000001"))
+
+
+def _load_temperature() -> Optional[float]:
+    # Set TEMPERATURE to an empty string / "none" / "null" to send NO temperature at
+    # all. Required for models that reject the parameter (e.g. Anthropic Opus 4.7+:
+    # "temperature is deprecated for this model"); LiteLLM's drop_params can't strip
+    # it because the deprecation isn't in its static param metadata, so it must be
+    # omitted at the source.
+    raw = os.environ.get("TEMPERATURE", "0.00000001").strip()
+    if raw.lower() in ("", "none", "null"):
+        return None
+    return float(raw)
+
+
+TEMPERATURE = _load_temperature()
 
 # Set default memory limit based on CPU architecture
 # ARM architectures typically need more memory

--- a/tests/common/test_temperature_env.py
+++ b/tests/common/test_temperature_env.py
@@ -1,0 +1,23 @@
+import os
+from unittest.mock import patch
+
+from holmes.common.env_vars import _load_temperature
+
+
+def test_temperature_can_be_disabled():
+    # Models like Anthropic Opus 4.7+ reject the temperature param; an empty/none
+    # value must omit it entirely (so completion() passes temperature=None).
+    for value in ("", "none", "None", "NULL"):
+        with patch.dict(os.environ, {"TEMPERATURE": value}):
+            assert _load_temperature() is None
+
+
+def test_temperature_explicit_value():
+    with patch.dict(os.environ, {"TEMPERATURE": "0.5"}):
+        assert _load_temperature() == 0.5
+
+
+def test_temperature_default_when_unset():
+    env = {k: v for k, v in os.environ.items() if k != "TEMPERATURE"}
+    with patch.dict(os.environ, env, clear=True):
+        assert _load_temperature() == 0.00000001


### PR DESCRIPTION
## Problem

Anthropic Opus 4.7 / 4.8 reject the `temperature` parameter:

```
invalid_request_error: `temperature` is deprecated for this model.
```

HolmesGPT always sends `temperature` (`tool_calling_llm.py` → `completion(..., temperature=TEMPERATURE)`, default `1e-8`), so these models 400 on every call. `drop_params=True` doesn't help — the deprecation is an Anthropic *runtime* behavior, not in LiteLLM's static param metadata (verified with litellm up to 1.86.2), so it isn't stripped.

## Fix

Make `TEMPERATURE` omittable: an empty string / `none` / `null` yields `None`, and `completion()` already skips the param when it's `None` — so no `temperature` is sent. Models that accept `temperature` are unaffected (default unchanged).

```bash
TEMPERATURE=none   # send no temperature param
```

## Verification
- Unit tests added (`tests/common/test_temperature_env.py`).
- End-to-end via a LiteLLM gateway: with `TEMPERATURE=none`, Opus 4.6 / 4.7 / 4.8 all complete successfully; without it, 4.7/4.8 return the 400 above.

Signed-off-by: Yakir Shriker <yakirshr@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temperature setting can now be disabled or nullified by setting the environment variable to empty string, "none", or "null" values, providing more flexible configuration control.

* **Tests**
  * Added tests verifying temperature configuration behavior under various conditions, including disabled states and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->