### PR TITLE
Add enable_todo flag to control TodoWrite feature in evals

### DIFF
--- a/tests/llm/test_ask_holmes.py
+++ b/tests/llm/test_ask_holmes.py
@@ -12,7 +12,7 @@ import pytest
 from holmes.config import Config
 from holmes.core.conversations import build_chat_messages
 from holmes.core.models import ChatRequest
-from holmes.core.prompt import build_initial_ask_messages
+from holmes.core.prompt import PromptComponent, build_initial_ask_messages
 from holmes.core.tool_calling_llm import LLMResult, ToolCallingLLM
 from holmes.core.tools_utils.filesystem_result_storage import tool_result_storage
 from holmes.core.tools_utils.tool_executor import ToolExecutor
@@ -185,6 +185,7 @@ def ask_holmes(
             test_case_folder=test_case.folder,
             allow_toolset_failures=getattr(test_case, "allow_toolset_failures", False),
             toolsets_config_path=getattr(test_case, "toolsets_config_path", None),
+            enable_todo=getattr(test_case, "enable_todo", False),
         )
 
         tool_executor = ToolExecutor(toolset_manager.toolsets)
@@ -202,6 +203,16 @@ def ask_holmes(
             llm=create_eval_llm(model=model, tracer=tracer),
             tool_results_dir=tool_results_dir,
         )
+
+        # Todos (TodoWrite) are disabled by default in evals; turn off the
+        # related prompt instructions/reminder unless the test opts in. The
+        # TodoWrite tool itself is dropped by TestToolsetManager (above).
+        prompt_component_overrides = None
+        if not getattr(test_case, "enable_todo", False):
+            prompt_component_overrides = {
+                PromptComponent.TODOWRITE_INSTRUCTIONS: False,
+                PromptComponent.TODOWRITE_REMINDER: False,
+            }
 
         test_type = (
             test_case.test_type
@@ -232,6 +243,7 @@ def ask_holmes(
                     tool_executor=ai.tool_executor,
                     skills=skills,
                     system_prompt_additions=additional_system_prompt,
+                    prompt_component_overrides=prompt_component_overrides,
                 )
         else:
             chat_request = ChatRequest(
@@ -256,6 +268,7 @@ def ask_holmes(
                 global_instructions=global_instructions,
                 skills=skills,
                 additional_system_prompt=additional_system_prompt,
+                prompt_component_overrides=prompt_component_overrides,
             )
 
         # Create LLM completion trace within current context

--- a/tests/llm/utils/test_case_utils.py
+++ b/tests/llm/utils/test_case_utils.py
@@ -150,6 +150,9 @@ class HolmesTestCase(BaseModel):
     max_tokens: Optional[int] = (
         None  # Maximum total tokens allowed; test fails if exceeded
     )
+    enable_todo: bool = (
+        False  # Enable the TodoWrite/todos feature (disabled by default in evals)
+    )
 
 
 class AskHolmesTestCase(HolmesTestCase, BaseModel):

--- a/tests/llm/utils/test_toolset.py
+++ b/tests/llm/utils/test_toolset.py
@@ -42,10 +42,12 @@ class TestToolsetManager:
         test_case_folder: str,
         allow_toolset_failures: bool = False,
         toolsets_config_path: Optional[str] = None,
+        enable_todo: bool = False,
     ):
         self.test_case_folder = test_case_folder
         self.allow_toolset_failures = allow_toolset_failures
         self.toolsets_config_path = toolsets_config_path
+        self.enable_todo = enable_todo
 
         # Initialize components
         self._initialize_toolsets()
@@ -170,6 +172,11 @@ class TestToolsetManager:
                 or toolset.name in mcp_toolsets
                 or toolset.name in database_toolsets
             ):
+                continue
+            # Todos (TodoWrite tool) are disabled by default in evals. Drop the
+            # core_investigation toolset entirely unless the test opts in via
+            # enable_todo, so the tool isn't even offered to the LLM.
+            if toolset.name == "core_investigation" and not self.enable_todo:
                 continue
             # Replace SkillsToolset with one that has test folder search path
             if toolset.name == "skills":


### PR DESCRIPTION
## Summary
Add a new `enable_todo` configuration flag to allow tests to opt-in to the TodoWrite/todos feature, which is disabled by default in evaluations. This prevents the TodoWrite tool and related prompt instructions from being offered to the LLM unless explicitly enabled by a test case.

## Changes
- **Test case configuration** (`test_case_utils.py`): Added `enable_todo: bool = False` field to `HolmesTestCase` to allow individual tests to enable the feature
- **Toolset manager** (`test_toolset.py`): 
  - Added `enable_todo` parameter to `TestToolsetManager.__init__`
  - Drop the `core_investigation` toolset entirely when `enable_todo=False` to prevent the TodoWrite tool from being offered to the LLM
- **Ask Holmes test runner** (`test_ask_holmes.py`):
  - Import `PromptComponent` from prompt module
  - Pass `enable_todo` flag from test case to `TestToolsetManager`
  - Create `prompt_component_overrides` dict to disable TodoWrite-related prompt instructions/reminders when `enable_todo=False`
  - Pass `prompt_component_overrides` to both CLI and API investigation paths

## Implementation Details
The TodoWrite feature is now controlled at three levels:
1. **Tool availability**: The `core_investigation` toolset (which contains TodoWrite) is dropped from the toolset manager unless opted in
2. **Prompt instructions**: TodoWrite-related prompt components (`TODOWRITE_INSTRUCTIONS` and `TODOWRITE_REMINDER`) are disabled via `prompt_component_overrides` unless opted in
3. **Test configuration**: Tests can enable the feature by setting `enable_todo: True` in their test case definition

This ensures the LLM won't be offered or reminded about the TodoWrite tool in evaluations unless a specific test explicitly enables it.

https://claude.ai/code/session_01HeCcwBCximu5VRbgno8gqr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-test `enable_todo` configuration option to control Todo-related functionality
  * Todo features and related tools are disabled by default and can be optionally enabled on a per-test basis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->