### PR TITLE
Tool limits are defaults, not ceilings (Datadog logs, Prometheus metadata)

### DIFF
--- a/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
@@ -35,6 +35,10 @@ from holmes.plugins.toolsets.utils import (
     toolset_name_for_one_liner,
 )
 
+# Maximum page size accepted by Datadog's POST /api/v2/logs/events/search.
+# Results beyond one page are reachable via the cursor parameter.
+DATADOG_LOGS_API_PAGE_MAX = 1000
+
 
 def format_logs(raw_logs: list[dict]) -> str:
     # Use similar structure to Datadog Log Explorer
@@ -179,7 +183,7 @@ class GetLogs(Tool):
             required=False,
         ),
         "limit": ToolParameter(
-            description=f"Maximum number of log records to return. Defaults to {DEFAULT_LOG_LIMIT}. This value is user-configured and represents the maximum allowed limit.",
+            description=f"Maximum number of log records to return. Defaults to the configured default_limit ({DEFAULT_LOG_LIMIT} unless overridden). Values above {DATADOG_LOGS_API_PAGE_MAX} are capped at {DATADOG_LOGS_API_PAGE_MAX} (the Datadog API page maximum); use the cursor to fetch further pages.",
             type="integer",
             required=False,
         ),
@@ -216,8 +220,12 @@ class GetLogs(Tool):
             from_time_ms = from_time_int * 1000
             to_time_ms = to_time_int * 1000
 
-            config_limit = self.toolset.dd_config.default_limit
-            limit = min(params.get("limit", config_limit), config_limit)
+            # The configured default_limit applies when the LLM doesn't ask for
+            # a specific limit. An explicit request is honored up to the Datadog
+            # API page maximum (previously it was silently clamped down to the
+            # config value, making larger fetches inexpressible).
+            limit = params.get("limit") or self.toolset.dd_config.default_limit
+            limit = min(limit, DATADOG_LOGS_API_PAGE_MAX)
             params["limit"] = limit
             sort = "timestamp" if params.get("sort_desc", False) else "-timestamp"
 

--- a/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_logs.py
@@ -224,8 +224,10 @@ class GetLogs(Tool):
             # a specific limit. An explicit request is honored up to the Datadog
             # API page maximum (previously it was silently clamped down to the
             # config value, making larger fetches inexpressible).
-            limit = params.get("limit") or self.toolset.dd_config.default_limit
-            limit = min(limit, DATADOG_LOGS_API_PAGE_MAX)
+            limit = params.get("limit")
+            if limit is None:
+                limit = self.toolset.dd_config.default_limit
+            limit = max(1, min(limit, DATADOG_LOGS_API_PAGE_MAX))
             params["limit"] = limit
             sort = "timestamp" if params.get("sort_desc", False) else "-timestamp"
 

--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1021,6 +1021,41 @@ class ListPrometheusRules(JsonFilterMixin, BasePrometheusTool):
         )
 
 
+def metadata_limit_param() -> ToolParameter:
+    """The model-overridable `limit` parameter shared by the metadata APIs."""
+    return ToolParameter(
+        description=(
+            f"Maximum number of results to return. Default: {PROMETHEUS_METADATA_API_LIMIT}. "
+            "Increase when a previous call reported _truncated=true and you need the complete list."
+        ),
+        type="integer",
+        required=False,
+    )
+
+
+def get_metadata_limit(params: dict) -> int:
+    limit = params.get("limit") or PROMETHEUS_METADATA_API_LIMIT
+    return max(1, int(limit))
+
+
+def mark_metadata_truncation(data: Any, limit: int, refine_hint: str) -> None:
+    """Flag a metadata API response whose result filled the limit.
+
+    Tells the model both recovery paths: raise the limit, or refine the query.
+    The result is a list for most endpoints; /api/v1/metadata returns a dict.
+    """
+    if (
+        "data" in data
+        and isinstance(data["data"], (list, dict))
+        and len(data["data"]) == limit
+    ):
+        data["_truncated"] = True
+        data["_message"] = (
+            f"Results truncated at limit={limit}. Re-run with a higher 'limit' "
+            f"parameter to see more results, or {refine_hint}"
+        )
+
+
 class GetMetricNames(BasePrometheusTool):
     """Thin wrapper around /api/v1/label/__name__/values - the fastest way to discover metric names"""
 
