### PR TITLE
Correct fetch_pod_logs description to match actual behavior

### DIFF
--- a/holmes/plugins/toolsets/logging_utils/logging_api.py
+++ b/holmes/plugins/toolsets/logging_utils/logging_api.py
@@ -128,8 +128,13 @@ class PodLoggingTool(Tool):
         toolset_name = toolset.name if toolset.name else "logging backend"
         description = (
             f"Fetch logs for a Kubernetes pod from {toolset_name}"
-            " with support for regex filtering and exclusion patterns"
-            f". Defaults: Fetches last {DEFAULT_TIME_SPAN_SECONDS // SECONDS_PER_DAY} days of logs, limited to {DEFAULT_LOG_LIMIT} most recent entries"
+            " with support for regex filtering and exclusion patterns."
+            " When neither start_time/end_time nor limit are provided, all currently"
+            " available logs for the pod are returned (no time window or line cap is"
+            " applied). Large outputs are truncated to fit the model's token budget -"
+            " the oldest lines are dropped first and a truncation marker is inserted."
+            " Use start_time/end_time to bound the time range and limit to cap the"
+            " number of returned lines."
         )
 
         parameters = {
@@ -142,7 +147,7 @@ class PodLoggingTool(Tool):
                 description="Kubernetes namespace", type="string", required=True
             ),
             "start_time": ToolParameter(
-                description=f"Start time for logs. Can be an RFC3339 formatted datetime (e.g. '2023-03-01T10:30:00Z') for absolute time or a negative string number (e.g. -3600) for relative seconds before end_time. Default: -{DEFAULT_TIME_SPAN_SECONDS} (last {DEFAULT_TIME_SPAN_SECONDS // SECONDS_PER_DAY} days)",
+                description="Start time for logs. Can be an RFC3339 formatted datetime (e.g. '2023-03-01T10:30:00Z') for absolute time or a negative string number (e.g. -3600) for relative seconds before end_time. If neither start_time nor end_time is provided, no time filtering is applied and all available logs are fetched.",
                 type="string",
                 required=False,
             ),
@@ -152,7 +157,7 @@ class PodLoggingTool(Tool):
                 required=False,
             ),
             "limit": ToolParameter(
-                description=f"Maximum number of logs to return. Default: {DEFAULT_LOG_LIMIT}",
+                description="Maximum number of (most recent) log lines to return. If not set, all matching log lines are returned, subject to token-budget truncation of large outputs.",
                 type="integer",
                 required=False,
             ),


### PR DESCRIPTION
## Problem

The `fetch_pod_logs` tool (`PodLoggingTool`, used by the `kubernetes/logs` toolset) advertised defaults it does not apply:

- Main description: *"Defaults: Fetches last 7 days of logs, limited to 100 most recent entries"*
- `start_time`: *"Default: -604800 (last 7 days)"*
- `limit`: *"Default: 100"*

But the Kubernetes backend (`kubernetes_logs.py`) only builds a time filter **when `start_time` or `end_time` is set** (`filter_logs`, the `if params.start_time or params.end_time` guard), and only truncates by count **when `limit` is set** (`if params.limit and params.limit < len(...)`). `_invoke` passes `limit=params.get("limit")` with no default. So when the LLM omits these (which is the documented "default" path), it gets the pod's **entire** available log history — bounded only by the post-hoc token-budget truncation — not a 7-day / 100-line window.

## Fix

Per maintainer decision, correct the descriptions to match the actual behavior rather than change the behavior:

- **Main description**: omitting `start_time`/`end_time` and `limit` returns all currently-available logs (no time window or line cap); large output is truncated to fit the token budget (oldest lines dropped first, with a truncation marker — this token-truncation was previously undocumented); use `start_time`/`end_time`/`limit` to bound output.
- **`start_time`**: no time filtering is applied when both `start_time` and `end_time` are omitted.
- **`limit`**: all matching lines are returned when unset, subject to token-budget truncation.

Description-only change — no behavior change, no eval risk. Existing kubernetes logs unit tests (34) pass.

Part of a series of tool-description-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pod logs tool default behavior: returns all available logs when no time window or line limit is specified, with automatic truncation handling when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->