### PR TITLE
OAuth MCP: delete expired token row on 401 so users can re-auth

### DIFF
--- a/holmes/core/tools_utils/oauth_tool_connector.py
+++ b/holmes/core/tools_utils/oauth_tool_connector.py
@@ -311,5 +311,5 @@ class OAuthToolConnector:
         with self._lock:
             self._user_tools.get(user_id, {}).pop(toolset.name, None)
             user_map = self._user_tool_to_toolset.get(user_id, {})
-            for tool_name in [n for n, ts in user_map.items() if ts is toolset]:
+            for tool_name in [n for n, ts in user_map.items() if ts.name == toolset.name]:
                 user_map.pop(tool_name, None)

--- a/holmes/core/tools_utils/oauth_tool_connector.py
+++ b/holmes/core/tools_utils/oauth_tool_connector.py
@@ -19,7 +19,6 @@ from holmes.core.oauth_config import (
 )
 from holmes.core.oauth_utils import _get_token_manager
 from holmes.core.tools import Tool
-from holmes.plugins.toolsets.mcp.oauth_token_store import DiskTokenStore
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +125,7 @@ class OAuthToolConnector:
                     user_id, toolset.name,
                 )
                 self._evict_expired_token(user_id, toolset)
+                self._clear_user_tools(user_id, toolset)
             else:
                 logger.warning(
                     "Failed to load OAuth tools for user %s on toolset %s: %s",
@@ -284,18 +284,32 @@ class OAuthToolConnector:
 
     @staticmethod
     def _evict_expired_token(user_id: str, toolset: Any) -> None:
-        """Remove an expired/revoked token from cache and disk (CLI only).
+        """Remove an expired/revoked token from cache and the backing store.
 
-        Only deletes from DiskTokenStore — DalTokenStore is shared across
-        clusters, so another cluster may have already refreshed the token.
+        Evicts the in-memory cache and deletes the persisted row so the
+        frontend stops showing "Failed" and the user sees a fresh "Login"
+        action. By the time we get here, the background refresh loop has
+        already failed to refresh — the stored token is genuinely dead.
         """
         try:
             mgr = _get_token_manager()
             oauth_config = toolset._mcp_config.oauth
             cache_key = mgr._get_cache_key(oauth_config, {"user_id": user_id})
             mgr._cache.evict(cache_key)
-            if isinstance(mgr._store, DiskTokenStore):
-                provider_name = oauth_config.authorization_url or "unknown"
-                mgr._store.delete_token(provider_name, user_id=user_id)
+            provider_name = oauth_config.authorization_url or "unknown"
+            mgr._store.delete_token(provider_name, user_id=user_id)
         except Exception:
             logger.debug("Failed to evict expired token for user %s", user_id, exc_info=True)
+
+    def _clear_user_tools(self, user_id: str, toolset: Any) -> None:
+        """Drop stale per-user tools for this toolset after a 401.
+
+        Without this, apply_user_tools keeps substituting dead tools for the
+        _connect placeholder, so the LLM keeps calling them and the user
+        never gets back to a recoverable state.
+        """
+        with self._lock:
+            self._user_tools.get(user_id, {}).pop(toolset.name, None)
+            user_map = self._user_tool_to_toolset.get(user_id, {})
+            for tool_name in [n for n, ts in user_map.items() if ts is toolset]:
+                user_map.pop(tool_name, None)

--- a/tests/core/tools_utils/test_oauth_tool_connector_eviction.py
+++ b/tests/core/tools_utils/test_oauth_tool_connector_eviction.py
@@ -87,3 +87,29 @@ def test_401_clears_stale_user_tools(patched_manager):
     assert "k8s_list_pods" not in connector._user_tool_to_toolset.get("u1", {}), (
         "stale tool->toolset mapping should be cleared on 401"
     )
+
+
+def test_401_clears_mapping_when_stored_under_different_instance(patched_manager):
+    """Fix #3: _user_tool_to_toolset is purged by toolset name, not object identity.
+
+    Toolsets get reloaded as new instances during config refresh; a stale entry
+    stored under the old instance must still be evicted on 401 against a
+    same-named new instance.
+    """
+    patched_manager._store = MagicMock(spec=DalTokenStore)
+    connector = OAuthToolConnector()
+
+    old_toolset = _make_toolset()
+    stale_tool = MagicMock()
+    stale_tool.name = "k8s_list_pods"
+    stale_tool.toolset = old_toolset
+    connector.store_user_tools("u1", "k8s", [stale_tool])
+
+    new_toolset = _make_toolset()
+    assert new_toolset is not old_toolset
+
+    connector.load_tools_for_user("u1", new_toolset, {"user_id": "u1"})
+
+    assert "k8s_list_pods" not in connector._user_tool_to_toolset.get("u1", {}), (
+        "mapping under old instance should still be evicted via name match"
+    )

--- a/tests/core/tools_utils/test_oauth_tool_connector_eviction.py
+++ b/tests/core/tools_utils/test_oauth_tool_connector_eviction.py
@@ -1,0 +1,89 @@
+"""Red→green tests for the OAuth expiry recovery fix.
+
+Before the fix:
+  - DalTokenStore.delete_token is NOT called (gated behind isinstance(DiskTokenStore))
+  - _user_tools still holds stale tools after a 401, so the _connect placeholder
+    never gets re-exposed and the LLM keeps calling dead tools.
+
+After the fix:
+  - delete_token is called for BOTH store types.
+  - _user_tools[user_id][toolset.name] is cleared, so apply_user_tools falls
+    through to the placeholder.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from holmes.core.tools_utils.oauth_tool_connector import OAuthToolConnector
+from holmes.plugins.toolsets.mcp.oauth_token_store import DalTokenStore, DiskTokenStore
+
+
+def _raise_401(_ctx=None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 401
+    raise httpx.HTTPStatusError("401 Unauthorized", request=MagicMock(), response=resp)
+
+
+def _make_toolset(name="k8s"):
+    ts = MagicMock()
+    ts.name = name
+    ts._load_remote_tools.side_effect = _raise_401
+    ts._mcp_config.oauth.authorization_url = "https://auth.example/authorize"
+    ts._mcp_config.oauth.client_id = "cid"
+    ts._mcp_config.oauth.token_url = "https://auth.example/token"
+    return ts
+
+
+@pytest.fixture
+def patched_manager(monkeypatch):
+    """A fake token manager wired into the connector module."""
+    mgr = MagicMock()
+    mgr._get_cache_key.return_value = "ck"
+    monkeypatch.setattr(
+        "holmes.core.tools_utils.oauth_tool_connector._get_token_manager",
+        lambda: mgr,
+    )
+    return mgr
+
+
+@pytest.mark.parametrize("store_cls", [DalTokenStore, DiskTokenStore])
+def test_401_deletes_token_in_both_stores(patched_manager, store_cls):
+    """Fix #1: delete_token must run for DalTokenStore too, not only DiskTokenStore."""
+    store = MagicMock(spec=store_cls)
+    patched_manager._store = store
+
+    connector = OAuthToolConnector()
+    toolset = _make_toolset()
+
+    out = connector.load_tools_for_user("u1", toolset, {"user_id": "u1"})
+
+    assert out == []
+    patched_manager._cache.evict.assert_called_once_with("ck")
+    store.delete_token.assert_called_once_with(
+        "https://auth.example/authorize", user_id="u1"
+    )
+
+
+def test_401_clears_stale_user_tools(patched_manager):
+    """Fix #2: after 401, _user_tools must be cleared so the _connect placeholder
+    is re-exposed and the LLM stops calling dead tools."""
+    patched_manager._store = MagicMock(spec=DalTokenStore)
+
+    connector = OAuthToolConnector()
+    toolset = _make_toolset()
+    stale_tool = MagicMock(); stale_tool.name = "k8s_list_pods"; stale_tool.toolset = toolset
+    connector.store_user_tools("u1", "k8s", [stale_tool])
+
+    assert connector._user_tools["u1"]["k8s"] == [stale_tool]
+    assert connector._user_tool_to_toolset["u1"]["k8s_list_pods"] is toolset
+
+    connector.load_tools_for_user("u1", toolset, {"user_id": "u1"})
+
+    assert "k8s" not in connector._user_tools.get("u1", {}), (
+        "stale tools should be cleared from _user_tools on 401"
+    )
+    assert "k8s_list_pods" not in connector._user_tool_to_toolset.get("u1", {}), (
+        "stale tool->toolset mapping should be cleared on 401"
+    )


### PR DESCRIPTION
## Summary

- Fix `OAuthToolConnector._evict_expired_token`: was gated to `DiskTokenStore` (CLI only). In server mode (`DalTokenStore`), the expired Supabase row was never deleted → frontend kept rendering "Failed" with no clickable recovery path → user stuck.
- Clear stale `_user_tools[user][toolset]` on the same 401 branch. Without this, `apply_user_tools` keeps substituting the now-dead tool list for the `_connect` placeholder, so the LLM keeps calling dead tools.

The old "another cluster may have refreshed in parallel" justification for the DAL gate doesn't survive scrutiny: by the time a 401 reaches `_evict_expired_token`, the background refresh loop has already failed against this stored token. The row is genuinely dead.

## Test plan

- [x] New unit tests in `tests/core/tools_utils/test_oauth_tool_connector_eviction.py` — red on master, green with the fix:
  - `test_401_deletes_token_in_both_stores[DalTokenStore]` — confirms `delete_token` is now called for the DAL store
  - `test_401_deletes_token_in_both_stores[DiskTokenStore]` — confirms disk-store behaviour is preserved
  - `test_401_clears_stale_user_tools` — confirms `_user_tools` cleanup
- [x] Live verified on a real cluster against Atlassian's hosted MCP (`https://mcp.atlassian.com/v1/mcp`): forced expiry via Supabase, rolled patched image → eviction path fires → row deleted → FE flips "Failed" → "Login" → re-auth → 31 Atlassian tools rediscover → recovery loop closed.
- [x] All 121 adjacent OAuth tests still pass (`tests/test_mcp_oauth.py tests/core/tools_utils/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication error handling for 401/403 failures by clearing expired tokens and removing any stale, per-user tools associated with the affected toolset. This prevents the app from substituting dead tools after an auth error, allowing the UI to recover cleanly and return to a fresh login state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->