### PR TITLE
Add health_check_tool to MCP toolsets for authentication verification

### DIFF
--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -106,6 +106,7 @@ data:
         "url" (printf "http://%s-github-mcp-server.%s.svc.cluster.local:8000/mcp" .Release.Name .Release.Namespace)
         "mode" "streamable-http"
         "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/github.svg"
+        "health_check_tool" "get_me"
     }}
     {{- $githubMcpServers := dict "github" (dict
         "description" "GitHub MCP Server - access repositories, pull requests, issues, and GitHub Actions. Debug CI failures, search code, and delegate tasks to Copilot."
@@ -119,6 +120,7 @@ data:
         "url" (printf "http://%s-github-mcp-server.%s.svc.cluster.local:8000/sse" .Release.Name .Release.Namespace)
         "mode" "sse"
         "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/github.svg"
+        "health_check_tool" "get_me"
     }}
     {{- $githubMcpServers := dict "github" (dict
         "description" "GitHub MCP Server - access repositories, pull requests, issues, and GitHub Actions. Debug CI failures, search code, and delegate tasks to Copilot."
@@ -136,6 +138,7 @@ data:
           "url" (printf "http://%s-gitlab-mcp-server.%s.svc.cluster.local:8000/sse" .Release.Name .Release.Namespace)
           "mode" "sse"
           "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/gitlab.svg"
+          "health_check_tool" "get_current_user"
         )
         "llm_instructions" (include "holmes.gitlabMcp.llmInstructions" . | trim)
       )

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -164,6 +164,14 @@ class MCPConfig(ToolsetConfig):
         title="OAuth",
         description="OAuth authorization_code configuration. When set, users authenticate via browser before tools can be used.",
     )
+    health_check_tool: Optional[str] = Field(
+        default=None,
+        title="Health Check Tool",
+        description="Name of a read-only tool to invoke during health check to verify authentication works. "
+        "If set, this tool will be called with empty arguments after loading tools to ensure the "
+        "connection is fully functional (e.g., API token is valid). Example: 'get_me' for GitHub MCP.",
+        examples=["get_me", "list_repositories"],
+    )
 
     def get_lock_string(self) -> str:
         return str(self.url)
@@ -200,6 +208,14 @@ class StdioMCPConfig(ToolsetConfig):
         default="https://registry.npmmirror.com/@lobehub/icons-static-png/1.46.0/files/light/mcp.png",
         description="Icon URL for this MCP server, displayed in the UI for tool calls.",
         examples=["https://cdn.simpleicons.org/github/181717"],
+    )
+    health_check_tool: Optional[str] = Field(
+        default=None,
+        title="Health Check Tool",
+        description="Name of a read-only tool to invoke during health check to verify authentication works. "
+        "If set, this tool will be called with empty arguments after loading tools to ensure the "
+        "connection is fully functional (e.g., API token is valid). Example: 'get_me' for GitHub MCP.",
+        examples=["get_me", "list_repositories"],
     )
 
     def get_lock_string(self) -> str:
@@ -932,6 +948,13 @@ class RemoteMCPToolset(Toolset):
             if not self.tools:
                 logging.warning("mcp server %s loaded 0 tools.", self.name)
 
+            # If health_check_tool is configured, invoke it to verify authentication
+            health_check_tool_name = self._mcp_config.health_check_tool
+            if health_check_tool_name:
+                health_check_result = self._run_health_check_tool(health_check_tool_name)
+                if not health_check_result[0]:
+                    return health_check_result
+
             return (True, "")
         except Exception as e:
             error_detail = _extract_root_error_message(e)
@@ -940,6 +963,49 @@ class RemoteMCPToolset(Toolset):
                 f"Failed to load mcp server {self.name}: {error_detail}"
                 ". If the server is still starting up, Holmes will retry automatically",
             )
