### PR TITLE
Disclose preconditions in kubectl_run_image and read_image_file descriptions

### DIFF
--- a/holmes/plugins/toolsets/bash/bash_toolset.py
+++ b/holmes/plugins/toolsets/bash/bash_toolset.py
@@ -320,11 +320,18 @@ class ReadImageFile(Tool):
                 "Read an image file from disk and return it for visual analysis. "
                 "Use this when a previous tool result was too large and its images "
                 "were saved to disk. The file path is provided in the spill message. "
+                "Only files inside the tool-result spill storage directory can be read "
+                "(arbitrary paths are rejected with 'Access denied'), the path must be "
+                "absolute, and the file must be 20MB or smaller. "
                 "Supported formats: PNG, JPEG, GIF, WebP."
             ),
             parameters={
                 "file_path": ToolParameter(
-                    description="Absolute path to the image file on disk.",
+                    description=(
+                        "Absolute path to the image file on disk, as provided in the spill "
+                        "message. Must resolve to a location inside the tool-result spill "
+                        "storage directory."
+                    ),
                     type="string",
                     required=True,
                 ),

--- a/holmes/plugins/toolsets/kubectl_run/kubectl_run_toolset.py
+++ b/holmes/plugins/toolsets/kubectl_run/kubectl_run_toolset.py
@@ -42,21 +42,26 @@ class KubectlRunImageCommand(Tool):
         super().__init__(
             name="kubectl_run_image",
             description=(
-                "Executes `kubectl run <name> --image=<image> ... -- <command>` return the result"
+                "Runs a command in a temporary, auto-deleted pod via "
+                "`kubectl run <name> --image=<image> --rm --attach --restart=Never -i -- <command>` "
+                "and returns the output. The image AND command must match an allow-list configured "
+                "by the operator - if no allow-list is configured, or the image/command is not "
+                "whitelisted, the call is rejected. The pod is ephemeral (created and deleted for "
+                "this single call) and runs in the 'default' namespace unless one is specified."
             ),
             parameters={
                 "image": ToolParameter(
-                    description="The image to run",
+                    description="The image to run (must be allow-listed by the operator)",
                     type="string",
                     required=True,
                 ),
                 "command": ToolParameter(
-                    description="The command to execute on the deployed pod",
+                    description="The command to execute on the deployed pod (must match the operator's allow-list)",
                     type="string",
                     required=True,
                 ),
                 "namespace": ToolParameter(
-                    description="The namespace in which to deploy the temporary pod",
+                    description="The namespace in which to deploy the temporary pod. Defaults to 'default'.",
                     type="string",
                     required=False,
                 ),


### PR DESCRIPTION
## Problem

Two tools hid hard preconditions/restrictions from their descriptions, so the LLM couldn't predict when or why they fail:

- **`kubectl_run_image`** — described only as "Executes `kubectl run ... -- <command>`". It omitted that:
  - the image **and** command must match an operator-configured allow-list (`validate_image_and_commands` raises otherwise; with no allow-list configured, **every** call is rejected),
  - the command always injects `--rm --attach --restart=Never -i` (an ephemeral, auto-deleted pod),
  - `namespace` defaults to `default`.
- **`read_image_file`** — didn't mention that reads are restricted to the tool-result spill storage directory (`HOLMES_TOOL_RESULT_STORAGE_PATH`; arbitrary paths return "Access denied"), that the path must be absolute, or the 20MB size cap.

## Fix

Description-only updates documenting each precondition so the LLM understands the allow-list requirement, the ephemeral-pod behavior, the namespace default, and the spill-directory/size restrictions. No behavior change; both modules import cleanly.

Part of a series of tool-description-accuracy fixes from an audit; sent as separate focused PRs for easier review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCHrPWGh515e2qpSsS6G26)_