### PR TITLE
Add bubblewrap sandboxing POC for bash tool execution

### DIFF
--- a/docs/design/2026-06-05_bash-sandboxing.md
+++ b/docs/design/2026-06-05_bash-sandboxing.md
@@ -1,0 +1,160 @@
+# Bash Tool Sandboxing
+
+## Intent
+
+HolmesGPT lets the LLM run shell commands through the `bash` toolset. Today the
+only thing standing between the model and the host is **string-level
+validation**: `holmes/plugins/toolsets/bash/validation.py` parses each command
+with `bashlex`, splits it into segments, and checks every segment against a
+prefix allow/deny list (`common/default_lists.py`), with `sudo`/`su`
+hard-blocked. The approved string is then executed by
+`common/bash.py:execute_bash_command()` via
+`subprocess.Popen(cmd, shell=True, executable="/bin/bash")`.
+
+This is a guardrail, not a security boundary:
+
+- The command runs **in the main Holmes process context** — same UID, same
+  filesystem, same network, and crucially the **same environment variables**.
+  `execute_bash_command` passes no `env=` argument, so every child inherits the
+  parent's kubeconfig, cloud credentials, and LLM API keys.
+- The allowlist is bypassable in principle (parser ambiguities, allowed binaries
+  with shell escapes such as `find -exec` or `kubectl exec`, env-var abuse).
+- In the HTTP server (`server.py`) there is a single long-lived process with a
+  shared, cached `ToolExecutor`. Only the tool-result temp directory is
+  per-request. There is **no OS-level isolation between concurrent sessions** —
+  an "allowed" command in one session can read another session's secrets off
+  disk or out of the environment.
+
+The goal of this work is to move from "is this command string allowed?" to
+"what can this process actually touch?" by executing each bash command inside an
+OS-level jail.
+
+## Approach: per-command OS jail via bubblewrap
+
+We evaluated four tiers of isolation: (0) in-process hardening, (1) OS-primitive
+jail via namespaces + seccomp + cgroups (bubblewrap / nsjail), (2) a container
+per session (Docker/Podman, optionally gVisor), (3) a microVM per session
+(Firecracker/Kata), and (4) a remote sandbox-as-a-service.
+
+**We chose Approach 1 with [bubblewrap](https://github.com/containers/bubblewrap)
+(`bwrap`) as the backend.** Rationale:
+
+- It is unprivileged (uses user namespaces), so it runs without root and inside
+  a non-privileged Kubernetes pod.
+- It is the one approach that runs in **all three** environments we care about:
+  the developer/agent sandbox, the GitHub Actions eval runners, and a production
+  Holmes pod.
+- It is a single, ubiquitously-packaged static binary (`apt install
+  bubblewrap`), battle-tested as the engine behind Flatpak.
+- Per-command jail setup is cheap (single-digit milliseconds), which matters
+  because the agentic loop fans out up to 16 tool calls in parallel.
+
+The jail wraps the **bash toolset only** for now (the single
+`execute_bash_command` call site), not every toolset that shells out. Widening
+it to a shared subprocess primitive is a possible follow-up.
+
+### What the jail does
+
+Each command runs as `bwrap [isolation args] /bin/bash -c "<ulimit prefix><cmd>"`
+with:
+
+- **Fresh namespaces**: user, pid, ipc, uts, cgroup. The process sees itself as
+  the only thing running, and its capabilities map to nothing on the host.
+- **A scrubbed environment**: `--clearenv` followed by an explicit allowlist of
+  variables re-injected with `--setenv`. This is the single most important
+  control — namespaces do **not** scrub the environment, and credential bleed
+  through env is the current worst case.
+- **A read-only root**: curated `--ro-bind` of system directories (`/usr`,
+  `/bin`, `/sbin`, `/lib`, `/lib64`) and a curated set of `/etc` files needed for
+  DNS/TLS (`resolv.conf`, `ssl`, `ca-certificates`, `hosts`, `nsswitch.conf`,
+  `passwd`, `group`). The host filesystem — `/home`, the Holmes config dir,
+  `~/.kube`, `~/.aws`, `/var/run/secrets/...` — is **not** mounted unless
+  explicitly bound.
+- **Ephemeral writable space**: a private `tmpfs` at `/tmp` and a `tmpfs` working
+  directory (`/work`, the cwd). Nothing the command writes touches the host.
+- **`--die-with-parent --new-session`** so a jailed process cannot outlive Holmes
+  or escape its controlling terminal.
+
+`no_new_privs` and capability dropping come for free — bwrap sets them by
+default — so they are not separate code.
+
+### Decisions
+
+These are the design forks and how we resolved them:
+
+| Decision | Choice | Notes |
+|----------|--------|-------|
+| **Backend** | bubblewrap | Portability and simplicity over nsjail's bundled resource controls. |
+| **Granularity** | Per-command (first increment) | Easiest to bolt onto the single `execute_bash_command` call site and gives the largest blast-radius reduction. A persistent per-session sandbox (keyed by `conversation_id`) is the natural next step for the HTTP-server isolation goal. |
+| **Network policy** | **None — share the host network** | Holmes's entire job is querying remote backends (K8s API, Prometheus, Grafana). A deny-all net namespace would break the product. We explicitly `--share-net` and rely on credential scoping (not network isolation) as the boundary. Per-session egress control is explicitly out of scope. |
+| **Resource limits** | **Keep today's `ulimit` / OOM handling** | We do **not** introduce cgroup v2 resource caps in this iteration. The existing `ulimit -v` prefix from `memory_limit.py` and the OOM-hint UX are preserved and continue to run inside the jail. cgroups remain a separate, later, feature-detected layer. |
+| **Seccomp** | Not in the POC | bwrap's default namespace isolation is the POC boundary. A curated seccomp allowlist (passed as a compiled BPF fd) is a follow-up hardening layer, gated on testing against the allowed binaries. |
+| **Landlock** | Not used | Optional future hardening; must be runtime-feature-detected because it is absent on some kernels (e.g. the current agent sandbox) even though present on CI/modern kernels. Never a hard dependency. |
+| **Credential injection** | Env allowlist only (POC) | The env passthrough allowlist is configurable. Binding a per-session, scoped kubeconfig / service-account token into the jail is the follow-up that makes the bash toolset fully functional under sandboxing. |
+| **Rollout** | Opt-in, default off | New `HOLMES_BASH_SANDBOX_ENABLED` flag. With graceful degradation: if the flag is on but the jail is unavailable (no `bwrap`, or unprivileged user namespaces are disabled), behaviour falls back to today's direct execution and logs a warning. |
+| **Scope** | Bash toolset only | Not yet a shared primitive for all subprocess-spawning toolsets. |
+
+### What remains from in-process hardening (Approach 0)
+
+With the jail in place, the Approach-0 checklist collapses to:
+
+- **Subsumed by bwrap** (now just jail config, not separate code): `no_new_privs`,
+  capability dropping.
+- **Still required, and more important** because the jail will not do it for you:
+  **environment scrubbing/allowlisting** (the jail's `--clearenv` + `--setenv`),
+  and **per-session credential partitioning** (the jail provides the mechanism;
+  the credential model is a follow-up).
+- **Dropped**: restricted shell (`rbash`) — a weak, bypassable control that the
+  jail makes redundant.
+- **Demoted, not removed**: the existing bashlex allowlist stays as
+  defense-in-depth and to drive the approval UX, but it is no longer the boundary
+  that keeps sessions apart.
+
+## Feature detection and graceful degradation
+
+Unprivileged user namespaces are the hard dependency and are **not** universally
+available — hardened clusters set `kernel.unprivileged_userns_clone=0` or
+seccomp-block `unshare`, and a restrictive container runtime (gVisor, a tight
+seccomp profile) hosting Holmes itself can block nested namespace creation.
+
+Detection is therefore a runtime probe, not a static assumption: we check that
+`bwrap` is on `PATH` and that a trivial jailed `true` actually runs, and we cache
+the result. If the probe fails while sandboxing is enabled, Holmes logs a clear
+warning and falls back to direct execution rather than refusing to run bash.
+
+Verified behaviour across the three target environments:
+
+| Capability | Agent sandbox | GitHub Actions (`ubuntu-latest`) | Production pod |
+|------------|:-:|:-:|:-:|
+| Unprivileged user namespaces | ✅ verified | ✅ | depends on runtime — probe at startup |
+| `bwrap` installable / present | ✅ (apt) | ✅ (apt) | bake into image |
+| Network share (`--share-net`) | ✅ | ✅ | ✅ |
+| cgroup v2 resource caps | ⚠️ weak (v1, no `CAP_SYS_RESOURCE`) | ✅ | depends | (not used in POC) |
+| Landlock | ❌ `ENOSYS` | ✅ | depends | (not used) |
+
+## Structure
+
+The POC adds one module and threads it into the single execution call site:
+
+- **`holmes/plugins/toolsets/bash/common/sandbox.py`** — all sandboxing logic.
+  - `is_sandbox_available()` — cached runtime probe (bwrap present + a jailed
+    `true` succeeds).
+  - `build_sandbox_argv()` — assembles the `bwrap` argument vector (namespaces,
+    curated read-only binds, tmpfs, env allowlist) in front of the bash invocation.
+  - `sandbox_enabled()` — reads the opt-in flag.
+- **`holmes/plugins/toolsets/bash/common/bash.py`** — `execute_bash_command`
+  builds the same `ulimit`-prefixed command as before, then either wraps it in
+  the jail (argv form, `shell=False`) or runs it directly (today's
+  `shell=True`), depending on availability.
+- **`holmes/common/env_vars.py`** — `HOLMES_BASH_SANDBOX_ENABLED` (default off)
+  and `HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH` (comma-separated extra env vars to
+  carry into the jail beyond the safe defaults).
+
+## Out of scope (follow-ups)
+
+- Persistent per-session sandbox keyed by `conversation_id` (the real fix for
+  HTTP-server session isolation).
+- Scoped per-session credential injection (bind a session kubeconfig / token).
+- cgroup v2 resource limits replacing `ulimit`.
+- A seccomp-bpf profile and optional Landlock filesystem layer.
+- Extending the jail to all subprocess-spawning toolsets, not just bash.

--- a/docs/design/2026-06-05_bash-sandboxing.md
+++ b/docs/design/2026-06-05_bash-sandboxing.md
@@ -78,6 +78,37 @@ with:
 `no_new_privs` and capability dropping come for free — bwrap sets them by
 default — so they are not separate code.
 
+### Interaction with tool-result spilling
+
+HolmesGPT spills oversized tool results to disk
+(`core/tools_utils/filesystem_result_storage.py`) and hands the LLM an absolute
+path with the instruction to read it back via bash:
+
+> `Saved to: /tmp/.holmes/<chat-uuid>/tool_results/<tool>_<id>.txt`
+> `Use \`cat <path>\` to read it ... \`cat <path> | jq ...\`, \`cat <path> | grep ...\``
+
+A naive jail with an ephemeral `tmpfs /tmp` **breaks this workflow** — the
+spilled file lives on the host, not in the jail, so `cat <path>` fails with "No
+such file or directory". This is a real regression the sandbox must avoid.
+
+The fix is to bind-mount the **per-session** spill directory into the jail at the
+**same absolute path**. The per-session `tool_results_dir` (already created once
+per chat/request) is threaded from the tool-call layer down through
+`ToolInvokeContext` → the bash tool → `execute_bash_command` →
+`build_sandbox_argv`, which adds a `--bind <dir> <dir>` *after* the `tmpfs /tmp`
+so it layers on top. Crucially we bind only that session's directory, never the
+shared `HOLMES_TOOL_RESULT_STORAGE_PATH` base — so one session's jail cannot see
+another session's spilled files, which keeps the isolation property intact.
+
+Images are unaffected: they are read back by the `read_image_file` Python tool,
+which reads the host filesystem directly rather than shelling out into the jail.
+
+Note this is per-command isolation, so scratch files written by one bash command
+to the ephemeral `/work` or `/tmp` are **not** visible to a later command in the
+same session. Persisting a per-session work dir is part of the per-session
+sandbox follow-up; the spill directory above is the one cross-command path that
+must survive, and it does.
+
 ### Decisions
 
 These are the design forks and how we resolved them:

--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -112,6 +112,18 @@ MAX_OUTPUT_TOKEN_RESERVATION = int(
 # When using the bash tool, setting BASH_TOOL_UNSAFE_ALLOW_ALL will skip any command validation and run any command requested by the LLM
 BASH_TOOL_UNSAFE_ALLOW_ALL = load_bool("BASH_TOOL_UNSAFE_ALLOW_ALL", False)
 
+# Sandbox bash tool execution inside a bubblewrap (bwrap) OS-level jail.
+# Opt-in (default off). When enabled but the jail is unavailable (no bwrap, or
+# unprivileged user namespaces disabled), Holmes logs a warning and falls back
+# to direct execution. See docs/design/2026-06-05_bash-sandboxing.md
+HOLMES_BASH_SANDBOX_ENABLED = load_bool("HOLMES_BASH_SANDBOX_ENABLED", False)
+# Comma-separated list of additional environment variable names to carry into
+# the sandbox beyond the safe defaults (PATH, HOME, LANG, LC_*, TERM, TZ).
+# The jail clears the environment by default; only allowlisted vars are passed.
+HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH = os.environ.get(
+    "HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH", ""
+)
+
 LOG_LLM_USAGE_RESPONSE = load_bool("LOG_LLM_USAGE_RESPONSE", False)
 TRACE_TOKEN_USAGE = load_bool("TRACE_TOKEN_USAGE", False)
 

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -776,6 +776,7 @@ class ToolCallingLLM:
                 tool_call_id=tool_call_id,
                 session_approved_prefixes=session_approved_prefixes or [],
                 request_context=request_context,
+                tool_results_dir=self.tool_results_dir,
             )
             tool_response = tool.invoke(tool_params, context=invoke_context)
 

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -11,6 +11,7 @@ import time
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -265,6 +266,10 @@ class ToolInvokeContext(BaseModel):
         str
     ] = []  # Bash prefixes approved during this session
     request_context: Optional[Dict[str, Any]] = None
+    # Per-session directory where large tool results are spilled to disk. When the
+    # bash tool runs inside a sandbox, this directory is bind-mounted into the jail
+    # at the same absolute path so the LLM can `cat`/`grep` spilled results.
+    tool_results_dir: Optional[Path] = None
 
     def model_dump(self, **kwargs):
         """Override to exclude sensitive context from serialization"""

--- a/holmes/plugins/toolsets/bash/bash_toolset.py
+++ b/holmes/plugins/toolsets/bash/bash_toolset.py
@@ -257,10 +257,19 @@ class RunBashCommand(Tool):
                     invocation=command_str,
                 )
 
