### PR TITLE
Bump github-mcp image to 1.0.4

### DIFF
--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -439,7 +439,7 @@ mcpAddons:
   github:
     enabled: false
 
-    image: "github-mcp:1.0.1"
+    image: "github-mcp:1.0.4"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
     imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bumps the GitHub MCP addon image from `github-mcp:1.0.1` to `github-mcp:1.0.4` in `helm/holmes/values.yaml`.

## Test plan
- [ ] Helm chart renders without changes other than the image tag
- [ ] Deployed GitHub MCP addon pulls and starts on `1.0.4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub MCP addon Docker image to version 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->