### PR TITLE
Revert "Bump github-mcp image to 1.0.4 (#2124)"

### DIFF
--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -439,7 +439,7 @@ mcpAddons:
   github:
     enabled: false
 
-    image: "github-mcp:1.0.4"
+    image: "github-mcp:1.0.1"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
     imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Reverts #2124, restoring the `github-mcp` addon image tag from `1.0.4` back to `1.0.1` in `helm/holmes/values.yaml`.

## Test plan
- [ ] Helm chart renders with `github-mcp:1.0.1`
- [ ] Deployed GitHub MCP addon pulls and starts on `1.0.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub MCP add-on component version in the deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->