### PR TITLE
Fix chat input multiline handling

### DIFF
--- a/experimental/ag-ui/front-end/src/App.css
+++ b/experimental/ag-ui/front-end/src/App.css
@@ -87,6 +87,25 @@ html, body {
   font-size: 1.1rem;
 }
 
+.sidebar-theme-control {
+  padding: 0 1rem 1rem;
+}
+
+.theme-toggle-button {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.theme-toggle-button:hover {
+  background-color: rgba(255, 255, 255, 0.18);
+}
+
 .main-content {
   flex: 1;
   min-width: 0;
@@ -1720,4 +1739,163 @@ servability Platform Styles */
     font-size: 0.75rem;
     margin-top: 0.375rem;
   }
+}
+
+
+/* Dark mode for the portal services and chat */
+.app.dark-mode {
+  color: #e5e7eb;
+  background-color: #0f172a;
+}
+
+.app.dark-mode .left-sidebar {
+  background-color: #020617;
+  border-right: 1px solid #1e293b;
+}
+
+.app.dark-mode .nav-item.active {
+  background-color: #1e293b;
+}
+
+.app.dark-mode .main-content,
+.app.dark-mode .observability-platform,
+.app.dark-mode .chat-assistant {
+  background-color: #0f172a;
+  color: #e5e7eb;
+}
+
+.app.dark-mode .platform-header {
+  background: linear-gradient(135deg, #111827 0%, #020617 100%);
+  border-bottom: 1px solid #1f2937;
+}
+
+.app.dark-mode .connection-status-bar,
+.app.dark-mode .query-section,
+.app.dark-mode .visualization-section,
+.app.dark-mode .chart-container,
+.app.dark-mode .logs-container,
+.app.dark-mode .trace-container,
+.app.dark-mode .chat-controls,
+.app.dark-mode .chat-input {
+  background-color: #111827;
+  color: #e5e7eb;
+  border-color: #1f2937;
+}
+
+.app.dark-mode .connection-label,
+.app.dark-mode .connection-url,
+.app.dark-mode .status-text,
+.app.dark-mode .section-header h2,
+.app.dark-mode .section-header p,
+.app.dark-mode label,
+.app.dark-mode .query-help,
+.app.dark-mode .query-info,
+.app.dark-mode .empty-state,
+.app.dark-mode .placeholder-text {
+  color: #d1d5db;
+}
+
+.app.dark-mode input,
+.app.dark-mode textarea,
+.app.dark-mode select {
+  background-color: #020617;
+  color: #e5e7eb;
+  border-color: #334155;
+}
+
+.app.dark-mode input:focus,
+.app.dark-mode textarea:focus,
+.app.dark-mode select:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
+}
+
+.app.dark-mode .assistant-message {
+  background: linear-gradient(to right, rgba(15, 23, 42, 0.95) 0%, rgba(20, 83, 45, 0.35) 100%);
+  color: #e5e7eb;
+  border-color: rgba(45, 212, 191, 0.25);
+}
+
+.app.dark-mode .user-message {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.92) 0%, rgba(30, 64, 175, 0.92) 100%);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.app.dark-mode .message-text code,
+.app.dark-mode .prompt-text code {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #f8fafc;
+}
+
+.app.dark-mode .assistant-message .message-text pre,
+.app.dark-mode .message-text pre {
+  background-color: rgba(2, 6, 23, 0.8);
+  border: 1px solid #1f2937;
+}
+
+.app.dark-mode .thinking-message {
+  background-color: #1f2937;
+  color: #d1d5db;
+}
+
+.app.dark-mode .auto-scroll-checkbox {
+  color: #d1d5db;
+}
+
+.app.dark-mode .chat-input textarea:disabled {
+  background-color: #1f2937;
+}
+
+.app.dark-mode .result-item,
+.app.dark-mode .result-header,
+.app.dark-mode .graph-modal,
+.app.dark-mode .indices-display,
+.app.dark-mode .metrics-display,
+.app.dark-mode .datasource-config,
+.app.dark-mode .config-card,
+.app.dark-mode .explorer-box,
+.app.dark-mode .series-explorer,
+.app.dark-mode .query-examples,
+.app.dark-mode .logs-table,
+.app.dark-mode .trace-details,
+.app.dark-mode .metric-card {
+  background-color: #111827;
+  color: #e5e7eb;
+  border-color: #1f2937;
+}
+
+.app.dark-mode .result-header,
+.app.dark-mode .explorer-header,
+.app.dark-mode .config-header,
+.app.dark-mode .metric-header {
+  background-color: #0b1220;
+  border-color: #1f2937;
+}
+
+.app.dark-mode .result-title,
+.app.dark-mode .metric-name,
+.app.dark-mode .index-name,
+.app.dark-mode .field-name,
+.app.dark-mode .config-title,
+.app.dark-mode .explorer-title,
+.app.dark-mode .query-label,
+.app.dark-mode .query-example {
+  color: #e5e7eb;
+}
+
+.app.dark-mode .result-meta,
+.app.dark-mode .metric-description,
+.app.dark-mode .index-meta,
+.app.dark-mode .field-type,
+.app.dark-mode .config-description,
+.app.dark-mode .help-text {
+  color: #94a3b8;
+}
+
+.app.dark-mode .badge,
+.app.dark-mode .tag,
+.app.dark-mode .chip {
+  background-color: #1e293b;
+  color: #dbeafe;
+  border-color: #334155;
 }

