### PR TITLE
Add per-request tracing experiment routing and span token metrics to server

### DIFF
--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -183,6 +183,13 @@ class OTelSpan:
 
         return OTelSpan(new_span, self._tracer, token)
 
+    # Braintrust-style metric names → OTel GenAI semantic convention attributes
+    _METRIC_ATTR_MAP = {
+        "prompt_tokens": ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+        "completion_tokens": ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+        "total_tokens": ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
+    }
+
     def log(self, *args: Any, **kwargs: Any) -> None:
         """Log attributes to the span.
 
@@ -190,6 +197,9 @@ class OTelSpan:
             input: Stored as the ``input`` span attribute (truncated to 4096 chars).
             output: Stored as the ``output`` span attribute (truncated to 4096 chars).
             metadata: A ``dict`` whose entries are set as individual span attributes.
+            metrics: A ``dict`` of numeric values set as span attributes; names
+                with a GenAI semantic convention equivalent (e.g. ``prompt_tokens``)
+                are renamed to it.
         """
         if "input" in kwargs:
             val = str(kwargs["input"])
@@ -203,6 +213,10 @@ class OTelSpan:
                     self._span.set_attribute(k, v)
                 else:
                     self._span.set_attribute(k, str(v))
+        if "metrics" in kwargs and isinstance(kwargs["metrics"], dict):
+            for k, v in kwargs["metrics"].items():
+                if isinstance(v, (int, float)):
+                    self._span.set_attribute(self._METRIC_ATTR_MAP.get(k, k), v)
 
     def end(self) -> None:
         """End the span and detach from context."""

--- a/server.py
+++ b/server.py
@@ -110,6 +110,42 @@ init_logging()
 # Initialize tracer — auto-detects OTel if OTEL_EXPORTER_OTLP_ENDPOINT is set
 server_tracer = TracingFactory.create_tracer(trace_type=os.environ.get("HOLMES_TRACE_BACKEND"))
 
+# Opt-in: let API callers route a request's trace spans into a named tracing
+# experiment via the `X-Braintrust-Experiment` header. Off by default so
+# external callers cannot influence experiment routing unless the operator
+# explicitly enables it.
+ALLOW_PER_REQUEST_EXPERIMENT = (
+    os.environ.get("HOLMES_ALLOW_PER_REQUEST_EXPERIMENT", "false").lower() == "true"
+)
+_request_experiment_lock = threading.Lock()
+_request_experiment_name: Optional[str] = None
+
+
+def open_experiment_from_request(http_request: Request) -> None:
+    """Open (or switch to) the tracing experiment named in the request header.
+
+    Without an open experiment, `server_tracer.start_trace` has no tracing
+    context to attach to and returns a no-op span — so server-side spans are
+    silently dropped. This lets a driver (e.g. an eval harness firing many
+    /api/chat calls) group all spans for one logical run under a dedicated
+    experiment name.
+
+    The experiment context is process-global (Braintrust tracks a current
+    experiment per process), so this assumes one logical client per server
+    process — e.g. a server spawned per run. Repeating the current name is a
+    no-op; a new name switches the experiment.
+    """
+    global _request_experiment_name
+    if not ALLOW_PER_REQUEST_EXPERIMENT:
+        return
+    name = http_request.headers.get("X-Braintrust-Experiment")
+    if not name:
+        return
+    with _request_experiment_lock:
+        if name != _request_experiment_name:
+            server_tracer.start_experiment(experiment_name=name)
+            _request_experiment_name = name
+
 if ENABLE_CONNECTION_KEEPALIVE:
     patch_socket_create_connection()
 
@@ -414,6 +450,8 @@ def chat(chat_request: ChatRequest, http_request: Request):
             f"streaming={chat_request.stream}"
         )
 
+        open_experiment_from_request(http_request)
+
         skills = config.get_skill_catalog()
 
         prompt_component_overrides = None
@@ -585,6 +623,23 @@ def chat(chat_request: ChatRequest, http_request: Request):
 
                 # Record usage event for non-streaming path (fire-and-forget).
                 record_from_llm_result(recorder_state, llm_call)
+
+                # Attach token usage and cost to the investigation span.
+                # Tracing backends derive their token/cost columns from span
+                # metrics; without these the columns stay empty even though
+                # the span itself is recorded.
+                trace_span.log(
+                    metrics={
+                        name: value
+                        for name, value in (
+                            ("prompt_tokens", llm_call.prompt_tokens),
+                            ("completion_tokens", llm_call.completion_tokens),
+                            ("total_tokens", llm_call.total_tokens),
+                            ("total_cost", llm_call.total_cost),
+                        )
+                        if value
+                    }
+                )
 
                 # Record investigation metrics
                 otel_metrics = TracingFactory.get_metrics()

--- a/server.py
+++ b/server.py
@@ -637,7 +637,7 @@ def chat(chat_request: ChatRequest, http_request: Request):
                             ("total_tokens", llm_call.total_tokens),
                             ("total_cost", llm_call.total_cost),
                         )
-                        if value
+                        if value is not None
                     }
                 )
 


### PR DESCRIPTION
## Summary

Two server-side tracing improvements for driving Holmes via the HTTP API:

- **Opt-in per-request experiment routing**: API callers can route a request's trace spans into a named tracing experiment via the `X-Braintrust-Experiment` header. This is gated behind `HOLMES_ALLOW_PER_REQUEST_EXPERIMENT=true` (off by default), so external callers cannot influence experiment routing unless the operator explicitly enables it. Without an open experiment, `server_tracer.start_trace` has no tracing context to attach to and returns a no-op span — server-side spans are silently dropped. This lets a driver (e.g. an eval harness firing many `/api/chat` calls) group all spans for one logical run under a dedicated experiment name.
- **Token/cost metrics on the investigation span**: attach `prompt_tokens`, `completion_tokens`, `total_tokens`, and `total_cost` as metrics on the investigation span in the non-streaming chat path. Tracing backends derive their token/cost columns from span metrics; without these the columns stay empty even though the span itself is recorded.

## Notes

- The experiment context is process-global (Braintrust tracks a current experiment per process), so per-request routing assumes one logical client per server process — e.g. a server spawned per run. Repeating the current name is a no-op; a new name switches the experiment.

https://claude.ai/code/session_019R4cF5Xvdc9xS33DCkyGuH

---
_Generated by [Claude Code](https://claude.ai/code/session_019R4cF5Xvdc9xS33DCkyGuH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in per-request experiment routing via request headers to group tracing spans into named experiments.
  * Automatic recording of LLM token usage and cost metrics onto investigation traces for improved observability and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->