### PR TITLE
ROB-4017: Harden Supabase DAL connection (HTTP/1.1, CA bundle, RemoteProtocolError retry)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ For the complete eval CLI reference (flags, env vars, model comparison, debuggin
 - Type hints required (mypy configuration in pyproject.toml)
 - Pre-commit hooks enforce quality checks in CI
 - **ALWAYS place Python imports at the top of the file**, not inside functions or methods
+- **Use `tenacity` for retries**, not hand-rolled retry loops — the `@retry(...)` decorator normally, or the `Retrying(...)` iterator form when the attempt budget/params must come from per-instance or dynamic values. Only hand-roll a retry when there's a real reason to, and document why.
 - **NEVER run `pre-commit`, `ruff`, or `mypy` unless the user explicitly asks you to**. These tools are triggered by commit hooks which are not installed on all machines, and running them causes widespread formatting/type changes to files unrelated to your task. Only lint/format files you are actively editing, and only if asked.
 
 **Documentation Examples**:

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -4,12 +4,14 @@ import gzip
 import json
 import logging
 import os
+import ssl
 import threading
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from uuid import uuid4
 
+import httpx
 import sentry_sdk
 import yaml  # type: ignore
 from cachetools import TTLCache  # type: ignore
@@ -22,6 +24,7 @@ from pydantic import BaseModel
 from supabase import create_client
 from supabase.lib.client_options import SyncClientOptions as ClientOptions
 from tenacity import (
+    RetryCallState,
     retry,
     retry_if_exception_type,
     retry_if_not_exception_type,
@@ -163,6 +166,61 @@ class SupabaseConnectionException(Exception):
         )
 
 
+_DISCONNECT_RETRY_ATTEMPTS = 3
+
+
+def _log_remote_protocol_retry(retry_state: RetryCallState) -> None:
+    """Log each RemoteProtocolError retry. ``handle_request`` is decorated, so its
+    request is the second positional arg (``self`` is the first)."""
+    request = retry_state.args[1] if len(retry_state.args) > 1 else None
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    logging.warning(
+        "Supabase request %s %s hit RemoteProtocolError (%s); "
+        "retrying on a fresh connection (attempt %d/%d)",
+        getattr(request, "method", "?"),
+        getattr(request, "url", "?"),
+        exc,
+        retry_state.attempt_number,
+        _DISCONNECT_RETRY_ATTEMPTS,
+    )
+
+
+class SupabaseRetryTransport(httpx.HTTPTransport):
+    """HTTP/1.1 transport that retries transient ``RemoteProtocolError``s.
+
+    Two problems are fixed at this transport, so every Supabase sub-client
+    (postgrest, auth/gotrue, storage, realtime) is hardened uniformly rather
+    than just postgrest table queries:
+
+    1. ``http2=False`` — httpcore's *sync* HTTP/2 connection is not thread-safe,
+       and one ``SupabaseDal`` client is shared across the conversation worker,
+       realtime callbacks and request threads. HTTP/1.1 gives each concurrent
+       request its own pooled, thread-safe connection.
+    2. Retry on ``RemoteProtocolError`` — even on HTTP/1.1, Supabase's edge
+       (Cloudflare / Kong / load balancer) closes idle keep-alive connections
+       server-side. A pooled connection the edge has already closed gets reused
+       and the next request fails with ``RemoteProtocolError: Server
+       disconnected without sending a response`` *before* it reaches Supabase.
+       The request was never processed, so retrying it on a fresh connection is
+       safe (postgrest/auth/storage bodies are buffered bytes, hence replayable).
+
+    This is the hardening Supabase support recommended (mirrors relay#573 /
+    ROB-4012; see ROB-4017).
+    """
+
+    # No backoff (no wait): a reaped keep-alive socket just needs a fresh
+    # connection, not a delay (see the class docstring for why retrying is safe).
+    # The budget is a fixed constant, so the @retry decorator suffices.
+    @retry(
+        retry=retry_if_exception_type(httpx.RemoteProtocolError),
+        stop=stop_after_attempt(_DISCONNECT_RETRY_ATTEMPTS),
+        reraise=True,
+        before_sleep=_log_remote_protocol_retry,
+    )
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return super().handle_request(request)
+
+
 class SupabaseDal:
     def __init__(self, cluster: str):
         self.enabled = self.__init_config()
@@ -175,7 +233,38 @@ class SupabaseDal:
         logging.info(
             f"Initializing Robusta platform connection for account {self.account_id}"
         )
-        options = ClientOptions(postgrest_client_timeout=SUPABASE_TIMEOUT_SECONDS)
+        # Build the client on SupabaseRetryTransport (HTTP/1.1 + RemoteProtocolError
+        # retry — see its docstring) and hand it to postgrest so postgrest doesn't
+        # build its own HTTP/2 client.
+        #
+        # Honor the environment's CA bundle (corporate / TLS-proxy CA in
+        # SSL_CERT_FILE / REQUESTS_CA_BUNDLE) the way supabase's default client does;
+        # our own client otherwise falls back to certifi and breaks TLS verification
+        # behind an intercepting proxy. Pass an SSLContext, not the path string
+        # (httpx deprecated `verify=<str>`), honoring a CA file or directory.
+        ca_bundle = os.environ.get("SSL_CERT_FILE") or os.environ.get(
+            "REQUESTS_CA_BUNDLE"
+        )
+        verify: "ssl.SSLContext | bool"
+        if not ca_bundle:
+            verify = True
+        elif os.path.isdir(ca_bundle):
+            verify = ssl.create_default_context(capath=ca_bundle)
+        else:
+            verify = ssl.create_default_context(cafile=ca_bundle)
+        # verify/http2 go on the transport (httpx ignores them on the client once a
+        # custom transport is supplied); timeout/follow_redirects stay on the client
+        # (supabase ignores postgrest_client_timeout once an httpx_client is given).
+        transport = SupabaseRetryTransport(http2=False, verify=verify)
+        httpx_client = httpx.Client(
+            transport=transport,
+            timeout=SUPABASE_TIMEOUT_SECONDS,
+            follow_redirects=True,
+        )
+        options = ClientOptions(
+            postgrest_client_timeout=SUPABASE_TIMEOUT_SECONDS,
+            httpx_client=httpx_client,
+        )
         sentry_sdk.set_tag("db_url", self.url)
         self.client = create_client(self.url, self.api_key, options)  # type: ignore
         self.user_id = self.sign_in()

--- a/tests/core/test_supabase_dal_retry.py
+++ b/tests/core/test_supabase_dal_retry.py
@@ -1,0 +1,70 @@
+"""ROB-4017: pin ``SupabaseRetryTransport``'s retry contract.
+
+Deterministically drive ``SupabaseRetryTransport.handle_request`` (with the base
+transport's ``handle_request`` patched to raise/return on demand) to verify it
+retries ``RemoteProtocolError`` on a fresh connection, stops after the fixed
+attempt budget, reraises the original exception, and does not retry other errors.
+See ``SupabaseRetryTransport`` for why this retry is needed and safe.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from holmes.core.supabase_dal import _DISCONNECT_RETRY_ATTEMPTS, SupabaseRetryTransport
+
+
+def _server_disconnected() -> httpx.RemoteProtocolError:
+    return httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("GET", "https://example.supabase.co/rest/v1/Issues")
+
+
+def test_transport_retries_on_remote_protocol_error_then_succeeds(monkeypatch):
+    transport = SupabaseRetryTransport()
+    response = MagicMock(name="response")
+    calls = {"n": 0}
+
+    def base_handle(_self, _request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _server_disconnected()
+        return response
+
+    monkeypatch.setattr(httpx.HTTPTransport, "handle_request", base_handle)
+
+    assert transport.handle_request(_request()) is response
+    assert calls["n"] == 2  # failed once, retried once, succeeded
+
+
+def test_transport_reraises_after_exhausting_retries(monkeypatch):
+    transport = SupabaseRetryTransport()
+    calls = {"n": 0}
+
+    def always_disconnect(_self, _request):
+        calls["n"] += 1
+        raise _server_disconnected()
+
+    monkeypatch.setattr(httpx.HTTPTransport, "handle_request", always_disconnect)
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        transport.handle_request(_request())
+    assert calls["n"] == _DISCONNECT_RETRY_ATTEMPTS  # exhausts the full budget
+
+
+def test_transport_does_not_retry_other_errors(monkeypatch):
+    transport = SupabaseRetryTransport()
+    calls = {"n": 0}
+
+    def base_handle(_self, _request):
+        calls["n"] += 1
+        raise httpx.ConnectTimeout("connect timed out")
+
+    monkeypatch.setattr(httpx.HTTPTransport, "handle_request", base_handle)
+
+    with pytest.raises(httpx.ConnectTimeout):
+        transport.handle_request(_request())
+    assert calls["n"] == 1  # not a RemoteProtocolError -> no retry

--- a/tests/core/test_supabase_dal_transport.py
+++ b/tests/core/test_supabase_dal_transport.py
@@ -1,0 +1,159 @@
+"""ROB-4017: pin the wiring that hands postgrest a thread-safe HTTP/1.1 client.
+
+SupabaseDal must build its httpx client on ``SupabaseRetryTransport`` and pass it
+to postgrest via ``ClientOptions(httpx_client=...)`` so postgrest doesn't build
+its own HTTP/2 client (see ``SupabaseRetryTransport`` for why). Because a custom
+transport is supplied, ``http2``/``verify`` live on the transport while
+``timeout``/``follow_redirects`` stay on the client.
+
+Deterministic (no network); retry behaviour is covered in
+``test_supabase_dal_retry.py``.
+"""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.core.supabase_dal import SUPABASE_TIMEOUT_SECONDS, SupabaseDal
+
+
+def _ui_token() -> str:
+    bundle = {
+        "store_url": "https://example.supabase.co",
+        "api_key": "anon-key",
+        "account_id": "acc-1",
+        "email": "svc@example.com",
+        "password": "pw",
+    }
+    return base64.b64encode(json.dumps(bundle).encode()).decode()
+
+
+def _build_dal(monkeypatch, ca_env=None):
+    """Construct a SupabaseDal with network mocked, capturing the kwargs passed
+    to ``SupabaseRetryTransport`` and ``httpx.Client``, the
+    ``ssl.create_default_context`` call (if any), and the ``ClientOptions``
+    handed to ``create_client``."""
+    monkeypatch.setenv("ROBUSTA_UI_TOKEN", _ui_token())
+    # Start from a clean CA-env slate; the test harness/sandbox may set these.
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    for k, v in (ca_env or {}).items():
+        monkeypatch.setenv(k, v)
+
+    captured: dict = {}
+    ssl_ctx_sentinel = MagicMock(name="ssl_context")
+    transport_sentinel = MagicMock(name="transport")
+
+    def fake_transport(*args, **kwargs):
+        captured["transport_kwargs"] = kwargs
+        return transport_sentinel
+
+    def fake_httpx_client(*args, **kwargs):
+        captured["httpx_kwargs"] = kwargs
+        client = MagicMock(name="httpx_client")
+        captured["created_client"] = client
+        return client
+
+    def fake_create_default_context(*args, **kwargs):
+        captured["ssl_ctx_kwargs"] = kwargs
+        return ssl_ctx_sentinel
+
+    with (
+        patch(
+            "holmes.core.supabase_dal.SupabaseRetryTransport",
+            side_effect=fake_transport,
+        ),
+        patch(
+            "holmes.core.supabase_dal.httpx.Client", side_effect=fake_httpx_client
+        ),
+        patch(
+            "holmes.core.supabase_dal.ssl.create_default_context",
+            side_effect=fake_create_default_context,
+        ),
+        patch("holmes.core.supabase_dal.create_client") as mock_create,
+        patch.object(SupabaseDal, "sign_in", return_value="user-1"),
+        patch.object(SupabaseDal, "patch_postgrest_execute"),
+    ):
+        dal = SupabaseDal(cluster="test-cluster")
+        # create_client(self.url, self.api_key, options) -> options is args[2]
+        captured["options"] = mock_create.call_args.args[2]
+    captured["ssl_ctx_sentinel"] = ssl_ctx_sentinel
+    captured["transport_sentinel"] = transport_sentinel
+    return dal, captured
+
+
+def test_dal_disables_http2_on_the_transport(monkeypatch):
+    dal, cap = _build_dal(monkeypatch)
+    assert dal.enabled is True
+    # http2 is disabled on the transport (httpx ignores http2 on the client when
+    # a custom transport is supplied).
+    assert cap["transport_kwargs"]["http2"] is False
+    # timeout + redirect handling stay on the client.
+    assert cap["httpx_kwargs"]["follow_redirects"] is True
+    assert cap["httpx_kwargs"]["timeout"] == SUPABASE_TIMEOUT_SECONDS
+
+
+def test_dal_client_uses_our_transport_and_forwards_client_to_postgrest(monkeypatch):
+    # The client must be built on our SupabaseRetryTransport, and that exact
+    # client must be handed to postgrest via ClientOptions so postgrest reuses it
+    # instead of building its own http2=True client. Compare against the
+    # instances the fakes actually created (not values read back from options,
+    # which would be tautological).
+    _, cap = _build_dal(monkeypatch)
+    assert cap["httpx_kwargs"]["transport"] is cap["transport_sentinel"]
+    assert cap["created_client"] is not None
+    assert cap["options"].httpx_client is cap["created_client"]
+
+
+def test_dal_verify_defaults_to_true_without_ca_env(monkeypatch):
+    _, cap = _build_dal(monkeypatch)
+    # No CA env -> verify=True on the transport and no SSLContext is built.
+    assert cap["transport_kwargs"]["verify"] is True
+    assert "ssl_ctx_kwargs" not in cap
+
+
+def test_dal_builds_sslcontext_not_string_for_verify(monkeypatch):
+    # Forward-compatible with httpx: verify must be an SSLContext, never a path
+    # string (httpx deprecated `verify=<str>`).
+    _, cap = _build_dal(monkeypatch, ca_env={"SSL_CERT_FILE": "/etc/ssl/custom-ca.pem"})
+    assert cap["transport_kwargs"]["verify"] is cap["ssl_ctx_sentinel"]
+    assert not isinstance(cap["transport_kwargs"]["verify"], str)
+
+
+def test_dal_honors_ssl_cert_file_as_cafile(monkeypatch):
+    _, cap = _build_dal(monkeypatch, ca_env={"SSL_CERT_FILE": "/etc/ssl/custom-ca.pem"})
+    assert cap["ssl_ctx_kwargs"] == {"cafile": "/etc/ssl/custom-ca.pem"}
+
+
+def test_dal_honors_requests_ca_bundle_as_cafile(monkeypatch):
+    _, cap = _build_dal(
+        monkeypatch, ca_env={"REQUESTS_CA_BUNDLE": "/etc/ssl/proxy-ca.pem"}
+    )
+    assert cap["ssl_ctx_kwargs"] == {"cafile": "/etc/ssl/proxy-ca.pem"}
+
+
+def test_dal_ssl_cert_file_takes_precedence_over_requests_ca_bundle(monkeypatch):
+    # Mirrors the code: SSL_CERT_FILE is checked before REQUESTS_CA_BUNDLE.
+    _, cap = _build_dal(
+        monkeypatch,
+        ca_env={
+            "SSL_CERT_FILE": "/etc/ssl/custom-ca.pem",
+            "REQUESTS_CA_BUNDLE": "/etc/ssl/proxy-ca.pem",
+        },
+    )
+    assert cap["ssl_ctx_kwargs"] == {"cafile": "/etc/ssl/custom-ca.pem"}
+
+
+def test_dal_uses_capath_when_bundle_is_a_directory(monkeypatch, tmp_path):
+    # A CA *directory* must be passed as capath, not cafile.
+    _, cap = _build_dal(monkeypatch, ca_env={"SSL_CERT_FILE": str(tmp_path)})
+    assert cap["ssl_ctx_kwargs"] == {"capath": str(tmp_path)}
+
+
+@pytest.mark.parametrize("ca_env", [None, {"SSL_CERT_FILE": "/etc/ssl/custom-ca.pem"}])
+def test_dal_always_disables_http2_regardless_of_ca(monkeypatch, ca_env):
+    # http2 must stay disabled no matter the CA configuration.
+    _, cap = _build_dal(monkeypatch, ca_env=ca_env)
+    assert cap["transport_kwargs"]["http2"] is False


### PR DESCRIPTION
## Summary (ROB-4017)

Hardens the Supabase DAL client against intermittent connection failures (dropped `HolmesStatus` upserts, dropped conversation claims) caused by a shared client under concurrency and by Supabase's edge closing idle keep-alive connections.

This is a **single PR** consolidating what were two stacked branches for the same ticket — the base client-wiring and the `RemoteProtocolError` retry follow-on. It now targets `master` directly and supersedes #2122 (which can be closed).

## Changes

- **Force HTTP/1.1** for the Supabase client. httpcore's *sync* HTTP/2 connection isn't thread-safe, and one `SupabaseDal` client is shared across the conversation worker, realtime callbacks and request threads — under concurrency the HTTP/2 framing corrupts and calls fail with `RemoteProtocolError: Server disconnected`.
- **Honor the environment CA bundle** (`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`) via an explicit `SSLContext`, rather than letting our own httpx client fall back to certifi (which breaks TLS verification behind an intercepting proxy). Passes an `SSLContext`, not a path string, since httpx has deprecated `verify=<str>`.
- **Retry `RemoteProtocolError` at the transport** (`SupabaseRetryTransport`, an `httpx.HTTPTransport` subclass using tenacity's `@retry`). Even on HTTP/1.1, Supabase's edge closes idle keep-alives, so a reused connection fails with "Server disconnected" *before* the request reaches Supabase — safe to replay on a fresh connection. Hardening at the transport covers every sub-client (postgrest, auth, storage, realtime) uniformly, with no backoff (a reaped socket just needs a fresh connection).
- **`CLAUDE.md`**: documents the convention to prefer `tenacity` for retries over hand-rolled loops.

## Tests

Deterministic, no network: `test_supabase_dal_retry.py` pins the retry contract (retry-then-succeed, budget exhaustion, non-retryable passthrough); `test_supabase_dal_transport.py` pins the client wiring (transport built, `http2` off, `verify` as `SSLContext`, client forwarded to postgrest).

Mirrors the relay-side fix (ROB-4012).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015thi2RsgXWp8BzuDCfxNzG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Supabase connectivity by retrying transient remote-protocol disconnects (with retry attempt logging) while avoiding retries for non-transient failures.
  * Unified HTTP client and TLS certificate verification behavior across the data layer.
* **Tests**
  * Added coverage for retry success, retry exhaustion, and immediate failure for non-retriable errors.
  * Expanded tests to confirm correct transport and TLS configuration.
* **Documentation**
  * Updated contribution guidance to prefer tenacity-based retries over custom retry loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->