### PR TITLE
helm: make GitHub MCP health_check_tool configurable per auth type

### DIFF
--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -102,11 +102,20 @@ data:
     {{- end }}
     {{- if .Values.mcpAddons.github.enabled }}
     {{- if .Values.mcpAddons.github.auth.githubApp.secretName }}
+    {{- /*
+      GitHub App installation tokens cannot call GET /user (403 "Resource not accessible
+      by integration"). health_check_tool defaults to "" for App auth so the check is
+      auto-skipped; set mcpAddons.github.healthCheckTool to override.
+    */}}
+    {{- $hct := "" }}
+    {{- if hasKey .Values.mcpAddons.github "healthCheckTool" }}
+    {{-   $hct = .Values.mcpAddons.github.healthCheckTool }}
+    {{- end }}
     {{- $githubConfig := dict
         "url" (printf "http://%s-github-mcp-server.%s.svc.cluster.local:8000/mcp" .Release.Name .Release.Namespace)
         "mode" "streamable-http"
         "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/github.svg"
-        "health_check_tool" "get_me"
+        "health_check_tool" $hct
     }}
     {{- $githubMcpServers := dict "github" (dict
         "description" "GitHub MCP Server - access repositories, pull requests, issues, and GitHub Actions. Debug CI failures, search code, and delegate tasks to Copilot."
@@ -116,11 +125,15 @@ data:
     }}
     {{- $mcpServers = merge $mcpServers $githubMcpServers }}
     {{- else }}
+    {{- $hct := "get_me" }}
+    {{- if hasKey .Values.mcpAddons.github "healthCheckTool" }}
+    {{-   $hct = .Values.mcpAddons.github.healthCheckTool }}
+    {{- end }}
     {{- $githubConfig := dict
         "url" (printf "http://%s-github-mcp-server.%s.svc.cluster.local:8000/sse" .Release.Name .Release.Namespace)
         "mode" "sse"
         "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/github.svg"
-        "health_check_tool" "get_me"
+        "health_check_tool" $hct
     }}
     {{- $githubMcpServers := dict "github" (dict
         "description" "GitHub MCP Server - access repositories, pull requests, issues, and GitHub Actions. Debug CI failures, search code, and delegate tasks to Copilot."

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -503,6 +503,13 @@ mcpAddons:
     # Custom LLM instructions (optional) - leave empty to use default
     llmInstructions: ""
 
+    # Health-check tool used by Holmes to verify the GitHub token is valid at startup.
+    # PAT auth default: "get_me" (calls GET /user — works with personal access tokens).
+    # GitHub App auth default: "" (no health check — App installation tokens cannot call
+    # GET /user and would always return 403 "Resource not accessible by integration").
+    # Set to any tool name exposed by the GitHub MCP server to override the default.
+    # healthCheckTool: ""
+
     nodeSelector: {}
     tolerations: []
     affinity: {}

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -965,12 +965,15 @@ class RemoteMCPToolset(Toolset):
             # Invoke a read-only tool to verify authentication actually works.
             # MCP servers (e.g. GitHub) often return their tool list even with
             # invalid credentials, so listing tools alone doesn't prove auth.
-            # Use the explicitly-configured tool if set, otherwise auto-detect a
-            # well-known read-only identity tool from the loaded tools.
-            health_check_tool_name = (
-                self._mcp_config.health_check_tool
-                or self._auto_detect_health_check_tool()
-            )
+            # - health_check_tool not set (None): auto-detect a well-known
+            #   read-only identity tool from the loaded tool list.
+            # - health_check_tool set to "": explicitly disable the check
+            #   (e.g. GitHub App installation tokens cannot call GET /user).
+            # - health_check_tool set to a name: call that specific tool.
+            if self._mcp_config.health_check_tool is None:
+                health_check_tool_name = self._auto_detect_health_check_tool()
+            else:
+                health_check_tool_name = self._mcp_config.health_check_tool
             if health_check_tool_name:
                 health_check_result = self._run_health_check_tool(health_check_tool_name)
                 if not health_check_result[0]:


### PR DESCRIPTION
Fixes #2205

## Changes

- **GitHub App auth**: `health_check_tool` defaults to `""` (health check skipped — App tokens cannot call `GET /user`)
- **PAT auth**: `health_check_tool` defaults to `"get_me"` (no change in behaviour)
- **Both**: new `mcpAddons.github.healthCheckTool` values field to override the default

## Why

`get_me` calls `GET /user`, which requires a user-level OAuth token. GitHub App installation tokens always return `403 Resource not accessible by integration` for this endpoint. This causes the `github` toolset to be permanently marked as failed and all GitHub tools become unavailable to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an override for the GitHub MCP health check tool, with authentication-aware defaults when using a GitHub App versus other authentication methods.
* **Bug Fixes**
  * Improved health check selection logic: `null` now triggers auto-detection, while an empty value cleanly disables the health/auth check; non-empty values directly select the tool.
* **Documentation**
  * Added inline explanations in Helm values and templates describing the default behavior and how to override the health check tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->