@@ -1030,8 +1065,8 @@ class GetMetricNames(BasePrometheusTool):
             description=(
                 "Get list of metric names using /api/v1/label/__name__/values. "
                 "FASTEST method for metric discovery when you need to explore available metrics. "
-                f"Returns up to {PROMETHEUS_METADATA_API_LIMIT} unique metric names (limit={PROMETHEUS_METADATA_API_LIMIT}). If {PROMETHEUS_METADATA_API_LIMIT} results returned, more may exist - use a more specific filter. "
-                f"ALWAYS use match[] parameter to filter metrics - without it you'll get random {PROMETHEUS_METADATA_API_LIMIT} metrics which is rarely useful. "
+                f"Returns up to 'limit' unique metric names (default {PROMETHEUS_METADATA_API_LIMIT}). If the response reports _truncated=true, raise 'limit' or use a more specific filter. "
+                f"ALWAYS use match[] parameter to filter metrics - without it you'll get arbitrary metrics which is rarely useful. "
                 "Note: Does not return metric metadata (type, description, labels). "
                 "By default returns metrics active in the last 1 hour (configurable via default_metadata_time_window_hrs)."
             ),
@@ -1059,6 +1094,7 @@ class GetMetricNames(BasePrometheusTool):
                     type="string",
                     required=False,
                 ),
+                "limit": metadata_limit_param(),
             },
             toolset=toolset,
         )
@@ -1082,8 +1118,9 @@ class GetMetricNames(BasePrometheusTool):
             url = urljoin(
                 self.toolset.config.prometheus_url, "api/v1/label/__name__/values"
             )
+            limit = get_metadata_limit(params)
             query_params = {
-                "limit": str(PROMETHEUS_METADATA_API_LIMIT),
+                "limit": str(limit),
                 "match[]": match_param,
             }
 
@@ -1114,16 +1151,9 @@ class GetMetricNames(BasePrometheusTool):
             response.raise_for_status()
             data = response.json()
 
-            # Check if results were truncated
-            if (
-                "data" in data
-                and isinstance(data["data"], list)
-                and len(data["data"]) == PROMETHEUS_METADATA_API_LIMIT
-            ):
-                data["_truncated"] = True
-                data["_message"] = (
-                    f"Results truncated at limit={PROMETHEUS_METADATA_API_LIMIT}. Use a more specific match filter to see additional metrics."
-                )
+            mark_metadata_truncation(
+                data, limit, "use a more specific match filter."
+            )
 
             return StructuredToolResult(
                 status=StructuredToolResultStatus.SUCCESS,
@@ -1150,7 +1180,7 @@ class GetLabelValues(BasePrometheusTool):
             description=(
                 "Get all values for a specific label using /api/v1/label/{label}/values. "
                 "Use this to discover pods, namespaces, jobs, instances, etc. "
-                f"Returns up to {PROMETHEUS_METADATA_API_LIMIT} unique values (limit={PROMETHEUS_METADATA_API_LIMIT}). If {PROMETHEUS_METADATA_API_LIMIT} results returned, more may exist - use match[] to filter. "
+                f"Returns up to 'limit' unique values (default {PROMETHEUS_METADATA_API_LIMIT}). If the response reports _truncated=true, raise 'limit' or use match[] to filter. "
                 "Supports optional match[] parameter to filter. "
                 "By default returns values from metrics active in the last 1 hour (configurable via default_metadata_time_window_hrs)."
             ),
@@ -1178,6 +1208,7 @@ class GetLabelValues(BasePrometheusTool):
                     type="string",
                     required=False,
                 ),
+                "limit": metadata_limit_param(),
             },
             toolset=toolset,
         )
@@ -1201,7 +1232,8 @@ class GetLabelValues(BasePrometheusTool):
             url = urljoin(
                 self.toolset.config.prometheus_url, f"api/v1/label/{label}/values"
             )
-            query_params = {"limit": str(PROMETHEUS_METADATA_API_LIMIT)}
+            limit = get_metadata_limit(params)
+            query_params = {"limit": str(limit)}
             if params.get("match"):
                 query_params["match[]"] = params["match"]
 
@@ -1232,16 +1264,9 @@ class GetLabelValues(BasePrometheusTool):
             response.raise_for_status()
             data = response.json()
 
