### PR TITLE
Propagate runtime-built llm_instructions through MultiInstanceToolset (fixes Confluence eval 210)

### DIFF
--- a/holmes/plugins/toolsets/multi_instance.py
+++ b/holmes/plugins/toolsets/multi_instance.py
@@ -287,6 +287,7 @@ class MultiInstanceToolset(Toolset):
 
         self._build_tools()
         self._publish_instance_meta()
+        self._publish_llm_instructions()
         return self._aggregate(failures, successes)
 
     def _publish_instance_meta(self) -> None:
@@ -318,6 +319,29 @@ class MultiInstanceToolset(Toolset):
         meta = dict(self.meta or {})
         meta["instances"] = instances_meta
         self.meta = meta
+
+    def _publish_llm_instructions(self) -> None:
+        """Mirror the children's runtime-built llm_instructions onto the wrapper.
+
+        Some toolsets (e.g. Confluence) only build their llm_instructions inside
+        prerequisites_callable because the content depends on the configured
+        endpoint (base URL, whitelisted paths, auth mode). The static mirror
+        taken from the template in __init__ predates that, so without this the
+        system prompt renders no usage instructions for the toolset and the
+        LLM has to guess request URLs.
+        """
+        sections: List[str] = []
+        multi = (len(self._children) + len(self._offline_instances)) > 1
+        for name, child in self._children.items():
+            if child.llm_instructions:
+                if multi:
+                    sections.append(f"### Instance `{name}`\n\n{child.llm_instructions}")
+                else:
+                    sections.append(child.llm_instructions)
+        # Keep the template-derived instructions when no child built any, so
+        # toolsets with static instructions are unaffected.
+        if sections:
+            self.llm_instructions = "\n\n".join(sections)
 
     def _forward_overrides(self, child: Toolset) -> None:
         """Propagate toolset-level overrides so the child enforces them too."""

--- a/tests/plugins/toolsets/test_multi_instance.py
+++ b/tests/plugins/toolsets/test_multi_instance.py
@@ -310,3 +310,57 @@ class TestConfigEditorCompat:
         ts = multi_instance(_FakeToolset)
         assert ts.config_classes == _FakeToolset.config_classes
         assert ts.config_classes  # non-empty
+
+
+class _RuntimeInstructionsToolset(_FakeToolset):
+    """Fake child that builds llm_instructions at prerequisite time, like
+    Confluence does — the content depends on the configured endpoint."""
+
+    def prerequisites_callable(self, config):
+        ok, msg = super().prerequisites_callable(config)
+        if ok:
+            self.llm_instructions = f"Base URL: {config['api_url']}"
+        return ok, msg
+
+
+class TestLlmInstructionsPropagation:
+    def test_runtime_instructions_reach_wrapper_for_flat_config(self):
+        # Regression test: ConfluenceToolset builds llm_instructions inside
+        # prerequisites_callable. The wrapper used to mirror instructions only
+        # from the unconfigured template in __init__, so the system prompt had
+        # no usage instructions and the LLM had to guess request URLs.
+        ts = multi_instance(_RuntimeInstructionsToolset)
+        ts.prerequisites_callable({"api_url": "http://one"})
+        assert ts.llm_instructions == "Base URL: http://one"
+
+    def test_runtime_instructions_labelled_per_instance_when_multi(self):
+        ts = multi_instance(_RuntimeInstructionsToolset)
+        ts.prerequisites_callable(
+            {"instances": [
+                {"name": "eu", "api_url": "http://eu"},
+                {"name": "us", "api_url": "http://us"},
+            ]}
+        )
+        assert "### Instance `eu`" in ts.llm_instructions
+        assert "Base URL: http://eu" in ts.llm_instructions
+        assert "### Instance `us`" in ts.llm_instructions
+        assert "Base URL: http://us" in ts.llm_instructions
+
+    def test_template_instructions_kept_when_children_build_none(self):
+        # Children that never set llm_instructions must not clobber the
+        # template-derived (static) instructions mirrored in __init__.
+        ts = multi_instance(_FakeToolset)
+        ts.llm_instructions = "static instructions"
+        ts.prerequisites_callable({"api_url": "http://one"})
+        assert ts.llm_instructions == "static instructions"
+
+    def test_offline_instances_contribute_no_instructions(self):
+        ts = multi_instance(_RuntimeInstructionsToolset)
+        ts.prerequisites_callable(
+            {"instances": [
+                {"name": "good", "api_url": "http://good"},
+                {"name": "bad"},
+            ]}
+        )
+        assert "http://good" in ts.llm_instructions
+        assert "bad" not in ts.llm_instructions


### PR DESCRIPTION
## Summary

`MultiInstanceToolset` mirrors the child's `llm_instructions` from the unconfigured template in `__init__` and never refreshes it after running the children's `prerequisites_callable`. Toolsets that build their instructions at prerequisite time — Confluence, where the content depends on the configured endpoint (base URL, gateway routing, whitelisted paths) — therefore rendered **no usage section in the system prompt** at all.

The visible symptom: the `210_confluence_skill_fetch` eval failed on every CI run. The trace shows the LLM was never told the Atlassian gateway base URL, so it guessed request URLs (`https://api.atlassian.com/wiki/api/v2/pages/...`, `https://api.atlassian.com/ex/confluence/wiki/rest/api/content/...` — both missing the `/ex/confluence/<cloud_id>` prefix), every guess was rejected by the endpoint whitelist, and it fell back to `fetch_webpage` (an explicit FAIL condition of the eval).

## Fix

After the wrapper runs its children's prerequisites, mirror the children's runtime-built `llm_instructions` onto the wrapper:

- single (flat) instance → the child's instructions verbatim
- multiple instances → per-instance sections labelled `### Instance \`<name>\``
- no child builds instructions → keep the template-derived static instructions (other wrapped toolsets unaffected)

## Validation

- 4 new unit tests in `tests/plugins/toolsets/test_multi_instance.py` (26/26 pass)
- `210_confluence_skill_fetch` passes locally with opus-4.6; the rendered system prompt now contains the full gateway base URL including the cloud id
- The `evals-id-210_confluence_skill_fetch` label is set on this PR so CI runs the eval here

https://claude.ai/code/session_01VLkU3Rj1FoXXpkmNAyS6vo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLkU3Rj1FoXXpkmNAyS6vo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-instance toolsets now correctly propagate runtime-generated instructions from child instances to the wrapper, with per-instance organization when multiple are configured.

* **Tests**
  * Added comprehensive test coverage for LLM instruction propagation in multi-instance toolset configurations, including single-instance, multi-instance, and offline instance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->