### PR TITLE
Refactor log-routing prompt to backend-agnostic policy (fix stale tool names)

### DIFF
--- a/holmes/plugins/prompts/_fetch_logs.jinja2
+++ b/holmes/plugins/prompts/_fetch_logs.jinja2
@@ -1,82 +1,39 @@
-{%- set loki_ts = toolsets | selectattr("name", "equalto", "grafana/loki") | first -%}
-{%- set coralogix_ts = toolsets | selectattr("name", "equalto", "coralogix") | first -%}
-{%- set k8s_base_ts = toolsets | selectattr("name", "equalto", "kubernetes/logs") | selectattr("fetch_pod_logs", "defined") | first -%}
-{%- set k8s_yaml_ts = toolsets | selectattr("name", "equalto", "kubernetes/logs") | rejectattr("fetch_pod_logs", "defined") | first -%}
-{%- set opensearch_ts = toolsets | selectattr("name", "equalto", "opensearch/logs") | first -%}
-{%- set datadog_ts = toolsets | selectattr("name", "equalto", "datadog/logs") | first -%}
-{%- set openshift_ts = toolsets | selectattr("name", "equalto", "openshift/logs") | first -%}
-{%- set bash_ts = toolsets | selectattr("name", "equalto", "bash") | first -%}
+{#
+  Backend-agnostic log-fetching policy.
+
+  This template intentionally does NOT name backend-specific log tools or their
+  parameters. The LLM already receives every tool's name, description and
+  parameters from the tool-calling schema, and each enabled log toolset injects
+  its own usage instructions (tool names, query syntax, time-parameter formats)
+  via `_toolsets_instructions.jinja2`. Restating those here only duplicated
+  information that then drifted out of sync with the real tools.
+
+  Keep this file limited to universal policy that applies to every log backend.
+#}
+{%- set log_toolset_names = ["grafana/loki", "coralogix", "kubernetes/logs", "datadog/logs", "openshift/logs", "victorialogs"] -%}
+{%- set enabled_log_toolsets = toolsets | default([]) | selectattr("status.value", "equalto", "enabled") | selectattr("name", "in", log_toolset_names) | list -%}
+{%- set bash_ts = toolsets | default([]) | selectattr("name", "equalto", "bash") | selectattr("status.value", "equalto", "enabled") | list -%}
 
 ## Logs
 
-* IMPORTANT: ALWAYS inform the user about what logs you fetched. For example: "Here are pod logs for ..."
-* IMPORTANT: If logs commands have limits mention them. For example: "Showing last 100 lines of logs:"
-* IMPORTANT: If a filter was used, mention the filter. For example: "Logs filtered for 'error':"
-* IMPORTANT: If a date range was used (even if just the default one and you didn't specify the parameter, mention the date range. For example: "Logs from last 1 hour..."
-
-{% if loki_ts and loki_ts.status == "enabled" -%}
-* For any logs, including for investigating kubernetes problems, use Loki
-* Use the tool fetch_loki_logs_for_resource to get the logs of any kubernetes pod or node
-* Use fetch_loki_logs and build a query for any other logs
-* Prefer fetching loki logs and avoid using kubectl logs commands
-* Before fetching logs through Loki, use `kubectl` commands to get the namespace and correct name of a resource
-* If you have an issue id or finding id, use `fetch_finding_by_id` as it contains time information about the issue (`starts_at`, `updated_at` and `ends_at`).
-** Then, defaults to `start_timestamp=-300` (5 minutes before end_timestamp) and `end_timestamp=<issue start_at time>`.
-** If there are too many logs, or not enough, narrow or widen the timestamps
-* If you are not provided with time information. Ignore start_timestamp and end_timestamp.
-{%- elif coralogix_ts and coralogix_ts.status == "enabled" -%}
-### coralogix
-#### Coralogix Toolset
-Tools to search and fetch logs, traces, metrics, and other telemetry data from Coralogix.
-{% include '_default_log_prompt.jinja2' %}
-{%- elif k8s_base_ts and k8s_base_ts.status == "enabled" -%}
-{% include '_default_log_prompt.jinja2' %}
-{%- elif datadog_ts and datadog_ts.status == "enabled" -%}
-* If you are not sure what is the pod namespace, search for the logs only by pod name.
-### datadog/logs
-#### Datadog Logs Toolset
-Tools to search and fetch logs from Datadog.
-* Use the tool `fetch_pod_logs` to access an application's logs.
-* Do fetch application logs yourself and DO not ask users to do so
-* If you have an alert/monitor try to figure out the time it fired
-** Then, use `start_time=-300` (5 minutes before `end_time`) and `end_time=<time monitor started firing>`  when calling `fetch_pod_logs`.
-** If there are too many logs, or not enough, narrow or widen the timestamps
-* If the user did not explicitly ask about a given timeframe, ignore the `start_time` and `end_time` so it will use the default.
-* IMPORTANT: ALWAYS inform the user about the actual time period fetched (e.g., "Looking at logs from the last <X> days")
-* IMPORTANT: If a limit was applied, ALWAYS tell the user how many logs were shown vs total (e.g., "Showing latest <Y> of <Z> logs")
-* IMPORTANT: If any filters were applied, ALWAYS mention them explicitly
-{%- elif openshift_ts and openshift_ts.status == "enabled" -%}
-### openshift/logs
-#### OpenShift Logs Toolset
-Tools to search and fetch logs from OpenShift.
-* Use the tool `oc_logs` to access an application's logs.
-* Do fetch application logs yourself and DO not ask users to do so
-* If you have an alert/monitor try to figure out the time it fired
-** If there are too many logs, or not enough, narrow or widen the timestamps
-* IMPORTANT: ALWAYS inform the user about the actual time period fetched (e.g., "Looking at logs from the last <X> days")
-* IMPORTANT: If a limit was applied, ALWAYS tell the user how many logs were shown vs total (e.g., "Showing latest <Y> of <Z> logs")
-* IMPORTANT: If any filters were applied, ALWAYS mention them explicitly
-{%- elif k8s_yaml_ts and k8s_yaml_ts.status == "enabled" -%}
-### kubernetes/logs
-#### Kubernetes Logs Toolset
-Tools to search and fetch logs from Kubernetes.
-* if the user wants to find a specific term in a pod's logs, use kubectl_logs_grep
-* use both kubectl_previous_logs and kubectl_logs when reading logs. Treat the output of both as a single unified logs stream
-* if a pod has multiple containers, make sure you fetch the logs for either all or relevant containers using one of the containers log functions like kubectl_logs_all_containers, kubectl_logs_all_containers_grep or any other.
-* Check both kubectl_logs and kubectl_previous_logs because a pod restart mean kubectl_logs may not have relevant logs
-{%- elif opensearch_ts and opensearch_ts.status == "enabled" -%}
-{% include '_default_log_prompt.jinja2' %}
-{%- elif bash_ts and bash_ts.status == "enabled" -%}
-Use the tool `run_bash_command` to run `kubectl logs` commands and fetch any relevant pod logs.
-DO NOT use `--tail` or `| tail` when calling `kubectl logs` because you may miss critical information.
+{% if enabled_log_toolsets -%}
+* Fetch logs yourself using the available log tools - do NOT ask the user to fetch logs for you.
+* ALWAYS tell the user which logs you fetched. For example: "Here are pod logs for ..."
+* If a limit or truncation was applied, ALWAYS tell the user how many lines were shown versus the total. For example: "Showing latest 100 of 5,000 logs".
+* If a filter was used, mention the filter. For example: "Logs filtered for 'error':".
+* If a time range was used - even the default one that you did not explicitly set - state it. For example: "Logs from the last 1 hour...".
+* If you have an issue id or finding id, use `fetch_finding_by_id` as it contains time information about the issue (`starts_at`, `updated_at` and `ends_at`) that you can use to scope the log time range.
+* The exact tool names, query syntax and time-parameter formats differ per backend and are documented in each enabled log toolset's own instructions below - follow those for the toolset you choose to use.
+{%- elif bash_ts -%}
+* You do not have a dedicated logs toolset enabled. Use the tool `run_bash_command` to run `kubectl logs` commands and fetch any relevant pod logs.
+* DO NOT use `--tail` or `| tail` when calling `kubectl logs` because you may miss critical information.
 {%- else -%}
 * You have not been given access to tools to fetch kubernetes logs for nodes, pods, services or apps. This is likely a misconfiguration.
 * If you need logs to answer questions or investigate issues, tell the user to configure the documentation and enable one of these toolsets:
 ** 'kubernetes/logs'
 ** 'grafana/loki'
-** 'opensearch/logs'
 ** 'coralogix'
 ** 'datadog/logs'
 ** 'openshift/logs'
-** 'newrelic'
+** 'victorialogs'
 {%- endif -%}

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_general.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_general.py
@@ -118,19 +118,19 @@ WHITELISTED_ENDPOINTS = [
     # Logs
     (
         r"^/api/v1/logs/config/indexes$",
-        "When available, prefer using fetch_pod_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset",
+        "When available, prefer using fetch_datadog_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset",
     ),
     (
         r"^/api/v2/logs/events$",
-        "When available, prefer using fetch_pod_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset. Use RFC3339 timestamps (e.g., '2024-01-01T00:00:00Z')",
+        "When available, prefer using fetch_datadog_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset. Use RFC3339 timestamps (e.g., '2024-01-01T00:00:00Z')",
     ),
     (
         r"^/api/v2/logs/events/search$",
-        'When available, prefer using fetch_pod_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset. RFC3339 time format. Example: {"filter": {"from": "2024-01-01T00:00:00Z", "to": "2024-01-02T00:00:00Z", "query": "*"}}',
+        'When available, prefer using fetch_datadog_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset. RFC3339 time format. Example: {"filter": {"from": "2024-01-01T00:00:00Z", "to": "2024-01-02T00:00:00Z", "query": "*"}}',
     ),
     (
         r"^/api/v2/logs/analytics/aggregate$",
-        "When available, prefer using fetch_pod_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset. Do not include 'sort' parameter",
+        "When available, prefer using fetch_datadog_logs tool from datadog/logs toolset instead of calling this API directly with the datadog/general toolset. Do not include 'sort' parameter",
     ),
     # Metrics
     (

--- a/holmes/plugins/toolsets/kubernetes_logs.py
+++ b/holmes/plugins/toolsets/kubernetes_logs.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -62,6 +63,10 @@ class KubernetesLogsToolset(Toolset):
         )
         # Now that parent is initialized and self.name exists, create the tool
         self.tools = [PodLoggingTool(self)]
+        self._load_llm_instructions_from_file(
+            file_dir=os.path.dirname(__file__),
+            filename="kubernetes_logs_instructions.jinja2",
+        )
         enabled, disabled_reason = self.health_check()
         prerequisite.enabled = enabled
         prerequisite.disabled_reason = disabled_reason

--- a/holmes/plugins/toolsets/kubernetes_logs.yaml
+++ b/holmes/plugins/toolsets/kubernetes_logs.yaml
@@ -7,6 +7,11 @@ toolsets:
       - core
     prerequisites:
       - command: "kubectl version --client"
+    llm_instructions: |
+      * if the user wants to find a specific term in a pod's logs, use kubectl_logs_grep
+      * use both kubectl_previous_logs and kubectl_logs when reading logs. Treat the output of both as a single unified logs stream
+      * if a pod has multiple containers, make sure you fetch the logs for either all or relevant containers using one of the containers log functions like kubectl_logs_all_containers, kubectl_logs_all_containers_grep or any other.
+      * Check both kubectl_logs and kubectl_previous_logs because a pod restart mean kubectl_logs may not have relevant logs
 
     # Note: Log tools use transformers with llm_summarize to automatically
     # summarize large log outputs when a fast model is configured. This helps

--- a/holmes/plugins/toolsets/kubernetes_logs_instructions.jinja2
+++ b/holmes/plugins/toolsets/kubernetes_logs_instructions.jinja2
@@ -3,11 +3,7 @@
 * If you find no logs, double check that the namespace and pod names are exact. Use kubectl tools to find the right resource names and pod name.
 * If you are not given the pod's namespace, look for existing pods using kubectl tools and infer the namespace that way
 * If you are not given the pod's exact name, or only have an application name or a deployment name, look for related pods using kubectl commands. Ask the user if you can't infer the pod logs.
-* Do fetch application logs yourself and DO not ask users to do so
 * If you have an issue id or finding id, use `fetch_finding_by_id` as it contains time information about the issue (`starts_at`, `updated_at` and `ends_at`).
 ** Then, use `start_time=-300` (5 minutes before `end_time`) and `end_time=<issue start_at time>`  when calling `fetch_pod_logs`.
 ** If there are too many logs, or not enough, narrow or widen the timestamps
 * If the user did not explicitly ask about a given timeframe, ignore the `start_time` and `end_time` so it will use the default.
-* IMPORTANT: ALWAYS inform the user about the actual time period fetched (e.g., "Looking at logs from the last <X> days")
-* IMPORTANT: If a limit was applied, ALWAYS tell the user how many logs were shown vs total (e.g., "Showing latest <Y> of <Z> logs")
-* IMPORTANT: If any filters were applied, ALWAYS mention them explicitly

--- a/tests/plugins/prompt/test_fetch_logs.py
+++ b/tests/plugins/prompt/test_fetch_logs.py
@@ -17,11 +17,14 @@ def test_no_logs_toolset():
 
 
 def test_kubernetes_yaml_toolset():
+    # Backend-specific tool guidance now lives in the toolset's own
+    # llm_instructions (injected via _toolsets_instructions.jinja2), not in
+    # _fetch_logs.jinja2 which only carries backend-agnostic policy.
     toolsets = load_toolsets_from_file(KUBERNETES_YAML_TOOLSET_PATH, strict_check=True)
     toolsets[0].enabled = True
     toolsets[0].status = ToolsetStatusEnum.ENABLED
     prompt = load_and_render_prompt(
-        "builtin://_fetch_logs.jinja2", {"toolsets": toolsets}
+        "builtin://_toolsets_instructions.jinja2", {"toolsets": toolsets}
     )
     print(f"** PROMPT:\n{prompt}")
     assert "use both kubectl_previous_logs and kubectl_logs when reading logs" in prompt
@@ -32,7 +35,7 @@ def test_kubernetes_python_toolset():
     toolset.enabled = True
     toolset.status = ToolsetStatusEnum.ENABLED
     prompt = load_and_render_prompt(
-        "builtin://_fetch_logs.jinja2", {"toolsets": [toolset]}
+        "builtin://_toolsets_instructions.jinja2", {"toolsets": [toolset]}
     )
     print(f"** PROMPT:\n{prompt}")
     assert "Use the tool `fetch_pod_logs` to access an application's logs" in prompt


### PR DESCRIPTION
## Problem

`_fetch_logs.jinja2` branched per log backend and hardcoded backend-specific **tool names and parameter names** in prose. Those copies drifted out of sync with the real tools, so whenever Loki / Datadog / Coralogix was the active log backend the prompt told the LLM to call tools that don't exist:

| Backend branch | Prompt said | Reality |
|---|---|---|
| Loki | `fetch_loki_logs`, `fetch_loki_logs_for_resource`, params `start_timestamp`/`end_timestamp` | only `grafana_loki_query` exists, params `start`/`end` |
| Datadog | `fetch_pod_logs`, params `start_time`/`end_time` | tool is `fetch_datadog_logs`, params `start_datetime`/`end_datetime` |
| Coralogix | `fetch_pod_logs` (via `_default_log_prompt.jinja2`) | only `coralogix_execute_dataprime_query` exists |
| `opensearch/logs` | whole branch | no such toolset exists |

The LLM already receives every tool's name/description/parameters from the tool-calling schema, and **each enabled log toolset already injects its own usage instructions** (correct tool names, query syntax, time formats) via `_toolsets_instructions.jinja2`. The central branches were redundant duplication — and the duplicate is exactly what rotted.

## Change

- **`_fetch_logs.jinja2`** is reduced to backend-agnostic policy: fetch logs yourself (don't ask the user), and always report the time range / limit / filter you used. Plus a `bash` fallback and a misconfiguration message. No tool/param names are hardcoded anymore.
- Backend-specific guidance is **relocated to the owning toolset's `llm_instructions`** (next to the code, reviewed when the tool changes):
  - New `kubernetes_logs_instructions.jinja2` for the structured `kubernetes/logs` toolset (carries the former `_default_log_prompt` `fetch_pod_logs` guidance).
  - `llm_instructions` added to `kubernetes_logs.yaml` for the `kubectl_*` log tools.
- **`datadog/general`** toolset: fixed 4 hints that referenced a non-existent `fetch_pod_logs` tool → `fetch_datadog_logs`.
- Removed the now-unused `_default_log_prompt.jinja2`.

## Tests

`tests/plugins/prompt/test_fetch_logs.py` updated to assert backend guidance through the real container (`_toolsets_instructions.jinja2`), which is how it actually reaches the model. All 3 tests pass.

## Note for reviewers

This changes the system prompt for **every** log backend, so it's worth a run of the log-fetching LLM evals to confirm the model still selects the right tool from the schema + per-toolset instructions alone. It should *improve* behavior, since today Loki/Datadog/Coralogix get contradictory, non-existent tool names.

Part of a series of tool-description / prompt-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Streamlined log-fetching instructions for Grafana Loki, Coralogix, Kubernetes, Datadog, OpenShift, and VictoriaLogs.
  * Enhanced Kubernetes pod log guidance with better multi-container and restart handling.
  * Improved Datadog log endpoint instructions for more accurate queries.
  * Added clearer configuration guidance when required log toolsets are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->