### PR TITLE
[ROB-321] Restore regression tag on ES multi-cluster evals + wire ES secrets in…

### DIFF
--- a/.github/workflows/eval-master.yaml
+++ b/.github/workflows/eval-master.yaml
@@ -69,6 +69,8 @@ jobs:
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
           CONFLUENCE_API_KEY: ${{ secrets.CONFLUENCE_API_KEY }}
+          ELASTICSEARCH_URL: ${{ secrets.ELASTICSEARCH_URL }}
+          ELASTICSEARCH_API_KEY: ${{ secrets.ELASTICSEARCH_API_KEY }}
           MODEL_LIST_FILE_LOCATION: /tmp/model_list.yaml
           # This name must match MASTER_EXPERIMENT_PREFIX in braintrust_history.py
           EXPERIMENT_ID: "master-${{ github.run_id }}"

--- a/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/254_elasticsearch_dr_test_log_check/test_case.yaml
@@ -41,6 +41,7 @@ tags:
   - elasticsearch
   - medium
   - transparency
+  - regression
   - multi-cluster
 
 setup_timeout: 300

--- a/tests/llm/fixtures/test_ask_holmes/259_wrong_cluster_logs_confusion/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/259_wrong_cluster_logs_confusion/test_case.yaml
@@ -61,6 +61,7 @@ tags:
   - elasticsearch
   - medium
   - transparency
+  - regression
   - multi-cluster
 
 setup_timeout: 300

--- a/tests/llm/fixtures/test_ask_holmes/260_global_es_remote_cluster_logs/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/260_global_es_remote_cluster_logs/test_case.yaml
@@ -41,6 +41,7 @@ tags:
   - elasticsearch
   - medium
   - transparency
+  - regression
   - multi-cluster
 
 setup_timeout: 300


### PR DESCRIPTION
Fixing regression tests

- Re-add `regression` tag to 254/259/260.
- Add ELASTICSEARCH_URL/ELASTICSEARCH_API_KEY to eval-master.yaml, mirroring eval-regression.yaml and eval-benchmarks.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated regression evaluation workflow to include additional infrastructure credentials.

* **Tests**
  * Added regression test tags to multiple test cases to strengthen test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->