### PR TITLE
Clarify Elasticsearch size/index limits in tool descriptions

### DIFF
--- a/holmes/plugins/toolsets/elasticsearch/elasticsearch.py
+++ b/holmes/plugins/toolsets/elasticsearch/elasticsearch.py
@@ -723,7 +723,11 @@ class ElasticsearchSearch(BaseElasticsearchTool):
                     required=False,
                 ),
                 "size": ToolParameter(
-                    description="Maximum number of documents to return (default: 100, max recommended: 500)",
+                    description=(
+                        "Maximum number of documents to return (default: 100). "
+                        "No enforced upper limit - large values can return very large "
+                        "responses, so keep this small and narrow results with filters/aggregations."
+                    ),
                     type="integer",
                     required=False,
                 ),

--- a/holmes/plugins/toolsets/elasticsearch/elasticsearch.py
+++ b/holmes/plugins/toolsets/elasticsearch/elasticsearch.py
@@ -614,8 +614,10 @@ class ElasticsearchCat(BaseElasticsearchTool):
                 "index": ToolParameter(
                     description=(
                         "Filter by index name or pattern. Supports wildcards (e.g., 'logs-*'). "
-                        "REQUIRED for shards, segments, recovery endpoints to avoid returning data for all indices. "
-                        "Recommended for indices endpoint when looking for specific indices."
+                        "STRONGLY RECOMMENDED for the shards, segments and recovery endpoints: it is "
+                        "not enforced, but omitting it returns data for ALL indices, which can be very "
+                        "large on big clusters. Also recommended for the indices endpoint when looking "
+                        "for specific indices. Ignored by endpoints that are not index-scoped (e.g. nodes, health)."
                     ),
                     type="string",
                     required=False,
@@ -695,7 +697,10 @@ class ElasticsearchSearch(BaseElasticsearchTool):
             description=(
                 "Execute an Elasticsearch search query using Query DSL. "
                 "Supports full Query DSL including bool queries, aggregations, and filters. "
-                "Returns up to 100 documents by default (configurable via size parameter)."
+                "Returns up to 100 documents by default; set the size parameter to change this. "
+                "Note: size is passed directly to Elasticsearch with no enforced upper limit, "
+                "so large values can return very large responses - keep size as small as possible "
+                "and use filters/aggregations to narrow results."
             ),
             parameters={
                 "elasticsearch_instance": ELASTICSEARCH_INSTANCE_PARAM,


### PR DESCRIPTION
## Problem

Two Elasticsearch tool descriptions implied safety limits the code does not enforce:

- **`elasticsearch_search`** — `size` was documented as *"max recommended: 500"*, but `_invoke` passes it straight to Elasticsearch (`body["size"] = params.get("size", 100)`) with **no cap**. The "max recommended" wording suggests a ceiling that doesn't exist.
- **`elasticsearch_cat`** — `index` was documented as *"REQUIRED for shards, segments, recovery endpoints"*, but the parameter is `required=False` and unenforced; omitting it issues `_cat/<endpoint>` for **all** indices (the documented 25K-token overflow risk).

## Fix

Per maintainer decision, correct the descriptions to match behavior (no code/behavior change):

- `elasticsearch_search`: state there is **no enforced upper limit** on `size` and that large values return very large responses; keep size small and narrow with filters/aggregations.
- `elasticsearch_cat`: `index` is **STRONGLY RECOMMENDED but not enforced** — omitting it returns data for all indices; also noted it is ignored by non-index-scoped endpoints (nodes, health).

Description-only. No test asserts the old strings; module imports cleanly.

Part of a series of tool-description-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for the `index` parameter in Elasticsearch catalog endpoints, making it explicit that omitting the parameter returns data for all indices for certain endpoints.
  * Revised Elasticsearch search tool documentation to warn that the `size` parameter is passed through without enforced limits and to recommend keeping sizes small and using filters/aggregations to limit results for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->