### PR TITLE
Document Prometheus query summary-substitution and empty-result behavior

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1566,7 +1566,12 @@ class ExecuteInstantQuery(BasePrometheusTool):
             description=(
                 f"Execute an instant PromQL query (single point in time). "
                 f"Default timeout is {DEFAULT_QUERY_TIMEOUT_SECONDS} seconds "
-                f"but can be increased up to {MAX_QUERY_TIMEOUT_SECONDS} seconds for complex/slow queries."
+                f"but can be increased up to {MAX_QUERY_TIMEOUT_SECONDS} seconds for complex/slow queries. "
+                f"If the result is too large for the response token budget, the raw data is replaced "
+                f"by a summary of series/label cardinality plus a topk() suggestion - narrow the query "
+                f"(e.g. with topk() or more label matchers) and run it again. "
+                f"A query that returns no data is reported as a failure asking you to check the query, "
+                f"not as an empty success."
             ),
             parameters={
                 "query": ToolParameter(
@@ -1756,10 +1761,15 @@ class ExecuteRangeQuery(BasePrometheusTool):
         super().__init__(
             name="execute_prometheus_range_query",
             description=(
-                f"Generates a graph and Execute a PromQL range query. "
+                f"Execute a PromQL range query (time series over a time range). "
                 f"Default timeout is {DEFAULT_QUERY_TIMEOUT_SECONDS} seconds "
                 f"but can be increased up to {MAX_QUERY_TIMEOUT_SECONDS} seconds for complex/slow queries. "
-                f"Default time range is last 1 hour."
+                f"Default time range is last 1 hour. "
+                f"If the result is too large for the response token budget, the raw data is replaced "
+                f"by a summary of series/label cardinality plus a topk() suggestion - narrow the query "
+                f"(e.g. with topk() or more label matchers) and run it again. "
+                f"A query that returns no data is reported as a failure asking you to check the query, "
+                f"not as an empty success."
             ),
             parameters={
                 "query": ToolParameter(


### PR DESCRIPTION
## Problem

`execute_prometheus_instant_query` and `execute_prometheus_range_query` omitted two behaviors that change how the LLM should interpret their results:

1. **Summary substitution** — when a result exceeds the response token budget, `_invoke` drops the raw data (`response_data.data = None`) and returns a summary of series/label cardinality plus a `topk()` suggestion. The LLM was never told this, so it could treat a summary as the full time series.
2. **Empty = error** — an empty result set is rewritten to a `Failed`/ERROR status (*"The prometheus query returned no result. Is the query correct?"*) rather than an empty success. This can push the LLM to "fix" a query that was actually correct over a quiet window.

## Fix

Both behaviors are now documented in the two tool descriptions. Also fixed the range-query wording (*"Generates a graph and Execute a PromQL range query"* → *"Execute a PromQL range query (time series over a time range)"* — the tool returns time-series JSON; graph rendering happens elsewhere).

Description-only; no behavior change. Module imports cleanly; no test asserts the old strings.

Part of a series of tool-description-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced descriptions for Prometheus query tools to clarify behavior when results exceed response limits (displays summary with label/series cardinality) and when queries return no data (reported as failures).
  * Improved range query description to explicitly indicate PromQL range query semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->