--- a/experimental/ag-ui/front-end/src/App.tsx
+++ b/experimental/ag-ui/front-end/src/App.tsx
@@ -15,6 +15,7 @@ const App: React.FC = () => {
   const [selectedPage, setSelectedPage] = useState<ObservabilityPage>('metrics');
   const [pageContext, setPageContext] = useState<ContextItem[]>([]);
   const [triggerQuery, setTriggerQuery] = useState<string | null>(null);
+  const [isDarkMode, setIsDarkMode] = useState(false);
 
   // Store separate queries for each page
   const [pageQueries, setPageQueries] = useState<Record<ObservabilityPage, string>>({
@@ -132,7 +133,7 @@ const App: React.FC = () => {
   };
 
   return (
-    <div className="app">
+    <div className={`app ${isDarkMode ? 'dark-mode' : ''}`}>
       <div className="left-sidebar">
         <div className="sidebar-header">
           <h2>ExampleOps ✨</h2>
@@ -161,6 +162,16 @@ const App: React.FC = () => {
             Traces
           </button>
         </nav>
+        <div className="sidebar-theme-control">
+          <button
+            type="button"
+            className="theme-toggle-button"
+            onClick={() => setIsDarkMode(prev => !prev)}
+            aria-pressed={isDarkMode}
+          >
+            {isDarkMode ? '☀️ Light mode' : '🌙 Dark mode'}
+          </button>
+        </div>
         <div className="sidebar-footer">
           <div className="credit-text">✨ vibe-coded with love by</div>
           <a

--- a/experimental/ag-ui/front-end/src/components/ChatAssistant.css
+++ b/experimental/ag-ui/front-end/src/components/ChatAssistant.css
@@ -1,3 +1,11 @@
+.chat-assistant {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.chat-assistant.large-font {
+  font-size: 1.08rem;
+}
+
 .chat-header {
   padding: 0.75rem 1rem;
   background-color: #009485;
@@ -87,6 +95,39 @@
 
 .message-text {
   margin-bottom: 0.25rem;
+}
+
+.prompt-message {
+  margin-bottom: 0.25rem;
+}
+
+.prompt-text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  font-family: inherit;
+  line-height: 1.45;
+}
+
+.prompt-text code,
+.markdown-message code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.prompt-collapse-button {
+  margin-top: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.18);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.prompt-collapse-button:hover {
+  background-color: rgba(255, 255, 255, 0.28);
 }
 
 /* Markdown styling within messages */
@@ -276,6 +317,25 @@
   background-color: rgba(255, 255, 255, 0.1);
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.chat-header-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.chat-toggle-button {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.chat-toggle-button:hover {
+  background-color: rgba(255, 255, 255, 0.25);
 }
 
 .connection-indicator {

--- a/experimental/ag-ui/front-end/src/components/ChatAssistant.css
+++ b/experimental/ag-ui/front-end/src/components/ChatAssistant.css
@@ -356,15 +356,20 @@
   border-top: 1px solid #e9ecef;
 }
 
-.chat-input input {
+.chat-input textarea {
   flex: 1;
+  min-height: 2.5rem;
+  max-height: 10rem;
   padding: 0.5rem;
   border: 1px solid #ddd;
   border-radius: 0.25rem;
   outline: none;
+  resize: vertical;
+  font: inherit;
+  line-height: 1.4;
 }
 
-.chat-input input:focus {
+.chat-input textarea:focus {
   border-color: #007bff;
 }
 
@@ -386,7 +391,7 @@
   cursor: not-allowed;
 }
 
-.chat-input input:disabled {
+.chat-input textarea:disabled {
   background-color: #f8f9fa;
   cursor: not-allowed;
 }

--- a/experimental/ag-ui/front-end/src/components/ChatAssistant.tsx
+++ b/experimental/ag-ui/front-end/src/components/ChatAssistant.tsx
@@ -839,13 +839,16 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
+      e.preventDefault();
       handleSendMessage();
       return;
     }
 
-    if (e.key === 'ArrowUp') {
+    const isSingleLinePrompt = !inputValue.includes('\n');
+
+    if (e.key === 'ArrowUp' && isSingleLinePrompt) {
       e.preventDefault();
       if (messageHistory.length === 0) return;
 
@@ -858,7 +861,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
       return;
     }
 
-    if (e.key === 'ArrowDown') {
+    if (e.key === 'ArrowDown' && isSingleLinePrompt) {
       e.preventDefault();
       if (historyIndex === -1) return;
 
@@ -966,8 +969,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
       </div>
 
       <div className="chat-input">
-        <input
-          type="text"
+        <textarea
           value={inputValue}
           onChange={(e) => {
             setInputValue(e.target.value);
@@ -979,6 +981,9 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
           onKeyDown={handleKeyDown}
           placeholder={isThinking ? "Holmes is thinking..." : "Type your message..."}
           disabled={isLoading || isThinking}
+          rows={3}
+          aria-label="Chat message"
+          enterKeyHint="enter"
         />
         <button
           onClick={() => handleSendMessage()}

--- a/experimental/ag-ui/front-end/src/components/ChatAssistant.tsx
+++ b/experimental/ag-ui/front-end/src/components/ChatAssistant.tsx
@@ -885,6 +885,10 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
       return;
     }
 
+    if (e.nativeEvent.isComposing) {
+      return;
+    }
+
     const isSingleLinePrompt = !inputValue.includes('\n');
 
     if (e.key === 'ArrowUp' && isSingleLinePrompt) {

--- a/experimental/ag-ui/front-end/src/components/ChatAssistant.tsx
+++ b/experimental/ag-ui/front-end/src/components/ChatAssistant.tsx
@@ -32,6 +32,44 @@ interface ChatAssistantProps {
   onExecutePPLQuery?: (query: string) => void;
 }
 
+
+const COLLAPSED_PROMPT_LINES = 8;
+const COLLAPSED_PROMPT_CHARS = 700;
+
+const renderInlineCode = (text: string): React.ReactNode[] => {
+  return text.split(/(`[^`]+`)/g).map((part, index) => {
+    if (part.startsWith('`') && part.endsWith('`') && part.length > 1) {
+      return <code key={index}>{part.slice(1, -1)}</code>;
+    }
+
+    return <React.Fragment key={index}>{part}</React.Fragment>;
+  });
+};
+
+const PromptMessage: React.FC<{ text: string }> = ({ text }) => {
+  const [expanded, setExpanded] = useState(false);
+  const lines = text.split('\n');
+  const shouldCollapse = lines.length > COLLAPSED_PROMPT_LINES || text.length > COLLAPSED_PROMPT_CHARS;
+  const visibleText = !shouldCollapse || expanded
+    ? text
+    : lines.slice(0, COLLAPSED_PROMPT_LINES).join('\n').slice(0, COLLAPSED_PROMPT_CHARS);
+
+  return (
+    <div className="prompt-message">
+      <pre className="prompt-text">{renderInlineCode(visibleText)}</pre>
+      {shouldCollapse && (
+        <button
+          type="button"
+          className="prompt-collapse-button"
+          onClick={() => setExpanded(prev => !prev)}
+        >
+          {expanded ? 'Show less' : `Show full prompt (${lines.length} lines)`}
+        </button>
+      )}
+    </div>
+  );
+};
+
 const TOOL_DEFINITIONS = [
   {
     name: 'graph_timeseries_data',
@@ -103,6 +141,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
   const [currentModel, setCurrentModel] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const [lastFailedMessage, setLastFailedMessage] = useState<string | null>(null);
+  const [useLargeFont, setUseLargeFont] = useState(false);
   const agentRef = useRef<HttpAgent | null>(null);
   const threadIdRef = useRef<string>('thread-' + Date.now());
   const currentMessageRef = useRef<string>('');
@@ -720,8 +759,8 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
   }, [isResizing]);
 
   const handleSendMessage = async (messageText?: string) => {
-    const textToSend = (messageText || inputValue).trim();
-    if (!textToSend || textToSend.length === 0 || !agentRef.current || isLoading) return;
+    const textToSend = messageText ?? inputValue;
+    if (!textToSend.trim() || !agentRef.current || isLoading) return;
 
     const userMessage: ChatMessage = {
       id: 'user-' + Date.now(),
@@ -753,10 +792,10 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
 
         // Add the user message to the agent's message history
         if (agentRef.current && userMessage.text && userMessage.text.trim()) {
-          const messageContent = userMessage.text.trim();
+          const messageContent = userMessage.text;
 
           // Double-check content is not empty before adding to agent
-          if (messageContent.length === 0) {
+          if (messageContent.trim().length === 0) {
             throw new Error('Cannot send empty message');
           }
 
@@ -880,7 +919,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
   return (
     <div
       ref={chatAssistantRef}
-      className="chat-assistant"
+      className={`chat-assistant ${useLargeFont ? 'large-font' : ''}`}
       style={{ width: `${width}px` }}
     >
       <div
@@ -902,6 +941,16 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
               {connectionStatus === 'error' && 'Connection Error'}
             </span>
           </div>
+        </div>
+        <div className="chat-header-controls">
+          <button
+            type="button"
+            className="chat-toggle-button"
+            onClick={() => setUseLargeFont(prev => !prev)}
+            aria-pressed={useLargeFont}
+          >
+            {useLargeFont ? 'Normal text' : 'Large text'}
+          </button>
         </div>
         {connectionStatus === 'connected' && currentModel && (
           <div className="model-info">
@@ -932,8 +981,10 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({ pageContext = [], onExecu
                   </button>
                 )}
               </div>
+            ) : message.sender === 'user' ? (
+              <PromptMessage text={message.text || ''} />
             ) : (
-              <div className="message-text">
+              <div className="message-text markdown-message">
                 <ReactMarkdown>{message.text || ''}</ReactMarkdown>
               </div>
             )}


### PR DESCRIPTION
## Summary
- replace the HolmesGPT chat text input with a multiline textarea
- make plain Enter insert a newline instead of submitting, including responsive/mobile keyboards
- keep keyboard submit available via Cmd/Ctrl+Enter and preserve history navigation for single-line prompts
- preserve submitted prompt formatting in the chat transcript, including line breaks and inline `code` styling, with long prompts collapsible
- add a chat font-size toggle for more readable output
- add a dark mode toggle that applies across the portal services and chat UI

## Verification
- `git diff --check`
- `CI=false yarn build` (passes; existing ESLint warnings remain)
- `CI=true yarn build` previously failed because pre-existing warnings are treated as errors: hook dependency and unused variable warnings in ChatAssistant/MainContent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat input now supports multiline prompts using a textarea.
  * Send is triggered by **Ctrl+Enter** (**Cmd+Enter** on Mac) instead of plain Enter.
  * Message history navigation with arrow keys is limited to single-line prompts.
  * Prompts can auto-collapse when long, with a toggle to expand/collapse.
  * Added **Large text** and **Dark mode** toggles.

* **UI Improvements**
  * Updated prompt/chat styling (including code formatting), header controls, and hover/disabled behavior.
  * Improved markdown rendering in assistant messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->