### PR TITLE
ROB-4015 Fix /api/chat 500 when request body arrives as raw bytes

### DIFF
--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -283,6 +283,20 @@ class ChatRequestBaseModel(BaseModel):
     # where the "role" field is expected to be "system".
     @model_validator(mode="before")
     def check_first_item_role(cls, values):
+        # A mode="before" validator receives the raw input, which is not always
+        # a dict. FastAPI hands us the raw request body (bytes/str) instead of a
+        # parsed dict when the client omits the "Content-Type: application/json"
+        # header, which previously crashed here with
+        # "'bytes' object has no attribute 'get'". Parse JSON payloads so a valid
+        # body still works, and skip the check for anything we can't treat as a
+        # mapping (Pydantic then raises a clean validation error).
+        if isinstance(values, (bytes, bytearray, str)):
+            try:
+                values = json.loads(values)
+            except (ValueError, TypeError):
+                return values
+        if not isinstance(values, dict):
+            return values
         conversation_history = values.get("conversation_history")
         if (
             conversation_history
@@ -290,6 +304,11 @@ class ChatRequestBaseModel(BaseModel):
             and len(conversation_history) > 0
         ):
             first_item = conversation_history[0]
+            # The first item may not be a dict (e.g. {"conversation_history": ["bad"]}).
+            # Skip the role check rather than crashing on .get(); Pydantic then
+            # raises a clean ValidationError for the malformed item shape.
+            if not isinstance(first_item, dict):
+                return values
             if not first_item.get("role") == "system":
                 raise ValueError(
                     "The first item in conversation_history must contain 'role': 'system'"

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1,0 +1,78 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from holmes.core.models import ChatRequest, ChatRequestBaseModel
+
+
+class TestCheckFirstItemRole:
+    """Tests for the check_first_item_role mode='before' validator.
+
+    Regression coverage for "'bytes' object has no attribute 'get'": FastAPI
+    hands the validator the raw request body (bytes/str) instead of a parsed
+    dict when the client omits the Content-Type: application/json header.
+    """
+
+    def test_dict_input_with_system_role_first(self):
+        model = ChatRequestBaseModel.model_validate(
+            {
+                "conversation_history": [
+                    {"role": "system", "content": "you are a helpful assistant"},
+                    {"role": "user", "content": "hi"},
+                ]
+            }
+        )
+        assert model.conversation_history[0]["role"] == "system"
+
+    def test_dict_input_without_system_role_first_raises(self):
+        with pytest.raises(ValidationError, match="must contain 'role': 'system'"):
+            ChatRequestBaseModel.model_validate(
+                {"conversation_history": [{"role": "user", "content": "hi"}]}
+            )
+
+    def test_bytes_json_body_is_parsed(self):
+        """A JSON body sent as raw bytes (missing Content-Type) must still validate."""
+        raw = json.dumps(
+            {
+                "conversation_history": [
+                    {"role": "system", "content": "sys"},
+                ]
+            }
+        ).encode("utf-8")
+        model = ChatRequestBaseModel.model_validate(raw)
+        assert model.conversation_history[0]["role"] == "system"
+
+    def test_str_json_body_is_parsed(self):
+        raw = json.dumps({"model": "gpt-5.4"})
+        model = ChatRequestBaseModel.model_validate(raw)
+        assert model.model == "gpt-5.4"
+
+    def test_bytes_json_body_enforces_system_role(self):
+        raw = json.dumps(
+            {"conversation_history": [{"role": "user", "content": "hi"}]}
+        ).encode("utf-8")
+        with pytest.raises(ValidationError, match="must contain 'role': 'system'"):
+            ChatRequestBaseModel.model_validate(raw)
+
+    def test_non_json_bytes_raises_validation_error_not_attribute_error(self):
+        """Garbage (non-JSON) bytes must produce a clean ValidationError, not a 500."""
+        with pytest.raises(ValidationError):
+            ChatRequestBaseModel.model_validate(b"not json at all")
+
+    def test_non_dict_first_item_raises_validation_error_not_attribute_error(self):
+        """A conversation_history whose first item is not a dict must produce a
+        clean ValidationError, not an AttributeError from first_item.get()."""
+        with pytest.raises(ValidationError):
+            ChatRequestBaseModel.model_validate({"conversation_history": ["bad"]})
+
+    def test_chat_request_from_bytes_body(self):
+        """End-to-end: the public ChatRequest model also tolerates a bytes body."""
+        raw = json.dumps(
+            {
+                "ask": "why is my pod crashing?",
+                "conversation_history": [{"role": "system", "content": "sys"}],
+            }
+        ).encode("utf-8")
+        model = ChatRequest.model_validate(raw)
+        assert model.ask == "why is my pod crashing?"


### PR DESCRIPTION
## What

Fixes a `/api/chat` 500 (`AttributeError: 'bytes' object has no attribute 'get'`) in the `check_first_item_role` validator on `ChatRequestBaseModel`.

## Why

`check_first_item_role` is a Pydantic `mode="before"` validator, so it receives the raw input rather than a guaranteed dict. FastAPI hands it the **raw request body as bytes** (instead of a parsed dict) when the client omits the `Content-Type: application/json` header — and the validator called `.get()` on it unconditionally.

This is a latent ~1.5-year-old assumption that became a **live regression after the CVE-2026-48710 dependency bump** (Starlette `0.49 → 1.0`, FastAPI `0.121 → 0.136`), which changed how a header-less body is delivered to the validator.

## How

The validator now:
- JSON-parses `bytes`/`str` input, so a valid body still works even without the `Content-Type` header
- returns non-dict input untouched — including a `conversation_history` whose first item is not a dict — so a malformed body yields a clean Pydantic `422` instead of a `500`

## Testing

Adds `tests/core/test_models.py` (8 tests): dict input, bytes/str JSON bodies, system-role enforcement via the bytes path, non-JSON bytes → ValidationError, and non-dict-first-item → ValidationError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for raw JSON request bodies in multiple formats (bytes, bytearray, string).
  * Improved validation error messages for malformed requests.

* **Tests**
  * Added comprehensive test coverage for request body parsing and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->