-            # Check if results were truncated
-            if (
-                "data" in data
-                and isinstance(data["data"], list)
-                and len(data["data"]) == PROMETHEUS_METADATA_API_LIMIT
-            ):
-                data["_truncated"] = True
-                data["_message"] = (
-                    f"Results truncated at limit={PROMETHEUS_METADATA_API_LIMIT}. Use match[] parameter to filter label '{label}' values."
-                )
+            mark_metadata_truncation(
+                data, limit, f"use match[] parameter to filter label '{label}' values."
+            )
 
             return StructuredToolResult(
                 status=StructuredToolResultStatus.SUCCESS,
@@ -1269,7 +1294,7 @@ class GetAllLabels(BasePrometheusTool):
             description=(
                 "Get list of all label names using /api/v1/labels. "
                 "Use this to discover what labels are available across all metrics. "
-                f"Returns up to {PROMETHEUS_METADATA_API_LIMIT} label names (limit={PROMETHEUS_METADATA_API_LIMIT}). If {PROMETHEUS_METADATA_API_LIMIT} results returned, more may exist - use match[] to filter. "
+                f"Returns up to 'limit' label names (default {PROMETHEUS_METADATA_API_LIMIT}). If the response reports _truncated=true, raise 'limit' or use match[] to filter. "
                 "Supports optional match[] parameter to filter. "
                 "By default returns labels from metrics active in the last 1 hour (configurable via default_metadata_time_window_hrs)."
             ),
@@ -1292,6 +1317,7 @@ class GetAllLabels(BasePrometheusTool):
                     type="string",
                     required=False,
                 ),
+                "limit": metadata_limit_param(),
             },
             toolset=toolset,
         )
@@ -1305,7 +1331,8 @@ class GetAllLabels(BasePrometheusTool):
             )
         try:
             url = urljoin(self.toolset.config.prometheus_url, "api/v1/labels")
-            query_params = {"limit": str(PROMETHEUS_METADATA_API_LIMIT)}
+            limit = get_metadata_limit(params)
+            query_params = {"limit": str(limit)}
             if params.get("match"):
                 query_params["match[]"] = params["match"]
 
@@ -1336,16 +1363,9 @@ class GetAllLabels(BasePrometheusTool):
             response.raise_for_status()
             data = response.json()
 
-            # Check if results were truncated
-            if (
-                "data" in data
-                and isinstance(data["data"], list)
-                and len(data["data"]) == PROMETHEUS_METADATA_API_LIMIT
-            ):
-                data["_truncated"] = True
-                data["_message"] = (
-                    f"Results truncated at limit={PROMETHEUS_METADATA_API_LIMIT}. Use match[] parameter to filter labels."
-                )
+            mark_metadata_truncation(
+                data, limit, "use match[] parameter to filter labels."
+            )
 
             return StructuredToolResult(
                 status=StructuredToolResultStatus.SUCCESS,
@@ -1373,7 +1393,7 @@ class GetSeries(BasePrometheusTool):
                 "Get time series using /api/v1/series. "
                 "Returns label sets for all time series matching the selector. "
                 "SLOWER than other discovery methods - use only when you need full label sets. "
-                f"Returns up to {PROMETHEUS_METADATA_API_LIMIT} series (limit={PROMETHEUS_METADATA_API_LIMIT}). If {PROMETHEUS_METADATA_API_LIMIT} results returned, more series exist - use more specific selector. "
+                f"Returns up to 'limit' series (default {PROMETHEUS_METADATA_API_LIMIT}). If the response reports _truncated=true, raise 'limit' or use a more specific selector. "
                 "Requires match[] parameter with PromQL selector. "
                 "By default returns series active in the last 1 hour (configurable via default_metadata_time_window_hrs)."
             ),
@@ -1397,6 +1417,7 @@ class GetSeries(BasePrometheusTool):
                     type="string",
                     required=False,
                 ),
+                "limit": metadata_limit_param(),
             },
             toolset=toolset,
         )
@@ -1418,9 +1439,10 @@ class GetSeries(BasePrometheusTool):
                 )
 
             url = urljoin(self.toolset.config.prometheus_url, "api/v1/series")
+            limit = get_metadata_limit(params)
             query_params = {
                 "match[]": match,
-                "limit": str(PROMETHEUS_METADATA_API_LIMIT),
+                "limit": str(limit),
             }
 
             # Add time parameters - use provided values or defaults
