### PR TITLE
ROB-4040 Add per-channel email/Slack delivery conditions for scheduled prompts

### DIFF
--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -353,3 +353,9 @@ class ChatResponse(BaseModel):
     follow_up_actions: Optional[List[FollowUpAction]] = []
     pending_approvals: Optional[List[PendingToolApproval]] = None
     metadata: Optional[Dict[Any, Any]] = None
+    # Per-notification-channel delivery decisions for scheduled prompts, keyed by
+    # sink type ("slack", "email"). A value of False asks the reporter (relay) to
+    # suppress delivery to that channel because the user's prompt specified a
+    # condition that was not met. Absent/None means "deliver everywhere" (the
+    # default), keeping all non-scheduled flows backwards-compatible.
+    sink_decisions: Optional[Dict[str, bool]] = None

--- a/holmes/core/scheduled_prompts/executor.py
+++ b/holmes/core/scheduled_prompts/executor.py
@@ -22,6 +22,7 @@ from holmes.core.scheduled_prompts.heartbeat_tracer import (
     ScheduledPromptsHeartbeatSpan,
 )
 from holmes.core.scheduled_prompts.models import ScheduledPrompt
+from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
 from holmes.core.supabase_dal import RunStatus
 
 # to prevent circular imports due to type hints
@@ -217,6 +218,7 @@ class ScheduledPromptsExecutor:
         if isinstance(response, ChatResponse):
             response.metadata = dict(response.metadata or {})
             response.metadata["duration_seconds"] = duration_seconds
