### PR TITLE
Align YAML toolset descriptions with their commands (cilium/argocd/kubevela)

### DIFF
--- a/holmes/plugins/toolsets/argocd.yaml
+++ b/holmes/plugins/toolsets/argocd.yaml
@@ -53,7 +53,7 @@ toolsets:
         command: "argocd app manifests {{app_name}}{% if revision %} --revision {{ revision }}{% endif %}{% if source %} --source {{ source }}{% endif %}"
 
       - name: "argocd_app_history"
-        description: "List the deployment history of an application in ArgoCD"
+        description: "List the deployment history of an application in ArgoCD. Requires both the application name and its namespace (the namespace the Application resource lives in)."
         command: "argocd app history {{app_name}} --app-namespace {{namespace}}"
 
       - name: "argocd_repo_list"

--- a/holmes/plugins/toolsets/cilium.yaml
+++ b/holmes/plugins/toolsets/cilium.yaml
@@ -145,7 +145,7 @@ toolsets:
     tools:
       # Flow Observation
       - name: "hubble_observe"
-        description: "Observe network flows in real-time (last 100 flows)"
+        description: "Fetch the most recent network flows (last 1000 flows). This is a one-shot historical query, not a live stream."
         command: "hubble observe --last 1000"
         transformers:
           - name: llm_summarize

--- a/holmes/plugins/toolsets/kubevela.yaml
+++ b/holmes/plugins/toolsets/kubevela.yaml
@@ -46,7 +46,7 @@ toolsets:
         command: "kubectl get application {{ app_name }} -n {{ namespace }} -o yaml"
 
       - name: "vela_logs"
-        description: "Get logs from a KubeVela application or specific component"
+        description: "Get logs from a KubeVela application or specific component. Returns up to the last 500 lines by default (override with the 'tail' parameter)."
         command: "vela logs {{ app_name }} -n {{ namespace }}{% if component %} -c {{ component }}{% endif %}{% if pod %} --pod {{ pod }}{% endif %} --tail {{ tail | default(500) }} -y"
 
       - name: "vela_port_forward"
@@ -90,9 +90,9 @@ toolsets:
         command: "kubectl top pods -l app.oam.dev/name={{ app_name }} -n {{ namespace }}"
 
       - name: "vela_dry_run"
-        description: "Preview the Kubernetes resources that would be created by an application spec"
+        description: "Preview the Kubernetes resources that would be created by an application spec. Requires file_path to point to a KubeVela application manifest that already exists on the HolmesGPT host filesystem; it cannot read manifests from the live cluster, so this is only usable when such a local file is available."
         command: "vela dry-run -f {{ file_path }}"
 
       - name: "vela_live_diff"
-        description: "Show difference between local spec and running application"
+        description: "Show the difference between a local application spec and the running application. Requires file_path to point to a KubeVela application manifest that already exists on the HolmesGPT host filesystem; it cannot read the local spec from the live cluster, so this is only usable when such a local file is available."
         command: "vela live-diff -f {{ file_path }} -n {{ namespace }}"


### PR DESCRIPTION
## Problem

Several YAML tool descriptions disagreed with the command they actually run:

| Tool | Description said | Command does |
|---|---|---|
| `hubble_observe` (cilium) | "real-time (last **100** flows)" | `hubble observe --last 1000` (one-shot historical) |
| `argocd_app_history` | only implies app name needed | requires `--app-namespace {{namespace}}` (no guard) |
| `vela_logs` (kubevela) | no mention of a cap | `--tail {{ tail \| default(500) }}` (500-line default) |
| `vela_dry_run` / `vela_live_diff` (kubevela) | no precondition | require `-f {{ file_path }}` — a manifest on the **HolmesGPT host filesystem** |

The `vela_dry_run`/`vela_live_diff` case is the most impactful: with no hint that `file_path` must be a local manifest, the LLM will hallucinate a path.

## Fix (description-only, no command changes)

- `hubble_observe`: "Fetch the most recent network flows (last 1000 flows). This is a one-shot historical query, not a live stream."
- `argocd_app_history`: note that the application's namespace is required.
- `vela_logs`: note the 500-line default (overridable via `tail`).
- `vela_dry_run` / `vela_live_diff`: document that `file_path` must point to a manifest already present on the HolmesGPT host filesystem.

All three YAML files parse cleanly.

### Not included (need maintainer with Azure access)

Two `aks-node-health.yaml` / `aks.yaml` items from the audit are genuine **command** bugs, not just descriptions, and need Azure validation:
- `check_top_resource_consuming_pods` greps `kubectl top pod` output for a node name, but that output has no node column (matches nothing).
- `aks_list_addons` queries `orchestrators[].addons`, a stale JMESPath that returns `[]` on current `az aks get-versions`.

Part of a series of tool-description-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_