@@ -1450,16 +1472,9 @@ class GetSeries(BasePrometheusTool):
             response.raise_for_status()
             data = response.json()
 
-            # Check if results were truncated
-            if (
-                "data" in data
-                and isinstance(data["data"], list)
-                and len(data["data"]) == PROMETHEUS_METADATA_API_LIMIT
-            ):
-                data["_truncated"] = True
-                data["_message"] = (
-                    f"Results truncated at limit={PROMETHEUS_METADATA_API_LIMIT}. Use a more specific match selector to see additional series."
-                )
+            mark_metadata_truncation(
+                data, limit, "use a more specific match selector to see additional series."
+            )
 
             return StructuredToolResult(
                 status=StructuredToolResultStatus.SUCCESS,
@@ -1487,7 +1502,7 @@ class GetMetricMetadata(BasePrometheusTool):
                 "Get metric metadata using /api/v1/metadata. "
                 "Returns type, help text, and unit for metrics. "
                 "Use after discovering metric names to get their descriptions. "
-                f"Returns up to {PROMETHEUS_METADATA_API_LIMIT} metrics (limit={PROMETHEUS_METADATA_API_LIMIT}). If {PROMETHEUS_METADATA_API_LIMIT} results returned, more may exist - filter by specific metric name. "
+                f"Returns up to 'limit' metrics (default {PROMETHEUS_METADATA_API_LIMIT}). If the response reports _truncated=true, raise 'limit' or filter by specific metric name. "
                 "Supports optional metric name filter."
             ),
             parameters={
@@ -1499,6 +1514,7 @@ class GetMetricMetadata(BasePrometheusTool):
                     type="string",
                     required=False,
                 ),
+                "limit": metadata_limit_param(),
             },
             toolset=toolset,
         )
@@ -1512,7 +1528,8 @@ class GetMetricMetadata(BasePrometheusTool):
             )
         try:
             url = urljoin(self.toolset.config.prometheus_url, "api/v1/metadata")
-            query_params = {"limit": str(PROMETHEUS_METADATA_API_LIMIT)}
+            limit = get_metadata_limit(params)
+            query_params = {"limit": str(limit)}
 
             if params.get("metric"):
                 query_params["metric"] = params["metric"]
@@ -1529,16 +1546,9 @@ class GetMetricMetadata(BasePrometheusTool):
             response.raise_for_status()
             data = response.json()
 
