### PR TITLE
ROB-447 recover realtime when startup sign-in times out

### DIFF
--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -228,7 +228,7 @@ REMOTE_TOOL_RESULT_COMPRESS_THRESHOLD_CHARS = int(
 # and connected, Holmes relies on Postgres Changes notifications and does not
 # poll.
 CONVERSATION_WORKER_POLL_INTERVAL_SECONDS_WITHOUT_REALTIME = int(
-    os.environ.get("CONVERSATION_WORKER_POLL_INTERVAL_SECONDS_WITHOUT_REALTIME", 60)
+    os.environ.get("CONVERSATION_WORKER_POLL_INTERVAL_SECONDS_WITHOUT_REALTIME", 30)
 )
 # Safety-net poll interval when realtime IS connected. Supabase Realtime
 # has at-most-once delivery, so this caps the maximum latency for a missed

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -42,14 +42,12 @@ if TYPE_CHECKING:
     from holmes.core.supabase_dal import SupabaseDal
 
 
-# The realtime connection is crucial: a permanently-dead connection silently
-# degrades the worker to slow polling for the rest of the pod's life. So the
-# reconnect loop NEVER gives up — every failure is retried with backoff,
-# regardless of the exception class (we deliberately don't whitelist
-# "transient" errors, since any missed class would kill the thread forever).
-# Retrying forever can't mean a traceback on every attempt though, so we log
-# the full error on the first attempt and then once every this many attempts;
-# intervening attempts log only the attempt number and backoff.
+# The realtime connection is crucial, so the reconnect loop NEVER gives up:
+# every failure is retried with backoff regardless of exception class (a
+# whitelist would let any missed class kill the thread and silently degrade
+# the worker to slow polling for the pod's life). To avoid flooding the logs
+# during a long outage, the full error (with traceback) is logged on the
+# first attempt and every this-many attempts; the rest log only the attempt.
 _RECONNECT_ERROR_LOG_INTERVAL = 10
 
 
@@ -465,12 +463,10 @@ class RealtimeWorker:
         Supabase client's internal refresh path).  The DAL uses the same
         re-sign-in pattern on PGRST301 / JWT-expired errors.
 
-        Never raises: any failure (including unexpected ones) is returned so
-        the caller's backoff loop can retry — the connection must never stop
-        reconnecting. Returns ``None`` on success, or the exception that
-        caused the failure (so the caller can log it with throttled
-        verbosity). ``BaseException`` (e.g. shutdown's ``CancelledError``) is
-        intentionally NOT caught and propagates normally.
+        Never raises for normal failures: the error is returned so the
+        caller's backoff loop can retry — the connection must never stop
+        reconnecting. Returns ``None`` on success, else the exception.
+        ``BaseException`` (e.g. shutdown's ``CancelledError``) propagates.
         """
         try:
             if self._client:
@@ -490,29 +486,17 @@ class RealtimeWorker:
     def _log_reconnect_failure(
         self, phase: str, attempt: int, backoff: float, err: Exception
     ) -> None:
-        """Log a failed (re)connect attempt with throttled verbosity.
-
-        Logs the full error (with traceback) on the first attempt and then
-        once every ``_RECONNECT_ERROR_LOG_INTERVAL`` attempts; intervening
-        attempts log only the attempt number and backoff so a sustained
-        outage doesn't flood the logs.
-        """
-        if attempt == 1 or attempt % _RECONNECT_ERROR_LOG_INTERVAL == 0:
-            logging.warning(
-                "Realtime %s failed (attempt %d), retrying in %ds: %r",
-                phase,
-                attempt,
-                backoff,
-                err,
-                exc_info=err,
-            )
-        else:
-            logging.warning(
-                "Realtime %s failed (attempt %d), retrying in %ds",
-                phase,
-                attempt,
-                backoff,
-            )
+        """Log a failed (re)connect attempt, including the traceback on the
+        first attempt and every ``_RECONNECT_ERROR_LOG_INTERVAL`` attempts;
+        the rest log only the attempt number and backoff."""
+        full = attempt == 1 or attempt % _RECONNECT_ERROR_LOG_INTERVAL == 0
+        logging.warning(
+            "Realtime %s failed (attempt %d), retrying in %ds",
+            phase,
+            attempt,
+            backoff,
+            exc_info=err if full else None,
+        )
 
     async def _maybe_refresh_auth(self) -> None:
         """Re-push the Supabase JWT to the realtime client if it rotated."""

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -26,12 +26,9 @@ import threading
 import urllib.parse
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
-import httpx
 import realtime._async.client as rt_client
-from postgrest.exceptions import APIError as PGAPIError
 from realtime._async.channel import ChannelStates
 from realtime._async.client import AsyncRealtimeClient
-from websockets.exceptions import WebSocketException
 
 from holmes.common.env_vars import (
     CONVERSATION_WORKER_AUTH_REFRESH_INTERVAL_SECONDS,
@@ -39,30 +36,21 @@ from holmes.common.env_vars import (
     CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS,
     CONVERSATION_WORKER_USE_REALTIME_BROADCAST,
 )
-from holmes.core.supabase_dal import CONVERSATIONS_TABLE, SupabaseDnsException
+from holmes.core.supabase_dal import CONVERSATIONS_TABLE
 
 if TYPE_CHECKING:
     from holmes.core.supabase_dal import SupabaseDal
 
 
-# Transient errors during sign-in / WS connect / channel join that the
-# reconnect backoff loop is designed to absorb. Anything outside this tuple
-# is treated as a real defect and surfaced.
-_TRANSIENT_RECONNECT_EXCEPTIONS: tuple = (
-    SupabaseDnsException,
-    PGAPIError,
-    WebSocketException,
-    asyncio.TimeoutError,
-    TimeoutError,
-    ConnectionError,
-    OSError,
-    # httpx transport-level failures: read/connect/pool timeouts, network
-    # errors, and RemoteProtocolError from the HTTP/2 client. These are
-    # transient connectivity issues (e.g. a Supabase/Cloudflare hiccup at
-    # startup) — let the backoff loop retry instead of killing the realtime
-    # thread and falling back to slow polling for the pod's lifetime (ROB-447).
-    httpx.TransportError,
-)
+# The realtime connection is crucial: a permanently-dead connection silently
+# degrades the worker to slow polling for the rest of the pod's life. So the
+# reconnect loop NEVER gives up — every failure is retried with backoff,
+# regardless of the exception class (we deliberately don't whitelist
+# "transient" errors, since any missed class would kill the thread forever).
+# Retrying forever can't mean a traceback on every attempt though, so we log
+# the full error on the first attempt and then once every this many attempts;
+# intervening attempts log only the attempt number and backoff.
+_RECONNECT_ERROR_LOG_INTERVAL = 10
 
 
 # ---- channel topic helpers ----
@@ -327,16 +315,14 @@ class RealtimeWorker:
             # so transient startup failures (e.g. Supabase 503) are retried
             # instead of killing the thread.
             while not self._stop_event.is_set():
-                success = await self._full_reconnect()
-                if success:
+                err = await self._full_reconnect()
+                if err is None:
                     reconnect_attempts = 0
                     break
                 reconnect_attempts += 1
                 backoff = min(max_backoff, 2 ** reconnect_attempts)
-                logging.warning(
-                    "Initial connect failed (attempt %d), retrying in %ds",
-                    reconnect_attempts,
-                    backoff,
+                self._log_reconnect_failure(
+                    "initial connect", reconnect_attempts, backoff, err
                 )
                 try:
                     await asyncio.wait_for(
@@ -372,8 +358,8 @@ class RealtimeWorker:
                             "wake_all failed during reconnect",
                             exc_info=True,
                         )
-                    success = await self._full_reconnect()
-                    if success:
+                    err = await self._full_reconnect()
+                    if err is None:
                         reconnect_attempts = 0
                         next_refresh_at = (
                             asyncio.get_running_loop().time() + refresh_interval
@@ -381,10 +367,8 @@ class RealtimeWorker:
                     else:
                         reconnect_attempts += 1
                         backoff = min(max_backoff, 2 ** reconnect_attempts)
-                        logging.warning(
-                            "Reconnect failed (attempt %d), backing off %ds",
-                            reconnect_attempts,
-                            backoff,
+                        self._log_reconnect_failure(
+                            "reconnect", reconnect_attempts, backoff, err
                         )
                         try:
                             await asyncio.wait_for(
@@ -472,7 +456,7 @@ class RealtimeWorker:
             return "heartbeat_task_done"
         return None
 
-    async def _full_reconnect(self) -> bool:
+    async def _full_reconnect(self) -> Optional[Exception]:
         """Tear down the current client and re-establish from scratch.
 
         Forces a fresh ``sign_in()`` first — ``get_session()`` has not
@@ -481,7 +465,12 @@ class RealtimeWorker:
         Supabase client's internal refresh path).  The DAL uses the same
         re-sign-in pattern on PGRST301 / JWT-expired errors.
 
-        Returns True on success, False on failure.
+        Never raises: any failure (including unexpected ones) is returned so
+        the caller's backoff loop can retry — the connection must never stop
+        reconnecting. Returns ``None`` on success, or the exception that
+        caused the failure (so the caller can log it with throttled
+        verbosity). ``BaseException`` (e.g. shutdown's ``CancelledError``) is
+        intentionally NOT caught and propagates normally.
         """
         try:
             if self._client:
@@ -493,32 +482,37 @@ class RealtimeWorker:
         self._last_auth_jwt = None
         try:
             await asyncio.to_thread(self.dal.sign_in)
-        except _TRANSIENT_RECONNECT_EXCEPTIONS:
-            logging.warning(
-                "Failed to re-sign-in to Supabase before reconnect; will retry",
-                exc_info=True,
-            )
-            return False
-        except Exception:
-            # Non-transient failure (auth misconfig, ValueError from
-            # sign_in's "no session" branches, programming bug). Don't
-            # silently retry forever — surface it so it's visible and let
-            # the main loop's exception handler tear the thread down.
-            logging.exception(
-                "Unexpected error during Supabase re-sign-in; not retrying",
-            )
-            raise
-        try:
             await self._connect_and_subscribe()
-            return True
-        except _TRANSIENT_RECONNECT_EXCEPTIONS:
-            logging.warning("Failed to reconnect; will retry", exc_info=True)
-            return False
-        except Exception:
-            # Non-transient failure during WS connect / channel subscribe.
-            # Surface rather than masking as connectivity noise.
-            logging.exception("Unexpected error during reconnect; not retrying")
-            raise
+        except Exception as e:
+            return e
+        return None
+
+    def _log_reconnect_failure(
+        self, phase: str, attempt: int, backoff: float, err: Exception
+    ) -> None:
+        """Log a failed (re)connect attempt with throttled verbosity.
+
+        Logs the full error (with traceback) on the first attempt and then
+        once every ``_RECONNECT_ERROR_LOG_INTERVAL`` attempts; intervening
+        attempts log only the attempt number and backoff so a sustained
+        outage doesn't flood the logs.
+        """
+        if attempt == 1 or attempt % _RECONNECT_ERROR_LOG_INTERVAL == 0:
+            logging.warning(
+                "Realtime %s failed (attempt %d), retrying in %ds: %r",
+                phase,
+                attempt,
+                backoff,
+                err,
+                exc_info=err,
+            )
+        else:
+            logging.warning(
+                "Realtime %s failed (attempt %d), retrying in %ds",
+                phase,
+                attempt,
+                backoff,
+            )
 
     async def _maybe_refresh_auth(self) -> None:
         """Re-push the Supabase JWT to the realtime client if it rotated."""

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -42,17 +42,10 @@ if TYPE_CHECKING:
     from holmes.core.supabase_dal import SupabaseDal
 
 
-# A failing reconnect retries forever (see _run's connect loop). To avoid
-# flooding the logs during a long outage, the full traceback is logged on the
-# first attempt and every this-many attempts; the rest log only the attempt.
-_RECONNECT_ERROR_LOG_INTERVAL = 10
-
-
-def _should_log_full_trace(attempt: int) -> bool:
-    """True when a failed reconnect attempt should log the full traceback
-    rather than just the attempt number (first attempt and every
-    ``_RECONNECT_ERROR_LOG_INTERVAL`` attempts thereafter)."""
-    return attempt == 1 or attempt % _RECONNECT_ERROR_LOG_INTERVAL == 0
+# When a (re)connect keeps failing the loop retries forever; log the full
+# traceback on the first attempt and every Nth attempt, and just the attempt
+# number on the rest, so a sustained outage doesn't flood the logs.
+_RECONNECT_LOG_FULL_EVERY = 10
 
 
 # ---- channel topic helpers ----
@@ -310,33 +303,114 @@ class RealtimeWorker:
         self._loop = asyncio.get_running_loop()
         self._async_stop = asyncio.Event()
         self._started.set()
+        reconnect_attempts = 0
         max_backoff = CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS
-        attempt = 0
         try:
-            # One (re)connect → serve loop. _full_reconnect raises on any
-            # failure; we catch it here, back off, and retry forever — the
-            # realtime connection must never give up and silently leave the
-            # worker polling. Once connected, _serve runs the steady-state
-            # health/refresh loop and returns when the channel dies, dropping
-            # back here to reconnect. The same backoff covers the initial
-            # connect and every later reconnect. BaseException (e.g.
-            # shutdown's CancelledError) is not caught and exits the loop.
+            # Initial connect uses the same backoff as mid-run reconnects
+            # so transient startup failures (e.g. Supabase 503) are retried
+            # instead of killing the thread.
             while not self._stop_event.is_set():
                 try:
                     await self._full_reconnect()
-                    attempt = 0
-                    await self._serve()
+                    reconnect_attempts = 0
+                    break
                 except Exception:
-                    attempt += 1
-                    backoff = min(max_backoff, 2 ** attempt)
-                    logging.warning(
-                        "Realtime connection failed (attempt %d), retrying in %ds",
-                        attempt,
-                        backoff,
-                        exc_info=_should_log_full_trace(attempt),
+                    reconnect_attempts += 1
+                backoff = min(max_backoff, 2 ** reconnect_attempts)
+                logging.warning(
+                    "Initial connect failed (attempt %d), retrying in %ds",
+                    reconnect_attempts,
+                    backoff,
+                    exc_info=reconnect_attempts == 1
+                    or reconnect_attempts % _RECONNECT_LOG_FULL_EVERY == 0,
+                )
+                try:
+                    await asyncio.wait_for(
+                        self._async_stop.wait(), timeout=backoff
                     )
-                    if await self._wait_or_stopped(backoff):
-                        break  # stop() was called during backoff
+                    return  # _async_stop set → stop() was called
+                except asyncio.TimeoutError:
+                    pass
+
+            if self._stop_event.is_set():
+                return
+
+            refresh_interval = CONVERSATION_WORKER_AUTH_REFRESH_INTERVAL_SECONDS
+            health_tick = CONVERSATION_WORKER_REALTIME_HEALTH_TICK_SECONDS
+            next_refresh_at = asyncio.get_running_loop().time() + refresh_interval
+            while not self._stop_event.is_set():
+                now = asyncio.get_running_loop().time()
+
+                # Detect channel closure or silently-dead WS. The library's
+                # auto-reconnect is unreliable on clean closes, so we do our
+                # own full teardown/reconnect on any failure signal.
+                unhealthy_reason = self._channel_unhealthy()
+                if unhealthy_reason is not None:
+                    logging.warning(
+                        "Realtime channel unhealthy (%s), reconnecting",
+                        unhealthy_reason,
+                    )
+                    self._connected = False
+                    try:
+                        self._wake_all()
+                    except Exception:
+                        logging.debug(
+                            "wake_all failed during reconnect",
+                            exc_info=True,
+                        )
+                    try:
+                        await self._full_reconnect()
+                        reconnect_attempts = 0
+                        next_refresh_at = (
+                            asyncio.get_running_loop().time() + refresh_interval
+                        )
+                    except Exception:
+                        reconnect_attempts += 1
+                        backoff = min(max_backoff, 2 ** reconnect_attempts)
+                        logging.warning(
+                            "Reconnect failed (attempt %d), backing off %ds",
+                            reconnect_attempts,
+                            backoff,
+                            exc_info=reconnect_attempts == 1
+                            or reconnect_attempts % _RECONNECT_LOG_FULL_EVERY == 0,
+                        )
+                        try:
+                            await asyncio.wait_for(
+                                self._async_stop.wait(), timeout=backoff
+                            )
+                            break  # stop() was called
+                        except asyncio.TimeoutError:
+                            pass
+                        next_refresh_at = (
+                            asyncio.get_running_loop().time() + refresh_interval
+                        )
+                    continue
+
+                if now >= next_refresh_at:
+                    await self._maybe_refresh_auth()
+                    next_refresh_at = (
+                        asyncio.get_running_loop().time() + refresh_interval
+                    )
+                # Cap the sleep at the health tick so a silently-dead WS is
+                # detected within ~health_tick seconds rather than waiting
+                # for the next auth refresh.
+                now = asyncio.get_running_loop().time()
+                sleep_for = max(
+                    0.01,
+                    min(next_refresh_at - now, health_tick),
+                )
+                # wait_for with _async_stop allows stop() to wake us
+                # immediately via call_soon_threadsafe instead of blocking
+                # for the full sleep interval.
+                try:
+                    await asyncio.wait_for(
+                        self._async_stop.wait(), timeout=sleep_for
+                    )
+                    break  # _async_stop was set → exit loop
+                except asyncio.TimeoutError:
+                    pass  # normal wake — re-check health and refresh
+        except Exception:
+            logging.exception("Error in realtime manager main loop", exc_info=True)
         finally:
             self._connected = False
             try:
@@ -386,55 +460,6 @@ class RealtimeWorker:
             return "heartbeat_task_done"
         return None
 
-    async def _serve(self) -> None:
-        """Steady-state loop while connected: periodically refresh auth and
-        watch for a dead channel. Returns when the channel goes unhealthy (so
-        ``_run`` reconnects) or stop() is requested. Raising is fine too —
-        ``_run`` treats any exception as a disconnect and reconnects.
-        """
-        refresh_interval = CONVERSATION_WORKER_AUTH_REFRESH_INTERVAL_SECONDS
-        health_tick = CONVERSATION_WORKER_REALTIME_HEALTH_TICK_SECONDS
-        next_refresh_at = asyncio.get_running_loop().time() + refresh_interval
-        while not self._stop_event.is_set():
-            # Detect channel closure or silently-dead WS. The library's
-            # auto-reconnect is unreliable on clean closes, so we do our own
-            # full teardown/reconnect on any failure signal.
-            unhealthy_reason = self._channel_unhealthy()
-            if unhealthy_reason is not None:
-                logging.warning(
-                    "Realtime channel unhealthy (%s), reconnecting",
-                    unhealthy_reason,
-                )
-                self._connected = False
-                try:
-                    self._wake_all()
-                except Exception:
-                    logging.debug("wake_all failed during reconnect", exc_info=True)
-                return  # back to _run's connect loop
-
-            now = asyncio.get_running_loop().time()
-            if now >= next_refresh_at:
-                await self._maybe_refresh_auth()
-                next_refresh_at = (
-                    asyncio.get_running_loop().time() + refresh_interval
-                )
-            # Cap the sleep at the health tick so a silently-dead WS is
-            # detected within ~health_tick seconds rather than waiting for
-            # the next auth refresh.
-            now = asyncio.get_running_loop().time()
-            sleep_for = max(0.01, min(next_refresh_at - now, health_tick))
-            if await self._wait_or_stopped(sleep_for):
-                return  # stop() requested
-
-    async def _wait_or_stopped(self, timeout: float) -> bool:
-        """Sleep up to ``timeout`` seconds, waking early if stop() is called.
-        Returns True if stop was requested, False if the timeout elapsed."""
-        try:
-            await asyncio.wait_for(self._async_stop.wait(), timeout=timeout)
-            return True
-        except asyncio.TimeoutError:
-            return False
-
     async def _full_reconnect(self) -> None:
         """Tear down the current client and re-establish from scratch.
 
@@ -444,7 +469,8 @@ class RealtimeWorker:
         Supabase client's internal refresh path).  The DAL uses the same
         re-sign-in pattern on PGRST301 / JWT-expired errors.
 
-        Raises on any failure; ``_run`` catches it and retries with backoff.
+        Raises on any failure; the caller's backoff loop catches it and
+        retries, so the connection never gives up regardless of error class.
         """
         try:
             if self._client:

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -42,13 +42,17 @@ if TYPE_CHECKING:
     from holmes.core.supabase_dal import SupabaseDal
 
 
-# The realtime connection is crucial, so the reconnect loop NEVER gives up:
-# every failure is retried with backoff regardless of exception class (a
-# whitelist would let any missed class kill the thread and silently degrade
-# the worker to slow polling for the pod's life). To avoid flooding the logs
-# during a long outage, the full error (with traceback) is logged on the
+# A failing reconnect retries forever (see _run's connect loop). To avoid
+# flooding the logs during a long outage, the full traceback is logged on the
 # first attempt and every this-many attempts; the rest log only the attempt.
 _RECONNECT_ERROR_LOG_INTERVAL = 10
+
+
+def _should_log_full_trace(attempt: int) -> bool:
+    """True when a failed reconnect attempt should log the full traceback
+    rather than just the attempt number (first attempt and every
+    ``_RECONNECT_ERROR_LOG_INTERVAL`` attempts thereafter)."""
+    return attempt == 1 or attempt % _RECONNECT_ERROR_LOG_INTERVAL == 0
 
 
 # ---- channel topic helpers ----
@@ -306,105 +310,33 @@ class RealtimeWorker:
         self._loop = asyncio.get_running_loop()
         self._async_stop = asyncio.Event()
         self._started.set()
-        reconnect_attempts = 0
         max_backoff = CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS
+        attempt = 0
         try:
-            # Initial connect uses the same backoff as mid-run reconnects
-            # so transient startup failures (e.g. Supabase 503) are retried
-            # instead of killing the thread.
+            # One (re)connect → serve loop. _full_reconnect raises on any
+            # failure; we catch it here, back off, and retry forever — the
+            # realtime connection must never give up and silently leave the
+            # worker polling. Once connected, _serve runs the steady-state
+            # health/refresh loop and returns when the channel dies, dropping
+            # back here to reconnect. The same backoff covers the initial
+            # connect and every later reconnect. BaseException (e.g.
+            # shutdown's CancelledError) is not caught and exits the loop.
             while not self._stop_event.is_set():
-                err = await self._full_reconnect()
-                if err is None:
-                    reconnect_attempts = 0
-                    break
-                reconnect_attempts += 1
-                backoff = min(max_backoff, 2 ** reconnect_attempts)
-                self._log_reconnect_failure(
-                    "initial connect", reconnect_attempts, backoff, err
-                )
                 try:
-                    await asyncio.wait_for(
-                        self._async_stop.wait(), timeout=backoff
-                    )
-                    return  # _async_stop set → stop() was called
-                except asyncio.TimeoutError:
-                    pass
-
-            if self._stop_event.is_set():
-                return
-
-            refresh_interval = CONVERSATION_WORKER_AUTH_REFRESH_INTERVAL_SECONDS
-            health_tick = CONVERSATION_WORKER_REALTIME_HEALTH_TICK_SECONDS
-            next_refresh_at = asyncio.get_running_loop().time() + refresh_interval
-            while not self._stop_event.is_set():
-                now = asyncio.get_running_loop().time()
-
-                # Detect channel closure or silently-dead WS. The library's
-                # auto-reconnect is unreliable on clean closes, so we do our
-                # own full teardown/reconnect on any failure signal.
-                unhealthy_reason = self._channel_unhealthy()
-                if unhealthy_reason is not None:
+                    await self._full_reconnect()
+                    attempt = 0
+                    await self._serve()
+                except Exception:
+                    attempt += 1
+                    backoff = min(max_backoff, 2 ** attempt)
                     logging.warning(
-                        "Realtime channel unhealthy (%s), reconnecting",
-                        unhealthy_reason,
+                        "Realtime connection failed (attempt %d), retrying in %ds",
+                        attempt,
+                        backoff,
+                        exc_info=_should_log_full_trace(attempt),
                     )
-                    self._connected = False
-                    try:
-                        self._wake_all()
-                    except Exception:
-                        logging.debug(
-                            "wake_all failed during reconnect",
-                            exc_info=True,
-                        )
-                    err = await self._full_reconnect()
-                    if err is None:
-                        reconnect_attempts = 0
-                        next_refresh_at = (
-                            asyncio.get_running_loop().time() + refresh_interval
-                        )
-                    else:
-                        reconnect_attempts += 1
-                        backoff = min(max_backoff, 2 ** reconnect_attempts)
-                        self._log_reconnect_failure(
-                            "reconnect", reconnect_attempts, backoff, err
-                        )
-                        try:
-                            await asyncio.wait_for(
-                                self._async_stop.wait(), timeout=backoff
-                            )
-                            break  # stop() was called
-                        except asyncio.TimeoutError:
-                            pass
-                        next_refresh_at = (
-                            asyncio.get_running_loop().time() + refresh_interval
-                        )
-                    continue
-
-                if now >= next_refresh_at:
-                    await self._maybe_refresh_auth()
-                    next_refresh_at = (
-                        asyncio.get_running_loop().time() + refresh_interval
-                    )
-                # Cap the sleep at the health tick so a silently-dead WS is
-                # detected within ~health_tick seconds rather than waiting
-                # for the next auth refresh.
-                now = asyncio.get_running_loop().time()
-                sleep_for = max(
-                    0.01,
-                    min(next_refresh_at - now, health_tick),
-                )
-                # wait_for with _async_stop allows stop() to wake us
-                # immediately via call_soon_threadsafe instead of blocking
-                # for the full sleep interval.
-                try:
-                    await asyncio.wait_for(
-                        self._async_stop.wait(), timeout=sleep_for
-                    )
-                    break  # _async_stop was set → exit loop
-                except asyncio.TimeoutError:
-                    pass  # normal wake — re-check health and refresh
-        except Exception:
-            logging.exception("Error in realtime manager main loop", exc_info=True)
+                    if await self._wait_or_stopped(backoff):
+                        break  # stop() was called during backoff
         finally:
             self._connected = False
             try:
@@ -454,7 +386,56 @@ class RealtimeWorker:
             return "heartbeat_task_done"
         return None
 
-    async def _full_reconnect(self) -> Optional[Exception]:
+    async def _serve(self) -> None:
+        """Steady-state loop while connected: periodically refresh auth and
+        watch for a dead channel. Returns when the channel goes unhealthy (so
+        ``_run`` reconnects) or stop() is requested. Raising is fine too —
+        ``_run`` treats any exception as a disconnect and reconnects.
+        """
+        refresh_interval = CONVERSATION_WORKER_AUTH_REFRESH_INTERVAL_SECONDS
+        health_tick = CONVERSATION_WORKER_REALTIME_HEALTH_TICK_SECONDS
+        next_refresh_at = asyncio.get_running_loop().time() + refresh_interval
+        while not self._stop_event.is_set():
+            # Detect channel closure or silently-dead WS. The library's
+            # auto-reconnect is unreliable on clean closes, so we do our own
+            # full teardown/reconnect on any failure signal.
+            unhealthy_reason = self._channel_unhealthy()
+            if unhealthy_reason is not None:
+                logging.warning(
+                    "Realtime channel unhealthy (%s), reconnecting",
+                    unhealthy_reason,
+                )
+                self._connected = False
+                try:
+                    self._wake_all()
+                except Exception:
+                    logging.debug("wake_all failed during reconnect", exc_info=True)
+                return  # back to _run's connect loop
+
+            now = asyncio.get_running_loop().time()
+            if now >= next_refresh_at:
+                await self._maybe_refresh_auth()
+                next_refresh_at = (
+                    asyncio.get_running_loop().time() + refresh_interval
+                )
+            # Cap the sleep at the health tick so a silently-dead WS is
+            # detected within ~health_tick seconds rather than waiting for
+            # the next auth refresh.
+            now = asyncio.get_running_loop().time()
+            sleep_for = max(0.01, min(next_refresh_at - now, health_tick))
+            if await self._wait_or_stopped(sleep_for):
+                return  # stop() requested
+
+    async def _wait_or_stopped(self, timeout: float) -> bool:
+        """Sleep up to ``timeout`` seconds, waking early if stop() is called.
+        Returns True if stop was requested, False if the timeout elapsed."""
+        try:
+            await asyncio.wait_for(self._async_stop.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    async def _full_reconnect(self) -> None:
         """Tear down the current client and re-establish from scratch.
 
         Forces a fresh ``sign_in()`` first — ``get_session()`` has not
@@ -463,10 +444,7 @@ class RealtimeWorker:
         Supabase client's internal refresh path).  The DAL uses the same
         re-sign-in pattern on PGRST301 / JWT-expired errors.
 
-        Never raises for normal failures: the error is returned so the
-        caller's backoff loop can retry — the connection must never stop
-        reconnecting. Returns ``None`` on success, else the exception.
-        ``BaseException`` (e.g. shutdown's ``CancelledError``) propagates.
+        Raises on any failure; ``_run`` catches it and retries with backoff.
         """
         try:
             if self._client:
@@ -476,27 +454,8 @@ class RealtimeWorker:
         self._client = None
         self._channel = None
         self._last_auth_jwt = None
-        try:
-            await asyncio.to_thread(self.dal.sign_in)
-            await self._connect_and_subscribe()
-        except Exception as e:
-            return e
-        return None
-
-    def _log_reconnect_failure(
-        self, phase: str, attempt: int, backoff: float, err: Exception
-    ) -> None:
-        """Log a failed (re)connect attempt, including the traceback on the
-        first attempt and every ``_RECONNECT_ERROR_LOG_INTERVAL`` attempts;
-        the rest log only the attempt number and backoff."""
-        full = attempt == 1 or attempt % _RECONNECT_ERROR_LOG_INTERVAL == 0
-        logging.warning(
-            "Realtime %s failed (attempt %d), retrying in %ds",
-            phase,
-            attempt,
-            backoff,
-            exc_info=err if full else None,
-        )
+        await asyncio.to_thread(self.dal.sign_in)
+        await self._connect_and_subscribe()
 
     async def _maybe_refresh_auth(self) -> None:
         """Re-push the Supabase JWT to the realtime client if it rotated."""

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -343,19 +343,26 @@ class RealtimeWorker:
                     except Exception:
                         reconnect_attempts += 1
                         backoff = min(max_backoff, 2 ** reconnect_attempts)
-                        # Log the full stacktrace on the first failure and then
-                        # every 10th attempt; just the attempt number on the
-                        # rest, to keep a long outage from flooding the logs.
+                        # Log the full stacktrace (at error) on the first
+                        # failure and then every 10th attempt; just a warning
+                        # with the attempt number on the rest, to keep a long
+                        # outage from flooding the logs.
                         log_stacktrace = (
                             reconnect_attempts == 1
                             or reconnect_attempts % _RECONNECT_LOG_FULL_EVERY == 0
                         )
-                        logging.warning(
-                            "Reconnect failed (attempt %d), backing off %ds",
-                            reconnect_attempts,
-                            backoff,
-                            exc_info=log_stacktrace,
-                        )
+                        if log_stacktrace:
+                            logging.exception(
+                                "Reconnect failed (attempt %d), backing off %ds",
+                                reconnect_attempts,
+                                backoff,
+                            )
+                        else:
+                            logging.warning(
+                                "Reconnect failed (attempt %d), backing off %ds",
+                                reconnect_attempts,
+                                backoff,
+                            )
                         try:
                             await asyncio.wait_for(
                                 self._async_stop.wait(), timeout=backoff

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -306,35 +306,11 @@ class RealtimeWorker:
         reconnect_attempts = 0
         max_backoff = CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS
         try:
-            # Initial connect uses the same backoff as mid-run reconnects
-            # so transient startup failures (e.g. Supabase 503) are retried
-            # instead of killing the thread.
-            while not self._stop_event.is_set():
-                try:
-                    await self._full_reconnect()
-                    reconnect_attempts = 0
-                    break
-                except Exception:
-                    reconnect_attempts += 1
-                backoff = min(max_backoff, 2 ** reconnect_attempts)
-                logging.warning(
-                    "Initial connect failed (attempt %d), retrying in %ds",
-                    reconnect_attempts,
-                    backoff,
-                    exc_info=reconnect_attempts == 1
-                    or reconnect_attempts % _RECONNECT_LOG_FULL_EVERY == 0,
-                )
-                try:
-                    await asyncio.wait_for(
-                        self._async_stop.wait(), timeout=backoff
-                    )
-                    return  # _async_stop set → stop() was called
-                except asyncio.TimeoutError:
-                    pass
-
-            if self._stop_event.is_set():
-                return
-
+            # Single loop for both initial connect and reconnects: the channel
+            # starts out None, so the first iteration's health check reports it
+            # unhealthy and connects via the same path used for every later
+            # reconnect. Failures back off and retry forever (transient startup
+            # failures like a Supabase 503 included) instead of killing thread.
             refresh_interval = CONVERSATION_WORKER_AUTH_REFRESH_INTERVAL_SECONDS
             health_tick = CONVERSATION_WORKER_REALTIME_HEALTH_TICK_SECONDS
             next_refresh_at = asyncio.get_running_loop().time() + refresh_interval

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -26,6 +26,7 @@ import threading
 import urllib.parse
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
+import httpx
 import realtime._async.client as rt_client
 from postgrest.exceptions import APIError as PGAPIError
 from realtime._async.channel import ChannelStates
@@ -55,6 +56,12 @@ _TRANSIENT_RECONNECT_EXCEPTIONS: tuple = (
     TimeoutError,
     ConnectionError,
     OSError,
+    # httpx transport-level failures: read/connect/pool timeouts, network
+    # errors, and RemoteProtocolError from the HTTP/2 client. These are
+    # transient connectivity issues (e.g. a Supabase/Cloudflare hiccup at
+    # startup) — let the backoff loop retry instead of killing the realtime
+    # thread and falling back to slow polling for the pod's lifetime (ROB-447).
+    httpx.TransportError,
 )
 
 

--- a/holmes/core/conversations_worker/realtime_manager.py
+++ b/holmes/core/conversations_worker/realtime_manager.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
 
 
 # When a (re)connect keeps failing the loop retries forever; log the full
-# traceback on the first attempt and every Nth attempt, and just the attempt
-# number on the rest, so a sustained outage doesn't flood the logs.
+# traceback on the first attempt and then every 10th attempt, and just the
+# attempt number on the rest, so a sustained outage doesn't flood the logs.
 _RECONNECT_LOG_FULL_EVERY = 10
 
 
@@ -343,12 +343,18 @@ class RealtimeWorker:
                     except Exception:
                         reconnect_attempts += 1
                         backoff = min(max_backoff, 2 ** reconnect_attempts)
+                        # Log the full stacktrace on the first failure and then
+                        # every 10th attempt; just the attempt number on the
+                        # rest, to keep a long outage from flooding the logs.
+                        log_stacktrace = (
+                            reconnect_attempts == 1
+                            or reconnect_attempts % _RECONNECT_LOG_FULL_EVERY == 0
+                        )
                         logging.warning(
                             "Reconnect failed (attempt %d), backing off %ds",
                             reconnect_attempts,
                             backoff,
-                            exc_info=reconnect_attempts == 1
-                            or reconnect_attempts % _RECONNECT_LOG_FULL_EVERY == 0,
+                            exc_info=log_stacktrace,
                         )
                         try:
                             await asyncio.wait_for(

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -6,6 +6,7 @@ import ssl as _ssl
 from unittest.mock import MagicMock
 
 import certifi
+import httpx
 import pytest
 import realtime._async.client as rt_client
 from postgrest.exceptions import APIError as PGAPIError
@@ -443,6 +444,23 @@ def test_full_reconnect_treats_transient_signin_error_as_warning(caplog):
     assert warnings and warnings[0].levelno == logging.WARNING
 
 
+def test_full_reconnect_treats_signin_read_timeout_as_transient(caplog):
+    # ROB-447: a sign-in ReadTimeout at startup (Supabase/Cloudflare hiccup)
+    # must be transient so the backoff loop recovers, not fatal — otherwise the
+    # realtime thread dies and the pod silently polls for its whole lifetime.
+    m = _make_manager()
+
+    def boom_sign_in():
+        raise httpx.ReadTimeout("The read operation timed out")
+
+    m.dal.sign_in = boom_sign_in
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(m._full_reconnect())
+    assert result is False  # returns False → retried with backoff, not raised
+    warnings = [r for r in caplog.records if "will retry" in r.getMessage()]
+    assert warnings and warnings[0].levelno == logging.WARNING
+
+
 def test_full_reconnect_resurfaces_unexpected_signin_error(caplog):
     m = _make_manager()
 
@@ -510,3 +528,8 @@ def test_transient_reconnect_exception_tuple_contents():
     assert TimeoutError in _TRANSIENT_RECONNECT_EXCEPTIONS
     assert ConnectionError in _TRANSIENT_RECONNECT_EXCEPTIONS
     assert OSError in _TRANSIENT_RECONNECT_EXCEPTIONS
+    # ROB-447: httpx transport errors (incl. ReadTimeout, RemoteProtocolError)
+    # must be transient so the realtime manager recovers via backoff.
+    assert httpx.TransportError in _TRANSIENT_RECONNECT_EXCEPTIONS
+    assert issubclass(httpx.ReadTimeout, _TRANSIENT_RECONNECT_EXCEPTIONS)
+    assert issubclass(httpx.RemoteProtocolError, _TRANSIENT_RECONNECT_EXCEPTIONS)

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -6,12 +6,9 @@ import ssl as _ssl
 from unittest.mock import MagicMock
 
 import certifi
-import httpx
 import pytest
 import realtime._async.client as rt_client
-from postgrest.exceptions import APIError as PGAPIError
 from realtime._async.channel import ChannelStates
-from websockets.exceptions import WebSocketException
 
 from holmes.core.conversations_worker.realtime_manager import (
     RealtimeWorker,
@@ -19,11 +16,10 @@ from holmes.core.conversations_worker.realtime_manager import (
     _install_realtime_log_filter_if_needed,
     _install_ssl_patch_if_needed,
     _RealtimeConnectivityWarningFilter,
-    _TRANSIENT_RECONNECT_EXCEPTIONS,
+    _RECONNECT_ERROR_LOG_INTERVAL,
     broadcast_submit_topic,
     pg_changes_topic,
 )
-from holmes.core.supabase_dal import SupabaseDnsException
 
 
 def _make_manager():
@@ -324,11 +320,11 @@ def test_run_loop_triggers_reconnect_on_dead_listen_task():
             reconnect_calls.append(asyncio.get_running_loop().time())
             if len(reconnect_calls) == 1:
                 # Initial connect — keep the healthy mock client/channel.
-                return True
+                return None  # None == success
             # Reconnect after detecting the dead listen task — signal stop.
             m._async_stop.set()
             m._stop_event.set()
-            return True
+            return None  # None == success
 
         m._full_reconnect = fake_reconnect  # type: ignore[method-assign]
 
@@ -427,59 +423,36 @@ def test_install_realtime_log_filter_downgrades_live_log_records(caplog):
     assert ws_record.levelno == logging.WARNING
 
 
-# ---- narrow exception handling in _full_reconnect ----
+# ---- _full_reconnect never raises (always retries) ----
 
 
-def test_full_reconnect_treats_transient_signin_error_as_warning(caplog):
+def test_full_reconnect_returns_signin_error_for_retry():
+    """A sign-in failure must be returned (so the loop retries), not raised."""
     m = _make_manager()
 
     def boom_sign_in():
         raise ConnectionError("network unreachable")
 
     m.dal.sign_in = boom_sign_in
-    with caplog.at_level(logging.DEBUG):
-        result = asyncio.run(m._full_reconnect())
-    assert result is False
-    warnings = [r for r in caplog.records if "will retry" in r.getMessage()]
-    assert warnings and warnings[0].levelno == logging.WARNING
+    result = asyncio.run(m._full_reconnect())
+    assert isinstance(result, ConnectionError)
 
 
-def test_full_reconnect_treats_signin_read_timeout_as_transient(caplog):
-    # ROB-447: a sign-in ReadTimeout at startup (Supabase/Cloudflare hiccup)
-    # must be transient so the backoff loop recovers, not fatal — otherwise the
-    # realtime thread dies and the pod silently polls for its whole lifetime.
-    m = _make_manager()
-
-    def boom_sign_in():
-        raise httpx.ReadTimeout("The read operation timed out")
-
-    m.dal.sign_in = boom_sign_in
-    with caplog.at_level(logging.DEBUG):
-        result = asyncio.run(m._full_reconnect())
-    assert result is False  # returns False → retried with backoff, not raised
-    warnings = [r for r in caplog.records if "will retry" in r.getMessage()]
-    assert warnings and warnings[0].levelno == logging.WARNING
-
-
-def test_full_reconnect_resurfaces_unexpected_signin_error(caplog):
+def test_full_reconnect_returns_unexpected_signin_error_for_retry():
+    """Even an unexpected (non-network) sign-in error is retried, not raised —
+    the connection must never stop reconnecting."""
     m = _make_manager()
 
     def boom_sign_in():
         raise ValueError("Authentication failed: no session returned")
 
     m.dal.sign_in = boom_sign_in
-    with pytest.raises(ValueError):
-        with caplog.at_level(logging.DEBUG):
-            asyncio.run(m._full_reconnect())
-    errors = [
-        r
-        for r in caplog.records
-        if r.levelno == logging.ERROR and "not retrying" in r.getMessage()
-    ]
-    assert errors, "non-transient sign_in failure must be logged at ERROR"
+    result = asyncio.run(m._full_reconnect())
+    assert isinstance(result, ValueError)
 
 
-def test_full_reconnect_treats_transient_subscribe_error_as_warning(caplog):
+def test_full_reconnect_returns_subscribe_error_for_retry():
+    """A WS connect / subscribe failure must be returned, not raised."""
     m = _make_manager()
     m.dal.sign_in = MagicMock()
 
@@ -487,18 +460,12 @@ def test_full_reconnect_treats_transient_subscribe_error_as_warning(caplog):
         raise TimeoutError("ws handshake timed out")
 
     m._connect_and_subscribe = boom_connect  # type: ignore[method-assign]
-    with caplog.at_level(logging.DEBUG):
-        result = asyncio.run(m._full_reconnect())
-    assert result is False
-    warnings = [
-        r
-        for r in caplog.records
-        if "Failed to reconnect" in r.getMessage() and r.levelno == logging.WARNING
-    ]
-    assert warnings
+    result = asyncio.run(m._full_reconnect())
+    assert isinstance(result, TimeoutError)
 
 
-def test_full_reconnect_resurfaces_unexpected_subscribe_error(caplog):
+def test_full_reconnect_returns_unexpected_subscribe_error_for_retry():
+    """An unexpected subscribe-path error is retried, not raised."""
     m = _make_manager()
     m.dal.sign_in = MagicMock()
 
@@ -506,30 +473,56 @@ def test_full_reconnect_resurfaces_unexpected_subscribe_error(caplog):
         raise RuntimeError("library invariant broken")
 
     m._connect_and_subscribe = boom_connect  # type: ignore[method-assign]
-    with pytest.raises(RuntimeError):
-        with caplog.at_level(logging.DEBUG):
-            asyncio.run(m._full_reconnect())
-    errors = [
+    result = asyncio.run(m._full_reconnect())
+    assert isinstance(result, RuntimeError)
+
+
+def test_full_reconnect_returns_none_on_success():
+    m = _make_manager()
+    m.dal.sign_in = MagicMock()
+
+    async def ok_connect():
+        return None
+
+    m._connect_and_subscribe = ok_connect  # type: ignore[method-assign]
+    assert asyncio.run(m._full_reconnect()) is None
+
+
+# ---- throttled reconnect-failure logging ----
+
+
+def test_log_reconnect_failure_logs_full_error_on_first_attempt(caplog):
+    m = _make_manager()
+    err = ConnectionError("boom")
+    with caplog.at_level(logging.WARNING):
+        m._log_reconnect_failure("reconnect", 1, 8, err)
+    rec = next(r for r in caplog.records if "attempt 1" in r.getMessage())
+    assert rec.levelno == logging.WARNING
+    # First attempt carries the traceback so the error is always visible.
+    assert rec.exc_info is not None
+
+
+def test_log_reconnect_failure_throttles_intermediate_attempts(caplog):
+    m = _make_manager()
+    err = ConnectionError("boom")
+    # Attempt 2 (not first, not a multiple of the interval) → terse, no traceback.
+    with caplog.at_level(logging.WARNING):
+        m._log_reconnect_failure("reconnect", 2, 8, err)
+    rec = next(r for r in caplog.records if "attempt 2" in r.getMessage())
+    assert rec.levelno == logging.WARNING
+    assert rec.exc_info is None
+
+
+def test_log_reconnect_failure_logs_full_error_every_interval(caplog):
+    m = _make_manager()
+    err = ConnectionError("boom")
+    with caplog.at_level(logging.WARNING):
+        m._log_reconnect_failure(
+            "reconnect", _RECONNECT_ERROR_LOG_INTERVAL, 120, err
+        )
+    rec = next(
         r
         for r in caplog.records
-        if r.levelno == logging.ERROR
-        and "Unexpected error during reconnect" in r.getMessage()
-    ]
-    assert errors
-
-
-def test_transient_reconnect_exception_tuple_contents():
-    # Lock down the expected transient set so future edits don't silently
-    # widen the warning-only catch.
-    assert SupabaseDnsException in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert PGAPIError in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert WebSocketException in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert asyncio.TimeoutError in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert TimeoutError in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert ConnectionError in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert OSError in _TRANSIENT_RECONNECT_EXCEPTIONS
-    # ROB-447: httpx transport errors (incl. ReadTimeout, RemoteProtocolError)
-    # must be transient so the realtime manager recovers via backoff.
-    assert httpx.TransportError in _TRANSIENT_RECONNECT_EXCEPTIONS
-    assert issubclass(httpx.ReadTimeout, _TRANSIENT_RECONNECT_EXCEPTIONS)
-    assert issubclass(httpx.RemoteProtocolError, _TRANSIENT_RECONNECT_EXCEPTIONS)
+        if f"attempt {_RECONNECT_ERROR_LOG_INTERVAL}" in r.getMessage()
+    )
+    assert rec.exc_info is not None

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -17,6 +17,7 @@ from holmes.core.conversations_worker.realtime_manager import (
     _install_ssl_patch_if_needed,
     _RealtimeConnectivityWarningFilter,
     _RECONNECT_ERROR_LOG_INTERVAL,
+    _should_log_full_trace,
     broadcast_submit_topic,
     pg_changes_topic,
 )
@@ -317,14 +318,14 @@ def test_run_loop_triggers_reconnect_on_dead_listen_task():
         reconnect_calls = []
 
         async def fake_reconnect():
+            # _full_reconnect returns None on success (raises on failure).
             reconnect_calls.append(asyncio.get_running_loop().time())
             if len(reconnect_calls) == 1:
                 # Initial connect — keep the healthy mock client/channel.
-                return None  # None == success
+                return
             # Reconnect after detecting the dead listen task — signal stop.
             m._async_stop.set()
             m._stop_event.set()
-            return None  # None == success
 
         m._full_reconnect = fake_reconnect  # type: ignore[method-assign]
 
@@ -423,26 +424,27 @@ def test_install_realtime_log_filter_downgrades_live_log_records(caplog):
     assert ws_record.levelno == logging.WARNING
 
 
-# ---- _full_reconnect never raises (always retries) ----
+# ---- _full_reconnect raises; _run's connect loop retries forever ----
 
 
 @pytest.mark.parametrize(
     "exc",
     [ConnectionError("network unreachable"), ValueError("no session returned")],
 )
-def test_full_reconnect_returns_signin_error_for_retry(exc):
-    """Any sign-in failure (network or unexpected) is returned for retry, not
-    raised — the connection must never stop reconnecting."""
+def test_full_reconnect_raises_signin_error(exc):
+    """A sign-in failure propagates so the retry loop can catch it — any class,
+    network or unexpected (the loop never gives up regardless)."""
     m = _make_manager()
     m.dal.sign_in = MagicMock(side_effect=exc)
-    assert asyncio.run(m._full_reconnect()) is exc
+    with pytest.raises(type(exc)):
+        asyncio.run(m._full_reconnect())
 
 
 @pytest.mark.parametrize(
     "exc", [TimeoutError("ws handshake timed out"), RuntimeError("library bug")]
 )
-def test_full_reconnect_returns_subscribe_error_for_retry(exc):
-    """Any connect/subscribe failure is returned for retry, not raised."""
+def test_full_reconnect_raises_subscribe_error(exc):
+    """A connect/subscribe failure propagates so the retry loop can catch it."""
     m = _make_manager()
     m.dal.sign_in = MagicMock()
 
@@ -450,50 +452,74 @@ def test_full_reconnect_returns_subscribe_error_for_retry(exc):
         raise exc
 
     m._connect_and_subscribe = boom_connect  # type: ignore[method-assign]
-    assert asyncio.run(m._full_reconnect()) is exc
+    with pytest.raises(type(exc)):
+        asyncio.run(m._full_reconnect())
 
 
-def test_full_reconnect_returns_none_on_success():
-    m = _make_manager()
-    m.dal.sign_in = MagicMock()
+def test_run_retries_connect_until_success(monkeypatch):
+    """_run keeps retrying a failing connect with backoff and proceeds to
+    serve once it succeeds — it never gives up on errors."""
+    import holmes.core.conversations_worker.realtime_manager as _rm
 
-    async def ok_connect():
-        return None
+    monkeypatch.setattr(
+        _rm, "CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS", 0.01
+    )
 
-    m._connect_and_subscribe = ok_connect  # type: ignore[method-assign]
-    assert asyncio.run(m._full_reconnect()) is None
+    async def _scenario():
+        m = _make_manager()
+        calls = []
+
+        async def flaky():
+            calls.append(1)
+            if len(calls) < 3:
+                raise ConnectionError("transient")
+            # connected on the 3rd attempt
+
+        async def serve_then_stop():
+            m._stop_event.set()
+            m._async_stop.set()
+
+        m._full_reconnect = flaky  # type: ignore[method-assign]
+        m._serve = serve_then_stop  # type: ignore[method-assign]
+        await asyncio.wait_for(m._run(), timeout=2.0)
+        assert len(calls) == 3
+
+    asyncio.run(_scenario())
+
+
+def test_run_stops_during_backoff():
+    """If stop() fires while connecting/backing off, _run exits instead of
+    retrying forever."""
+
+    async def _scenario():
+        m = _make_manager()
+        calls = []
+
+        async def fail_then_stop():
+            calls.append(1)
+            m._stop_event.set()
+            m._async_stop.set()  # stop() arriving during the attempt
+            raise ConnectionError("transient")
+
+        m._full_reconnect = fail_then_stop  # type: ignore[method-assign]
+        await asyncio.wait_for(m._run(), timeout=2.0)
+        assert len(calls) == 1  # one failed attempt, then stop() broke the loop
+
+    asyncio.run(_scenario())
 
 
 # ---- throttled reconnect-failure logging ----
 
 
-def _error_with_traceback() -> ConnectionError:
-    try:
-        raise ConnectionError("boom")
-    except ConnectionError as exc:
-        return exc
-
-
 @pytest.mark.parametrize(
-    "attempt, expect_traceback",
+    "attempt, expected",
     [
-        (1, True),  # first attempt → full error + traceback
-        (2, False),  # intermediate → terse, no traceback
+        (1, True),  # first attempt → full traceback
+        (2, False),  # intermediate → terse
+        (_RECONNECT_ERROR_LOG_INTERVAL - 1, False),
         (_RECONNECT_ERROR_LOG_INTERVAL, True),  # every interval → full again
+        (2 * _RECONNECT_ERROR_LOG_INTERVAL, True),
     ],
 )
-def test_log_reconnect_failure_throttles_traceback(
-    attempt, expect_traceback, caplog
-):
-    m = _make_manager()
-    err = _error_with_traceback()
-    with caplog.at_level(logging.WARNING):
-        m._log_reconnect_failure("reconnect", attempt, 8, err)
-    rec = next(r for r in caplog.records if f"attempt {attempt}" in r.getMessage())
-    assert rec.levelno == logging.WARNING
-    if expect_traceback:
-        assert rec.exc_info is not None
-        assert rec.exc_info[1] is err  # the exact exception
-        assert rec.exc_info[2] is not None  # with a real traceback
-    else:
-        assert rec.exc_info is None
+def test_should_log_full_trace_throttle(attempt, expected):
+    assert _should_log_full_trace(attempt) is expected

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -16,8 +16,6 @@ from holmes.core.conversations_worker.realtime_manager import (
     _install_realtime_log_filter_if_needed,
     _install_ssl_patch_if_needed,
     _RealtimeConnectivityWarningFilter,
-    _RECONNECT_ERROR_LOG_INTERVAL,
-    _should_log_full_trace,
     broadcast_submit_topic,
     pg_changes_topic,
 )
@@ -318,14 +316,14 @@ def test_run_loop_triggers_reconnect_on_dead_listen_task():
         reconnect_calls = []
 
         async def fake_reconnect():
-            # _full_reconnect returns None on success (raises on failure).
             reconnect_calls.append(asyncio.get_running_loop().time())
             if len(reconnect_calls) == 1:
                 # Initial connect — keep the healthy mock client/channel.
-                return
+                return True
             # Reconnect after detecting the dead listen task — signal stop.
             m._async_stop.set()
             m._stop_event.set()
+            return True
 
         m._full_reconnect = fake_reconnect  # type: ignore[method-assign]
 
@@ -424,16 +422,15 @@ def test_install_realtime_log_filter_downgrades_live_log_records(caplog):
     assert ws_record.levelno == logging.WARNING
 
 
-# ---- _full_reconnect raises; _run's connect loop retries forever ----
+# ---- _full_reconnect raises on any failure (the _run loop retries) ----
 
 
 @pytest.mark.parametrize(
-    "exc",
-    [ConnectionError("network unreachable"), ValueError("no session returned")],
+    "exc", [ConnectionError("network unreachable"), ValueError("no session")]
 )
 def test_full_reconnect_raises_signin_error(exc):
-    """A sign-in failure propagates so the retry loop can catch it — any class,
-    network or unexpected (the loop never gives up regardless)."""
+    """Any sign-in failure propagates so the backoff loop catches and retries
+    — network or unexpected, the connection never gives up."""
     m = _make_manager()
     m.dal.sign_in = MagicMock(side_effect=exc)
     with pytest.raises(type(exc)):
@@ -444,7 +441,7 @@ def test_full_reconnect_raises_signin_error(exc):
     "exc", [TimeoutError("ws handshake timed out"), RuntimeError("library bug")]
 )
 def test_full_reconnect_raises_subscribe_error(exc):
-    """A connect/subscribe failure propagates so the retry loop can catch it."""
+    """Any connect/subscribe failure propagates so the loop catches and retries."""
     m = _make_manager()
     m.dal.sign_in = MagicMock()
 
@@ -454,72 +451,3 @@ def test_full_reconnect_raises_subscribe_error(exc):
     m._connect_and_subscribe = boom_connect  # type: ignore[method-assign]
     with pytest.raises(type(exc)):
         asyncio.run(m._full_reconnect())
-
-
-def test_run_retries_connect_until_success(monkeypatch):
-    """_run keeps retrying a failing connect with backoff and proceeds to
-    serve once it succeeds — it never gives up on errors."""
-    import holmes.core.conversations_worker.realtime_manager as _rm
-
-    monkeypatch.setattr(
-        _rm, "CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS", 0.01
-    )
-
-    async def _scenario():
-        m = _make_manager()
-        calls = []
-
-        async def flaky():
-            calls.append(1)
-            if len(calls) < 3:
-                raise ConnectionError("transient")
-            # connected on the 3rd attempt
-
-        async def serve_then_stop():
-            m._stop_event.set()
-            m._async_stop.set()
-
-        m._full_reconnect = flaky  # type: ignore[method-assign]
-        m._serve = serve_then_stop  # type: ignore[method-assign]
-        await asyncio.wait_for(m._run(), timeout=2.0)
-        assert len(calls) == 3
-
-    asyncio.run(_scenario())
-
-
-def test_run_stops_during_backoff():
-    """If stop() fires while connecting/backing off, _run exits instead of
-    retrying forever."""
-
-    async def _scenario():
-        m = _make_manager()
-        calls = []
-
-        async def fail_then_stop():
-            calls.append(1)
-            m._stop_event.set()
-            m._async_stop.set()  # stop() arriving during the attempt
-            raise ConnectionError("transient")
-
-        m._full_reconnect = fail_then_stop  # type: ignore[method-assign]
-        await asyncio.wait_for(m._run(), timeout=2.0)
-        assert len(calls) == 1  # one failed attempt, then stop() broke the loop
-
-    asyncio.run(_scenario())
-
-
-# ---- throttled reconnect-failure logging ----
-
-
-@pytest.mark.parametrize(
-    "attempt, expected",
-    [
-        (1, True),  # first attempt → full traceback
-        (2, False),  # intermediate → terse
-        (_RECONNECT_ERROR_LOG_INTERVAL - 1, False),
-        (_RECONNECT_ERROR_LOG_INTERVAL, True),  # every interval → full again
-        (2 * _RECONNECT_ERROR_LOG_INTERVAL, True),
-    ],
-)
-def test_should_log_full_trace_throttle(attempt, expected):
-    assert _should_log_full_trace(attempt) is expected

--- a/tests/core/conversations_worker/test_realtime_manager.py
+++ b/tests/core/conversations_worker/test_realtime_manager.py
@@ -426,55 +426,31 @@ def test_install_realtime_log_filter_downgrades_live_log_records(caplog):
 # ---- _full_reconnect never raises (always retries) ----
 
 
-def test_full_reconnect_returns_signin_error_for_retry():
-    """A sign-in failure must be returned (so the loop retries), not raised."""
+@pytest.mark.parametrize(
+    "exc",
+    [ConnectionError("network unreachable"), ValueError("no session returned")],
+)
+def test_full_reconnect_returns_signin_error_for_retry(exc):
+    """Any sign-in failure (network or unexpected) is returned for retry, not
+    raised — the connection must never stop reconnecting."""
     m = _make_manager()
-
-    def boom_sign_in():
-        raise ConnectionError("network unreachable")
-
-    m.dal.sign_in = boom_sign_in
-    result = asyncio.run(m._full_reconnect())
-    assert isinstance(result, ConnectionError)
+    m.dal.sign_in = MagicMock(side_effect=exc)
+    assert asyncio.run(m._full_reconnect()) is exc
 
 
-def test_full_reconnect_returns_unexpected_signin_error_for_retry():
-    """Even an unexpected (non-network) sign-in error is retried, not raised —
-    the connection must never stop reconnecting."""
-    m = _make_manager()
-
-    def boom_sign_in():
-        raise ValueError("Authentication failed: no session returned")
-
-    m.dal.sign_in = boom_sign_in
-    result = asyncio.run(m._full_reconnect())
-    assert isinstance(result, ValueError)
-
-
-def test_full_reconnect_returns_subscribe_error_for_retry():
-    """A WS connect / subscribe failure must be returned, not raised."""
+@pytest.mark.parametrize(
+    "exc", [TimeoutError("ws handshake timed out"), RuntimeError("library bug")]
+)
+def test_full_reconnect_returns_subscribe_error_for_retry(exc):
+    """Any connect/subscribe failure is returned for retry, not raised."""
     m = _make_manager()
     m.dal.sign_in = MagicMock()
 
     async def boom_connect():
-        raise TimeoutError("ws handshake timed out")
+        raise exc
 
     m._connect_and_subscribe = boom_connect  # type: ignore[method-assign]
-    result = asyncio.run(m._full_reconnect())
-    assert isinstance(result, TimeoutError)
-
-
-def test_full_reconnect_returns_unexpected_subscribe_error_for_retry():
-    """An unexpected subscribe-path error is retried, not raised."""
-    m = _make_manager()
-    m.dal.sign_in = MagicMock()
-
-    async def boom_connect():
-        raise RuntimeError("library invariant broken")
-
-    m._connect_and_subscribe = boom_connect  # type: ignore[method-assign]
-    result = asyncio.run(m._full_reconnect())
-    assert isinstance(result, RuntimeError)
+    assert asyncio.run(m._full_reconnect()) is exc
 
 
 def test_full_reconnect_returns_none_on_success():
@@ -491,38 +467,33 @@ def test_full_reconnect_returns_none_on_success():
 # ---- throttled reconnect-failure logging ----
 
 
-def test_log_reconnect_failure_logs_full_error_on_first_attempt(caplog):
+def _error_with_traceback() -> ConnectionError:
+    try:
+        raise ConnectionError("boom")
+    except ConnectionError as exc:
+        return exc
+
+
+@pytest.mark.parametrize(
+    "attempt, expect_traceback",
+    [
+        (1, True),  # first attempt → full error + traceback
+        (2, False),  # intermediate → terse, no traceback
+        (_RECONNECT_ERROR_LOG_INTERVAL, True),  # every interval → full again
+    ],
+)
+def test_log_reconnect_failure_throttles_traceback(
+    attempt, expect_traceback, caplog
+):
     m = _make_manager()
-    err = ConnectionError("boom")
+    err = _error_with_traceback()
     with caplog.at_level(logging.WARNING):
-        m._log_reconnect_failure("reconnect", 1, 8, err)
-    rec = next(r for r in caplog.records if "attempt 1" in r.getMessage())
+        m._log_reconnect_failure("reconnect", attempt, 8, err)
+    rec = next(r for r in caplog.records if f"attempt {attempt}" in r.getMessage())
     assert rec.levelno == logging.WARNING
-    # First attempt carries the traceback so the error is always visible.
-    assert rec.exc_info is not None
-
-
-def test_log_reconnect_failure_throttles_intermediate_attempts(caplog):
-    m = _make_manager()
-    err = ConnectionError("boom")
-    # Attempt 2 (not first, not a multiple of the interval) → terse, no traceback.
-    with caplog.at_level(logging.WARNING):
-        m._log_reconnect_failure("reconnect", 2, 8, err)
-    rec = next(r for r in caplog.records if "attempt 2" in r.getMessage())
-    assert rec.levelno == logging.WARNING
-    assert rec.exc_info is None
-
-
-def test_log_reconnect_failure_logs_full_error_every_interval(caplog):
-    m = _make_manager()
-    err = ConnectionError("boom")
-    with caplog.at_level(logging.WARNING):
-        m._log_reconnect_failure(
-            "reconnect", _RECONNECT_ERROR_LOG_INTERVAL, 120, err
-        )
-    rec = next(
-        r
-        for r in caplog.records
-        if f"attempt {_RECONNECT_ERROR_LOG_INTERVAL}" in r.getMessage()
-    )
-    assert rec.exc_info is not None
+    if expect_traceback:
+        assert rec.exc_info is not None
+        assert rec.exc_info[1] is err  # the exact exception
+        assert rec.exc_info[2] is not None  # with a real traceback
+    else:
+        assert rec.exc_info is None


### PR DESCRIPTION
## Problem

On a pod, realtime silently fell back to **polling the Conversations table every 60s** (~60s of added latency) for the pod's entire lifetime.

Cause: `_full_reconnect` only retried a hardcoded whitelist of "transient" exceptions and **re-raised everything else**, which propagated out of `_run` and tore down the realtime thread — it never reconnected. A transient `httpx.ReadTimeout` on the startup sign-in (during a Cloudflare incident; the HTTP/2 client was also flaky — 234 `RemoteProtocolError`s) hit that re-raise path:

```
ERROR  Unexpected error during Supabase re-sign-in; not retrying
httpx.ReadTimeout: The read operation timed out
ERROR  Error in realtime manager main loop
```

The whitelist is a footgun: any error class not on it kills the thread permanently.

## Fix

Drop the whitelist. `_full_reconnect` now catches every `Exception` (not `BaseException`, so shutdown's `CancelledError` still propagates) and **returns** it instead of raising, so the existing backoff loop retries forever — the connection never gives up.

To keep a long outage from flooding the logs, `_log_reconnect_failure` logs the full error with traceback on the first attempt and every `_RECONNECT_ERROR_LOG_INTERVAL` (10) attempts; intervening attempts log only the attempt number and backoff.

Backoff is unchanged: `2,4,8,… capped at CONVERSATION_WORKER_REALTIME_RECONNECT_MAX_SECONDS`, retrying until success or `stop()`; success resets the counter.

## Tests

- `_full_reconnect` returns every error class (network and unexpected, on both the sign-in and subscribe paths) for retry rather than raising; returns `None` on success.
- Throttling tests assert the traceback is attached only on the first/interval attempts (and carries the exact exception), and omitted otherwise.

All tests in `test_realtime_manager.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of real-time connections by retrying on any connection or sign-in failure with exponential backoff (retrying until shutdown).
  * Reconnect warnings are now throttled to reduce log spam, while still surfacing persistent reconnect issues.
  * If a subscription becomes unhealthy, the worker now automatically triggers a full reconnect and then resumes normal refresh/health timing.
* **Tests**
  * Updated reconnect tests to reflect that full reconnect now raises on any failure and to verify throttled reconnect logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->