### PR TITLE
Warn when prompt caching appears misconfigured

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -315,6 +315,15 @@ class LLM:
     def get_context_window_size(self) -> int:
         pass
 
+    def is_prompt_caching_enabled(self) -> bool:
+        """Whether Holmes sends prompt-cache hints for this model.
+
+        Used to decide whether to warn about missing cache reads. Defaults to
+        True; DefaultLLM overrides this to exclude routes (e.g. Gemini) where
+        Holmes deliberately skips the cache hint.
+        """
+        return True
+
     @abstractmethod
     def get_maximum_output_token(self) -> int:
         pass
@@ -646,6 +655,16 @@ class DefaultLLM(LLM):
         else:
             return self.model
 
+    def is_prompt_caching_enabled(self) -> bool:
+        """Whether Holmes sends prompt-cache hints for this model.
+
+        Mirrors the gating used in completion(): every route gets
+        cache_control_injection_points except Gemini (Google AI Studio and
+        Vertex-hosted Gemini), which rejects CachedContent combined with
+        system_instruction / tools / tool_config.
+        """
+        return not _is_gemini_route(self.get_litellm_corrected_name_for_robusta_ai())
+
     def completion(
         self,
         messages: List[Dict[str, Any]],
@@ -729,7 +748,7 @@ class DefaultLLM(LLM):
         # providers - including non-Gemini models on Vertex like Claude - keep
         # their cache benefit.
         cache_kwargs: Dict[str, Any] = {}
-        if not _is_gemini_route(litellm_model_name):
+        if self.is_prompt_caching_enabled():
             cache_kwargs["cache_control_injection_points"] = [
                 {
                     "location": "message",

--- a/holmes/core/llm_usage.py
+++ b/holmes/core/llm_usage.py
@@ -7,6 +7,74 @@ from litellm.types.utils import ModelResponse
 from pydantic import BaseModel
 
 
+# Minimum prompt size (in tokens) before prompt caching is expected to kick in.
+# Anthropic requires >=1024 tokens to cache (2048 for some smaller models) and
+# OpenAI only auto-caches prompts longer than 1024 tokens. Below this, zero
+# cache reads is normal and must not be treated as a misconfiguration.
+PROMPT_CACHING_MIN_PROMPT_TOKENS = 1024
+
+
+class PromptCachingValidator:
+    """Detects when prompt caching looks misconfigured during an agentic loop.
+
+    Holmes runs an agentic loop that makes many sequential LLM calls sharing a
+    large, growing prefix (system prompt + tool schemas + prior turns). With
+    prompt caching working, the first call *creates* the cache and every call
+    after it should report cache *read* tokens. When a caching-enabled model
+    repeatedly reports zero cache reads on a large prompt, caching is almost
+    certainly not working - a common symptom of a model/deployment that hasn't
+    been set up for prompt caching. That silently inflates cost and latency.
+
+    This logs a single warning per investigation when that pattern is seen,
+    while avoiding false positives:
+
+    - models where Holmes doesn't enable caching (e.g. Gemini) are skipped
+    - the first call is skipped (it creates the cache; reads start on call 2)
+    - prompts below the provider minimum (~1024 tokens) are skipped
+    - once a non-zero cache read is observed, caching is confirmed working and
+      no further checks are made
+    """
+
+    def __init__(self, model: str, caching_enabled: bool):
+        self.model = model
+        self.caching_enabled = caching_enabled
+        self._calls_seen = 0
+        self._done = False
+
+    def record(self, prompt_tokens: int, cached_tokens: Optional[int]) -> None:
+        """Inspect one LLM call's usage and warn once if caching looks broken."""
+        if self._done or not self.caching_enabled:
+            return
+
+        self._calls_seen += 1
+        # The first call of a conversation creates the cache; cache *reads*
+        # only appear from the second call onward, so don't judge the first.
+        if self._calls_seen < 2:
+            return
+
+        if cached_tokens:  # non-zero -> caching is confirmed working
+            self._done = True
+            return
+
+        # Prompts below the provider minimum are never cached, so zero reads
+        # here is expected rather than a sign of misconfiguration.
+        if prompt_tokens < PROMPT_CACHING_MIN_PROMPT_TOKENS:
+            return
+
+        # Caching enabled, past the first call, large prompt, yet 0 cache reads.
+        self._done = True
+        logging.warning(
+            "Prompt caching does not appear to be working for model '%s': "
+            "%d prompt tokens were sent on a repeated request but the provider "
+            "reported 0 cached tokens. This usually means prompt caching is not "
+            "enabled for your model or deployment, which significantly increases "
+            "cost and latency. Verify that your provider/model supports prompt "
+            "caching and that it is enabled for your account.",
+            self.model,
+            prompt_tokens,
+        )
+
+
 def _extract_detail_field(details: object, field: str) -> Optional[int]:
     """Extract an optional int field from a token-details object or dict.
 

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -26,7 +26,7 @@ from holmes.common.env_vars import (
     load_bool,
 )
 from holmes.core.llm import LLM
-from holmes.core.llm_usage import RequestStats
+from holmes.core.llm_usage import PromptCachingValidator, RequestStats
 from holmes.core.models import (
     FrontendToolResult,
     PendingFrontendToolCall,
@@ -1098,6 +1098,10 @@ class ToolCallingLLM:
         max_steps = self.max_steps
         metadata: Dict[Any, Any] = {}
         stats = RequestStats()
+        caching_validator = PromptCachingValidator(
+            model=self.llm.model,
+            caching_enabled=self.llm.is_prompt_caching_enabled(),
+        )
         if iteration_offset < 0:
             raise ValueError("iteration_offset must be non-negative")
         i = iteration_offset
@@ -1190,6 +1194,12 @@ class ToolCallingLLM:
                     if usage:
                         logging.info(f"LLM usage response:\n{usage}\n")
                 stats += response_stats
+
+                # Warn once if prompt caching looks misconfigured (caching-enabled
+                # model repeatedly returning 0 cache reads on a large prompt).
+                caching_validator.record(
+                    response_stats.prompt_tokens, response_stats.cached_tokens
+                )
 
                 # Record OTel LLM metrics
                 otel_metrics = TracingFactory.get_metrics()

--- a/tests/core/test_prompt_caching_validator.py
+++ b/tests/core/test_prompt_caching_validator.py
@@ -1,0 +1,128 @@
+"""Tests for prompt-caching misconfiguration detection.
+
+Holmes enables prompt caching for every non-Gemini model. In the agentic loop
+the first LLM call creates the cache and every call after it should report
+cache *read* tokens. A caching-enabled model that keeps returning 0 cache reads
+on a large prompt is almost certainly misconfigured, and PromptCachingValidator
+logs a single warning when it sees that pattern - without false-positiving on
+the first call, small prompts, or models where caching is disabled.
+"""
+
+import logging
+
+from holmes.core.llm import DefaultLLM
+from holmes.core.llm_usage import (
+    PROMPT_CACHING_MIN_PROMPT_TOKENS,
+    PromptCachingValidator,
+)
+
+LARGE = PROMPT_CACHING_MIN_PROMPT_TOKENS + 100
+SMALL = PROMPT_CACHING_MIN_PROMPT_TOKENS - 1
+
+WARNING_FRAGMENT = "Prompt caching does not appear to be working"
+
+
+def _warnings(caplog) -> list[str]:
+    return [r.message for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def _make_llm(model: str) -> DefaultLLM:
+    """Build a DefaultLLM bypassing __init__ so we can control self.model."""
+    llm = DefaultLLM.__new__(DefaultLLM)
+    llm.model = model
+    llm.is_robusta_model = False
+    return llm
+
+
+class TestWarns:
+    def test_warns_when_caching_enabled_model_never_reads_cache(self, caplog):
+        v = PromptCachingValidator(model="anthropic/claude-sonnet-4-5", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            v.record(prompt_tokens=LARGE, cached_tokens=0)  # first call creates cache
+            v.record(prompt_tokens=LARGE, cached_tokens=0)  # 2nd call: expected a read
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert WARNING_FRAGMENT in warnings[0]
+        assert "anthropic/claude-sonnet-4-5" in warnings[0]
+
+    def test_treats_none_cached_tokens_as_no_cache(self, caplog):
+        """Providers that don't report the field at all (None) count as 0 reads."""
+        v = PromptCachingValidator(model="openai/gpt-4o", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            v.record(prompt_tokens=LARGE, cached_tokens=None)
+            v.record(prompt_tokens=LARGE, cached_tokens=None)
+        assert len(_warnings(caplog)) == 1
+
+    def test_warns_only_once_per_investigation(self, caplog):
+        v = PromptCachingValidator(model="openai/gpt-4o", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                v.record(prompt_tokens=LARGE, cached_tokens=0)
+        assert len(_warnings(caplog)) == 1
+
+
+class TestDoesNotWarn:
+    def test_first_call_alone_never_warns(self, caplog):
+        """The first call creates the cache - 0 reads there is expected."""
+        v = PromptCachingValidator(model="anthropic/claude-sonnet-4-5", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            v.record(prompt_tokens=LARGE, cached_tokens=0)
+        assert _warnings(caplog) == []
+
+    def test_no_warning_when_cache_reads_present(self, caplog):
+        v = PromptCachingValidator(model="anthropic/claude-sonnet-4-5", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            v.record(prompt_tokens=LARGE, cached_tokens=0)
+            v.record(prompt_tokens=LARGE, cached_tokens=LARGE - 50)  # cache hit
+        assert _warnings(caplog) == []
+
+    def test_caching_confirmed_then_a_miss_does_not_warn(self, caplog):
+        """Once caching is observed working, later misses (e.g. TTL expiry) are ignored."""
+        v = PromptCachingValidator(model="anthropic/claude-sonnet-4-5", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            v.record(prompt_tokens=LARGE, cached_tokens=0)
+            v.record(prompt_tokens=LARGE, cached_tokens=500)  # confirmed working
+            v.record(prompt_tokens=LARGE, cached_tokens=0)  # later miss
+        assert _warnings(caplog) == []
+
+    def test_small_prompts_never_warn(self, caplog):
+        """Prompts below the provider minimum are never cached - 0 reads is fine."""
+        v = PromptCachingValidator(model="anthropic/claude-sonnet-4-5", caching_enabled=True)
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                v.record(prompt_tokens=SMALL, cached_tokens=0)
+        assert _warnings(caplog) == []
+
+    def test_caching_disabled_model_never_warns(self, caplog):
+        """Models where Holmes disables caching (e.g. Gemini) must not warn."""
+        v = PromptCachingValidator(model="gemini/gemini-3.1-pro-preview", caching_enabled=False)
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                v.record(prompt_tokens=LARGE, cached_tokens=0)
+        assert _warnings(caplog) == []
+
+
+class TestIsPromptCachingEnabled:
+    """The validator's caching_enabled input comes from llm.is_prompt_caching_enabled(),
+    which must stay in sync with completion()'s cache-hint gating (non-Gemini only).
+    """
+
+    def test_non_gemini_models_enabled(self):
+        for model in [
+            "anthropic/claude-sonnet-4-5",
+            "gpt-5.4",
+            "openai/gpt-4o",
+            "azure/gpt-4.1",
+            "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+            "vertex_ai/claude-3-5-sonnet",
+        ]:
+            assert _make_llm(model).is_prompt_caching_enabled() is True, model
+
+    def test_gemini_models_disabled(self):
+        for model in [
+            "gemini/gemini-3.1-pro-preview",
+            "gemini/gemini-1.5-pro",
+            "vertex_ai/gemini-2.0-flash",
+            "vertex_ai_beta/gemini-2.5-pro",
+        ]:
+            assert _make_llm(model).is_prompt_caching_enabled() is False, model

--- a/tests/core/test_prompt_caching_validator.py
+++ b/tests/core/test_prompt_caching_validator.py
@@ -53,6 +53,22 @@ class TestWarns:
             v.record(prompt_tokens=LARGE, cached_tokens=None)
         assert len(_warnings(caplog)) == 1
 
+    def test_warns_for_opaque_deployment_name_hiding_anthropic(self, caplog):
+        """The real-world case: an Azure AI / Bedrock deployment whose name gives
+        no hint it's Anthropic underneath, with caching misconfigured. The warning
+        must still fire because the gate is non-Gemini, not 'is anthropic'.
+        """
+        llm = _make_llm("azure/my-company-prod-deployment")
+        v = PromptCachingValidator(
+            model=llm.model, caching_enabled=llm.is_prompt_caching_enabled()
+        )
+        with caplog.at_level(logging.WARNING):
+            v.record(prompt_tokens=LARGE, cached_tokens=0)
+            v.record(prompt_tokens=LARGE, cached_tokens=0)
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert "azure/my-company-prod-deployment" in warnings[0]
+
     def test_warns_only_once_per_investigation(self, caplog):
         v = PromptCachingValidator(model="openai/gpt-4o", caching_enabled=True)
         with caplog.at_level(logging.WARNING):
@@ -115,6 +131,19 @@ class TestIsPromptCachingEnabled:
             "azure/gpt-4.1",
             "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
             "vertex_ai/claude-3-5-sonnet",
+        ]:
+            assert _make_llm(model).is_prompt_caching_enabled() is True, model
+
+    def test_opaque_custom_deployment_names_enabled(self):
+        """Azure AI / Bedrock deployments often have custom names that hide the
+        underlying Anthropic model. Detection is negative (non-Gemini), not based
+        on recognizing the model as Anthropic, so these still get the warning.
+        """
+        for model in [
+            "azure/my-company-prod-deployment",  # custom Azure AI deployment name
+            "azure_ai/team-llm-v2",
+            "bedrock/arn:aws:bedrock:us-east-1:123456789:provisioned-model/abc123",
+            "some-internal-gateway-model",  # opaque proxy/gateway name
         ]:
             assert _make_llm(model).is_prompt_caching_enabled() is True, model
 


### PR DESCRIPTION
Users frequently run models without prompt caching properly enabled,
silently inflating cost and latency. Add a per-investigation warning
that fires when a caching-enabled model repeatedly returns zero cache
reads on a large prompt.

The signal: in the agentic loop the first LLM call creates the cache and
every call after it should report cache *read* tokens. A caching-enabled
(non-Gemini) model that keeps reporting 0 cache reads on a prompt above
the provider minimum (~1024 tokens) is almost certainly misconfigured.

PromptCachingValidator (holmes/core/llm_usage.py) tracks this per
call_stream invocation and logs a single warning, while avoiding false
positives on the first call (cache creation), small prompts, models where
Holmes disables caching, and cases where caching is confirmed working.

is_prompt_caching_enabled() on the LLM class exposes the same non-Gemini
gating that completion() uses for cache_control_injection_points, keeping
the warning in sync with where caching is actually requested.

Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Language models now support configurable prompt caching with per-model control settings.
  * Added automatic detection and warning alerts for prompt caching misconfiguration issues.
  * Prompt caching is now disabled by default for specific model providers to ensure optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->