### PR TITLE
fix(multi_instance): treat `instances: []` as zero instances, not flat default

### DIFF
--- a/holmes/plugins/toolsets/multi_instance.py
+++ b/holmes/plugins/toolsets/multi_instance.py
@@ -92,14 +92,21 @@ def _merge_instance_config(globals_: Dict[str, Any], entry: Dict[str, Any]) -> D
 def _parse_instances(config: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any]]]:
     """Decompose a wrapper config into ordered (instance_name, flat_child_config) pairs.
 
-    Flat config (no `instances:`) → one instance named `default`.
+    Flat config (no `instances:` key) → one instance named `default`.
+    An explicit empty `instances: []` → zero instances.
     """
     raw = config.get("instances")
-    if not raw:
+    if raw is None:
         flat = {k: v for k, v in config.items() if k != "instances"}
         return [("default", flat)]
     if not isinstance(raw, list):
         raise ValueError("`instances` must be a list")
+    # An explicit empty list means "zero instances configured", not "flat single
+    # instance". Collapsing `instances: []` into a synthetic `default` from the
+    # top-level globals would silently leave a routable endpoint enabled; instead
+    # let it flow to `_aggregate`'s "No instances configured" path.
+    if not raw:
+        return []
     globals_ = {k: v for k, v in config.items() if k != "instances"}
     seen: set = set()
     out: List[Tuple[str, Dict[str, Any]]] = []

--- a/tests/plugins/toolsets/test_multi_instance.py
+++ b/tests/plugins/toolsets/test_multi_instance.py
@@ -227,6 +227,24 @@ class TestHealthAggregation:
         assert ok is True
         assert "failed:" in msg
 
+    def test_explicit_empty_instances_yields_zero_instances(self):
+        # `instances: []` must mean "zero instances", not collapse into a synthetic
+        # `default` built from top-level globals. Otherwise an explicitly-emptied
+        # config would silently leave a routable endpoint enabled.
+        ts = multi_instance(_FakeToolset)
+        ok, msg = ts.prerequisites_callable({"api_url": "http://global", "instances": []})
+        assert ok is False
+        assert "No instances configured" in msg
+        assert list(ts._children) == []
+        assert ts.tools == []
+
+    def test_missing_instances_key_still_flat_default(self):
+        # Absence of the `instances` key keeps the backwards-compatible flat shape.
+        ts = multi_instance(_FakeToolset)
+        ok, _ = ts.prerequisites_callable({"api_url": "http://one"})
+        assert ok is True
+        assert list(ts._children) == ["default"]
+
 
 class TestOfflineInstances:
     def _wrap_one_bad(self):


### PR DESCRIPTION
## Problem

`_parse_instances` in `holmes/plugins/toolsets/multi_instance.py` used `if not raw:` to detect the flat (single-instance) config shape. Because an empty list is falsy, this treats an **explicit** `instances: []` identically to a **missing** `instances` key — synthesizing a `default` child from the top-level globals.

That bypasses the `"No instances configured"` path in `_aggregate()` and can leave a routable endpoint silently enabled when the config explicitly declared zero instances.

## Fix

Distinguish absence from emptiness:

- `raw is None` (key missing) → flat `default` instance (unchanged, backwards compatible)
- `raw == []` (explicit empty list) → zero instances, flows to `_aggregate()`'s `"No instances configured"` result

```diff
 raw = config.get("instances")
-if not raw:
+if raw is None:
     flat = {k: v for k, v in config.items() if k != "instances"}
     return [("default", flat)]
 if not isinstance(raw, list):
     raise ValueError("`instances` must be a list")
+if not raw:
+    return []
```

## Tests

Added two cases to `TestHealthAggregation`:

- `test_explicit_empty_instances_yields_zero_instances` — `instances: []` (with top-level globals present) → prereqs fail with `"No instances configured"`, no children, no tools.
- `test_missing_instances_key_still_flat_default` — absent key keeps the flat `default` shape.

All 24 tests in `tests/plugins/toolsets/test_multi_instance.py` pass.

## Context

Found by CodeRabbit while reviewing #2148 (it surfaced in that PR's diff only because of a master merge). The line is unrelated to #2148's approval refactor and originates in #2115, so it's split out here as a focused fix.

https://claude.ai/code/session_01FoqM3sjnrRgPjdqYdqutzK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoqM3sjnrRgPjdqYdqutzK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration parsing to properly distinguish between explicitly empty instances (`instances: []`) and missing instances key. Empty instances now correctly indicate "no instances configured," while maintaining backward compatibility.

* **Tests**
  * Added test cases for multi-instance configuration edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->