### PR TITLE
fix: CLI OAuth token storage and bash config dict crash

### DIFF
--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -242,9 +242,14 @@ class ToolCallingLLM:
         for toolset in self.tool_executor.enabled_toolsets:
             if toolset.name == "bash":
                 config = toolset.config
-                if config:
-                    return config.builtin_allowlist != "none"
-                return False
+                if not config:
+                    return False
+                # config may still be a raw dict if the toolset has not been
+                # lazily initialized (prerequisites_callable parses it into
+                # BashExecutorConfig on first use).
+                if isinstance(config, dict):
+                    return config.get("builtin_allowlist", "core") != "none"
+                return config.builtin_allowlist != "none"
         return False
 
     def _execute_tool_decisions(

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -46,6 +46,7 @@ from holmes.core.tools import (
     Toolset,
     ToolsetType,
 )
+from holmes.common.env_vars import DEFAULT_CLI_USER
 from holmes.plugins.toolsets.mcp.oauth_token_manager import _get_user_id
 from holmes.utils.header_rendering import render_header_templates
 from holmes.utils.pydantic_utils import ToolsetConfig
@@ -330,18 +331,25 @@ class RemoteMCPTool(Tool):
         oauth_config = self.toolset._mcp_config.oauth
         disk_key = str(self.toolset._mcp_config.url) if isinstance(self.toolset._mcp_config, MCPConfig) else None
 
+        # CLI mode: no request_context means the call came from the CLI, not the API server
+        is_cli = context.request_context is None
+
+        # The CLI has no authenticated user, so the tool-invocation path keys
+        # tokens under DEFAULT_CLI_USER. Use the same id here so token storage
+        # and retrieval are consistent (otherwise the stored token can't be
+        # found and every request 401s).
+        effective_context = context.request_context or {"user_id": DEFAULT_CLI_USER}
+
         # Try to get a token from cache → refresh → DB → disk
         mgr = _get_token_manager()
-        token = mgr.get_access_token(oauth_config, context.request_context, disk_key=disk_key)
+        token = mgr.get_access_token(oauth_config, effective_context, disk_key=disk_key)
         if token:
             logger.info("OAuth MCP %s: token available via manager", self.toolset.name)
             return None
 
         # No token found anywhere — need to authenticate
-        user_id = _get_user_id(context.request_context)
+        user_id = _get_user_id(effective_context)
 
-        # CLI mode: no request_context means the call came from the CLI, not the API server
-        is_cli = context.request_context is None
         if is_cli:
             # CLI mode: run browser OAuth flow synchronously
             logger.info("OAuth MCP %s: CLI mode, running browser OAuth flow", self.toolset.name)
@@ -356,7 +364,7 @@ class RemoteMCPTool(Tool):
             token_data = cli_oauth_flow(oauth_endpoints, self.toolset.name)
             if token_data:
                 _get_token_manager().store_token(
-                    oauth_config, token_data, context.request_context,
+                    oauth_config, token_data, effective_context,
                     disk_key=disk_key, store_to_disk=True,
                 )
                 logger.info("OAuth MCP %s: CLI auth successful", self.toolset.name)


### PR DESCRIPTION
> 🤖 **This PR was generated with AI assistance (Factory Droid).** The changes were authored and verified by a human against a live CLI session before submission.

Fixes #2143

## What

Fixes two independent, deterministic bugs that surface when the **bash** toolset is enabled alongside an **OAuth-based remote MCP server** in CLI mode (reproduced against the hosted Rootly MCP, but neither bug is Rootly-specific).

### 1. `_has_bash_for_file_access` crash (`holmes/core/tool_calling_llm.py`)

`toolset.config` may still be a raw `dict` if the bash toolset hasn't been lazily initialized yet (`prerequisites_callable` is what parses it into `BashExecutorConfig`). The previous code called `config.builtin_allowlist` directly, raising:

```
AttributeError: 'dict' object has no attribute 'builtin_allowlist'
```

Now both the dict and parsed-config forms are handled.

### 2. CLI OAuth token never persisted → 401 (`holmes/plugins/toolsets/mcp/toolset_mcp.py`)

`requires_approval` detected CLI mode via `request_context is None` and then passed that same `None` to `store_token`, which refuses to store without a `user_id`. The tool-invocation path keys tokens under `DEFAULT_CLI_USER` (`main.py`), so the lookup always missed and the request 401'd after a successful browser login:

```
OAuthTokenManager: refusing to store token without a user_id
OAuth MCP server <server>: no OAuth token available — request will 401
```

CLI token lookup **and** storage are now normalized to `DEFAULT_CLI_USER`, so they're consistent.

## How tested

- Reproduced both crashes/401s in a live CLI session (`holmes ask` against the hosted Rootly OAuth MCP server) with `openai/glm-5.1`.
- After the fix, the OAuth browser flow completes and Holmes successfully lists incidents via the remote MCP server, with the bash toolset enabled concurrently.
- Both bugs are model-agnostic (Python control flow, not LLM output).

## Notes

- Scope kept small and focused per CONTRIBUTING.md.
- No unit tests added yet — happy to add regression tests for `_has_bash_for_file_access` (dict vs. typed config) and the CLI OAuth `user_id` normalization if maintainers prefer them in this PR.
- Commit is DCO signed-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced bash toolset configuration handling to support multiple initialization states
* Improved OAuth token handling for CLI-invoked operations to ensure consistent authentication behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->