### PR TITLE
Fix Datadog logs/traces sort_desc parameter (inverted / ignored)

### DIFF
--- a/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
@@ -219,7 +219,9 @@ class GetLogs(Tool):
             config_limit = self.toolset.dd_config.default_limit
             limit = min(params.get("limit", config_limit), config_limit)
             params["limit"] = limit
-            sort = "timestamp" if params.get("sort_desc", False) else "-timestamp"
+            # Datadog Logs API: "-timestamp" = descending (newest first),
+            # "timestamp" = ascending (oldest first). Default to descending.
+            sort = "-timestamp" if params.get("sort_desc", True) else "timestamp"
 
             url = f"{self.toolset.dd_config.api_url}/api/v2/logs/events/search"
             headers = get_headers(self.toolset.dd_config)

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_traces.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_traces.py
@@ -246,10 +246,11 @@ class GetSpans(BaseDatadogTracesTool):
 
             query: str = params.get("query") if params.get("query") else "*"  # type: ignore
             limit = params.get("limit") if params.get("limit") else 10
-            if params.get("sort") is not None:
-                sort = "-timestamp" if params.get("sort") else True
-            else:
-                sort = "-timestamp"
+            # Datadog Spans API: "-timestamp" = descending (newest first),
+            # "timestamp" = ascending (oldest first). Default to descending.
+            # NB: read the declared "sort_desc" parameter (this previously read a
+            # non-existent "sort" key, so the parameter was silently ignored).
+            sort = "-timestamp" if params.get("sort_desc", True) else "timestamp"
 
             # Use POST endpoint for more complex searches
             url = f"{self.toolset.dd_config.api_url}/api/v2/spans/events/search"

--- a/tests/plugins/toolsets/datadog/logs/test_fetch_logs.py
+++ b/tests/plugins/toolsets/datadog/logs/test_fetch_logs.py
@@ -7,6 +7,7 @@ Run with:
 """
 
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -58,3 +59,41 @@ class TestGetLogsTokenCount:
             print(f"\nData preview:\n{str(result.data)[:1000]}...")
         else:
             print(f"Error: {result.error}")
+
+
+class TestGetLogsSort:
+    """Unit tests for the sort order of the Datadog logs search."""
+
+    def setup_method(self):
+        self.toolset = DatadogLogsToolset()
+        self.toolset.dd_config = MagicMock()
+        self.toolset.dd_config.api_url = "https://api.datadoghq.com"
+        self.toolset.dd_config.default_limit = 100
+        self.toolset.dd_config.storage_tier = "indexes"
+        self.toolset.dd_config.indexes = []
+        self.toolset.dd_config.timeout_seconds = 60
+        self.toolset.dd_config.compact_logs = False
+        self.tool = GetLogs(toolset=self.toolset)
+
+    @patch(
+        "holmes.plugins.toolsets.datadog.toolset_datadog_logs.execute_datadog_http_request"
+    )
+    def test_sort_desc(self, mock_execute):
+        """sort_desc must map to the correct Datadog sort direction.
+
+        Regression test: the mapping used to be inverted (sort_desc=True
+        produced ascending order) and the documented default (true/descending)
+        did not match the code default.
+        """
+        mock_execute.return_value = {"data": []}
+
+        def sort_for(params):
+            self.tool._invoke(params, context=create_mock_tool_invoke_context())
+            return mock_execute.call_args[1]["payload_or_params"]["sort"]
+
+        # Omitted -> default descending (newest first)
+        assert sort_for({"query": "*"}) == "-timestamp"
+        # Explicit True -> descending
+        assert sort_for({"query": "*", "sort_desc": True}) == "-timestamp"
+        # Explicit False -> ascending (oldest first)
+        assert sort_for({"query": "*", "sort_desc": False}) == "timestamp"

--- a/tests/plugins/toolsets/datadog/traces/test_datadog_traces.py
+++ b/tests/plugins/toolsets/datadog/traces/test_datadog_traces.py
@@ -146,6 +146,30 @@ class TestFetchDatadogSpansByFilter:
     @patch(
         "holmes.plugins.toolsets.datadog.toolset_datadog_traces.execute_datadog_http_request"
     )
+    def test_invoke_sort_desc(self, mock_execute):
+        """The declared sort_desc parameter must control the sort order.
+
+        Regression test: the implementation used to read a non-existent "sort"
+        key, so sort_desc was silently ignored and the sort was always
+        descending (and an invalid boolean True could be sent to the API).
+        """
+        mock_execute.return_value = {"data": []}
+
+        def sort_for(params):
+            self.tool._invoke(params, context=create_mock_tool_invoke_context())
+            payload = mock_execute.call_args[1]["payload_or_params"]
+            return payload["data"]["attributes"]["sort"]
+
+        # Omitted -> default descending (newest first)
+        assert sort_for({"query": "*"}) == "-timestamp"
+        # Explicit True -> descending
+        assert sort_for({"query": "*", "sort_desc": True}) == "-timestamp"
+        # Explicit False -> ascending (oldest first)
+        assert sort_for({"query": "*", "sort_desc": False}) == "timestamp"
+
+    @patch(
+        "holmes.plugins.toolsets.datadog.toolset_datadog_traces.execute_datadog_http_request"
+    )
     def test_invoke_no_spans_found(self, mock_execute):
         """Test invocation when no spans are found."""
         mock_execute.return_value = {"data": []}


### PR DESCRIPTION
## Problem

Two related bugs in the Datadog toolset's `sort_desc` handling, found in a tool-description/behavior audit:

**1. Logs (`fetch_datadog_logs`) — inverted mapping + wrong default**

```python
sort = "timestamp" if params.get("sort_desc", False) else "-timestamp"
```

The Datadog Logs API uses `-timestamp` for descending (newest first) and `timestamp` for ascending. So `sort_desc=True` produced **ascending** order — the opposite of what the parameter name and its documented default (`default: true`) promise. The code default (`False`) also contradicted the documented default.

**2. Traces (`fetch_datadog_spans`) — parameter silently ignored**

```python
if params.get("sort") is not None:
    sort = "-timestamp" if params.get("sort") else True
else:
    sort = "-timestamp"
```

The declared parameter is `sort_desc`, but the code read a non-existent `sort` key, so `sort_desc` was **always ignored** (sort hardcoded to descending). The `else: sort = True` branch could also send a non-string boolean to the API.

## Fix

Both now read the declared `sort_desc` (default `True`) and map it correctly:

```python
sort = "-timestamp" if params.get("sort_desc", True) else "timestamp"
```

The default output order (descending, newest-first) is unchanged when the parameter is omitted; only the explicit `sort_desc` semantics are corrected. The documented `default: true` now matches the code.

## Tests

Added unit tests for both tools asserting the `sort` value placed in the request payload for omitted / explicit-`True` / explicit-`False`. Both pass.

Part of a series of tool-description / behavior-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed sort order behavior in Datadog logs integration—now defaults to descending timestamp order and correctly respects ascending order selections
* Fixed sort order behavior in Datadog traces integration—now defaults to descending timestamp order and correctly respects ascending order selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->