-            # Check if results were truncated (metadata endpoint returns a dict, not a list)
-            if (
-                "data" in data
-                and isinstance(data["data"], dict)
-                and len(data["data"]) == PROMETHEUS_METADATA_API_LIMIT
-            ):
-                data["_truncated"] = True
-                data["_message"] = (
-                    f"Results truncated at limit={PROMETHEUS_METADATA_API_LIMIT}. Use metric parameter to filter by specific metric name."
-                )
+            mark_metadata_truncation(
+                data, limit, "use metric parameter to filter by specific metric name."
+            )
 
             return StructuredToolResult(
                 status=StructuredToolResultStatus.SUCCESS,

--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1034,7 +1034,9 @@ def metadata_limit_param() -> ToolParameter:
 
 
 def get_metadata_limit(params: dict) -> int:
-    limit = params.get("limit") or PROMETHEUS_METADATA_API_LIMIT
+    limit = params.get("limit")
+    if limit is None:
+        limit = PROMETHEUS_METADATA_API_LIMIT
     return max(1, int(limit))
 
 

--- a/tests/plugins/toolsets/datadog/logs/test_fetch_logs_limit.py
+++ b/tests/plugins/toolsets/datadog/logs/test_fetch_logs_limit.py
@@ -1,0 +1,72 @@
+"""The `limit` parameter on fetch_datadog_logs is a default, not a ceiling.
+
+An explicit model-requested limit must be honored on the wire (up to the
+Datadog API page maximum) instead of being silently clamped down to the
+configured default_limit.
+"""
+
+import json
+import re
+
+import responses
+
+from holmes.plugins.toolsets.datadog.toolset_datadog_logs import (
+    DATADOG_LOGS_API_PAGE_MAX,
+    DatadogLogsToolset,
+    GetLogs,
+)
+from tests.conftest import create_mock_tool_invoke_context
+
+US = "https://api.datadoghq.com"
+_OK_BODY = {"data": [], "meta": {"page": {"after": None}}}
+
+
+def _register_search(rsps):
+    # api_url is a pydantic AnyUrl (trailing slash), so the real URL has a double
+    # slash before /api. Match host + path tolerant of slash count; matches both
+    # the health probe and later tool calls.
+    rsps.add(
+        responses.POST,
+        re.compile(re.escape(US) + r"/+api/v2/logs/events/search"),
+        json=_OK_BODY,
+        status=200,
+    )
+
+
+def _build(rsps):
+    _register_search(rsps)
+    ts = DatadogLogsToolset()
+    ok, error = ts.prerequisites_callable(
+        {"api_key": "k", "app_key": "a", "api_url": US, "default_limit": 100}
+    )
+    assert ok is True, error
+    return next(t for t in ts.tools if isinstance(t, GetLogs))
+
+
+def _page_limit_of_last_call(rsps) -> int:
+    payload = json.loads(rsps.calls[-1].request.body)
+    return payload["page"]["limit"]
+
+
+class TestFetchLogsLimit:
+    def test_no_limit_uses_config_default(self):
+        with responses.RequestsMock() as rsps:
+            tool = _build(rsps)
+            tool.invoke({"query": "*"}, create_mock_tool_invoke_context())
+            assert _page_limit_of_last_call(rsps) == 100
+
+    def test_explicit_limit_above_default_is_honored(self):
+        with responses.RequestsMock() as rsps:
+            tool = _build(rsps)
+            tool.invoke(
+                {"query": "*", "limit": 500}, create_mock_tool_invoke_context()
+            )
+            assert _page_limit_of_last_call(rsps) == 500
+
+    def test_limit_capped_at_datadog_api_page_max(self):
+        with responses.RequestsMock() as rsps:
+            tool = _build(rsps)
+            tool.invoke(
+                {"query": "*", "limit": 5000}, create_mock_tool_invoke_context()
+            )
+            assert _page_limit_of_last_call(rsps) == DATADOG_LOGS_API_PAGE_MAX

--- a/tests/plugins/toolsets/datadog/logs/test_fetch_logs_limit.py
+++ b/tests/plugins/toolsets/datadog/logs/test_fetch_logs_limit.py
@@ -70,3 +70,10 @@ class TestFetchLogsLimit:
                 {"query": "*", "limit": 5000}, create_mock_tool_invoke_context()
             )
             assert _page_limit_of_last_call(rsps) == DATADOG_LOGS_API_PAGE_MAX
+
+    def test_explicit_zero_clamped_to_one_not_default(self):
+        # An explicit 0 must not be silently replaced with the default
+        with responses.RequestsMock() as rsps:
+            tool = _build(rsps)
+            tool.invoke({"query": "*", "limit": 0}, create_mock_tool_invoke_context())
+            assert _page_limit_of_last_call(rsps) == 1

--- a/tests/plugins/toolsets/test_prometheus_unit.py
+++ b/tests/plugins/toolsets/test_prometheus_unit.py
@@ -3,12 +3,63 @@ import logging
 import pytest
 
 from holmes.plugins.toolsets.prometheus.prometheus import (
+    PROMETHEUS_METADATA_API_LIMIT,
     AzurePrometheusConfig,
+    GetAllLabels,
+    GetLabelValues,
+    GetMetricMetadata,
+    GetMetricNames,
+    GetSeries,
     PrometheusConfig,
     PrometheusToolset,
     adjust_step_for_max_points,
     get_config_field,
+    get_metadata_limit,
+    mark_metadata_truncation,
 )