+
+    def _run_health_check_tool(self, tool_name: str) -> Tuple[bool, str]:
+        """Invoke a tool to verify authentication actually works.
+
+        MCP servers may return a tool list even with invalid credentials (e.g., bad
+        GitHub token). This method calls a specified read-only tool with empty
+        arguments to verify the connection is fully functional.
+        """
+        matching_tools = [t for t in self.tools if t.name == tool_name]
+        if not matching_tools:
+            available = [t.name for t in self.tools]
+            return (
+                False,
+                f"MCP server {self.name}: health_check_tool '{tool_name}' not found. "
+                f"Available tools: {', '.join(available[:10])}{'...' if len(available) > 10 else ''}",
+            )
+
+        try:
+            result = asyncio.run(self._call_health_check_tool_async(tool_name))
+            if result.isError:
+                error_text = ""
+                if result.content:
+                    for item in result.content:
+                        if hasattr(item, "text"):
+                            error_text = item.text
+                            break
+                return (
+                    False,
+                    f"MCP server {self.name}: health check failed - {error_text or 'unknown error'}",
+                )
+            logging.info("MCP server %s health check passed (tool: %s)", self.name, tool_name)
+            return (True, "")
+        except Exception as e:
+            error_detail = _extract_root_error_message(e)
+            return (
+                False,
+                f"MCP server {self.name}: health check failed - {error_detail}",
+            )
+
+    async def _call_health_check_tool_async(self, tool_name: str):
+        """Call a tool during health check (no request context available)."""
+        async with get_initialized_mcp_session(self, None) as session:
+            return await session.call_tool(tool_name, {})
 
     def _check_oauth_server_reachable(self) -> Tuple[bool, str]:
         """For OAuth MCP servers, verify reachability without authenticating.

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -170,7 +170,7 @@ class MCPConfig(ToolsetConfig):
         description="Name of a read-only tool to invoke during health check to verify authentication works. "
         "If set, this tool will be called with empty arguments after loading tools to ensure the "
         "connection is fully functional (e.g., API token is valid). Example: 'get_me' for GitHub MCP.",
-        examples=["get_me", "list_repositories"],
+        examples=["get_me", "get_current_user"],
     )
 
     def get_lock_string(self) -> str:
@@ -215,7 +215,7 @@ class StdioMCPConfig(ToolsetConfig):
         description="Name of a read-only tool to invoke during health check to verify authentication works. "
         "If set, this tool will be called with empty arguments after loading tools to ensure the "
         "connection is fully functional (e.g., API token is valid). Example: 'get_me' for GitHub MCP.",
-        examples=["get_me", "list_repositories"],
+        examples=["get_me", "get_current_user"],
     )
 
     def get_lock_string(self) -> str:
@@ -983,12 +983,15 @@ class RemoteMCPToolset(Toolset):
         try:
             result = asyncio.run(self._call_health_check_tool_async(tool_name))
             if result.isError:
-                error_text = ""
-                if result.content:
-                    for item in result.content:
-                        if hasattr(item, "text"):
-                            error_text = item.text
-                            break
+                error_chunks = [
+                    RemoteMCPTool._extract_text_from_content_block(c)
+                    for c in result.content
+                ]
+                error_text = " ".join(t for t in error_chunks if t)
+                logging.warning(
+                    "MCP server %s health check failed (tool: %s): %s",
+                    self.name, tool_name, error_text or "unknown error"
+                )
                 return (
                     False,
                     f"MCP server {self.name}: health check failed - {error_text or 'unknown error'}",
@@ -997,6 +1000,10 @@ class RemoteMCPToolset(Toolset):
             return (True, "")
         except Exception as e:
             error_detail = _extract_root_error_message(e)
+            logging.warning(
+                "MCP server %s health check exception (tool: %s): %s",
+                self.name, tool_name, error_detail
+            )
             return (
                 False,
                 f"MCP server {self.name}: health check failed - {error_detail}",

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -2574,3 +2574,206 @@ class TestJenkinsMCPConfig:
 
         assert ok is False
         assert msg  # error message must be non-empty
+
+
+class TestMCPHealthCheckTool:
+    """Tests for the health_check_tool feature that validates authentication."""
+
+    def test_health_check_tool_success(self, monkeypatch, suppress_migration_warnings):
+        """When health_check_tool succeeds, prerequisites pass."""
+        toolset = RemoteMCPToolset(
+            name="github",
+            description="GitHub MCP",
+            config={"url": "http://localhost:8000", "health_check_tool": "get_me"},
+        )
+
+        # Mock _get_server_tools to return a tool list including get_me
+        async def mock_get_server_tools():
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="get_me",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="Get current user",
+                    ),
+                    Tool(
+                        name="list_repos",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="List repositories",
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
+
+        # Mock _call_health_check_tool_async to return success
+        async def mock_call_health_check(tool_name):
+            return CallToolResult(content=[TextContent(type="text", text='{"login": "user"}')])
+
+        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+
+        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        assert ok is True
+        assert msg == ""
+
+    def test_health_check_tool_auth_failure(self, monkeypatch, suppress_migration_warnings):
+        """When health_check_tool returns an error, prerequisites fail with clear message."""
+        toolset = RemoteMCPToolset(
+            name="github",
+            description="GitHub MCP",
+            config={"url": "http://localhost:8000", "health_check_tool": "get_me"},
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="get_me",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="Get current user",
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
+
+        # Mock _call_health_check_tool_async to return an error (bad token)
+        async def mock_call_health_check(tool_name):
+            return CallToolResult(
+                isError=True,
+                content=[TextContent(type="text", text="401 Unauthorized: Bad credentials")],
+            )
+
+        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+
+        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        assert ok is False
+        assert "health check failed" in msg
+        assert "401 Unauthorized" in msg
+
+    def test_health_check_tool_not_found(self, monkeypatch, suppress_migration_warnings):
+        """When health_check_tool specifies a non-existent tool, prerequisites fail."""
+        toolset = RemoteMCPToolset(
+            name="github",
+            description="GitHub MCP",
+            config={"url": "http://localhost:8000", "health_check_tool": "nonexistent_tool"},
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="get_me",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="Get current user",
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
+
+        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        assert ok is False
+        assert "not found" in msg
+        assert "nonexistent_tool" in msg
+        assert "get_me" in msg  # should list available tools
+
+    def test_health_check_tool_exception(self, monkeypatch, suppress_migration_warnings):
+        """When health_check_tool throws an exception, prerequisites fail with clear message."""
+        toolset = RemoteMCPToolset(
+            name="github",
+            description="GitHub MCP",
+            config={"url": "http://localhost:8000", "health_check_tool": "get_me"},
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="get_me",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="Get current user",
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
+
+        # Mock _call_health_check_tool_async to raise an exception
+        async def mock_call_health_check(tool_name):
+            raise ConnectionRefusedError("Connection refused")
+
+        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+
+        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        assert ok is False
+        assert "health check failed" in msg
+        assert "Connection refused" in msg
+
+    def test_no_health_check_tool_skips_check(self, monkeypatch, suppress_migration_warnings):
+        """When health_check_tool is not set, no additional check is performed."""
+        toolset = RemoteMCPToolset(
+            name="github",
+            description="GitHub MCP",
+            config={"url": "http://localhost:8000"},  # no health_check_tool
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="get_me",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="Get current user",
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
+
+        # Should not call _call_health_check_tool_async at all
+        call_count = {"count": 0}
+
+        async def mock_call_health_check(tool_name):
+            call_count["count"] += 1
+            return CallToolResult(content=[])
+
+        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+
+        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        assert ok is True
+        assert call_count["count"] == 0  # health check should not be called
+
+    def test_health_check_tool_in_stdio_mode(self, monkeypatch, suppress_migration_warnings):
+        """Health check tool also works in stdio mode."""
+        toolset = RemoteMCPToolset(
+            name="github",
+            description="GitHub MCP",
+            config={
+                "mode": "stdio",
+                "command": "github-mcp-server",
+                "args": ["stdio"],
+                "health_check_tool": "get_me",
+            },
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="get_me",
+                        inputSchema={"type": "object", "properties": {}},
+                        description="Get current user",
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
+
+        async def mock_call_health_check(tool_name):
+            return CallToolResult(content=[TextContent(type="text", text='{"login": "user"}')])
+
+        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+
+        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        assert ok is True

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -2740,7 +2740,7 @@ class TestMCPHealthCheckTool:
 
         monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
 
-        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        ok, _ = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True
         assert call_count["count"] == 0  # health check should not be called
 
@@ -2775,5 +2775,5 @@ class TestMCPHealthCheckTool:
 
         monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
 
-        ok, msg = toolset.prerequisites_callable(config=toolset.config)
+        ok, _ = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True


### PR DESCRIPTION
## Summary

Adds a `health_check_tool` configuration option to MCP (Model Context Protocol) toolsets that enables verification of authentication credentials by invoking a read-only tool during the prerequisites check. This addresses the issue where MCP servers may return a tool list even with invalid credentials (e.g., expired API tokens), allowing Holmes to detect authentication failures early.

## Key Changes

- **Config Schema Updates**: Added `health_check_tool` optional field to both `MCPConfig` and `StdioMCPConfig` classes with documentation and examples
- **Health Check Implementation**: 
  - Added `_run_health_check_tool()` method to invoke the specified tool with empty arguments
  - Added `_call_health_check_tool_async()` helper to call tools without a request context
  - Integrated health check into `prerequisites_callable()` to run after tools are loaded
- **Error Handling**: Provides clear error messages when:
  - The specified health check tool is not found (lists available tools)
  - The tool returns an error (includes the error details from the API)
  - An exception occurs during the health check (includes the root cause)
- **Comprehensive Tests**: Added 6 test cases covering:
  - Successful health check
  - Authentication failures with error details
  - Non-existent tool handling
  - Exception handling
  - Skipping check when not configured
  - Stdio mode compatibility
- **Helm Configuration**: Updated default GitHub MCP server configuration to use `get_me` as the health check tool

## Implementation Details

- Health check is optional and only runs if `health_check_tool` is configured
- Uses `asyncio.run()` to execute async tool calls synchronously during prerequisites check
- Extracts error text from `CallToolResult` content for user-friendly error messages
- Works with both HTTP and stdio MCP server modes
- Logs successful health checks at INFO level for debugging

https://claude.ai/code/session_01Cmrtm14E7JiDsG3DnQwCAJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server integrations can now be configured with an optional health_check_tool to validate authentication and connectivity before tools are offered.
  * Helm chart now exposes health_check_tool settings for GitHub and GitLab MCP server configurations.

* **Tests**
  * Added tests covering successful and failing health checks, missing tool handling, exception cases, skip behavior when unset, and stdio mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->