### PR TITLE
[ROB-232] Update benchmark models opus-4.8 gpt-5.5

### DIFF
--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -25,6 +25,11 @@ on:
         description: 'Number of iterations per test (max 10)'
         required: false
         default: '5'
+      create_pr:
+        description: 'Open a PR with the benchmark results. Uncheck to only post a Slack notification (no PR).'
+        required: false
+        type: boolean
+        default: true
 
   # Run weekly on Sunday at 2 AM UTC
   schedule:
@@ -138,7 +143,7 @@ jobs:
 
       - name: Create PR with benchmark results
         id: create-pr
-        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_pr == 'true'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -194,10 +199,15 @@ jobs:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         run: |
           PR_URL="${{ steps.create-pr.outputs.pr_url }}"
+          if [ -n "$PR_URL" ]; then
+            TEXT="Weekly eval benchmarks finished! Here is the PR: ${PR_URL}"
+          else
+            TEXT="Eval benchmarks finished! No PR was created for this run."
+          fi
           curl -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"channel\": \"#backend\", \"text\": \"Weekly eval benchmarks finished! Here is the PR: ${PR_URL}\"}"
+            -d "{\"channel\": \"#backend\", \"text\": \"${TEXT}\"}"
 
       - name: Notify Slack on failure or cancellation
         if: steps.run-benchmarks.outcome != 'success'

--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -16,7 +16,7 @@ on:
         description: 'Comma-separated list of models to test'
         required: false
         # NOTE: Keep in sync with DEFAULT_BENCHMARK_MODELS env var
-        default: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex'
+        default: 'opus-4.8,opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.5,gpt-5.4,gpt-5.3-codex,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat'
       test_markers:
         description: 'Custom pytest markers (ONLY use if not using benchmark_type). Cannot be combined with benchmark_type.'
         required: false
@@ -33,7 +33,7 @@ on:
 env:
   # Default models for benchmarks - single source of truth
   # NOTE: Keep workflow_dispatch default in sync with this for UI display
-  DEFAULT_BENCHMARK_MODELS: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex'
+  DEFAULT_BENCHMARK_MODELS: 'opus-4.8,opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.5,gpt-5.4,gpt-5.3-codex,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat'
 
 jobs:
   run-benchmarks:

--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -124,6 +124,8 @@ jobs:
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
           CONFLUENCE_API_KEY: ${{ secrets.CONFLUENCE_API_KEY }}
+          ELASTICSEARCH_URL: ${{ secrets.ELASTICSEARCH_URL }}
+          ELASTICSEARCH_API_KEY: ${{ secrets.ELASTICSEARCH_API_KEY }}
           MODEL_LIST_FILE_LOCATION: /tmp/model_list.yaml
           EXPERIMENT_ID: "ci-benchmark-${{ github.run_id }}"
         run: |

--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -16,7 +16,7 @@ on:
         description: 'Comma-separated list of models to test'
         required: false
         # NOTE: Keep in sync with DEFAULT_BENCHMARK_MODELS env var
-        default: 'opus-4.8,opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.5,gpt-5.4,gpt-5.3-codex,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat'
+        default: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex,opus-4.8,gpt-5.5'
       test_markers:
         description: 'Custom pytest markers (ONLY use if not using benchmark_type). Cannot be combined with benchmark_type.'
         required: false
@@ -33,7 +33,7 @@ on:
 env:
   # Default models for benchmarks - single source of truth
   # NOTE: Keep workflow_dispatch default in sync with this for UI display
-  DEFAULT_BENCHMARK_MODELS: 'opus-4.8,opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.5,gpt-5.4,gpt-5.3-codex,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat'
+  DEFAULT_BENCHMARK_MODELS: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex,opus-4.8,gpt-5.5'
 
 jobs:
   run-benchmarks:

--- a/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
@@ -41,7 +41,6 @@ tags:
   - elasticsearch
   - medium
   - transparency
-  - regression
   - multi-cluster
 
 setup_timeout: 300

--- a/tests/llm/fixtures/test_ask_holmes/259_wrong_cluster_logs_confusion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_wrong_cluster_logs_confusion/test_case.yaml
@@ -61,7 +61,6 @@ tags:
   - elasticsearch
   - medium
   - transparency
-  - regression
   - multi-cluster
 
 setup_timeout: 300

--- a/tests/llm/fixtures/test_ask_holmes/260_global_es_remote_cluster_logs/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/260_global_es_remote_cluster_logs/test_case.yaml
@@ -41,7 +41,6 @@ tags:
   - elasticsearch
   - medium
   - transparency
-  - regression
   - multi-cluster
 
 setup_timeout: 300


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded default benchmark model set to include opus-4.8 and gpt-5.5 for evaluations.
  * Added a manual toggle (create_pr) to control whether a PR is created from manual benchmark runs (default: true).
  * Success notifications now include the PR link when a PR is created, or indicate that no PR was made.
  * Evaluation runs now surface Elasticsearch credentials from secrets for remote reporting.

* **Tests**
  * Updated several test fixture tags: replaced `regression` with `multi-cluster`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->