### PR TITLE
Mark llm_summarize transformer as legacy / not recommended

### DIFF
--- a/docs/development/transformers.md
+++ b/docs/development/transformers.md
@@ -1,5 +1,9 @@
 # Tool Output Transformers
 
+!!! warning "Legacy feature — not recommended"
+
+    The `llm_summarize` transformer is a legacy feature. It is disabled by default and we don't recommend enabling it: summarization is lossy (the original tool output cannot be recovered afterwards) and it adds latency and cost to every large tool call. HolmesGPT now handles oversized tool results by [spilling them to disk](../reference/context-management.md), which preserves the full data for the model to read back. This page is kept for users with existing transformer configurations.
+
 HolmesGPT supports **transformers** that can process tool outputs before they're sent to the primary LLM. This enables automatic summarization of large outputs, reducing context window usage while preserving essential information.
 
 ## Overview

--- a/holmes/core/transformers/llm_summarize.py
+++ b/holmes/core/transformers/llm_summarize.py
@@ -1,5 +1,12 @@
 """
 LLM Summarize Transformer for fast model summarization of large tool outputs.
+
+LEGACY — disabled by default and NOT recommended. This predates the
+spill-to-disk mechanism (see docs/reference/context-management.md) and never
+worked well in practice: summarization is lossy (the original tool output is
+unrecoverable afterwards), adds latency and cost to every large tool call,
+and modern models do better working from the full data spilled to disk.
+Kept for backwards compatibility with existing configs that reference it.
 """
 
 import logging
@@ -16,6 +23,10 @@ logger = logging.getLogger(__name__)
 class LLMSummarizeTransformer(BaseTransformer):
     """
     Transformer that uses a fast LLM model to summarize large tool outputs.
+
+    LEGACY — disabled by default and NOT recommended (see module docstring).
+    Prefer the spill-to-disk mechanism, which preserves the full tool output
+    on disk for the model to read back.
 
     This transformer applies summarization when:
     1. A fast model is available


### PR DESCRIPTION
Documentation-only change, no behavior change.

The `llm_summarize` transformer predates the spill-to-disk mechanism, is disabled by default, and never worked well in practice: summarization is lossy (the original tool output is unrecoverable afterwards) and it adds latency and cost to every large tool call. Modern models do better working from the full data spilled to disk.

This marks it as legacy in the module/class docstrings and adds a warning admonition to `docs/development/transformers.md`, so future contributors don't build on it and users don't enable it expecting good results. Kept for backwards compatibility with existing configs that reference it.

Part of a series of targeted fixes removing old-model data limitations from built-in tools (see #2167, #2168, #2169).

https://claude.ai/code/session_01BwJeGAGBLoby5rShhQADwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJeGAGBLoby5rShhQADwq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added notices marking the `llm_summarize` transformer as a legacy feature that is disabled by default. This feature is not recommended for new configurations due to lossy summarization, increased latency, and associated costs. Documentation has been updated to recommend the spill-to-disk mechanism as the preferred alternative for handling oversized tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->