+
+
+class TestMetadataLimit:
+    """Metadata API limits are defaults the model can raise, not hard ceilings."""
+
+    def test_default_limit(self):
+        assert get_metadata_limit({}) == PROMETHEUS_METADATA_API_LIMIT
+
+    def test_explicit_limit_honored(self):
+        assert get_metadata_limit({"limit": 2500}) == 2500
+
+    def test_invalid_limit_clamped_to_one(self):
+        assert get_metadata_limit({"limit": -5}) == 1
+
+    def test_all_metadata_tools_expose_limit_param(self):
+        toolset = PrometheusToolset()
+        for tool_cls in (
+            GetMetricNames,
+            GetLabelValues,
+            GetAllLabels,
+            GetSeries,
+            GetMetricMetadata,
+        ):
+            tool = tool_cls(toolset=toolset)
+            assert "limit" in tool.parameters, tool.name
+
+    def test_truncation_marker_set_when_list_fills_limit(self):
+        data = {"data": ["a", "b", "c"]}
+        mark_metadata_truncation(data, limit=3, refine_hint="use match[] to filter.")
+        assert data["_truncated"] is True
+        assert "higher 'limit'" in data["_message"]
+        assert "use match[] to filter." in data["_message"]
+
+    def test_truncation_marker_set_for_dict_results(self):
+        # /api/v1/metadata returns a dict keyed by metric name
+        data = {"data": {"up": [], "node_cpu_seconds_total": []}}
+        mark_metadata_truncation(data, limit=2, refine_hint="filter by metric name.")
+        assert data["_truncated"] is True
+
+    def test_no_marker_below_limit(self):
+        data = {"data": ["a"]}
+        mark_metadata_truncation(data, limit=3, refine_hint="hint")
+        assert "_truncated" not in data
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/toolsets/test_prometheus_unit.py
+++ b/tests/plugins/toolsets/test_prometheus_unit.py
@@ -31,6 +31,10 @@ class TestMetadataLimit:
     def test_invalid_limit_clamped_to_one(self):
         assert get_metadata_limit({"limit": -5}) == 1
 
+    def test_explicit_zero_clamped_to_one_not_default(self):
+        # An explicit 0 must not be silently replaced with the default
+        assert get_metadata_limit({"limit": 0}) == 1
+
     def test_all_metadata_tools_expose_limit_param(self):
         toolset = PrometheusToolset()
         for tool_cls in (


### PR DESCRIPTION
## Problem

Two places where the model literally could not express a larger query, even when it explicitly asked for one. These were designed for older models that couldn't be trusted with limit parameters:

1. **`fetch_datadog_logs`**: `limit = min(params.get("limit", config_limit), config_limit)` — a model requesting `limit: 500` was **silently clamped to 100**. The config field even describes itself as "Default maximum number of log events to return *when a limit is not explicitly provided*", but the code enforced it as a hard ceiling.
2. **Prometheus metadata APIs** (`get_metric_names`, `get_label_values`, `get_all_labels`, `get_series`, `get_metric_metadata`): hardcoded `limit=100` with no parameter at all. On truncation the model was told only to "use a more specific match filter" — there was no way to just see the full list.

## Changes

- **Datadog logs**: the configured `default_limit` now acts as the default; an explicit model-supplied `limit` is honored up to `DATADOG_LOGS_API_PAGE_MAX` (1000, the Datadog API page maximum), with the existing cursor for further pages. Parameter description updated to match.
- **Prometheus metadata APIs**: all five tools gain an optional `limit` parameter (default unchanged at 100). The repeated truncation-detection blocks are factored into `mark_metadata_truncation()`, and the `_truncated` message now names both recovery paths: raise `limit`, or refine the filter. Tool descriptions updated accordingly.

## Testing

- New wire-level tests (mocked with `responses`) asserting `page.limit` sent to Datadog honors explicit requests, defaults correctly, and caps at the API max.
- New unit tests for `get_metadata_limit` / `mark_metadata_truncation` (list + dict result shapes) and that all five metadata tools expose `limit`.
- Full non-LLM suite: 2489 passed, 91 skipped.

Part of a series of targeted fixes removing old-model data limitations from built-in tools (see #2167, #2168).

Note: `database`/`mongodb` `max_rows` was deliberately left as a ceiling — it's an explicit user-configured guardrail against expensive queries on production databases, unlike these two cases where the cap was an accident of old-model defensiveness.

https://claude.ai/code/session_01BwJeGAGBLoby5rShhQADwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJeGAGBLoby5rShhQADwq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datadog Logs: Better pagination — explicit per-request limits are honored, with results pageable via cursor and capped at the provider’s page-size maximum.
  * Prometheus: Metadata discovery tools now accept optional limits and report when results are truncated with guidance to refine queries.

* **Bug Fixes**
  * Datadog Logs: Limit handling fixed so user-specified limits are respected rather than silently clamped.

* **Tests**
  * Added tests covering limit, clamping, capping, and truncation behaviors for Datadog and Prometheus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->