### PR TITLE
Add retry logic to Supabase DAL operations

### DIFF
--- a/holmes/core/conversations_worker/event_publisher.py
+++ b/holmes/core/conversations_worker/event_publisher.py
@@ -149,14 +149,12 @@ class ConversationEventPublisher:
     def _post_with_retry(
         self, events_to_flush: List[Dict[str, Any]], compact: bool
     ) -> Optional[int]:
-        """Post events via the DAL.
+        """Post events via the DAL, which already retries transient errors and
+        promotes mismatch errors to ConversationReassignedError.
 
-        The DAL (``post_conversation_events``) already retries transient
-        infrastructure errors with bounded exponential backoff and promotes
-        mismatch errors (assignee / request_sequence / status) to
-        ConversationReassignedError. We propagate reassignment so the worker
-        can exit cleanly, and translate any other post-retry failure to None so
-        ``_flush`` retains the events and retries them on the next flush.
+        Reassignment propagates so the worker exits cleanly; any other
+        post-retry failure becomes None so ``_flush`` retains the events and
+        retries them on the next flush.
         """
         try:
             return self.dal.post_conversation_events(
@@ -169,9 +167,7 @@ class ConversationEventPublisher:
         except ConversationReassignedError:
             raise
         except Exception as e:
-            # Defensive: the DAL already promotes mismatch errors, but if a raw
-            # mismatch leaks through, promote it here too so the worker exits
-            # the processing loop cleanly rather than retaining stale events.
+            # Defensive: promote a raw mismatch if one leaks past the DAL.
             if "mismatch" in str(e).lower():
                 raise ConversationReassignedError(str(e)) from e
             logging.warning(

--- a/holmes/core/conversations_worker/event_publisher.py
+++ b/holmes/core/conversations_worker/event_publisher.py
@@ -4,14 +4,6 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Generator, List, Optional, TYPE_CHECKING
 
-from tenacity import (
-    RetryError,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
-
 from holmes.core.conversations_worker.models import ConversationReassignedError
 from holmes.utils.stream import StreamEvents, StreamMessage
 
@@ -49,10 +41,6 @@ _COMPACT_ON_FLUSH_EVENTS = {
     StreamEvents.APPROVAL_REQUIRED,
     StreamEvents.CONVERSATION_HISTORY_COMPACTED,
 }
-
-
-class _TransientPostError(Exception):
-    """Raised internally to drive tenacity retries when the DAL post fails."""
 
 
 class ConversationEventPublisher:
@@ -161,42 +149,31 @@ class ConversationEventPublisher:
     def _post_with_retry(
         self, events_to_flush: List[Dict[str, Any]], compact: bool
     ) -> Optional[int]:
-        """Post events to the DAL with bounded retry on transient errors.
+        """Post events via the DAL.
 
-        Mismatch errors (assignee / request_sequence / status) are NOT retried —
-        they are surfaced to the caller as ConversationReassignedError.
+        The DAL (``post_conversation_events``) already retries transient
+        infrastructure errors with bounded exponential backoff and promotes
+        mismatch errors (assignee / request_sequence / status) to
+        ConversationReassignedError. We propagate reassignment so the worker
+        can exit cleanly, and translate any other post-retry failure to None so
+        ``_flush`` retains the events and retries them on the next flush.
         """
-
-        @retry(
-            retry=retry_if_exception_type(_TransientPostError),
-            stop=stop_after_attempt(3),
-            wait=wait_exponential(multiplier=0.5, min=0.5, max=4.0),
-            reraise=True,
-        )
-        def _attempt() -> Optional[int]:
-            try:
-                return self.dal.post_conversation_events(
-                    conversation_id=self.conversation_id,
-                    assignee=self.assignee,
-                    request_sequence=self.request_sequence,
-                    events=events_to_flush,
-                    compact=compact,
-                )
-            except ConversationReassignedError:
-                raise
-            except Exception as e:
-                # The RPCs prefix mismatch errors (status / assignee / request_sequence)
-                # with "MISMATCH " — promote those to ConversationReassignedError so
-                # the worker can exit the processing loop cleanly.
-                if "mismatch" in str(e).lower():
-                    raise ConversationReassignedError(str(e)) from e
-                # Anything else is treated as transient (network hiccup, 5xx,
-                # supabase proxy DNS, etc.) and retried.
-                raise _TransientPostError(str(e)) from e
-
         try:
-            return _attempt()
-        except _TransientPostError as e:
+            return self.dal.post_conversation_events(
+                conversation_id=self.conversation_id,
+                assignee=self.assignee,
+                request_sequence=self.request_sequence,
+                events=events_to_flush,
+                compact=compact,
+            )
+        except ConversationReassignedError:
+            raise
+        except Exception as e:
+            # Defensive: the DAL already promotes mismatch errors, but if a raw
+            # mismatch leaks through, promote it here too so the worker exits
+            # the processing loop cleanly rather than retaining stale events.
+            if "mismatch" in str(e).lower():
+                raise ConversationReassignedError(str(e)) from e
             logging.warning(
                 "post_conversation_events failed after retries for conversation %s: %s",
                 self.conversation_id,
@@ -212,17 +189,7 @@ class ConversationEventPublisher:
             events_to_flush = list(self._pending_events)
             compact = self._pending_compact
 
-        try:
-            seq = self._post_with_retry(events_to_flush, compact)
-        except RetryError as e:
-            # Defensive: tenacity should reraise the original due to reraise=True,
-            # but if a wrapped RetryError leaks out, treat as transient.
-            logging.warning(
-                "Unexpected RetryError flushing conversation %s: %s",
-                self.conversation_id,
-                e,
-            )
-            seq = None
+        seq = self._post_with_retry(events_to_flush, compact)
 
         if seq is None:
             # All retries exhausted (or the DAL is disabled). Keep events and

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -1086,18 +1086,15 @@ class SupabaseDal:
         if not self.enabled:
             return []
 
-        # Retry a few times on transient infrastructure errors (DNS/cache
-        # overflows in the Supabase proxy, 5xx gateway errors, etc.) so a
-        # transient hiccup doesn't skip a poll cycle and leave queued
-        # conversations unclaimed. There are no semantic/mismatch errors to
-        # exclude here — every failure is treated as transient.
+        # Retry transient infrastructure errors (Supabase proxy DNS/cache
+        # overflows, 5xx gateways) so a hiccup doesn't skip a poll cycle.
         @retry(
             retry=retry_if_exception_type(Exception),
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
             reraise=True,
         )
-        def _claim() -> List[Dict]:
+        def _claim_with_retry() -> List[Dict]:
             res = self.client.rpc(
                 "claim_conversations",
                 {
@@ -1113,7 +1110,7 @@ class SupabaseDal:
             return [res.data]
 
         try:
-            return _claim()
+            return _claim_with_retry()
         except Exception:
             logging.exception(
                 "Supabase error while claiming conversations (after retries)",
@@ -1164,22 +1161,16 @@ class SupabaseDal:
         if not self.enabled:
             return False
 
-        # The RPC raises 'MISMATCH ...' / 'not found' when a stale or duplicate
-        # worker posts after the row was reassigned, stopped, or already
-        # finished (first result wins). That's terminal — surface it as the
-        # _RemoteToolResultRejected sentinel so tenacity does NOT retry it.
-
-        # Retry a few times on transient infrastructure errors (DNS/cache
-        # overflows in the Supabase proxy, 5xx gateway errors, etc.) so a
-        # transient hiccup doesn't drop a finished tool result. Mismatch /
-        # not-found are excluded from retry (see above).
+        # Retry transient infrastructure errors so a hiccup doesn't drop a
+        # finished tool result. MISMATCH / not-found mean the row was
+        # reassigned/stopped/already-finished — terminal, never retried.
         @retry(
             retry=retry_if_not_exception_type(_RemoteToolResultRejected),
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
             reraise=True,
         )
-        def _post() -> bool:
+        def _post_with_retry() -> bool:
             try:
                 res = self.client.rpc(
                     "post_remote_tool_call_result",
@@ -1199,7 +1190,7 @@ class SupabaseDal:
                 raise
 
         try:
-            return _post()
+            return _post_with_retry()
         except _RemoteToolResultRejected as e:
             # Stale/duplicate worker: log calmly and drop (first result wins).
             logging.info(
@@ -1238,19 +1229,16 @@ class SupabaseDal:
         if not self.enabled:
             return None
 
-        # Retry a few times on transient infrastructure errors (DNS/cache
-        # overflows in the Supabase proxy, 5xx gateway errors, etc.) so a
-        # transient hiccup doesn't drop a batch of conversation events.
-        # Mismatch errors are NOT retried — they mean the row was reassigned
-        # (assignee / request_sequence / status guard failed) and the worker
-        # should exit cleanly rather than hammer a stale transition.
+        # Retry transient infrastructure errors so a hiccup doesn't drop a
+        # batch of events. MISMATCH means the row was reassigned — never
+        # retried, raised as ConversationReassignedError so the worker exits.
         @retry(
             retry=retry_if_not_exception_type(ConversationReassignedError),
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
             reraise=True,
         )
-        def _post() -> Optional[int]:
+        def _post_with_retry() -> Optional[int]:
             try:
                 res = self.client.rpc(
                     "post_conversation_events",
@@ -1282,7 +1270,7 @@ class SupabaseDal:
                 raise
 
         try:
-            return _post()
+            return _post_with_retry()
         except ConversationReassignedError:
             raise
         except Exception:
@@ -1323,19 +1311,16 @@ class SupabaseDal:
             )
             return False
 
-        # Retry a few times on transient infrastructure errors (DNS/cache
-        # overflows in the Supabase proxy, 5xx gateway errors, etc.).  Without
-        # this a transient hiccup leaves the conversation stuck in a non-terminal
-        # state (e.g. "Failed to mark conversation ... complete").  Mismatch
-        # errors are NOT retried — they mean the row was reassigned and the
-        # worker should exit cleanly rather than hammer a stale transition.
+        # Retry transient infrastructure errors so a hiccup doesn't leave the
+        # conversation stuck in a non-terminal state. MISMATCH means the row
+        # was reassigned — never retried, raised as ConversationReassignedError.
         @retry(
             retry=retry_if_not_exception_type(ConversationReassignedError),
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
             reraise=True,
         )
-        def _update() -> bool:
+        def _update_with_retry() -> bool:
             try:
                 res = self.client.rpc(
                     "update_conversation_status",
@@ -1349,15 +1334,12 @@ class SupabaseDal:
                 ).execute()
                 return bool(res.data)
             except Exception as e:
-                # The RPC raises MISMATCH errors when assignee, request_sequence,
-                # or status guards fail — propagate these so the worker can exit
-                # cleanly rather than retrying a stale transition.
                 if "mismatch" in str(e).lower():
                     raise ConversationReassignedError(str(e)) from e
                 raise
 
         try:
-            return _update()
+            return _update_with_retry()
         except ConversationReassignedError:
             raise
         except Exception:
@@ -1391,18 +1373,16 @@ class SupabaseDal:
         if not self.enabled:
             return []
 
-        # Retry a few times on transient infrastructure errors (DNS/cache
-        # overflows in the Supabase proxy, 5xx gateway errors, etc.).  The
-        # caller's fallback when this returns [] is to mark the conversation
-        # failed for lack of a user question, so a transient hiccup here
-        # would cause a spurious permanent failure.
+        # Retry transient infrastructure errors. The caller treats [] as "no
+        # user question" and fails the conversation, so a hiccup here would
+        # cause a spurious permanent failure.
         @retry(
             retry=retry_if_exception_type(Exception),
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
             reraise=True,
         )
-        def _fetch() -> List[Dict]:
+        def _fetch_with_retry() -> List[Dict]:
             res = self.client.rpc(
                 "get_conversation_events",
                 {
@@ -1415,7 +1395,7 @@ class SupabaseDal:
             return res.data or []
 
         try:
-            return _fetch()
+            return _fetch_with_retry()
         except Exception:
             logging.exception(
                 "Supabase error while fetching conversation events (after retries)",

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -1086,7 +1086,18 @@ class SupabaseDal:
         if not self.enabled:
             return []
 
-        try:
+        # Retry a few times on transient infrastructure errors (DNS/cache
+        # overflows in the Supabase proxy, 5xx gateway errors, etc.) so a
+        # transient hiccup doesn't skip a poll cycle and leave queued
+        # conversations unclaimed. There are no semantic/mismatch errors to
+        # exclude here — every failure is treated as transient.
+        @retry(
+            retry=retry_if_exception_type(Exception),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
+            reraise=True,
+        )
+        def _claim() -> List[Dict]:
             res = self.client.rpc(
                 "claim_conversations",
                 {
@@ -1100,9 +1111,13 @@ class SupabaseDal:
             if isinstance(res.data, list):
                 return res.data
             return [res.data]
+
+        try:
+            return _claim()
         except Exception:
             logging.exception(
-                "Supabase error while claiming conversations", exc_info=True
+                "Supabase error while claiming conversations (after retries)",
+                exc_info=True,
             )
             return []
 
@@ -1214,31 +1229,66 @@ class SupabaseDal:
         previous events in the conversation with seq < new_seq as compacted=true
         (global per conversation, not scoped to request_sequence).
         """
+        # Lazy imports avoid a circular import: conversations_worker pulls in
+        # conversations.py → config → llm → supabase_dal at module load time.
+        from holmes.core.conversations_worker.models import (
+            ConversationReassignedError,
+        )
+
         if not self.enabled:
             return None
 
-        try:
-            res = self.client.rpc(
-                "post_conversation_events",
-                {
-                    "_account_id": self.account_id,
-                    "_conversation_id": conversation_id,
-                    "_assignee": assignee,
-                    "_request_sequence": request_sequence,
-                    "_events": events,
-                    "_compact": compact,
-                },
-            ).execute()
-            if res.data is None:
-                return None
-            if isinstance(res.data, list):
-                if not res.data:
+        # Retry a few times on transient infrastructure errors (DNS/cache
+        # overflows in the Supabase proxy, 5xx gateway errors, etc.) so a
+        # transient hiccup doesn't drop a batch of conversation events.
+        # Mismatch errors are NOT retried — they mean the row was reassigned
+        # (assignee / request_sequence / status guard failed) and the worker
+        # should exit cleanly rather than hammer a stale transition.
+        @retry(
+            retry=retry_if_not_exception_type(ConversationReassignedError),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
+            reraise=True,
+        )
+        def _post() -> Optional[int]:
+            try:
+                res = self.client.rpc(
+                    "post_conversation_events",
+                    {
+                        "_account_id": self.account_id,
+                        "_conversation_id": conversation_id,
+                        "_assignee": assignee,
+                        "_request_sequence": request_sequence,
+                        "_events": events,
+                        "_compact": compact,
+                    },
+                ).execute()
+                if res.data is None:
                     return None
-                return int(res.data[0]) if not isinstance(res.data[0], dict) else None
-            return int(res.data)
+                if isinstance(res.data, list):
+                    if not res.data:
+                        return None
+                    return (
+                        int(res.data[0])
+                        if not isinstance(res.data[0], dict)
+                        else None
+                    )
+                return int(res.data)
+            except ConversationReassignedError:
+                raise
+            except Exception as e:
+                if "mismatch" in str(e).lower():
+                    raise ConversationReassignedError(str(e)) from e
+                raise
+
+        try:
+            return _post()
+        except ConversationReassignedError:
+            raise
         except Exception:
             logging.exception(
-                "Supabase error while posting conversation events", exc_info=True
+                "Supabase error while posting conversation events (after retries)",
+                exc_info=True,
             )
             raise
 

--- a/tests/core/conversations_worker/integration/conftest.py
+++ b/tests/core/conversations_worker/integration/conftest.py
@@ -1,3 +1,32 @@
-"""conftest for conversation worker integration tests."""
+"""conftest for conversation worker integration tests.
+
+These tests talk to the real Robusta platform + Supabase (and the
+retry-resilience test builds a real in-process SupabaseDal via ``import
+server``). Override the unit-test autouse fixtures from the root conftest so
+they don't mock out the DAL / HTTP layer for this directory.
+"""
+import pytest
+import responses as responses_
+
 # Re-export the session-scoped fixture so all test modules can use it.
 from tests.core.conversations_worker.integration import supabase_fx  # noqa: F401
+
+
+@pytest.fixture(autouse=True, scope="session")
+def storage_dal_mock():
+    """Override root: do NOT patch holmes.config.SupabaseDal — these tests need
+    the real DAL talking to the real Supabase backend."""
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def patch_supabase():
+    """Override root: do NOT swap in fake Supabase connection settings."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def responses():
+    """Override root: let all HTTP through to the real services."""
+    with responses_.RequestsMock(passthru_prefixes=("http://", "https://")) as rsps:
+        yield rsps

--- a/tests/core/conversations_worker/integration/test_retry_resilience.py
+++ b/tests/core/conversations_worker/integration/test_retry_resilience.py
@@ -1,0 +1,179 @@
+"""Integration test: a conversation completes end-to-end even when the worker's
+Supabase RPCs hit transient infrastructure errors.
+
+Unlike the other tests in this directory (which assume an *external* Holmes
+server processes the conversation), this one runs the worker **in-process** so
+it can wrap the worker's Supabase client and inject simulated transient
+failures (503s) into every conversation RPC. The bounded retry policy added to
+``SupabaseDal`` must absorb them and still drive the conversation to
+``completed``.
+
+Requires a Robusta token + cluster and uses the Robusta LLM endpoint:
+    ROBUSTA_UI_TOKEN   - base64 JSON with Supabase credentials + account_id
+    CLUSTER_NAME       - target cluster
+    ROBUSTA_API_ENDPOINT - Holmes uses it to reach the LLM
+
+Run:
+    poetry run pytest tests/core/conversations_worker/integration/test_retry_resilience.py \
+        -m conversation_worker --no-cov -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from typing import Any, Dict, Optional
+
+import pytest
+
+from tests.core.conversations_worker.integration import SupabaseFixture
+
+pytestmark = [pytest.mark.conversation_worker, pytest.mark.integration]
+
+# The conversation RPCs whose transient errors the retry policy must absorb.
+_CONVERSATION_RPCS = {
+    "claim_conversations",
+    "get_conversation_events",
+    "post_conversation_events",
+    "update_conversation_status",
+}
+
+
+@pytest.fixture(scope="module")
+def inprocess_worker():
+    """Import the fully-wired Holmes server (config, dal, chat, worker) and run
+    the conversation worker in this process. Heavy (~30s) — module scoped."""
+    if not os.environ.get("ROBUSTA_UI_TOKEN"):
+        pytest.skip("ROBUSTA_UI_TOKEN not set")
+
+    from holmes.core.supabase_dal import SupabaseDal
+
+    import server  # builds config, dal, chat, conversation_worker at import
+
+    # In a combined session a unit test may have activated the root
+    # session-scoped ``storage_dal_mock`` (patches holmes.config.SupabaseDal)
+    # before this dir's override took effect, leaving server.dal a MagicMock.
+    # Run this test in isolation with ``-m conversation_worker``.
+    if not isinstance(server.dal, SupabaseDal):
+        pytest.skip(
+            "SupabaseDal is mocked — run in isolation: "
+            "pytest tests/core/conversations_worker/integration -m conversation_worker"
+        )
+    if server.conversation_worker is None:
+        pytest.skip("conversation worker not enabled (ENABLE_CONVERSATION_WORKER)")
+    if not server.dal.enabled:
+        pytest.skip("Supabase DAL not enabled")
+    server.dal.sign_in()
+    return server
+
+
+class _TransientFaultInjector:
+    """Wrap a Supabase client's ``rpc().execute()`` so it raises a simulated
+    transient error with probability ``p`` — but never more than ``max_consec``
+    times in a row, so the bounded (3-attempt) retry always recovers."""
+
+    def __init__(self, client: Any, p: float = 0.6, max_consec: int = 2, seed: int = 7):
+        self._client = client
+        self._real_rpc = client.rpc
+        self._rng = random.Random(seed)
+        self.p = p
+        self.max_consec = max_consec
+        self.on = False
+        self.consec = 0
+        self.injected = 0
+        self.by_rpc: Dict[str, int] = {}
+
+    def install(self) -> "_TransientFaultInjector":
+        inj = self
+        real_rpc = self._real_rpc
+
+        def flaky_rpc(name, params=None):
+            builder = real_rpc(name, params) if params is not None else real_rpc(name)
+            real_execute = builder.execute
+
+            def execute(*a, **k):
+                if (
+                    inj.on
+                    and inj.consec < inj.max_consec
+                    and inj._rng.random() < inj.p
+                ):
+                    inj.consec += 1
+                    inj.injected += 1
+                    inj.by_rpc[name] = inj.by_rpc.get(name, 0) + 1
+                    raise Exception(
+                        "503 Service Unavailable (simulated transient Supabase error)"
+                    )
+                inj.consec = 0
+                return real_execute(*a, **k)
+
+            builder.execute = execute
+            return builder
+
+        self._client.rpc = flaky_rpc
+        return self
+
+    def restore(self) -> None:
+        self._client.rpc = self._real_rpc
+
+
+def test_conversation_completes_through_transient_supabase_failures(
+    inprocess_worker, supabase_fx: SupabaseFixture
+):
+    worker = inprocess_worker.conversation_worker
+    dal = inprocess_worker.dal
+
+    injector = _TransientFaultInjector(dal.client).install()
+    # We drive the worker manually, so skip the broadcast notify on create
+    # (it would otherwise need a live Realtime WS that nothing listens on here).
+    prev_pgchanges = supabase_fx.use_pgchanges
+    supabase_fx.use_pgchanges = True
+    try:
+        conv = supabase_fx.create_conversation(
+            ask="Reply with exactly the single word PONG and nothing else.",
+            title="retry-resilience-e2e",
+        )
+        cid = conv["conversation_id"]
+
+        # Faults on from here: every worker RPC may hit a transient 503.
+        injector.on = True
+
+        # Poll the claim like the real worker's poll loop — the just-created
+        # row may not be visible to the very first claim (create→claim race).
+        mine: list = []
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            claimed = worker.dal.claim_conversations(worker.holmes_id)
+            mine = [c for c in claimed if c["conversation_id"] == cid]
+            if mine:
+                break
+            time.sleep(1)
+        assert mine, "worker did not claim the created conversation within 20s"
+        task = worker._build_task_from_conversation_row(mine[0])
+
+        assert worker.dal.update_conversation_status(
+            conversation_id=task.conversation_id,
+            request_sequence=task.request_sequence,
+            assignee=worker.holmes_id,
+            status="running",
+        )
+        worker._process_conversation(task)
+
+        injector.on = False
+
+        final = supabase_fx.wait_for_terminal(cid, request_sequence=1, timeout=120)
+        term: Optional[Dict[str, Any]] = supabase_fx.find_terminal_event(cid)
+        events_blob = json.dumps(supabase_fx.get_events(cid))
+
+        assert final["status"] == "completed", f"unexpected status: {final}"
+        assert term and term.get("event") == "ai_answer_end"
+        assert "PONG" in events_blob.upper(), "LLM answer not persisted"
+
+        # The point of the test: transient failures were actually injected and
+        # absorbed, and only on the conversation RPCs.
+        assert injector.injected > 0, "no transient failures were injected"
+        assert set(injector.by_rpc) <= _CONVERSATION_RPCS, injector.by_rpc
+    finally:
+        injector.restore()
+        supabase_fx.use_pgchanges = prev_pgchanges
+        # supabase_fx session teardown stops + deletes created conversations.

--- a/tests/core/conversations_worker/test_dal_contract.py
+++ b/tests/core/conversations_worker/test_dal_contract.py
@@ -63,6 +63,61 @@ def test_post_conversation_events_default_compact_false():
     assert params["_compact"] is False
 
 
+def test_post_conversation_events_retries_transient_error_then_succeeds():
+    """A transient Supabase error should be retried and eventually succeed."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(
+            side_effect=[
+                Exception("502 Bad Gateway"),
+                MagicMock(data=7),
+            ]
+        )
+    )
+    seq = dal.post_conversation_events(
+        conversation_id="c",
+        assignee="h",
+        request_sequence=1,
+        events=[{"event": "x", "data": {}, "ts": "t"}],
+    )
+    assert seq == 7
+    assert dal.client.rpc.return_value.execute.call_count == 2
+
+
+def test_post_conversation_events_raises_after_exhausting_retries():
+    """Persistent transient errors exhaust retries and re-raise (caller handles)."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(side_effect=Exception("502 Bad Gateway"))
+    )
+    with pytest.raises(Exception, match="502 Bad Gateway"):
+        dal.post_conversation_events(
+            conversation_id="c",
+            assignee="h",
+            request_sequence=1,
+            events=[{"event": "x", "data": {}, "ts": "t"}],
+        )
+    assert dal.client.rpc.return_value.execute.call_count == 3
+
+
+def test_post_conversation_events_does_not_retry_mismatch():
+    """MISMATCH errors must not be retried — the row was reassigned."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(
+            side_effect=Exception("MISMATCH Assignee expected h-old, got h-new")
+        )
+    )
+    with pytest.raises(ConversationReassignedError, match="MISMATCH"):
+        dal.post_conversation_events(
+            conversation_id="c",
+            assignee="h",
+            request_sequence=1,
+            events=[{"event": "x", "data": {}, "ts": "t"}],
+        )
+    assert dal.client.rpc.return_value.execute.call_count == 1
+
+
 # ---- get_conversation_events (RPC-based, returns flat list) ----
 
 
@@ -122,6 +177,32 @@ def test_claim_conversations_uses_assignee_param():
     assert params["_assignee"] == "my-pod-1"
     assert params["_account_id"] == "acc-1"
     assert params["_cluster_id"] == "cluster-1"
+
+
+def test_claim_conversations_retries_transient_error_then_succeeds():
+    """A transient Supabase error should be retried and eventually succeed."""
+    dal = _build_dal()
+    claimed = [{"conversation_id": "c1"}]
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(
+            side_effect=[
+                Exception("502 Bad Gateway"),
+                MagicMock(data=claimed),
+            ]
+        )
+    )
+    assert dal.claim_conversations(holmes_id="h") == claimed
+    assert dal.client.rpc.return_value.execute.call_count == 2
+
+
+def test_claim_conversations_returns_empty_after_exhausting_retries():
+    """Persistent transient errors exhaust retries and return [] (not raise)."""
+    dal = _build_dal()
+    dal.client.rpc.return_value = MagicMock(
+        execute=MagicMock(side_effect=Exception("502 Bad Gateway"))
+    )
+    assert dal.claim_conversations(holmes_id="h") == []
+    assert dal.client.rpc.return_value.execute.call_count == 3
 
 
 # ---- update_conversation_status ----


### PR DESCRIPTION
## Summary

Moves retry logic from the event publisher layer into the Supabase DAL, centralizing transient error handling and distinguishing between retryable infrastructure errors and non-retryable semantic errors (conversation reassignment).

## Key Changes

- **`supabase_dal.py`**:
  - Added bounded exponential backoff retry (3 attempts, 0.5-2.0s delays) to `claim_conversations()` for transient infrastructure errors (DNS, 5xx, proxy cache overflows)
  - Added bounded exponential backoff retry (3 attempts, 0.5-2.0s delays) to `post_conversation_events()` with selective retry logic:
    - Retries all exceptions except `ConversationReassignedError`
    - Detects "mismatch" errors (assignee/request_sequence/status guard failures) and promotes them to `ConversationReassignedError` without retry
    - Allows caller to distinguish between transient failures (retry at higher level) and reassignment (exit cleanly)
  - Updated error log messages to indicate retries have been exhausted

- **`event_publisher.py`**:
  - Removed local retry decorator and `_TransientPostError` helper class
  - Simplified `_post_with_retry()` to call DAL directly and handle only `ConversationReassignedError` (which now comes from DAL)
  - Removed `RetryError` handling from `_flush()` since DAL now handles all retries
  - Added defensive mismatch detection in event publisher as fallback

- **`test_dal_contract.py`**:
  - Added 6 new tests covering retry behavior:
    - `test_post_conversation_events_retries_transient_error_then_succeeds()`: Verifies transient errors are retried
    - `test_post_conversation_events_raises_after_exhausting_retries()`: Verifies exhausted retries re-raise
    - `test_post_conversation_events_does_not_retry_mismatch()`: Verifies mismatch errors fail fast without retry
    - `test_claim_conversations_retries_transient_error_then_succeeds()`: Verifies transient errors are retried
    - `test_claim_conversations_returns_empty_after_exhausting_retries()`: Verifies exhausted retries return empty list

## Implementation Details

- Retry logic uses `tenacity` library with `retry_if_exception_type()` / `retry_if_not_exception_type()` for selective retry
- `claim_conversations()` returns empty list on failure (non-raising) to allow poll cycles to continue
- `post_conversation_events()` re-raises after retries so caller can decide whether to retain events or fail
- Lazy import of `ConversationReassignedError` in DAL avoids circular dependency with conversations_worker
- Exponential backoff parameters (0.5-2.0s) prevent thundering herd on infrastructure recovery

https://claude.ai/code/session_01DXaVPZejKoNwZsPTKoaxaZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced resilience when posting and retrieving conversation events, including safe handling of unexpected response shapes.
  * Improved mismatch/reassignment behavior to ensure the correct error is raised and that event posting doesn’t lose pending work on transient failures.
  * Added broader retry handling across key conversation-related RPC operations while avoiding retries for reassignment mismatch scenarios.

* **Tests**
  * Expanded unit test coverage for retry and mismatch/error handling behavior.
  * Added an in-process integration test that verifies conversation completion through simulated transient backend failures, plus updated integration test configuration to use real services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->