-        # Execute command (user_approved or validation passed)
+        # Execute command (user_approved or validation passed). When sandboxing is
+        # active, bind the per-session tool-result spill dir into the jail so the
+        # LLM can cat/grep results the framework wrote to disk at that path.
         display_logger.info(f"Executing bash command: {command_str}")
+        sandbox_bind_paths = (
+            [str(context.tool_results_dir)] if context.tool_results_dir else None
+        )
         try:
-            result = execute_bash_command(cmd=command_str, timeout=timeout)
+            result = execute_bash_command(
+                cmd=command_str,
+                timeout=timeout,
+                sandbox_bind_paths=sandbox_bind_paths,
+            )
         except FileNotFoundError:
             return StructuredToolResult(
                 status=StructuredToolResultStatus.ERROR,

--- a/holmes/plugins/toolsets/bash/common/bash.py
+++ b/holmes/plugins/toolsets/bash/common/bash.py
@@ -1,8 +1,15 @@
+import logging
 import subprocess
 from dataclasses import dataclass
 from typing import Optional
 
+from holmes.plugins.toolsets.bash.common.sandbox import (
+    build_sandbox_argv,
+    should_sandbox,
+)
 from holmes.utils.memory_limit import check_oom_and_append_hint, get_ulimit_prefix
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -26,13 +33,24 @@ def execute_bash_command(cmd: str, timeout: int) -> BashResult:
         BashResult with stdout, return_code, and timed_out flag
     """
     protected_cmd = get_ulimit_prefix() + cmd
+
+    if should_sandbox():
+        # Run inside a bubblewrap jail. The ulimit-prefixed command is handed to
+        # bash -c *inside* the jail, so shell semantics are preserved while the
+        # host environment, credentials, and filesystem are isolated away.
+        logger.debug("Executing bash command inside bubblewrap sandbox")
+        popen_args: list = build_sandbox_argv(protected_cmd)
+        popen_kwargs: dict = {}
+    else:
+        popen_args = protected_cmd  # type: ignore[assignment]
+        popen_kwargs = {"shell": True, "executable": "/bin/bash"}
+
     process = subprocess.Popen(
-        protected_cmd,
-        shell=True,
-        executable="/bin/bash",
+        popen_args,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        **popen_kwargs,
     )
 
     try:

--- a/holmes/plugins/toolsets/bash/common/bash.py
+++ b/holmes/plugins/toolsets/bash/common/bash.py
@@ -21,13 +21,19 @@ class BashResult:
     timed_out: bool
 
 
-def execute_bash_command(cmd: str, timeout: int) -> BashResult:
+def execute_bash_command(
+    cmd: str, timeout: int, sandbox_bind_paths: Optional[list] = None
+) -> BashResult:
     """
     Execute a bash command and return the result.
 
     Args:
         cmd: The bash command to execute
         timeout: Timeout in seconds
+        sandbox_bind_paths: Host directories to bind-mount read-write into the
+            sandbox at the same absolute path (e.g. the per-session tool-result
+            spill dir, so the LLM can cat/grep spilled results). Ignored when the
+            sandbox is not active.
 
     Returns:
         BashResult with stdout, return_code, and timed_out flag
@@ -39,7 +45,9 @@ def execute_bash_command(cmd: str, timeout: int) -> BashResult:
         # bash -c *inside* the jail, so shell semantics are preserved while the
         # host environment, credentials, and filesystem are isolated away.
         logger.debug("Executing bash command inside bubblewrap sandbox")
-        popen_args: list = build_sandbox_argv(protected_cmd)
+        popen_args: list = build_sandbox_argv(
+            protected_cmd, rw_bind_paths=sandbox_bind_paths
+        )
         popen_kwargs: dict = {}
     else:
         popen_args = protected_cmd  # type: ignore[assignment]

--- a/holmes/plugins/toolsets/bash/common/sandbox.py
+++ b/holmes/plugins/toolsets/bash/common/sandbox.py
@@ -1,0 +1,186 @@
+"""
+Bubblewrap (bwrap) based sandboxing for bash tool execution.
+
+This module wraps an approved bash command in an unprivileged OS-level jail so
+that the command cannot read the host's credentials, environment, or filesystem.
+It is an opt-in proof of concept; see docs/design/2026-06-05_bash-sandboxing.md
+for the full design and the list of follow-ups.
+
+Key properties of the jail:
+- Fresh user/pid/ipc/uts/cgroup namespaces (no privilege required).
+- A scrubbed environment: the env is cleared and only an allowlist is re-injected.
+- A curated read-only system root; the host's home, config, and secret dirs are
+  NOT mounted.
+- Ephemeral tmpfs for /tmp and the working directory.
+- The host network is intentionally shared (Holmes must reach K8s/Prometheus/etc).
+"""
+
+import functools
+import logging
+import os
+import shutil
+import subprocess
+from typing import List
+
+from holmes.common.env_vars import (
+    HOLMES_BASH_SANDBOX_ENABLED,
+    HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH,
+)
+
+logger = logging.getLogger(__name__)
+
+BWRAP_BINARY = "bwrap"
+
+# System directories bind-mounted read-only into the jail. Only those that exist
+# on the host are bound. Deliberately excludes /etc as a whole (it may hold host
+# secrets); specific /etc files needed for DNS/TLS are bound separately below.
+_RO_SYSTEM_DIRS = ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/lib32"]
+
+# Specific /etc files needed for name resolution and TLS verification.
+_RO_ETC_FILES = [
+    "/etc/resolv.conf",
+    "/etc/ssl",
+    "/etc/ca-certificates",
+    "/etc/ca-certificates.conf",
+    "/etc/hosts",
+    "/etc/nsswitch.conf",
+    "/etc/passwd",
+    "/etc/group",
+]
+
+# Environment variables always carried into the jail. Intentionally minimal and
+# credential-free. Anything else must be opted in via
+# HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH.
+_DEFAULT_ENV_ALLOWLIST = ["PATH", "HOME", "LANG", "TERM", "TZ"]
+_DEFAULT_ENV_PREFIXES = ["LC_"]
+
+# Working directory (and HOME) inside the jail. Backed by tmpfs, so ephemeral.
+_JAIL_WORKDIR = "/work"
+
+
+def sandbox_enabled() -> bool:
+    """Whether bash sandboxing has been opted into via env var."""
+    return bool(HOLMES_BASH_SANDBOX_ENABLED)
+
+
+@functools.lru_cache(maxsize=1)
+def is_sandbox_available() -> bool:
+    """
+    Runtime probe for whether the bwrap jail actually works here.
+
+    Checks that the bwrap binary is present AND that a trivial jailed command
+    can be created (this exercises unprivileged user-namespace creation, which
+    some hardened kernels/containers disable). The result is cached.
+    """
+    if shutil.which(BWRAP_BINARY) is None:
+        logger.warning(
+            "Bash sandboxing requested but '%s' is not on PATH; "
+            "falling back to direct execution.",
+            BWRAP_BINARY,
+        )
+        return False
+
+    try:
+        # Probe with the real jail layout so the check matches actual execution
+        # (in particular it exercises unprivileged user-namespace creation and
+        # confirms the bind set is sufficient to exec bash).
+        probe = subprocess.run(
+            build_sandbox_argv("exit 0"),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning(
+            "Bash sandboxing requested but the bwrap probe failed (%s); "
+            "falling back to direct execution.",
+            e,
+        )
+        return False
+
+    if probe.returncode != 0:
+        logger.warning(
+            "Bash sandboxing requested but the bwrap probe exited %s "
+            "(unprivileged user namespaces may be disabled): %s; "
+            "falling back to direct execution.",
+            probe.returncode,
+            probe.stderr.decode(errors="replace").strip(),
+        )
+        return False
+
+    return True
+
+
+def should_sandbox() -> bool:
+    """True if sandboxing is both opted into and actually usable here."""
+    return sandbox_enabled() and is_sandbox_available()
+
+
+def _env_allowlist() -> List[str]:
+    extra = [
+        name.strip()
+        for name in HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH.split(",")
+        if name.strip()
+    ]
+    return _DEFAULT_ENV_ALLOWLIST + extra
+
+
+def _setenv_args() -> List[str]:
+    """Build --setenv args for the allowlisted environment variables that are set."""
+    args: List[str] = []
+    allowlist = _env_allowlist()
+    for name, value in os.environ.items():
+        if name in allowlist or any(name.startswith(p) for p in _DEFAULT_ENV_PREFIXES):
+            args += ["--setenv", name, value]
+    # Ensure HOME points at the writable jail workdir even if not set on the host.
+    if "HOME" not in os.environ:
+        args += ["--setenv", "HOME", _JAIL_WORKDIR]
+    # Guarantee a sane PATH inside the jail.
+    if "PATH" not in os.environ:
+        args += ["--setenv", "PATH", "/usr/bin:/bin:/usr/sbin:/sbin"]
+    return args
+
+
+def build_sandbox_argv(inner_cmd: str) -> List[str]:
+    """
+    Build the full bwrap argv that runs ``inner_cmd`` via /bin/bash inside the jail.
+
+    ``inner_cmd`` is the already-prepared shell string (e.g. the ulimit-prefixed
+    command). It is passed to ``bash -c`` inside the jail, so normal shell
+    semantics (pipes, &&, etc.) still apply.
+    """
+    argv: List[str] = [
+        BWRAP_BINARY,
+        # Isolation: fresh namespaces. Network is intentionally NOT unshared.
+        "--unshare-user",
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-uts",
+        "--unshare-cgroup-try",
+        "--die-with-parent",
+        "--new-session",
+        # Scrub the environment, then re-inject only the allowlist.
+        "--clearenv",
+    ]
+    argv += _setenv_args()
+
+    # Read-only system root (only what exists).
+    for path in _RO_SYSTEM_DIRS:
+        if os.path.exists(path):
+            argv += ["--ro-bind", path, path]
+    for path in _RO_ETC_FILES:
+        if os.path.exists(path):
+            argv += ["--ro-bind", path, path]
+
+    # Kernel/dev filesystems and ephemeral writable space.
+    argv += [
+        "--proc", "/proc",
+        "--dev", "/dev",
+        "--tmpfs", "/tmp",
+        "--tmpfs", _JAIL_WORKDIR,
+        "--chdir", _JAIL_WORKDIR,
+    ]
+
+    # The command itself.
+    argv += ["/bin/bash", "-c", inner_cmd]
+    return argv

--- a/holmes/plugins/toolsets/bash/common/sandbox.py
+++ b/holmes/plugins/toolsets/bash/common/sandbox.py
@@ -20,7 +20,7 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from holmes.common.env_vars import (
     HOLMES_BASH_SANDBOX_ENABLED,
@@ -141,13 +141,22 @@ def _setenv_args() -> List[str]:
     return args
 
 
-def build_sandbox_argv(inner_cmd: str) -> List[str]:
+def build_sandbox_argv(
+    inner_cmd: str, rw_bind_paths: Optional[List[str]] = None
+) -> List[str]:
     """
     Build the full bwrap argv that runs ``inner_cmd`` via /bin/bash inside the jail.
 
     ``inner_cmd`` is the already-prepared shell string (e.g. the ulimit-prefixed
     command). It is passed to ``bash -c`` inside the jail, so normal shell
     semantics (pipes, &&, etc.) still apply.
+
+    ``rw_bind_paths`` is an optional list of host directories to bind-mount
+    read-write at the same absolute path inside the jail. This is how the
+    per-session tool-result spill directory is made visible so the LLM can
+    ``cat``/``grep`` large results that the framework wrote to disk. These paths
+    are session-scoped on purpose — the whole spill base is never bound, so one
+    session's jail cannot see another session's spilled files.
     """
     argv: List[str] = [
         BWRAP_BINARY,
@@ -180,6 +189,13 @@ def build_sandbox_argv(inner_cmd: str) -> List[str]:
         "--tmpfs", _JAIL_WORKDIR,
         "--chdir", _JAIL_WORKDIR,
     ]
+
+    # Session-scoped read-write binds (e.g. the tool-result spill dir). These come
+    # AFTER the tmpfs mounts so that a bind under /tmp layers on top of the tmpfs
+    # rather than being hidden by it (bwrap applies operations in argv order).
+    for path in rw_bind_paths or []:
+        if path and os.path.isdir(path):
+            argv += ["--bind", path, path]
 
     # The command itself.
     argv += ["/bin/bash", "-c", inner_cmd]

--- a/tests/plugins/toolsets/bash/test_sandbox.py
+++ b/tests/plugins/toolsets/bash/test_sandbox.py
@@ -1,0 +1,138 @@
+"""
+Tests for bubblewrap-based bash sandboxing.
+
+The argv-construction tests always run. The end-to-end isolation tests are
+skipped automatically when a working bwrap jail is not available (e.g. CI
+without bubblewrap installed, or kernels with unprivileged user namespaces
+disabled).
+"""
+
+import os
+
+import pytest
+
+from holmes.plugins.toolsets.bash.common import bash as bash_module
+from holmes.plugins.toolsets.bash.common import sandbox as sandbox_module
+from holmes.plugins.toolsets.bash.common.bash import execute_bash_command
+from holmes.plugins.toolsets.bash.common.sandbox import (
+    build_sandbox_argv,
+    is_sandbox_available,
+)
+
+requires_jail = pytest.mark.skipif(
+    not is_sandbox_available(),
+    reason="bubblewrap jail not available in this environment",
+)
+
+
+class TestBuildSandboxArgv:
+    def test_wraps_command_in_bwrap_and_bash(self):
+        argv = build_sandbox_argv("echo hi")
+        assert argv[0] == "bwrap"
+        # The inner command is handed to bash -c at the end.
+        assert argv[-3:] == ["/bin/bash", "-c", "echo hi"]
+
+    def test_clears_environment(self):
+        argv = build_sandbox_argv("true")
+        assert "--clearenv" in argv
+
+    def test_isolates_namespaces_but_not_network(self):
+        argv = build_sandbox_argv("true")
+        assert "--unshare-user" in argv
+        assert "--unshare-pid" in argv
+        # Network is intentionally shared so Holmes can reach K8s/Prometheus/etc.
+        assert "--unshare-net" not in argv
+
+    def test_does_not_bind_host_secret_dirs(self):
+        argv = build_sandbox_argv("true")
+        # Collect the source path of every bind mount.
+        bound_sources = [
+            argv[i + 1]
+            for i, tok in enumerate(argv)
+            if tok in ("--bind", "--ro-bind", "--ro-bind-try")
+        ]
+        # Whole /etc is never bound (only curated files); host homes/secrets never bound.
+        assert "/etc" not in bound_sources
+        for forbidden in ("/home", "/root", "/var/run/secrets"):
+            assert not any(
+                src == forbidden or src.startswith(forbidden + "/")
+                for src in bound_sources
+            ), f"{forbidden} must not be bind-mounted into the jail"
+
+    def test_env_allowlist_passes_through_only_allowlisted(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("MY_SECRET_TOKEN", "do-not-leak")
+        argv = build_sandbox_argv("true")
+        # PATH is on the default allowlist; the secret is not.
+        assert "PATH" in argv
+        assert "MY_SECRET_TOKEN" not in argv
+        assert "do-not-leak" not in argv
+
+    def test_env_passthrough_allowlist_opt_in(self, monkeypatch):
+        monkeypatch.setattr(
+            sandbox_module, "HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH", "KUBECONFIG"
+        )
+        monkeypatch.setenv("KUBECONFIG", "/some/path")
+        argv = build_sandbox_argv("true")
+        assert "KUBECONFIG" in argv
+
+
+@requires_jail
+class TestSandboxIsolationEndToEnd:
+    """Runs real commands through the jail via execute_bash_command."""
+
+    @pytest.fixture(autouse=True)
+    def force_sandbox(self, monkeypatch):
+        # Force the execution path to sandbox regardless of the env-var default.
+        monkeypatch.setattr(bash_module, "should_sandbox", lambda: True)
+
+    def test_command_still_runs_and_returns_output(self):
+        result = execute_bash_command("echo hello-from-jail", timeout=20)
+        assert result.return_code == 0
+        assert "hello-from-jail" in result.stdout
+
+    def test_environment_is_scrubbed(self, monkeypatch):
+        monkeypatch.setenv("LEAKED_SECRET", "TOPSECRET")
+        result = execute_bash_command(
+            'env | grep LEAKED_SECRET || echo NO_LEAK', timeout=20
+        )
+        assert "TOPSECRET" not in result.stdout
+        assert "NO_LEAK" in result.stdout
+
+    def test_host_home_not_visible(self):
+        result = execute_bash_command('ls /home 2>&1 || echo NO_HOME', timeout=20)
+        assert "NO_HOME" in result.stdout
+
+    def test_host_secret_file_not_visible(self, tmp_path):
+        secret = tmp_path / "creds"
+        secret.write_text("aws_secret=SHOULD-NOT-BE-VISIBLE")
+        result = execute_bash_command(
+            f'cat {secret} 2>&1 || echo NO_FILE', timeout=20
+        )
+        assert "SHOULD-NOT-BE-VISIBLE" not in result.stdout
+        assert "NO_FILE" in result.stdout
+
+    def test_workdir_is_writable_and_ephemeral(self):
+        result = execute_bash_command(
+            'echo data > ./scratch && cat ./scratch && pwd', timeout=20
+        )
+        assert result.return_code == 0
+        assert "data" in result.stdout
+        assert "/work" in result.stdout
+
+
+def test_sandbox_disabled_by_default():
+    # Without opting in, the default env var keeps sandboxing off.
+    assert sandbox_module.HOLMES_BASH_SANDBOX_ENABLED in (False, None)
+
+
+def test_unavailable_jail_does_not_break_execution(monkeypatch):
+    # Even if enabled, an unavailable jail must fall back to direct execution.
+    monkeypatch.setattr(sandbox_module, "is_sandbox_available", lambda: False)
+    monkeypatch.setattr(sandbox_module, "sandbox_enabled", lambda: True)
+    assert sandbox_module.should_sandbox() is False
+    result = execute_bash_command("echo fallback-ok", timeout=10)
+    assert result.return_code == 0
+    assert "fallback-ok" in result.stdout
+    # Sanity: confirm we are not accidentally in a jail here.
+    assert "PATH" in os.environ

--- a/tests/plugins/toolsets/bash/test_sandbox.py
+++ b/tests/plugins/toolsets/bash/test_sandbox.py
@@ -76,6 +76,25 @@ class TestBuildSandboxArgv:
         argv = build_sandbox_argv("true")
         assert "KUBECONFIG" in argv
 
+    def test_rw_bind_paths_added_after_tmpfs(self, tmp_path):
+        # A bind under /tmp must come AFTER the --tmpfs /tmp so it isn't hidden.
+        d = tmp_path / "tool_results"
+        d.mkdir()
+        argv = build_sandbox_argv("true", rw_bind_paths=[str(d)])
+        assert "--bind" in argv
+        bind_idx = argv.index("--bind")
+        assert argv[bind_idx + 1] == str(d)
+        assert argv[bind_idx + 2] == str(d)
+        # Ordering invariant relative to the tmpfs mount.
+        tmpfs_tmp_idx = next(
+            i for i, t in enumerate(argv) if t == "--tmpfs" and argv[i + 1] == "/tmp"
+        )
+        assert bind_idx > tmpfs_tmp_idx
+
+    def test_nonexistent_bind_path_skipped(self):
+        argv = build_sandbox_argv("true", rw_bind_paths=["/does/not/exist"])
+        assert "/does/not/exist" not in argv
+
 
 @requires_jail
 class TestSandboxIsolationEndToEnd:
@@ -119,6 +138,47 @@ class TestSandboxIsolationEndToEnd:
         assert result.return_code == 0
         assert "data" in result.stdout
         assert "/work" in result.stdout
+
+    def test_spilled_result_dir_is_readable_when_bound(self, tmp_path):
+        # Simulate the framework spilling a large tool result to the session dir.
+        results_dir = tmp_path / ".holmes" / "chat-uuid" / "tool_results"
+        results_dir.mkdir(parents=True)
+        spilled = results_dir / "kubectl_get_pods_abc.txt"
+        spilled.write_text("SPILLED-MATCH-7x9k2m4p\nnoise\n")
+        result = execute_bash_command(
+            f"cat {spilled} | grep MATCH",
+            timeout=20,
+            sandbox_bind_paths=[str(results_dir)],
+        )
+        assert result.return_code == 0
+        assert "SPILLED-MATCH-7x9k2m4p" in result.stdout
+
+    def test_spilled_result_dir_invisible_without_bind(self, tmp_path):
+        # Without the bind, the host path does not exist inside the jail.
+        results_dir = tmp_path / ".holmes" / "chat-uuid" / "tool_results"
+        results_dir.mkdir(parents=True)
+        spilled = results_dir / "out.txt"
+        spilled.write_text("data\n")
+        result = execute_bash_command(
+            f"cat {spilled} 2>&1 || echo MISSING", timeout=20, sandbox_bind_paths=None
+        )
+        assert "MISSING" in result.stdout
+        assert "data" not in result.stdout
+
+    def test_other_session_dir_not_visible(self, tmp_path):
+        # Binding one session's dir must not expose another session's dir.
+        mine = tmp_path / ".holmes" / "chat-mine" / "tool_results"
+        mine.mkdir(parents=True)
+        other = tmp_path / ".holmes" / "chat-other" / "tool_results"
+        other.mkdir(parents=True)
+        (other / "secret.txt").write_text("OTHER-SESSION-SECRET\n")
+        result = execute_bash_command(
+            f"cat {other}/secret.txt 2>&1 || echo NOT_VISIBLE",
+            timeout=20,
+            sandbox_bind_paths=[str(mine)],
+        )
+        assert "NOT_VISIBLE" in result.stdout
+        assert "OTHER-SESSION-SECRET" not in result.stdout
 
 
 def test_sandbox_disabled_by_default():


### PR DESCRIPTION
Adds an opt-in OS-level jail (Approach 1) for the bash toolset so commands
run in fresh namespaces with a scrubbed environment and isolated filesystem,
instead of relying solely on the bashlex prefix allowlist.

- docs/design: full design doc covering decisions (bubblewrap backend,
  per-command granularity, no network policy, ulimit kept for resource
  limits) and out-of-scope follow-ups.
- sandbox.py: bwrap argv builder + cached runtime availability probe.
- bash.py: execute_bash_command wraps the ulimit-prefixed command in the
  jail when enabled+available, else falls back to direct execution.
- env_vars: HOLMES_BASH_SANDBOX_ENABLED (default off) and
  HOLMES_BASH_SANDBOX_ENV_PASSTHROUGH allowlist.
- tests: argv construction + end-to-end isolation (auto-skip when no jail).

Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional opt-in bash sandboxing for running commands in an isolated unprivileged jail, with graceful fallback to normal execution.
  * Sandbox can bind per-session result directories so command-run outputs remain accessible when needed.
  * New configuration toggles to enable sandboxing and control environment passthrough.

* **Documentation**
  * Added a comprehensive design document describing sandbox architecture, behavior, and rollout decisions.

* **Tests**
  * Added unit and end-to-end tests validating sandbox behavior, environment scrubbing, and bind-mount isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->