+            self._populate_sink_decisions(sp, response)
 
         result_data = (
             response.model_dump() if isinstance(response, ChatResponse) else {}
@@ -225,6 +227,29 @@ class ScheduledPromptsExecutor:
         self._finish_run(status=RunStatus.COMPLETED, result=result_data, sp=sp)
 
         return response
+
+    def _populate_sink_decisions(
+        self, sp: ScheduledPrompt, response: ChatResponse
+    ) -> None:
+        """Evaluate per-channel delivery conditions written in the user's prompt.
+
+        Sets ``response.sink_decisions`` to a {sink_type: bool} map (e.g.
+        ``{"slack": True, "email": False}``) that the reporter uses to decide
+        which channels to deliver to. Any failure leaves ``sink_decisions`` as
+        None, which the reporter treats as "deliver to all configured channels".
+        """
+        try:
+            prompt_text = self._extract_prompt_text(sp.prompt)
+            llm = self.config._get_llm(model_key=sp.model_name)
+            decisions = evaluate_sink_decisions(llm, prompt_text, response.analysis)
+            if decisions:
+                response.sink_decisions = decisions
+        except Exception:
+            logging.exception(
+                "Failed to evaluate sink delivery conditions for run %s; "
+                "defaulting to deliver to all configured channels",
+                sp.id,
+            )
 
     def _fetch_additional_system_prompt(
         self, fallback: Optional[str] = None

--- a/holmes/core/scheduled_prompts/executor.py
+++ b/holmes/core/scheduled_prompts/executor.py
@@ -193,7 +193,8 @@ class ScheduledPromptsExecutor:
             "Found pending run %s, executing with model %s", run_id, sp.model_name
         )
         self._execute_prompt(sp)
-        logging.info("Successfully completed run %s", run_id)
+        # Completion is logged by _finish_run based on whether the store write
+        # actually persisted — a failed finish must NOT be reported as success.
 
     def _execute_prompt(
         self,
@@ -230,10 +231,11 @@ class ScheduledPromptsExecutor:
         response = self.chat_function(chat_request, empty_request)
         duration_seconds = time.perf_counter() - start
 
+        sink_usage = None
         if isinstance(response, ChatResponse):
             response.metadata = dict(response.metadata or {})
             response.metadata["duration_seconds"] = duration_seconds
-            self._populate_sink_decisions(sp, response)
+            sink_usage = self._populate_sink_decisions(sp, response)
 
         result_data = (
             response.model_dump() if isinstance(response, ChatResponse) else {}
@@ -241,11 +243,20 @@ class ScheduledPromptsExecutor:
 
         self._finish_run(status=RunStatus.COMPLETED, result=result_data, sp=sp)
 
+        # Record the sink-decision LLM usage AFTER the run is finished. The
+        # recorder fires its Supabase write on a background thread; doing it
+        # before _finish_run let that write race the (critical) finish write on
+        # the single shared Supabase HTTP/2 client, terminating the connection
+        # and failing the finish — which stranded the run in RUNNING and caused
+        # it to be reclaimed and re-executed. Deferring keeps finish uncontended.
+        if sink_usage is not None:
+            self._record_sink_decision_usage(sp, *sink_usage)
+
         return response
 
     def _populate_sink_decisions(
         self, sp: ScheduledPrompt, response: ChatResponse
-    ) -> None:
+    ) -> Optional[tuple]:
         """Evaluate per-channel delivery conditions written in the user's prompt.
 
         The conditions come from the prompt's dedicated ``notification_prompt``
@@ -262,19 +273,22 @@ class ScheduledPromptsExecutor:
         """
         notification_prompt = self._extract_notification_prompt(sp.prompt)
         if not notification_prompt:
-            return
+            return None
 
         try:
             llm = self.config._get_llm(model_key=sp.model_name)
             result = evaluate_sink_decisions(
                 llm, notification_prompt, response.analysis
             )
-            self._record_sink_decision_usage(sp, llm, result)
             if result.decisions:
                 response.sink_decisions = result.decisions
                 note = format_delivery_note(result.suppressed(), result.rationale)
                 if note:
                     response.analysis = (response.analysis or "") + note
+            # Return the call's llm + result so the caller can record usage AFTER
+            # the run is finished (see _execute_prompt). Recording it here, before
+            # _finish_run, races the finish write on the shared Supabase client.
+            return (llm, result)
         except Exception:
             logging.exception(
                 "Failed to evaluate sink delivery conditions for run %s "
@@ -282,6 +296,7 @@ class ScheduledPromptsExecutor:
                 sp.id,
                 sp.model_name,
             )
+            return None
 
     def _record_sink_decision_usage(
         self, sp: ScheduledPrompt, llm, result
@@ -366,8 +381,8 @@ class ScheduledPromptsExecutor:
         status: RunStatus,
         result: dict,
         sp: ScheduledPrompt,
-    ) -> None:
-        self.dal.finish_scheduled_prompt_run(
+    ) -> bool:
+        persisted = self.dal.finish_scheduled_prompt_run(
             status=status,
             result=result,
             run_id=sp.id,
@@ -375,6 +390,19 @@ class ScheduledPromptsExecutor:
             version=get_version(),
             metadata=sp.metadata,
         )
+        if persisted:
+            logging.info("Run %s finished and persisted as %s", sp.id, status.value)
+        else:
+            # Do NOT report this as success: the store write failed, so the run
+            # is still RUNNING and will likely be reclaimed and re-executed
+            # (usually a transient Supabase connection error).
+            logging.error(
+                "Run %s finished locally but the store write FAILED; it was NOT "
+                "marked %s and may be reclaimed and re-executed",
+                sp.id,
+                status.value,
+            )
+        return persisted
 
     def _extract_prompt_text(self, prompt: Union[str, dict]) -> str:
         """

--- a/holmes/core/scheduled_prompts/executor.py
+++ b/holmes/core/scheduled_prompts/executor.py
@@ -264,9 +264,10 @@ class ScheduledPromptsExecutor:
                     response.analysis = (response.analysis or "") + note
         except Exception:
             logging.exception(
-                "Failed to evaluate sink delivery conditions for run %s; "
-                "defaulting to deliver to all configured channels",
+                "Failed to evaluate sink delivery conditions for run %s "
+                "(model=%s); defaulting to deliver to all configured channels",
                 sp.id,
+                sp.model_name,
             )
 
     @staticmethod

--- a/holmes/core/scheduled_prompts/executor.py
+++ b/holmes/core/scheduled_prompts/executor.py
@@ -27,6 +27,18 @@ from holmes.core.scheduled_prompts.sink_conditions import (
     format_delivery_note,
 )
 from holmes.core.supabase_dal import RunStatus
+from holmes.core.usage_recorder import (
+    RequestStatus,
+    UsageRecorderState,
+    record_single_llm_call,
+    resolve_provider,
+)
+
+# request_source for the sink-delivery decision's LLM call. The "internal_"
+# prefix marks it (alongside is_internal=True) as a server-internal side-call so
+# it's filtered out of user-facing activity/cost dashboards, separate from the
+# user-facing investigation run (request_source="scheduler").
+SINK_DECISION_REQUEST_SOURCE = "internal_scheduled_prompt_notification"
 
 # to prevent circular imports due to type hints
 if TYPE_CHECKING:
@@ -257,6 +269,7 @@ class ScheduledPromptsExecutor:
             result = evaluate_sink_decisions(
                 llm, notification_prompt, response.analysis
             )
+            self._record_sink_decision_usage(sp, llm, result)
             if result.decisions:
                 response.sink_decisions = result.decisions
                 note = format_delivery_note(result.suppressed(), result.rationale)
@@ -268,6 +281,47 @@ class ScheduledPromptsExecutor:
                 "(model=%s); defaulting to deliver to all configured channels",
                 sp.id,
                 sp.model_name,
+            )
+
+    def _record_sink_decision_usage(
+        self, sp: ScheduledPrompt, llm, result
+    ) -> None:
+        """Record AI usage for the sink-delivery decision's LLM call.
+
+        This is a separate, non-streaming ``llm.completion`` call that bypasses
+        the ChatRequest/usage-recorder path the investigation uses, so its tokens
+        would otherwise go untracked. Tag it as a server-internal side-call
+        (``is_internal=True`` + an ``internal_``-prefixed request_source) so it's
+        excluded from user-facing dashboards but still counted for cost.
+
+        Best-effort: telemetry must never break the run, so any failure here is
+        swallowed.
+        """
+        try:
+            model = getattr(llm, "model", None) or sp.model_name
+            state = UsageRecorderState(
+                dal=self.dal,
+                request_type="scheduled_prompt",
+                request_source=SINK_DECISION_REQUEST_SOURCE,
+                source_ref=sp.id,
+                is_internal=True,
+                is_streaming=False,
+                model=model,
+                provider=resolve_provider(model),
+                is_robusta_model=getattr(llm, "is_robusta_model", False),
+            )
+            # result.stats is None only when the completion itself raised.
+            status = (
+                RequestStatus.SUCCESS
+                if result.stats is not None
+                else RequestStatus.ERROR
+            )
+            record_single_llm_call(state, result.stats, status=status)
+        except Exception:
+            logging.debug(
+                "Failed to record sink-decision usage for run %s",
+                sp.id,
+                exc_info=True,
             )
 
     @staticmethod

--- a/holmes/core/scheduled_prompts/executor.py
+++ b/holmes/core/scheduled_prompts/executor.py
@@ -236,6 +236,11 @@ class ScheduledPromptsExecutor:
     ) -> None:
         """Evaluate per-channel delivery conditions written in the user's prompt.
 
+        The conditions come from the prompt's dedicated ``notification_prompt``
+        field (kept separate from the main ``raw_prompt`` so older Holmes builds
+        ignore it). When it is absent, no evaluation happens and delivery falls
+        back to every configured channel.
+
         Sets ``response.sink_decisions`` to a {sink_type: bool} map (e.g.
         ``{"slack": True, "email": False}``) that the reporter uses to decide
         which channels to deliver to. When a channel is suppressed, a short
@@ -243,10 +248,15 @@ class ScheduledPromptsExecutor:
         visible in the chat result. Any failure leaves ``sink_decisions`` as
         None, which the reporter treats as "deliver to all configured channels".
         """
+        notification_prompt = self._extract_notification_prompt(sp.prompt)
+        if not notification_prompt:
+            return
+
         try:
-            prompt_text = self._extract_prompt_text(sp.prompt)
             llm = self.config._get_llm(model_key=sp.model_name)
-            result = evaluate_sink_decisions(llm, prompt_text, response.analysis)
+            result = evaluate_sink_decisions(
+                llm, notification_prompt, response.analysis
+            )
             if result.decisions:
                 response.sink_decisions = result.decisions
                 note = format_delivery_note(result.suppressed(), result.rationale)
@@ -258,6 +268,20 @@ class ScheduledPromptsExecutor:
                 "defaulting to deliver to all configured channels",
                 sp.id,
             )
+
+    @staticmethod
+    def _extract_notification_prompt(prompt: Union[str, dict]) -> Optional[str]:
+        """Read the optional ``notification_prompt`` delivery-conditions field.
+
+        Returns the trimmed instructions, or None when the prompt is not a dict
+        or the field is absent/blank (the common case for prompts created by
+        clients that don't set delivery conditions).
+        """
+        if isinstance(prompt, dict):
+            value = prompt.get("notification_prompt")
+            if isinstance(value, str) and value.strip():
+                return value
+        return None
 
     def _fetch_additional_system_prompt(
         self, fallback: Optional[str] = None

--- a/holmes/core/scheduled_prompts/executor.py
+++ b/holmes/core/scheduled_prompts/executor.py
@@ -22,7 +22,10 @@ from holmes.core.scheduled_prompts.heartbeat_tracer import (
     ScheduledPromptsHeartbeatSpan,
 )
 from holmes.core.scheduled_prompts.models import ScheduledPrompt
-from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
+from holmes.core.scheduled_prompts.sink_conditions import (
+    evaluate_sink_decisions,
+    format_delivery_note,
+)
 from holmes.core.supabase_dal import RunStatus
 
 # to prevent circular imports due to type hints
@@ -235,15 +238,20 @@ class ScheduledPromptsExecutor:
 
         Sets ``response.sink_decisions`` to a {sink_type: bool} map (e.g.
         ``{"slack": True, "email": False}``) that the reporter uses to decide
-        which channels to deliver to. Any failure leaves ``sink_decisions`` as
+        which channels to deliver to. When a channel is suppressed, a short
+        delivery note is appended to ``response.analysis`` so the suppression is
+        visible in the chat result. Any failure leaves ``sink_decisions`` as
         None, which the reporter treats as "deliver to all configured channels".
         """
         try:
             prompt_text = self._extract_prompt_text(sp.prompt)
             llm = self.config._get_llm(model_key=sp.model_name)
-            decisions = evaluate_sink_decisions(llm, prompt_text, response.analysis)
-            if decisions:
-                response.sink_decisions = decisions
+            result = evaluate_sink_decisions(llm, prompt_text, response.analysis)
+            if result.decisions:
+                response.sink_decisions = result.decisions
+                note = format_delivery_note(result.suppressed(), result.rationale)
+                if note:
+                    response.analysis = (response.analysis or "") + note
         except Exception:
             logging.exception(
                 "Failed to evaluate sink delivery conditions for run %s; "

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -35,6 +35,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
+from holmes.common.env_vars import TEMPERATURE
 from holmes.core.llm import LLM
 
 # Maps the structured-output field names to the sink-type keys relay expects.
@@ -176,10 +177,17 @@ def evaluate_sink_decisions(
     ]
 
     try:
+        # Use the same TEMPERATURE contract as the main investigation chat
+        # (tool_calling_llm). A hardcoded value here breaks models that reject
+        # the parameter: Anthropic with extended thinking enabled requires
+        # temperature unset or 1 (0 is a 400), and Opus 4.7+ deprecates it
+        # entirely. TEMPERATURE is None in those deployments, sending no
+        # temperature at all. drop_params can't strip these at the provider, so
+        # the value must be omitted at the source.
         result = llm.completion(
             messages=messages,
             response_format=SINK_DECISION_RESPONSE_FORMAT,
-            temperature=0,
+            temperature=TEMPERATURE,
             drop_params=True,
         )
         content = result.choices[0].message.content  # type: ignore[union-attr]

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -26,7 +26,8 @@ Design notes:
 
 import json
 import logging
-from typing import Any, Dict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
 
 from holmes.core.llm import LLM
 
@@ -35,6 +36,30 @@ _FIELD_TO_SINK = {
     "send_to_slack": "slack",
     "send_to_email": "email",
 }
+
+# Human-readable label for each sink type, used in the delivery note.
+_SINK_LABELS = {
+    "slack": "Slack",
+    "email": "email",
+}
+
+
+@dataclass
+class SinkDecisions:
+    """Outcome of evaluating a scheduled prompt's delivery conditions.
+
+    ``decisions`` maps sink type ("slack"/"email") to whether it should be
+    delivered. ``rationale`` is the model's brief explanation, surfaced in the
+    chat result when a channel is suppressed. An empty ``decisions`` map means
+    "deliver to every configured channel" (the safe default).
+    """
+
+    decisions: Dict[str, bool] = field(default_factory=dict)
+    rationale: str = ""
+
+    def suppressed(self) -> List[str]:
+        """Sink types explicitly suppressed (decision is False)."""
+        return [sink for sink, send in self.decisions.items() if send is False]
 
 SINK_DECISION_RESPONSE_FORMAT = {
     "type": "json_schema",
@@ -107,17 +132,28 @@ def _coerce_decisions(content: str) -> Dict[str, bool]:
     return decisions
 
 
+def _coerce_rationale(content: str) -> str:
+    """Best-effort extraction of the model's rationale string."""
+    try:
+        parsed = json.loads(content or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if isinstance(parsed, dict) and isinstance(parsed.get("rationale"), str):
+        return parsed["rationale"].strip()
+    return ""
+
+
 def evaluate_sink_decisions(
     llm: LLM, prompt_text: str, analysis: str
-) -> Dict[str, bool]:
+) -> SinkDecisions:
     """Decide, per sink type, whether to deliver the report.
 
-    Returns a map like {"slack": True, "email": False}. Returns an empty map on
-    any failure or when there is nothing to evaluate, which the reporter treats
-    as "deliver to every configured channel" (the safe default).
+    Returns a :class:`SinkDecisions`. Empty decisions (on any failure or when
+    there is nothing to evaluate) tell the reporter to deliver to every
+    configured channel (the safe default).
     """
     if not prompt_text or not prompt_text.strip():
-        return {}
+        return SinkDecisions()
 
     user_content = (
         "Here is the user's scheduled-prompt request:\n"
@@ -139,10 +175,35 @@ def evaluate_sink_decisions(
             drop_params=True,
         )
         content = result.choices[0].message.content  # type: ignore[union-attr]
-        return _coerce_decisions(content)
+        return SinkDecisions(
+            decisions=_coerce_decisions(content),
+            rationale=_coerce_rationale(content),
+        )
     except Exception:
         logging.exception(
             "Failed to evaluate scheduled-prompt sink delivery conditions; "
             "defaulting to deliver to all configured channels"
         )
-        return {}
+        return SinkDecisions()
+
+
+def format_delivery_note(suppressed: List[str], rationale: str) -> str:
+    """Build a short, clearly-delimited note for channels that were withheld.
+
+    Phrased as the delivery *decision* (not actual transport) so it stays
+    accurate regardless of which channels the account has configured.
+    """
+    if not suppressed:
+        return ""
+    labels = [_SINK_LABELS.get(sink, sink) for sink in suppressed]
+    if len(labels) == 1:
+        targets = labels[0]
+    else:
+        targets = f"{', '.join(labels[:-1])} and {labels[-1]}"
+    note = (
+        f"\n\n---\n_Delivery note: based on the conditions in your prompt, "
+        f"this report was not sent to {targets}._"
+    )
+    if rationale:
+        note += f"\n_Reason: {rationale}_"
+    return note

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -32,6 +32,7 @@ Design notes:
 
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
@@ -68,36 +69,6 @@ class SinkDecisions:
         """Sink types explicitly suppressed (decision is False)."""
         return [sink for sink, send in self.decisions.items() if send is False]
 
-SINK_DECISION_RESPONSE_FORMAT = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "sink_delivery_decision",
-        "strict": True,
-        "schema": {
-            "type": "object",
-            "properties": {
-                "rationale": {
-                    "type": "string",
-                    "description": (
-                        "Briefly state whether the user's request contained any "
-                        "delivery conditions and, if so, whether the report meets them."
-                    ),
-                },
-                "send_to_slack": {
-                    "type": "boolean",
-                    "description": "Should this report be delivered to Slack?",
-                },
-                "send_to_email": {
-                    "type": "boolean",
-                    "description": "Should this report be delivered by email?",
-                },
-            },
-            "required": ["rationale", "send_to_slack", "send_to_email"],
-            "additionalProperties": False,
-        },
-    },
-}
-
 SINK_DECISION_SYSTEM_PROMPT = """\
 You decide whether a scheduled report should be delivered to each notification \
 channel (Slack and email).
@@ -117,7 +88,50 @@ it's critical", "don't email unless action is needed") — apply each condition 
 to the channel it names, and leave the other channel at its default of true.
 - Base your decision ONLY on the notification instructions and the report's \
 findings below. Do not invent conditions that were not stated.
-- When in doubt, prefer sending (true)."""
+- When in doubt, prefer sending (true).
+
+Respond with ONLY a single JSON object and nothing else — no prose, no \
+explanation, no markdown, no code fences. The object must have exactly these \
+keys:
+{"rationale": "<brief reason>", "send_to_slack": <true|false>, "send_to_email": <true|false>}"""
+
+
+def _extract_json_object(content: str) -> Dict[str, Any]:
+    """Best-effort parse of a JSON object from an LLM text response.
+
+    The sink-decision call relies on prompt instructions rather than a strict
+    ``response_format`` json_schema, because that schema is rejected (HTTP 400)
+    by some providers/proxies (e.g. the Robusta AI proxy). Models therefore may
+    wrap the JSON in markdown code fences or surrounding prose, so we tolerate
+    both: try a direct parse first, strip ```code fences```, then fall back to
+    the first ``{...}`` block. Returns ``{}`` if nothing parseable is found.
+    """
+    if not content:
+        return {}
+    text = content.strip()
+
+    # Strip a leading/trailing markdown code fence, e.g. ```json ... ```.
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z0-9]*\s*", "", text)
+        text = re.sub(r"\s*```$", "", text).strip()
+
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Fallback: pull the first {...} span out of surrounding prose.
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            parsed = json.loads(match.group(0))
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return {}
 
 
 def _coerce_decisions(content: str) -> Dict[str, bool]:
@@ -126,15 +140,10 @@ def _coerce_decisions(content: str) -> Dict[str, bool]:
     Only well-formed boolean fields are kept; anything else is ignored so a
     partially-malformed response can never accidentally suppress a channel.
     """
-    try:
-        parsed: Any = json.loads(content or "{}")
-    except (json.JSONDecodeError, TypeError):
-        return {}
-    if not isinstance(parsed, dict):
-        return {}
+    parsed = _extract_json_object(content)
     decisions: Dict[str, bool] = {}
-    for field, sink in _FIELD_TO_SINK.items():
-        value = parsed.get(field)
+    for field_name, sink in _FIELD_TO_SINK.items():
+        value = parsed.get(field_name)
         if isinstance(value, bool):
             decisions[sink] = value
     return decisions
@@ -142,13 +151,9 @@ def _coerce_decisions(content: str) -> Dict[str, bool]:
 
 def _coerce_rationale(content: str) -> str:
     """Best-effort extraction of the model's rationale string."""
-    try:
-        parsed = json.loads(content or "{}")
-    except (json.JSONDecodeError, TypeError):
-        return ""
-    if isinstance(parsed, dict) and isinstance(parsed.get("rationale"), str):
-        return parsed["rationale"].strip()
-    return ""
+    parsed = _extract_json_object(content)
+    rationale = parsed.get("rationale")
+    return rationale.strip() if isinstance(rationale, str) else ""
 
 
 def evaluate_sink_decisions(
@@ -177,22 +182,34 @@ def evaluate_sink_decisions(
     ]
 
     try:
-        # Use the same TEMPERATURE contract as the main investigation chat
-        # (tool_calling_llm). A hardcoded value here breaks models that reject
-        # the parameter: Anthropic with extended thinking enabled requires
-        # temperature unset or 1 (0 is a 400), and Opus 4.7+ deprecates it
-        # entirely. TEMPERATURE is None in those deployments, sending no
-        # temperature at all. drop_params can't strip these at the provider, so
-        # the value must be omitted at the source.
+        # Keep this request shaped like the main investigation chat, which we
+        # know the provider/proxy accepts:
+        #   - Use the shared TEMPERATURE contract (None on deployments whose
+        #     model rejects the parameter — e.g. Anthropic with extended
+        #     thinking, which requires temperature unset/1, or Opus 4.7+ which
+        #     deprecates it; drop_params can't strip these at the provider).
+        #   - Do NOT pass a strict response_format json_schema. Some providers
+        #     and the Robusta AI proxy reject it with HTTP 400 (error_code
+        #     5400). We instead instruct JSON output in the system prompt and
+        #     parse it tolerantly via _extract_json_object.
         result = llm.completion(
             messages=messages,
-            response_format=SINK_DECISION_RESPONSE_FORMAT,
             temperature=TEMPERATURE,
             drop_params=True,
         )
         content = result.choices[0].message.content  # type: ignore[union-attr]
+        decisions = _coerce_decisions(content)
+        if not decisions:
+            # Successful call but unparseable output: log it so this never fails
+            # silently again (deliver-everywhere is still the safe fallback).
+            logging.warning(
+                "Scheduled-prompt sink delivery evaluation produced no usable "
+                "decisions; model output was not parseable as the expected JSON. "
+                "Defaulting to deliver to all configured channels. Output: %r",
+                (content or "")[:300],
+            )
         return SinkDecisions(
-            decisions=_coerce_decisions(content),
+            decisions=decisions,
             rationale=_coerce_rationale(content),
         )
     except Exception:

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -1,0 +1,148 @@
+"""
+Per-channel delivery conditions for scheduled prompts.
+
+A scheduled prompt's report is, by default, delivered to every notification
+channel configured for it (Slack, email). Users may, however, write delivery
+conditions directly in their prompt, e.g.:
+
+    "Always post the summary to Slack. Only send the email if there is a
+     critical issue that needs human attention."
+
+After the investigation runs, this module asks the LLM to translate those
+free-text instructions into a per-sink-type decision map that the reporter
+(relay) consumes:
+
+    {"slack": True, "email": False}
+
+Design notes:
+- The default is always SEND. A channel is only suppressed when the user's
+  prompt specifies a condition for it (or for delivery in general) and the
+  report's findings show that condition is not met.
+- This is fail-safe: any error (LLM failure, malformed output, empty prompt)
+  returns an empty map, which the reporter treats as "deliver everywhere".
+- Granularity is per sink *type* (all Slack channels share one decision, all
+  email recipients share another), matching the reporter's sink model.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+from holmes.core.llm import LLM
+
+# Maps the structured-output field names to the sink-type keys relay expects.
+_FIELD_TO_SINK = {
+    "send_to_slack": "slack",
+    "send_to_email": "email",
+}
+
+SINK_DECISION_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "sink_delivery_decision",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "rationale": {
+                    "type": "string",
+                    "description": (
+                        "Briefly state whether the user's request contained any "
+                        "delivery conditions and, if so, whether the report meets them."
+                    ),
+                },
+                "send_to_slack": {
+                    "type": "boolean",
+                    "description": "Should this report be delivered to Slack?",
+                },
+                "send_to_email": {
+                    "type": "boolean",
+                    "description": "Should this report be delivered by email?",
+                },
+            },
+            "required": ["rationale", "send_to_slack", "send_to_email"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+SINK_DECISION_SYSTEM_PROMPT = """\
+You decide whether a scheduled report should be delivered to each notification \
+channel (Slack and email).
+
+The DEFAULT is to SEND the report to every channel. Only suppress a channel when \
+the user's request contains an explicit condition about when to send/notify, AND \
+the report's findings show that condition is NOT satisfied.
+
+Rules:
+- If the user's request says nothing about when or whether to send/notify/alert, \
+return send_to_slack=true and send_to_email=true.
+- A condition may be global ("only notify me if there is a problem", "skip if \
+everything is healthy") — apply it to BOTH channels.
+- A condition may be channel-specific ("always post to Slack", "only email me if \
+it's critical", "don't email unless action is needed") — apply each condition only \
+to the channel it names, and leave the other channel at its default of true.
+- Base your decision ONLY on the user's request and the report's findings below. \
+Do not invent conditions the user did not state.
+- When in doubt, prefer sending (true)."""
+
+
+def _coerce_decisions(content: str) -> Dict[str, bool]:
+    """Parse the LLM's JSON content into a {sink_type: bool} map.
+
+    Only well-formed boolean fields are kept; anything else is ignored so a
+    partially-malformed response can never accidentally suppress a channel.
+    """
+    try:
+        parsed: Any = json.loads(content or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    decisions: Dict[str, bool] = {}
+    for field, sink in _FIELD_TO_SINK.items():
+        value = parsed.get(field)
+        if isinstance(value, bool):
+            decisions[sink] = value
+    return decisions
+
+
+def evaluate_sink_decisions(
+    llm: LLM, prompt_text: str, analysis: str
+) -> Dict[str, bool]:
+    """Decide, per sink type, whether to deliver the report.
+
+    Returns a map like {"slack": True, "email": False}. Returns an empty map on
+    any failure or when there is nothing to evaluate, which the reporter treats
+    as "deliver to every configured channel" (the safe default).
+    """
+    if not prompt_text or not prompt_text.strip():
+        return {}
+
+    user_content = (
+        "Here is the user's scheduled-prompt request:\n"
+        f"<request>\n{prompt_text}\n</request>\n\n"
+        "Here is the report that was produced:\n"
+        f"<report>\n{analysis or ''}\n</report>\n\n"
+        "Decide whether to deliver this report to Slack and to email."
+    )
+    messages = [
+        {"role": "system", "content": SINK_DECISION_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    try:
+        result = llm.completion(
+            messages=messages,
+            response_format=SINK_DECISION_RESPONSE_FORMAT,
+            temperature=0,
+            drop_params=True,
+        )
+        content = result.choices[0].message.content  # type: ignore[union-attr]
+        return _coerce_decisions(content)
+    except Exception:
+        logging.exception(
+            "Failed to evaluate scheduled-prompt sink delivery conditions; "
+            "defaulting to deliver to all configured channels"
+        )
+        return {}

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -75,6 +75,41 @@ class SinkDecisions:
         """Sink types explicitly suppressed (decision is False)."""
         return [sink for sink, send in self.decisions.items() if send is False]
 
+
+# Strict structured-output schema, mirroring checks.py's CHECK_RESPONSE_FORMAT.
+# Sent on the first attempt so compliant providers return validated JSON. Some
+# stacks reject it (see evaluate_sink_decisions) and we fall back to
+# prompt-instructed JSON, so this is best-effort, not a hard dependency.
+SINK_DECISION_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "sink_delivery_decision",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "rationale": {
+                    "type": "string",
+                    "description": (
+                        "Briefly state whether the user's request contained any "
+                        "delivery conditions and, if so, whether the report meets them."
+                    ),
+                },
+                "send_to_slack": {
+                    "type": "boolean",
+                    "description": "Should this report be delivered to Slack?",
+                },
+                "send_to_email": {
+                    "type": "boolean",
+                    "description": "Should this report be delivered by email?",
+                },
+            },
+            "required": ["rationale", "send_to_slack", "send_to_email"],
+            "additionalProperties": False,
+        },
+    },
+}
+
 SINK_DECISION_SYSTEM_PROMPT = """\
 You decide whether a scheduled report should be delivered to each notification \
 channel (Slack and email).
@@ -192,22 +227,40 @@ def evaluate_sink_decisions(
         {"role": "user", "content": user_content},
     ]
 
+    # temperature uses the shared TEMPERATURE contract (None on deployments
+    # whose model rejects the parameter — e.g. Anthropic with extended thinking,
+    # which requires temperature unset/1, or Opus 4.7+ which deprecates it;
+    # drop_params can't strip these at the provider).
+    base_kwargs = {
+        "messages": messages,
+        "temperature": TEMPERATURE,
+        "drop_params": True,
+    }
+
+    # Attempt 1: request a strict json_schema so compliant providers return
+    # validated JSON (the same approach checks.py uses). Some stacks reject it —
+    # notably Anthropic with extended thinking, where litellm encodes structured
+    # output as a forced tool call that the API forbids while thinking is on;
+    # via the Robusta AI proxy this surfaces as HTTP 400 (error_code 5400). When
+    # that happens, fall back to a plain call: the system prompt already asks for
+    # raw JSON, which _extract_json_object parses tolerantly.
+    result = None
     try:
-        # Keep this request shaped like the main investigation chat, which we
-        # know the provider/proxy accepts:
-        #   - Use the shared TEMPERATURE contract (None on deployments whose
-        #     model rejects the parameter — e.g. Anthropic with extended
-        #     thinking, which requires temperature unset/1, or Opus 4.7+ which
-        #     deprecates it; drop_params can't strip these at the provider).
-        #   - Do NOT pass a strict response_format json_schema. Some providers
-        #     and the Robusta AI proxy reject it with HTTP 400 (error_code
-        #     5400). We instead instruct JSON output in the system prompt and
-        #     parse it tolerantly via _extract_json_object.
         result = llm.completion(
-            messages=messages,
-            temperature=TEMPERATURE,
-            drop_params=True,
+            response_format=SINK_DECISION_RESPONSE_FORMAT, **base_kwargs
         )
+    except Exception:
+        logging.warning(
+            "Scheduled-prompt sink delivery: response_format json_schema was "
+            "rejected; retrying without it (prompt-instructed JSON). Expected "
+            "for models that don't support structured output here (e.g. "
+            "thinking-enabled Anthropic via the proxy).",
+            exc_info=True,
+        )
+
+    try:
+        if result is None:
+            result = llm.completion(**base_kwargs)
         content = result.choices[0].message.content  # type: ignore[union-attr]
         decisions = _coerce_decisions(content)
         if not decisions:

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -2,11 +2,16 @@
 Per-channel delivery conditions for scheduled prompts.
 
 A scheduled prompt's report is, by default, delivered to every notification
-channel configured for it (Slack, email). Users may, however, write delivery
-conditions directly in their prompt, e.g.:
+channel configured for it (Slack, email). A user may, however, attach delivery
+conditions to the scheduled prompt via a dedicated ``notification_prompt`` field
+(stored alongside ``title`` and ``raw_prompt`` in the prompt definition), e.g.:
 
     "Always post the summary to Slack. Only send the email if there is a
      critical issue that needs human attention."
+
+This is kept separate from the main ``raw_prompt`` on purpose: older Holmes
+builds that don't support this feature simply ignore the unknown field, so the
+conditions never leak into the investigation prompt.
 
 After the investigation runs, this module asks the LLM to translate those
 free-text instructions into a per-sink-type decision map that the reporter
@@ -15,13 +20,14 @@ free-text instructions into a per-sink-type decision map that the reporter
     {"slack": True, "email": False}
 
 Design notes:
-- The default is always SEND. A channel is only suppressed when the user's
-  prompt specifies a condition for it (or for delivery in general) and the
-  report's findings show that condition is not met.
-- This is fail-safe: any error (LLM failure, malformed output, empty prompt)
+- The default is always SEND. A channel is only suppressed when the
+  notification instructions specify a condition for it (or for delivery in
+  general) and the report's findings show that condition is not met.
+- This is fail-safe: any error (LLM failure, malformed output, no instructions)
   returns an empty map, which the reporter treats as "deliver everywhere".
 - Granularity is per sink *type* (all Slack channels share one decision, all
-  email recipients share another), matching the reporter's sink model.
+  email recipients share another), matching the reporter's sink model. A single
+  ``notification_prompt`` drives both channels.
 """
 
 import json
@@ -95,20 +101,21 @@ SINK_DECISION_SYSTEM_PROMPT = """\
 You decide whether a scheduled report should be delivered to each notification \
 channel (Slack and email).
 
-The DEFAULT is to SEND the report to every channel. Only suppress a channel when \
-the user's request contains an explicit condition about when to send/notify, AND \
-the report's findings show that condition is NOT satisfied.
+You are given the user's NOTIFICATION INSTRUCTIONS and the report that was \
+produced. The DEFAULT is to SEND the report to every channel. Only suppress a \
+channel when the instructions contain an explicit condition about when to \
+send/notify, AND the report's findings show that condition is NOT satisfied.
 
 Rules:
-- If the user's request says nothing about when or whether to send/notify/alert, \
+- If the instructions say nothing about when or whether to send/notify/alert, \
 return send_to_slack=true and send_to_email=true.
 - A condition may be global ("only notify me if there is a problem", "skip if \
 everything is healthy") — apply it to BOTH channels.
 - A condition may be channel-specific ("always post to Slack", "only email me if \
 it's critical", "don't email unless action is needed") — apply each condition only \
 to the channel it names, and leave the other channel at its default of true.
-- Base your decision ONLY on the user's request and the report's findings below. \
-Do not invent conditions the user did not state.
+- Base your decision ONLY on the notification instructions and the report's \
+findings below. Do not invent conditions that were not stated.
 - When in doubt, prefer sending (true)."""
 
 
@@ -144,20 +151,21 @@ def _coerce_rationale(content: str) -> str:
 
 
 def evaluate_sink_decisions(
-    llm: LLM, prompt_text: str, analysis: str
+    llm: LLM, notification_instructions: str, analysis: str
 ) -> SinkDecisions:
     """Decide, per sink type, whether to deliver the report.
 
+    ``notification_instructions`` is the user's free-text ``notification_prompt``.
     Returns a :class:`SinkDecisions`. Empty decisions (on any failure or when
-    there is nothing to evaluate) tell the reporter to deliver to every
-    configured channel (the safe default).
+    there are no instructions) tell the reporter to deliver to every configured
+    channel (the safe default).
     """
-    if not prompt_text or not prompt_text.strip():
+    if not notification_instructions or not notification_instructions.strip():
         return SinkDecisions()
 
     user_content = (
-        "Here is the user's scheduled-prompt request:\n"
-        f"<request>\n{prompt_text}\n</request>\n\n"
+        "Here are the user's notification instructions:\n"
+        f"<instructions>\n{notification_instructions}\n</instructions>\n\n"
         "Here is the report that was produced:\n"
         f"<report>\n{analysis or ''}\n</report>\n\n"
         "Decide whether to deliver this report to Slack and to email."

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -34,10 +34,11 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from holmes.common.env_vars import TEMPERATURE
 from holmes.core.llm import LLM
+from holmes.core.llm_usage import RequestStats
 
 # Maps the structured-output field names to the sink-type keys relay expects.
 _FIELD_TO_SINK = {
@@ -64,6 +65,11 @@ class SinkDecisions:
 
     decisions: Dict[str, bool] = field(default_factory=dict)
     rationale: str = ""
+    # Token/cost stats for the single LLM call this evaluation made, extracted
+    # from the completion response. ``None`` means the call never produced a
+    # response (it raised) — the caller records that as an error usage event.
+    # A non-None (possibly zero) value means the call succeeded.
+    stats: Optional[RequestStats] = None
 
     def suppressed(self) -> List[str]:
         """Sink types explicitly suppressed (decision is False)."""
@@ -208,9 +214,18 @@ def evaluate_sink_decisions(
                 "Defaulting to deliver to all configured channels. Output: %r",
                 (content or "")[:300],
             )
+        # Extract token/cost stats for usage tracking. The call succeeded, so
+        # always return a (possibly empty) RequestStats — never None — to mark
+        # this as a successful LLM call. Guarded so a stats-extraction hiccup
+        # can never turn a good decision into a swallowed failure.
+        try:
+            stats = RequestStats.from_response(result)
+        except Exception:
+            stats = RequestStats()
         return SinkDecisions(
             decisions=decisions,
             rationale=_coerce_rationale(content),
+            stats=stats,
         )
     except Exception:
         logging.exception(

--- a/holmes/core/scheduled_prompts/sink_conditions.py
+++ b/holmes/core/scheduled_prompts/sink_conditions.py
@@ -128,11 +128,16 @@ def _extract_json_object(content: str) -> Dict[str, Any]:
     except (json.JSONDecodeError, TypeError):
         pass
 
-    # Fallback: pull the first {...} span out of surrounding prose.
-    match = re.search(r"\{.*\}", text, re.DOTALL)
-    if match:
+    # Fallback: decode the first JSON object embedded in surrounding prose.
+    # raw_decode stops at the end of the first valid object, so trailing prose
+    # — or a second object — no longer breaks parsing. A greedy `\{.*\}` regex
+    # would instead span from the first brace to the LAST brace anywhere in the
+    # text and fail json.loads ("Extra data"); it also mishandles braces inside
+    # string values. raw_decode handles both correctly.
+    start = text.find("{")
+    if start != -1:
         try:
-            parsed = json.loads(match.group(0))
+            parsed, _ = json.JSONDecoder().raw_decode(text[start:])
             if isinstance(parsed, dict):
                 return parsed
         except (json.JSONDecodeError, TypeError):

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from uuid import uuid4
 
+import httpx
 import sentry_sdk
 import yaml  # type: ignore
 from cachetools import TTLCache  # type: ignore
@@ -1269,27 +1270,48 @@ class SupabaseDal:
             )
             return False
 
-        try:
-            self.client.rpc(
-                "finish_scheduled_prompt_run",
-                {
-                    "_cluster_name": self.cluster,
-                    "_account_id": self.account_id,
-                    "_status": status.value,
-                    "_result": result,
-                    "_scheduled_prompt_run_id": run_id,
-                    "_scheduled_prompt_definition_id": scheduled_prompt_definition_id,
-                    "_version": version,
-                    "_metadata": metadata,
-                },
-            ).execute()
-            return True
-        except Exception:
-            logging.exception(
-                "Supabase error while finishing scheduled prompt run",
-                exc_info=True,
-            )
-            return False
+        payload = {
+            "_cluster_name": self.cluster,
+            "_account_id": self.account_id,
+            "_status": status.value,
+            "_result": result,
+            "_scheduled_prompt_run_id": run_id,
+            "_scheduled_prompt_definition_id": scheduled_prompt_definition_id,
+            "_version": version,
+            "_metadata": metadata,
+        }
+        # Retry transient connection failures. The shared Supabase HTTP/2 client
+        # can emit RemoteProtocolError (ConnectionTerminated / GOAWAY) under
+        # concurrent use or server-side connection recycling. If finishing isn't
+        # persisted the run stays RUNNING and gets reclaimed and re-executed, so
+        # it's worth a couple of retries — this RPC is an idempotent status
+        # update, and httpx opens a fresh connection on the next attempt.
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, 4):
+            try:
+                self.client.rpc("finish_scheduled_prompt_run", payload).execute()
+                return True
+            except httpx.TransportError as exc:
+                last_exc = exc
+                logging.warning(
+                    "Transient Supabase error finishing scheduled prompt run "
+                    "(attempt %d/3): %s",
+                    attempt,
+                    exc,
+                )
+            except Exception:
+                logging.exception(
+                    "Supabase error while finishing scheduled prompt run",
+                    exc_info=True,
+                )
+                return False
+        logging.error(
+            "Failed to persist scheduled prompt run %s completion after 3 "
+            "attempts; it may be reclaimed and re-executed",
+            run_id,
+            exc_info=last_exc,
+        )
+        return False
 
     # --- OAuth Token Storage ---
 

--- a/holmes/core/usage_recorder.py
+++ b/holmes/core/usage_recorder.py
@@ -575,6 +575,29 @@ def record_error(state: UsageRecorderState, exc: Exception) -> None:
     state._fire()
 
 
+def record_single_llm_call(
+    state: UsageRecorderState,
+    stats: Optional["RequestStats"],
+    *,
+    status: RequestStatus = RequestStatus.SUCCESS,
+) -> None:
+    """Record usage for a single, non-streaming, non-agentic ``llm.completion`` call.
+
+    For side-calls that bypass the ChatRequest / tool-calling path (e.g. the
+    scheduled-prompt sink-delivery decision), the caller already has the
+    ``RequestStats`` it extracted from the raw litellm response (typically via
+    ``RequestStats.from_response``). This sets the single-call runtime fields
+    (one iteration, no tool calls) and fires the row. ``stats=None`` is recorded
+    as a zero-stats row, which pairs with ``status=RequestStatus.ERROR`` when the
+    completion itself failed.
+    """
+    state.stats = stats if stats is not None else RequestStats()
+    state.iterations = 1
+    state.tool_call_count = 0
+    state.status = status
+    state._fire()
+
+
 __all__ = [
     "RequestStatus",
     "UsageRecorderState",
@@ -582,6 +605,7 @@ __all__ = [
     "detect_slack_origin",
     "record_error",
     "record_from_llm_result",
+    "record_single_llm_call",
     "resolve_provider",
     "stream_with_usage_recording",
 ]

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -673,6 +673,10 @@ class TestSinkDeliveryConditions:
         )
         mock_config._get_llm = MagicMock(return_value=llm)
 
+        sample_scheduled_prompt_payload["prompt"] = {
+            "raw_prompt": "Check cluster health",
+            "notification_prompt": "Only email me if there's a critical issue",
+        }
         sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
         response = executor._execute_prompt(sp)
 
@@ -684,12 +688,29 @@ class TestSinkDeliveryConditions:
         assert result_arg["sink_decisions"] == {"slack": True, "email": False}
         assert "not sent to email" in result_arg["analysis"]
 
+    def test_execute_prompt_skips_evaluation_without_notification_prompt(
+        self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
+    ):
+        """No notification_prompt -> no LLM call, deliver everywhere (None)."""
+        mock_config._get_llm = MagicMock()
+
+        # sample payload's prompt has only raw_prompt, no notification_prompt
+        sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
+        response = executor._execute_prompt(sp)
+
+        assert response.sink_decisions is None
+        mock_config._get_llm.assert_not_called()
+
     def test_execute_prompt_leaves_decisions_none_on_failure(
         self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
     ):
         """If evaluation fails, sink_decisions stays None (deliver everywhere)."""
         mock_config._get_llm = MagicMock(side_effect=RuntimeError("no llm"))
 
+        sample_scheduled_prompt_payload["prompt"] = {
+            "raw_prompt": "Check cluster health",
+            "notification_prompt": "Only notify if there are problems",
+        }
         sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
         response = executor._execute_prompt(sp)
 

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -664,18 +664,47 @@ class TestSinkDeliveryConditions:
         assert kwargs["temperature"] == TEMPERATURE
         assert kwargs["temperature"] != 0
 
-    def test_evaluate_does_not_send_strict_response_format(self):
-        """Regression: a strict response_format json_schema is rejected (HTTP
-        400, error_code 5400) by some providers / the Robusta AI proxy, which
-        was swallowed and left sink_decisions null. The call must rely on prompt
-        instructions + tolerant parsing instead, never a strict schema."""
+    def test_evaluate_requests_structured_output_schema(self):
+        """The first attempt requests validated JSON via a strict json_schema
+        response_format (so compliant providers don't need text parsing)."""
         llm = self._completion_returning(
             {"send_to_slack": True, "send_to_email": True, "rationale": "x"}
         )
         evaluate_sink_decisions(llm, "notify only on problems", "analysis")
 
         kwargs = llm.completion.call_args.kwargs
-        assert kwargs.get("response_format") is None
+        rf = kwargs.get("response_format")
+        assert rf is not None
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["strict"] is True
+
+    def test_evaluate_falls_back_when_response_format_rejected(self):
+        """If the strict schema is rejected (e.g. thinking-enabled Anthropic via
+        the proxy → HTTP 400), retry WITHOUT response_format and still parse the
+        prompt-instructed JSON, rather than silently returning no decisions."""
+        message = MagicMock()
+        message.content = json.dumps(
+            {"send_to_slack": True, "send_to_email": False, "rationale": "x"}
+        )
+        choice = MagicMock()
+        choice.message = message
+        good = MagicMock()
+        good.choices = [choice]
+
+        llm = MagicMock()
+        llm.completion = MagicMock(side_effect=[RuntimeError("400 invalid"), good])
+
+        out = evaluate_sink_decisions(llm, "email only if critical", "healthy")
+
+        assert out.decisions == {"slack": True, "email": False}
+        assert llm.completion.call_count == 2
+        # First attempt carries the schema; the retry drops it.
+        assert (
+            llm.completion.call_args_list[0].kwargs.get("response_format") is not None
+        )
+        assert (
+            llm.completion.call_args_list[1].kwargs.get("response_format") is None
+        )
 
     def test_coerce_decisions_handles_code_fenced_json(self):
         fenced = '```json\n{"send_to_slack": true, "send_to_email": false}\n```'

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -1,3 +1,4 @@
+import json
 import time
 from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
@@ -5,13 +6,22 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from pydantic import ValidationError
 
+from holmes.common.env_vars import TEMPERATURE
 from holmes.core.models import ChatResponse
 from holmes.core.scheduled_prompts import (
     ScheduledPrompt,
     ScheduledPromptsExecutor,
     ScheduledPromptsHeartbeatSpan,
+    sink_conditions,
+)
+from holmes.core.scheduled_prompts.sink_conditions import (
+    _coerce_decisions,
+    _coerce_rationale,
+    evaluate_sink_decisions,
+    format_delivery_note,
 )
 from holmes.core.supabase_dal import RunStatus
+from holmes.core.usage_recorder import RequestStatus
 
 
 @pytest.fixture
@@ -589,10 +599,8 @@ class TestSinkDeliveryConditions:
 
     def _completion_returning(self, payload):
         """Build a mock LLM whose completion returns the given JSON payload."""
-        import json as _json
-
         message = MagicMock()
-        message.content = _json.dumps(payload)
+        message.content = json.dumps(payload)
         choice = MagicMock()
         choice.message = message
         result = MagicMock()
@@ -602,31 +610,23 @@ class TestSinkDeliveryConditions:
         return llm
 
     def test_coerce_decisions_valid(self):
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         out = _coerce_decisions(
             '{"send_to_slack": true, "send_to_email": false, "rationale": "x"}'
         )
         assert out == {"slack": True, "email": False}
 
     def test_coerce_decisions_malformed_returns_empty(self):
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         assert _coerce_decisions("not json") == {}
         assert _coerce_decisions("") == {}
         assert _coerce_decisions("[1, 2, 3]") == {}
 
     def test_coerce_decisions_ignores_non_bool(self):
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         # Non-bool fields are dropped, valid ones kept.
         assert _coerce_decisions('{"send_to_slack": "yes", "send_to_email": true}') == {
             "email": True
         }
 
     def test_evaluate_returns_empty_for_blank_prompt(self):
-        from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
-
         llm = MagicMock()
         out = evaluate_sink_decisions(llm, "   ", "some analysis")
         assert out.decisions == {}
@@ -634,8 +634,6 @@ class TestSinkDeliveryConditions:
         llm.completion.assert_not_called()
 
     def test_evaluate_maps_structured_output(self):
-        from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
-
         llm = self._completion_returning(
             {"send_to_slack": True, "send_to_email": False, "rationale": "not critical"}
         )
@@ -646,8 +644,6 @@ class TestSinkDeliveryConditions:
         llm.completion.assert_called_once()
 
     def test_evaluate_returns_empty_on_llm_error(self):
-        from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
-
         llm = MagicMock()
         llm.completion = MagicMock(side_effect=RuntimeError("boom"))
         # Fail-safe: any error -> empty (reporter then delivers to all channels).
@@ -659,11 +655,6 @@ class TestSinkDeliveryConditions:
         sink_decisions silently stays null). The call must instead pass the
         shared TEMPERATURE constant, which is None when temperature must be
         omitted entirely."""
-        from holmes.common.env_vars import TEMPERATURE
-        from holmes.core.scheduled_prompts.sink_conditions import (
-            evaluate_sink_decisions,
-        )
-
         llm = self._completion_returning(
             {"send_to_slack": True, "send_to_email": True, "rationale": "x"}
         )
@@ -678,10 +669,6 @@ class TestSinkDeliveryConditions:
         400, error_code 5400) by some providers / the Robusta AI proxy, which
         was swallowed and left sink_decisions null. The call must rely on prompt
         instructions + tolerant parsing instead, never a strict schema."""
-        from holmes.core.scheduled_prompts.sink_conditions import (
-            evaluate_sink_decisions,
-        )
-
         llm = self._completion_returning(
             {"send_to_slack": True, "send_to_email": True, "rationale": "x"}
         )
@@ -691,14 +678,10 @@ class TestSinkDeliveryConditions:
         assert kwargs.get("response_format") is None
 
     def test_coerce_decisions_handles_code_fenced_json(self):
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         fenced = '```json\n{"send_to_slack": true, "send_to_email": false}\n```'
         assert _coerce_decisions(fenced) == {"slack": True, "email": False}
 
     def test_coerce_decisions_handles_prose_wrapped_json(self):
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         prose = (
             "Sure! Based on the report:\n"
             '{"rationale": "all healthy", "send_to_slack": true, '
@@ -710,8 +693,6 @@ class TestSinkDeliveryConditions:
         """Regression: a greedy `{.*}` regex spans first-to-last brace and fails
         json.loads ('Extra data') when the model emits more than one object;
         raw_decode must take the first valid object instead."""
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         multi = (
             'Result: {"send_to_slack": true, "send_to_email": false} '
             'or maybe {"other": 1}'
@@ -720,8 +701,6 @@ class TestSinkDeliveryConditions:
 
     def test_coerce_decisions_handles_trailing_prose_with_brace(self):
         """A `}` in trailing prose must not break extraction of the first object."""
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
-
         text = (
             '{"send_to_slack": false, "send_to_email": true} '
             "note: use the }}-syntax elsewhere"
@@ -730,16 +709,12 @@ class TestSinkDeliveryConditions:
 
     def test_coerce_rationale_handles_brace_inside_string(self):
         """A brace inside the rationale string must not truncate parsing."""
-        from holmes.core.scheduled_prompts.sink_conditions import _coerce_rationale
-
         text = '{"rationale": "use the {placeholder}", "send_to_slack": true}'
         assert _coerce_rationale(text) == "use the {placeholder}"
 
     def test_evaluate_warns_when_output_unparseable(self):
         """A successful call with non-JSON output must log (not silently return
         null) and fall back to deliver-everywhere."""
-        from holmes.core.scheduled_prompts import sink_conditions
-
         llm = MagicMock()
         message = MagicMock()
         message.content = "I cannot decide that."  # not JSON
@@ -758,8 +733,6 @@ class TestSinkDeliveryConditions:
         mock_logging.warning.assert_called_once()
 
     def test_format_delivery_note(self):
-        from holmes.core.scheduled_prompts.sink_conditions import format_delivery_note
-
         assert format_delivery_note([], "x") == ""
         single = format_delivery_note(["email"], "no critical issues")
         assert "not sent to email" in single
@@ -850,8 +823,6 @@ class TestSinkDeliveryConditions:
         assert state.request_type == "scheduled_prompt"
         assert state.source_ref == sp.id
         # SUCCESS status is passed when the completion returned a response.
-        from holmes.core.usage_recorder import RequestStatus
-
         assert rec.call_args.kwargs["status"] == RequestStatus.SUCCESS
 
     def test_sink_decision_usage_not_recorded_without_notification_prompt(

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -582,3 +582,98 @@ class TestScheduledPromptModel:
         assert sp.scheduled_prompt_definition_id is None
         assert sp.msg is None
         assert sp.metadata is None
+
+
+class TestSinkDeliveryConditions:
+    """Tests for per-channel delivery conditions on scheduled prompts."""
+
+    def _completion_returning(self, payload):
+        """Build a mock LLM whose completion returns the given JSON payload."""
+        import json as _json
+
+        message = MagicMock()
+        message.content = _json.dumps(payload)
+        choice = MagicMock()
+        choice.message = message
+        result = MagicMock()
+        result.choices = [choice]
+        llm = MagicMock()
+        llm.completion = MagicMock(return_value=result)
+        return llm
+
+    def test_coerce_decisions_valid(self):
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        out = _coerce_decisions(
+            '{"send_to_slack": true, "send_to_email": false, "rationale": "x"}'
+        )
+        assert out == {"slack": True, "email": False}
+
+    def test_coerce_decisions_malformed_returns_empty(self):
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        assert _coerce_decisions("not json") == {}
+        assert _coerce_decisions("") == {}
+        assert _coerce_decisions("[1, 2, 3]") == {}
+
+    def test_coerce_decisions_ignores_non_bool(self):
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        # Non-bool fields are dropped, valid ones kept.
+        assert _coerce_decisions('{"send_to_slack": "yes", "send_to_email": true}') == {
+            "email": True
+        }
+
+    def test_evaluate_returns_empty_for_blank_prompt(self):
+        from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
+
+        llm = MagicMock()
+        assert evaluate_sink_decisions(llm, "   ", "some analysis") == {}
+        # No conditions to evaluate -> must not even call the model.
+        llm.completion.assert_not_called()
+
+    def test_evaluate_maps_structured_output(self):
+        from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
+
+        llm = self._completion_returning(
+            {"send_to_slack": True, "send_to_email": False, "rationale": "not critical"}
+        )
+        out = evaluate_sink_decisions(llm, "email me only if critical", "all healthy")
+        assert out == {"slack": True, "email": False}
+        llm.completion.assert_called_once()
+
+    def test_evaluate_returns_empty_on_llm_error(self):
+        from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
+
+        llm = MagicMock()
+        llm.completion = MagicMock(side_effect=RuntimeError("boom"))
+        # Fail-safe: any error -> {} (reporter then delivers to all channels).
+        assert evaluate_sink_decisions(llm, "some prompt", "analysis") == {}
+
+    def test_execute_prompt_sets_sink_decisions(
+        self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
+    ):
+        """A successful condition evaluation must be attached to the result."""
+        llm = self._completion_returning(
+            {"send_to_slack": True, "send_to_email": False, "rationale": "healthy"}
+        )
+        mock_config._get_llm = MagicMock(return_value=llm)
+
+        sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
+        response = executor._execute_prompt(sp)
+
+        assert response.sink_decisions == {"slack": True, "email": False}
+        # The decision is persisted as part of the result payload.
+        result_arg = mock_dal.finish_scheduled_prompt_run.call_args.kwargs["result"]
+        assert result_arg["sink_decisions"] == {"slack": True, "email": False}
+
+    def test_execute_prompt_leaves_decisions_none_on_failure(
+        self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
+    ):
+        """If evaluation fails, sink_decisions stays None (deliver everywhere)."""
+        mock_config._get_llm = MagicMock(side_effect=RuntimeError("no llm"))
+
+        sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
+        response = executor._execute_prompt(sp)
+
+        assert response.sink_decisions is None

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -628,7 +628,8 @@ class TestSinkDeliveryConditions:
         from holmes.core.scheduled_prompts.sink_conditions import evaluate_sink_decisions
 
         llm = MagicMock()
-        assert evaluate_sink_decisions(llm, "   ", "some analysis") == {}
+        out = evaluate_sink_decisions(llm, "   ", "some analysis")
+        assert out.decisions == {}
         # No conditions to evaluate -> must not even call the model.
         llm.completion.assert_not_called()
 
@@ -639,7 +640,9 @@ class TestSinkDeliveryConditions:
             {"send_to_slack": True, "send_to_email": False, "rationale": "not critical"}
         )
         out = evaluate_sink_decisions(llm, "email me only if critical", "all healthy")
-        assert out == {"slack": True, "email": False}
+        assert out.decisions == {"slack": True, "email": False}
+        assert out.rationale == "not critical"
+        assert out.suppressed() == ["email"]
         llm.completion.assert_called_once()
 
     def test_evaluate_returns_empty_on_llm_error(self):
@@ -647,8 +650,19 @@ class TestSinkDeliveryConditions:
 
         llm = MagicMock()
         llm.completion = MagicMock(side_effect=RuntimeError("boom"))
-        # Fail-safe: any error -> {} (reporter then delivers to all channels).
-        assert evaluate_sink_decisions(llm, "some prompt", "analysis") == {}
+        # Fail-safe: any error -> empty (reporter then delivers to all channels).
+        assert evaluate_sink_decisions(llm, "some prompt", "analysis").decisions == {}
+
+    def test_format_delivery_note(self):
+        from holmes.core.scheduled_prompts.sink_conditions import format_delivery_note
+
+        assert format_delivery_note([], "x") == ""
+        single = format_delivery_note(["email"], "no critical issues")
+        assert "not sent to email" in single
+        assert "no critical issues" in single
+        both = format_delivery_note(["slack", "email"], "")
+        assert "Slack and email" in both
+        assert "Reason:" not in both  # no rationale -> no reason line
 
     def test_execute_prompt_sets_sink_decisions(
         self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
@@ -663,9 +677,12 @@ class TestSinkDeliveryConditions:
         response = executor._execute_prompt(sp)
 
         assert response.sink_decisions == {"slack": True, "email": False}
+        # The suppressed channel is surfaced in the chat result.
+        assert "not sent to email" in response.analysis
         # The decision is persisted as part of the result payload.
         result_arg = mock_dal.finish_scheduled_prompt_run.call_args.kwargs["result"]
         assert result_arg["sink_decisions"] == {"slack": True, "email": False}
+        assert "not sent to email" in result_arg["analysis"]
 
     def test_execute_prompt_leaves_decisions_none_on_failure(
         self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -867,3 +867,84 @@ class TestSinkDeliveryConditions:
             executor._execute_prompt(sp)
 
         rec.assert_not_called()
+
+    def test_sink_usage_recorded_after_finish(
+        self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
+    ):
+        """Usage recording must happen AFTER the run is finished, so the
+        background Supabase write can't race (and terminate) the finish write —
+        which would strand the run in RUNNING and cause re-execution."""
+        llm = self._completion_returning(
+            {"send_to_slack": True, "send_to_email": False, "rationale": "x"}
+        )
+        mock_config._get_llm = MagicMock(return_value=llm)
+        sample_scheduled_prompt_payload["prompt"] = {
+            "raw_prompt": "Check cluster health",
+            "notification_prompt": "Only email me if there's a critical issue",
+        }
+        sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
+
+        order = []
+        mock_dal.finish_scheduled_prompt_run.side_effect = (
+            lambda **kwargs: order.append("finish") or True
+        )
+        with patch(
+            "holmes.core.scheduled_prompts.executor.record_single_llm_call",
+            side_effect=lambda *a, **k: order.append("record"),
+        ):
+            executor._execute_prompt(sp)
+
+        assert order == ["finish", "record"]
+
+
+class TestFinishScheduledPromptRunRetry:
+    """finish_scheduled_prompt_run must survive transient Supabase connection
+    errors, so a completed run is actually persisted and not reclaimed."""
+
+    def _make_dal(self, execute_side_effect):
+        from holmes.core.supabase_dal import SupabaseDal
+
+        dal = object.__new__(SupabaseDal)
+        dal.enabled = True
+        dal.cluster = "test-cluster"
+        dal.account_id = "acc"
+        exec_builder = MagicMock()
+        exec_builder.execute = MagicMock(side_effect=execute_side_effect)
+        dal.client = MagicMock()
+        dal.client.rpc = MagicMock(return_value=exec_builder)
+        return dal, exec_builder
+
+    def _finish(self, dal):
+        return dal.finish_scheduled_prompt_run(
+            status=RunStatus.COMPLETED,
+            result={},
+            run_id="r",
+            scheduled_prompt_definition_id=None,
+            version="v",
+            metadata=None,
+        )
+
+    def test_retries_then_succeeds_on_transient_error(self):
+        import httpx
+
+        dal, exec_builder = self._make_dal(
+            [
+                httpx.RemoteProtocolError("terminated"),
+                httpx.RemoteProtocolError("terminated"),
+                MagicMock(),
+            ]
+        )
+        assert self._finish(dal) is True
+        assert exec_builder.execute.call_count == 3
+
+    def test_returns_false_after_exhausting_retries(self):
+        import httpx
+
+        dal, exec_builder = self._make_dal(httpx.RemoteProtocolError("terminated"))
+        assert self._finish(dal) is False
+        assert exec_builder.execute.call_count == 3
+
+    def test_non_transient_error_is_not_retried(self):
+        dal, exec_builder = self._make_dal(ValueError("schema error"))
+        assert self._finish(dal) is False
+        assert exec_builder.execute.call_count == 1

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -706,6 +706,35 @@ class TestSinkDeliveryConditions:
         )
         assert _coerce_decisions(prose) == {"slack": True, "email": False}
 
+    def test_coerce_decisions_handles_multiple_json_objects(self):
+        """Regression: a greedy `{.*}` regex spans first-to-last brace and fails
+        json.loads ('Extra data') when the model emits more than one object;
+        raw_decode must take the first valid object instead."""
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        multi = (
+            'Result: {"send_to_slack": true, "send_to_email": false} '
+            'or maybe {"other": 1}'
+        )
+        assert _coerce_decisions(multi) == {"slack": True, "email": False}
+
+    def test_coerce_decisions_handles_trailing_prose_with_brace(self):
+        """A `}` in trailing prose must not break extraction of the first object."""
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        text = (
+            '{"send_to_slack": false, "send_to_email": true} '
+            "note: use the }}-syntax elsewhere"
+        )
+        assert _coerce_decisions(text) == {"slack": False, "email": True}
+
+    def test_coerce_rationale_handles_brace_inside_string(self):
+        """A brace inside the rationale string must not truncate parsing."""
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_rationale
+
+        text = '{"rationale": "use the {placeholder}", "send_to_slack": true}'
+        assert _coerce_rationale(text) == "use the {placeholder}"
+
     def test_evaluate_warns_when_output_unparseable(self):
         """A successful call with non-JSON output must log (not silently return
         null) and fall back to deliver-everywhere."""

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -653,6 +653,26 @@ class TestSinkDeliveryConditions:
         # Fail-safe: any error -> empty (reporter then delivers to all channels).
         assert evaluate_sink_decisions(llm, "some prompt", "analysis").decisions == {}
 
+    def test_evaluate_uses_temperature_contract_not_hardcoded_zero(self):
+        """Regression: a hardcoded temperature=0 breaks thinking-enabled and
+        Opus 4.7+ models (the provider 400s, the error is swallowed, and
+        sink_decisions silently stays null). The call must instead pass the
+        shared TEMPERATURE constant, which is None when temperature must be
+        omitted entirely."""
+        from holmes.common.env_vars import TEMPERATURE
+        from holmes.core.scheduled_prompts.sink_conditions import (
+            evaluate_sink_decisions,
+        )
+
+        llm = self._completion_returning(
+            {"send_to_slack": True, "send_to_email": True, "rationale": "x"}
+        )
+        evaluate_sink_decisions(llm, "notify only on problems", "analysis")
+
+        kwargs = llm.completion.call_args.kwargs
+        assert kwargs["temperature"] == TEMPERATURE
+        assert kwargs["temperature"] != 0
+
     def test_format_delivery_note(self):
         from holmes.core.scheduled_prompts.sink_conditions import format_delivery_note
 

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -790,3 +790,51 @@ class TestSinkDeliveryConditions:
         response = executor._execute_prompt(sp)
 
         assert response.sink_decisions is None
+
+    def test_sink_decision_usage_recorded_as_internal(
+        self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
+    ):
+        """The 2nd (sink-decision) LLM call must be recorded as a server-internal
+        usage event: is_internal=True and an 'internal_'-prefixed request_source."""
+        llm = self._completion_returning(
+            {"send_to_slack": True, "send_to_email": False, "rationale": "healthy"}
+        )
+        llm.model = "anthropic/claude-x"
+        llm.is_robusta_model = False
+        mock_config._get_llm = MagicMock(return_value=llm)
+
+        sample_scheduled_prompt_payload["prompt"] = {
+            "raw_prompt": "Check cluster health",
+            "notification_prompt": "Only email me if there's a critical issue",
+        }
+        sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
+
+        with patch(
+            "holmes.core.scheduled_prompts.executor.record_single_llm_call"
+        ) as rec:
+            executor._execute_prompt(sp)
+
+        rec.assert_called_once()
+        state = rec.call_args.args[0]
+        assert state.is_internal is True
+        assert state.request_source.startswith("internal_")
+        assert state.request_type == "scheduled_prompt"
+        assert state.source_ref == sp.id
+        # SUCCESS status is passed when the completion returned a response.
+        from holmes.core.usage_recorder import RequestStatus
+
+        assert rec.call_args.kwargs["status"] == RequestStatus.SUCCESS
+
+    def test_sink_decision_usage_not_recorded_without_notification_prompt(
+        self, executor, mock_dal, mock_config, sample_scheduled_prompt_payload
+    ):
+        """No notification_prompt -> no 2nd LLM call -> nothing to record."""
+        mock_config._get_llm = MagicMock()
+
+        sp = ScheduledPrompt(**sample_scheduled_prompt_payload)
+        with patch(
+            "holmes.core.scheduled_prompts.executor.record_single_llm_call"
+        ) as rec:
+            executor._execute_prompt(sp)
+
+        rec.assert_not_called()

--- a/tests/test_scheduled_prompts.py
+++ b/tests/test_scheduled_prompts.py
@@ -673,6 +673,61 @@ class TestSinkDeliveryConditions:
         assert kwargs["temperature"] == TEMPERATURE
         assert kwargs["temperature"] != 0
 
+    def test_evaluate_does_not_send_strict_response_format(self):
+        """Regression: a strict response_format json_schema is rejected (HTTP
+        400, error_code 5400) by some providers / the Robusta AI proxy, which
+        was swallowed and left sink_decisions null. The call must rely on prompt
+        instructions + tolerant parsing instead, never a strict schema."""
+        from holmes.core.scheduled_prompts.sink_conditions import (
+            evaluate_sink_decisions,
+        )
+
+        llm = self._completion_returning(
+            {"send_to_slack": True, "send_to_email": True, "rationale": "x"}
+        )
+        evaluate_sink_decisions(llm, "notify only on problems", "analysis")
+
+        kwargs = llm.completion.call_args.kwargs
+        assert kwargs.get("response_format") is None
+
+    def test_coerce_decisions_handles_code_fenced_json(self):
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        fenced = '```json\n{"send_to_slack": true, "send_to_email": false}\n```'
+        assert _coerce_decisions(fenced) == {"slack": True, "email": False}
+
+    def test_coerce_decisions_handles_prose_wrapped_json(self):
+        from holmes.core.scheduled_prompts.sink_conditions import _coerce_decisions
+
+        prose = (
+            "Sure! Based on the report:\n"
+            '{"rationale": "all healthy", "send_to_slack": true, '
+            '"send_to_email": false}\nLet me know if you need more.'
+        )
+        assert _coerce_decisions(prose) == {"slack": True, "email": False}
+
+    def test_evaluate_warns_when_output_unparseable(self):
+        """A successful call with non-JSON output must log (not silently return
+        null) and fall back to deliver-everywhere."""
+        from holmes.core.scheduled_prompts import sink_conditions
+
+        llm = MagicMock()
+        message = MagicMock()
+        message.content = "I cannot decide that."  # not JSON
+        choice = MagicMock()
+        choice.message = message
+        result = MagicMock()
+        result.choices = [choice]
+        llm.completion = MagicMock(return_value=result)
+
+        with patch.object(sink_conditions, "logging") as mock_logging:
+            out = sink_conditions.evaluate_sink_decisions(
+                llm, "only notify on problems", "analysis"
+            )
+
+        assert out.decisions == {}
+        mock_logging.warning.assert_called_once()
+
     def test_format_delivery_note(self):
         from holmes.core.scheduled_prompts.sink_conditions import format_delivery_note
 


### PR DESCRIPTION
Adds per-channel (Slack/email) delivery conditions for scheduled prompts via a dedicated `notification_prompt` field, and surfaces suppressed channels in the chat result.

Also fixes two bugs that caused `sink_decisions` to be silently written as `null`:
- Hardcoded `temperature=0` rejected by thinking-enabled / Opus 4.7+ models — now uses the shared `TEMPERATURE` contract.
- Strict `response_format` json_schema rejected by the Robusta AI proxy (HTTP 400) — now uses prompt-driven JSON with tolerant parsing, plus a non-silent warning when output is unparseable.

Ticket: https://robusta-dev.atlassian.net/browse/ROB-4040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled prompts can evaluate per-channel delivery and attach per-channel suppression info to responses; suppressed channels get a human-readable delivery note appended to analysis.

* **Reliability**
  * Missing or failed evaluations default to delivering to all channels; failures are logged and non-blocking.

* **Tests**
  * Added coverage for parsing, evaluation behavior, note formatting, and executor integration.

* **Chores**
  * Added internal telemetry for evaluation calls and a helper to record single LLM-call usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->