### PR TITLE
Fix TodoWrite schema and parallelism guidance in investigator instructions

### DIFF
--- a/holmes/plugins/toolsets/investigator/investigator_instructions.jinja2
+++ b/holmes/plugins/toolsets/investigator/investigator_instructions.jinja2
@@ -73,7 +73,7 @@ Use this tool proactively in these scenarios:
 3. User explicitly requests todo list - When the user directly asks you to use the todo list
 4. User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
 5. After receiving new instructions - Immediately capture user requirements as todos
-6. When you start working on a task - Mark it as in_progress BEFORE beginning work. Ideally you should only have one todo as in_progress at a time
+6. When you start working on a task - Mark it as in_progress BEFORE beginning work. You may have multiple tasks in_progress at once when they are independent of one another; keep dependent tasks sequential
 7. After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation
 
 ## When NOT to Use This Tool
@@ -211,7 +211,7 @@ The assistant did not use the todo list because this is a single command executi
 
 1. **Task States**: Use these states to track progress:
    - pending: Task not yet started
-   - in_progress: Currently working on (limit to ONE task at a time)
+   - in_progress: Currently working on (multiple independent tasks may be in_progress at once; keep dependent tasks sequential)
    - completed: Task finished successfully
 
 2. **Task Management**:
@@ -241,8 +241,7 @@ When in doubt, use this tool. Being proactive with task management demonstrates 
   // The updated todo list
   todos: {
     content: string;
-    status: "pending" | "in_progress" | "completed";
-    priority: "high" | "medium" | "low";
+    status: "pending" | "in_progress" | "completed" | "failed";
     id: string;
   }[];
 }


### PR DESCRIPTION
## Problem

`investigator_instructions.jinja2` (injected as the investigator toolset's `llm_instructions`) had two LLM-facing inaccuracies:

1. **Phantom `priority` field.** The documented `TodoWrite` schema included `priority: "high" | "medium" | "low"`, but the real `TodoWriteTool` only accepts `id`, `content`, and `status` (`core_investigation.py`). The LLM was instructed to send a parameter the tool ignores. The status enum was also missing `failed` (the tool's `TaskStatus` is `pending | in_progress | completed | failed`).
2. **Contradictory parallelism guidance.** The file said "only have one todo as in_progress at a time" / "limit to ONE task at a time", which contradicts both another line in the *same* file ("If tasks are not dependent on one another, handle multiple tasks in parallel and mark them in_progress") and the system prompt (`generic_ask.jinja2`), which explicitly push parallelism for independent tasks.

## Fix

- Removed the `priority` line from the schema; added `failed` to the status enum.
- Reworded both "ONE task at a time" statements to allow multiple **independent** tasks in_progress while keeping dependent tasks sequential — consistent with the rest of the file and the system prompt.

Template renders correctly; no test asserts the old text.

### Not included

The TodoWrite section still uses coding-assistant examples (dark-mode toggle, `npm install`, `getCwd` rename) that aren't relevant to a read-only troubleshooting agent. That's a larger, more subjective rewrite — left for a separate change.

Part of a series of tool-description / prompt-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_