### PR TITLE
Fix compaction crashing claude-opus-4.6+ ("assistant message prefill" 400)

### DIFF
--- a/holmes/core/truncation/compaction.py
+++ b/holmes/core/truncation/compaction.py
@@ -94,7 +94,7 @@ def compact_conversation_history(
       1. Original system prompt, uncompacted (if present)
       2. Last user prompt, uncompacted (if present)
       3. Compacted conversation history (role=assistant)
-      4. Compaction message (role=system)
+      4. Compaction message (role=user)
     """
     conversation_history, system_prompt_message = strip_system_prompt(
         original_conversation_history
@@ -164,7 +164,12 @@ def compact_conversation_history(
 
     compacted_conversation_history.append(
         {
-            "role": "system",
+            # Must be a user message so the conversation does not end on the
+            # assistant summary: Anthropic folds trailing system messages, and
+            # a trailing assistant message is treated as prefill, which
+            # claude-opus-4.6 and newer reject with "This model does not
+            # support assistant message prefill" (HTTP 400).
+            "role": "user",
             "content": "The conversation history has been compacted to preserve available space in the context window. Continue.",
         }
     )

--- a/tests/core/truncation/test_compaction.py
+++ b/tests/core/truncation/test_compaction.py
@@ -53,7 +53,7 @@ def test_conversation_history_compaction_system_prompt_untouched():
 
         assert compacted_history[2]["role"] == "assistant"
 
-        assert compacted_history[3]["role"] == "system"
+        assert compacted_history[3]["role"] == "user"
         assert "compacted" in compacted_history[3]["content"].lower()
 
 
@@ -76,7 +76,7 @@ def test_conversation_history_compaction():
 
         assert compacted_history[1]["role"] == "assistant"
 
-        assert compacted_history[2]["role"] == "system"
+        assert compacted_history[2]["role"] == "user"
         assert "compacted" in compacted_history[2]["content"].lower()
 
         original_tokens = llm.count_tokens(conversation_history)
@@ -87,6 +87,91 @@ def test_conversation_history_compaction():
         )
         print(compacted_history[1]["content"])
         assert compacted_tokens.total_tokens < expected_max_compacted_token_count
+
+
+# --- Regression test: post-compaction message shape (no LLM required) ---
+#
+# claude-opus-4.6 and newer reject any request whose conversation ends on an
+# assistant turn: "This model does not support assistant message prefill"
+# (HTTP 400). The post-compaction history used to end with
+# [..., assistant summary, system marker]; Anthropic folds trailing system
+# messages, so the request effectively ended on the assistant summary and
+# every compaction-triggering investigation on opus-4.6 crashed mid-loop.
+# The continuation marker must therefore be a user message.
+
+
+def _fake_llm_for_compaction(summary_text="Summary of the investigation so far."):
+    """Minimal LLM stub for compact_conversation_history (no network)."""
+
+    class FakeUsage:
+        total_tokens = 100
+
+    class FakeMessage:
+        def model_dump(self, **kwargs):
+            return {"role": "assistant", "content": summary_text}
+
+    class FakeChoice:
+        message = FakeMessage()
+
+    class FakeResponse:
+        choices = [FakeChoice()]
+        usage = None  # RequestStats.from_response handles missing usage
+
+    class FakeLLM:
+        def count_tokens(self, messages):
+            return FakeUsage()
+
+        def get_context_window_size(self):
+            return 128000
+
+        def get_maximum_output_token(self):
+            return 4096
+
+        def completion(self, messages, **kwargs):
+            return FakeResponse()
+
+    return FakeLLM()
+
+
+def test_compacted_history_must_end_with_user_message():
+    """The next LLM call after compaction must not end on an assistant turn."""
+    conversation_history = [
+        {"role": "system", "content": "You are an investigation agent."},
+        {"role": "user", "content": "Why is my payment service failing?"},
+        {"role": "assistant", "content": "Let me check the pods."},
+        {"role": "assistant", "content": "I found several restarts, digging into logs."},
+    ]
+
+    result = compact_conversation_history(
+        original_conversation_history=conversation_history,
+        llm=_fake_llm_for_compaction(),  # type: ignore[arg-type]
+    )
+    messages = result.messages_after_compaction
+
+    # Shape: [system prompt, last user prompt, assistant summary, continuation marker]
+    assert [m["role"] for m in messages] == ["system", "user", "assistant", "user"]
+    assert "compacted" in messages[-1]["content"].lower()
+
+    # The critical invariant: the conversation must NOT end on the assistant
+    # summary (directly, or via a trailing system message that providers fold),
+    # otherwise opus >= 4.6 rejects the next request as assistant prefill.
+    assert messages[-1]["role"] == "user"
+
+
+def test_compacted_history_without_system_prompt_ends_with_user_message():
+    conversation_history = [
+        {"role": "user", "content": "Investigate the checkout latency."},
+        {"role": "assistant", "content": "Checking metrics now."},
+    ]
+
+    result = compact_conversation_history(
+        original_conversation_history=conversation_history,
+        llm=_fake_llm_for_compaction(),  # type: ignore[arg-type]
+    )
+    messages = result.messages_after_compaction
+
+    assert [m["role"] for m in messages] == ["user", "assistant", "user"]
+    assert messages[-1]["role"] == "user"
 
 
 # --- Unit tests for _strip_images_for_compaction (no LLM required) ---


### PR DESCRIPTION
## Problem

The post-compaction conversation history ends with `[..., assistant summary, system marker]`. Anthropic does not deliver a trailing system message as a turn, so the conversation effectively ends on the assistant summary. Models before opus-4.6 accept that as *assistant prefill*; **claude-opus-4.6+ removed prefill support** and rejects it:

```
invalid_request_error: This model does not support assistant message prefill.
The conversation must end with a user message.
```

## Fix

Make the post-compaction continuation marker a `user` message so the conversation always ends on a user turn — a shape that is valid for every provider and routing path. One-line behavioral change in `holmes/core/truncation/compaction.py`.

## Verification — what is and is not proven

**On this PR (CI, `/eval` cross-branch runs, opus-4.6, compaction evals 163 + 244):**
- This branch: **2/2 passed** — [run](https://github.com/HolmesGPT/holmesgpt/actions/runs/27332486674) (163 survived **25** consecutive compactions)
- `branch: master`: **2/2 passed** — [run](https://github.com/HolmesGPT/holmesgpt/actions/runs/27332501134)

So with the CI environment's `opus-4.6` model-list entry, master does **not** crash — the routing path used there tolerates or rewrites the trailing-system shape. Maintainers: worth checking what that entry routes through.

**Where the crash is real and deterministic — OpenAI-compatible routing (OpenRouter-style):** running the same two evals locally with `opus-4.6` via OpenRouter (`openai/anthropic/claude-opus-4.6`):
- master: **0/2 — provider 400 `assistant message prefill`** (16 occurrences in logs; OpenRouter's error metadata shows Anthropic, Bedrock, Vertex and Azure upstreams all rejecting the forwarded shape)
- this branch: **2/2 passed**

Additionally, litellm's native Anthropic transform verifiably hoists the trailing system marker into the `system` param, leaving the request ending on the assistant turn (`AnthropicConfig.transform_request` on the post-compaction shape → last message role `assistant`) — i.e. the old shape depends on the provider path to be tolerated.

**Latent issue on pre-4.6 models:** with the old shape, a sonnet-4.5 run ended with **no final answer** (`result=None`, no API error) — consistent with the model treating its own summary as a prefilled reply to continue. With the fix, sonnet-4.5 passes 2/2 with normal answers.

A no-network unit test pins the message-shape invariant (`test_compacted_history_must_end_with_user_message`). The `evals-tag-compaction` label is applied so future CI runs on this PR include the compaction evals.

(The red `llm_evals` check from Jun 10 15:10 UTC is a CI infra flake: the run aborted on transient GitHub API 401s in its comment-posting steps before any evals ran. The two failing Benchmark checks fail identically on master — the CI OpenRouter key's weekly credit limit is exhausted.)

https://claude.ai/code/session_01PSmQQaqAySANWeaeBqScu7