### PR TITLE
Retry transient Supabase errors in conversation status updates

### DIFF
--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -24,6 +24,7 @@ from supabase.lib.client_options import SyncClientOptions as ClientOptions
 from tenacity import (
     retry,
     retry_if_exception_type,
+    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
@@ -1160,7 +1161,10 @@ class SupabaseDal:
         """
         # Lazy imports avoid a circular import: conversations_worker pulls in
         # conversations.py → config → llm → supabase_dal at module load time.
-        from holmes.core.conversations_worker.models import ConversationStatus
+        from holmes.core.conversations_worker.models import (
+            ConversationReassignedError,
+            ConversationStatus,
+        )
 
         if not self.enabled:
             return False
@@ -1171,30 +1175,47 @@ class SupabaseDal:
             )
             return False
 
-        try:
-            res = self.client.rpc(
-                "update_conversation_status",
-                {
-                    "_account_id": self.account_id,
-                    "_conversation_id": conversation_id,
-                    "_request_sequence": request_sequence,
-                    "_assignee": assignee,
-                    "_status": status,
-                },
-            ).execute()
-            return bool(res.data)
-        except Exception as e:
-            # The RPC raises MISMATCH errors when assignee, request_sequence,
-            # or status guards fail — propagate these so the worker can exit
-            # cleanly rather than retrying a stale transition.
-            if "mismatch" in str(e).lower():
-                from holmes.core.conversations_worker.models import (
-                    ConversationReassignedError,
-                )
+        # Retry a few times on transient infrastructure errors (DNS/cache
+        # overflows in the Supabase proxy, 5xx gateway errors, etc.).  Without
+        # this a transient hiccup leaves the conversation stuck in a non-terminal
+        # state (e.g. "Failed to mark conversation ... complete").  Mismatch
+        # errors are NOT retried — they mean the row was reassigned and the
+        # worker should exit cleanly rather than hammer a stale transition.
+        @retry(
+            retry=retry_if_not_exception_type(ConversationReassignedError),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
+            reraise=True,
+        )
+        def _update() -> bool:
+            try:
+                res = self.client.rpc(
+                    "update_conversation_status",
+                    {
+                        "_account_id": self.account_id,
+                        "_conversation_id": conversation_id,
+                        "_request_sequence": request_sequence,
+                        "_assignee": assignee,
+                        "_status": status,
+                    },
+                ).execute()
+                return bool(res.data)
+            except Exception as e:
+                # The RPC raises MISMATCH errors when assignee, request_sequence,
+                # or status guards fail — propagate these so the worker can exit
+                # cleanly rather than retrying a stale transition.
+                if "mismatch" in str(e).lower():
+                    raise ConversationReassignedError(str(e)) from e
+                raise
 
-                raise ConversationReassignedError(str(e)) from e
+        try:
+            return _update()
+        except ConversationReassignedError:
+            raise
+        except Exception:
             logging.exception(
-                "Supabase error while updating conversation status", exc_info=True
+                "Supabase error while updating conversation status (after retries)",
+                exc_info=True,
             )
             return False
 

--- a/tests/core/conversations_worker/test_dal_contract.py
+++ b/tests/core/conversations_worker/test_dal_contract.py
@@ -202,3 +202,58 @@ def test_update_conversation_status_promotes_mismatch_to_reassigned_error():
             assignee="h",
             status="running",
         )
+
+
+def test_update_conversation_status_retries_transient_error_then_succeeds():
+    """A transient Supabase error should be retried and eventually succeed."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(
+            side_effect=[
+                Exception("502 Bad Gateway"),
+                MagicMock(data=True),
+            ]
+        )
+    )
+    result = dal.update_conversation_status(
+        conversation_id="c",
+        request_sequence=1,
+        assignee="h",
+        status="completed",
+    )
+    assert result is True
+    assert dal.client.rpc.return_value.execute.call_count == 2
+
+
+def test_update_conversation_status_returns_false_after_exhausting_retries():
+    """Persistent transient errors exhaust retries and return False (not raise)."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(side_effect=Exception("502 Bad Gateway"))
+    )
+    result = dal.update_conversation_status(
+        conversation_id="c",
+        request_sequence=1,
+        assignee="h",
+        status="completed",
+    )
+    assert result is False
+    assert dal.client.rpc.return_value.execute.call_count == 3
+
+
+def test_update_conversation_status_does_not_retry_mismatch():
+    """MISMATCH errors must not be retried — the row was reassigned."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(
+            side_effect=Exception("MISMATCH Assignee expected h-old, got h-new")
+        )
+    )
+    with pytest.raises(ConversationReassignedError, match="MISMATCH"):
+        dal.update_conversation_status(
+            conversation_id="c",
+            request_sequence=1,
+            assignee="h",
+            status="running",
+        )
+    assert dal.client.rpc.return_value.execute.call_count == 1


### PR DESCRIPTION
## Summary
Add automatic retry logic for transient infrastructure errors when updating conversation status in Supabase, while ensuring that MISMATCH errors (indicating the conversation was reassigned) are not retried and propagate immediately.

## Changes
- **Retry mechanism**: Wrapped the RPC call in a `@retry` decorator that retries up to 3 times with exponential backoff (0.5s-2s) for transient errors like DNS failures, cache overflows, and 5xx gateway errors
- **Selective retry**: Uses `retry_if_not_exception_type(ConversationReassignedError)` to skip retries for MISMATCH errors, allowing the worker to exit cleanly when a conversation has been reassigned
- **Error handling**: Converts MISMATCH errors to `ConversationReassignedError` exceptions that bypass retry logic, while other exceptions are retried and eventually logged as failures
- **Test coverage**: Added three new tests covering:
  - Successful retry after transient error
  - Exhaustion of retries returning False (not raising)
  - MISMATCH errors not being retried (immediate propagation)

## Implementation Details
- Extracted the RPC call into an inner `_update()` function decorated with `@retry`
- MISMATCH detection logic remains unchanged (case-insensitive string matching)
- Outer try-except preserves the original behavior: `ConversationReassignedError` is re-raised, other exceptions are logged and return False
- Updated log message to clarify that failures occur "after retries"

https://claude.ai/code/session_01L6SMoR2U3Rbg1spsjnxAAR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Conversation status updates are now more resilient to temporary network disruptions through intelligent automatic retry logic with exponential backoff, significantly improving robustness of critical background operations.
* Improved error handling for conflicting or reassigned conversation states, ensuring the system responds appropriately without attempting unnecessary retries and maintains proper graceful shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->