### PR TITLE
Fix Custom Headers auth example: use name/value, not header_name/head…

### DIFF
--- a/docs/data-sources/api-toolsets.md
+++ b/docs/data-sources/api-toolsets.md
@@ -103,8 +103,8 @@ auth:
 ```yaml
 auth:
   type: header
-  header_name: "X-API-Key"
-  header_value: "{{ env.API_KEY }}"
+  name: "X-API-Key"
+  value: "{{ env.API_KEY }}"
 ```
 
 ### Environment Variables


### PR DESCRIPTION
…er_value

The documentation incorrectly showed header_name and header_value parameters for Custom Headers authentication, but the actual AuthConfig model uses name and value fields.

Slack thread: https://robustaco.slack.com/archives/C047B4M8Y7K/p1780378353887489?thread_ts=1780376741.654799&cid=C047B4M8Y7K

https://claude.ai/code/session_01ARbBZaCi7i7Nx8dfLLwJrU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP connector custom-header authentication documentation to reflect the current field naming conventions for header-based API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->