### PR TITLE
ROB-386 Document Teams channel-lookup scopes (Team/Channel.ReadBasic.All)

### DIFF
--- a/docs/reference/teams-permissions.md
+++ b/docs/reference/teams-permissions.md
@@ -63,6 +63,15 @@ Delegated permissions require an admin to complete a one-time OAuth flow. These 
     - Files are created in the team's SharePoint Documents library for easy sharing and collaboration
     - The bot does not read, modify, or delete existing SharePoint content
 
+- **`Team.ReadBasic.All`** - List the teams the authenticated user belongs to
+    - **Read-only.** Used to resolve a team's display **name** to its ID so the Platform MCP `lookup_teams_channel` tool can find the right team before posting a message
+    - Returns only basic team properties (ID and display name); does not read team content, members, or settings
+
+- **`Channel.ReadBasic.All`** - List channels within those teams
+    - **Read-only.** Used together with `Team.ReadBasic.All` to resolve a channel's display **name** to its `conversation_id` (e.g. `19:...@thread.tacv2`)
+    - This is what lets you reference a Teams channel by name in alert-triage workflows instead of pasting a raw conversation ID — the resolved `conversation_id` is then passed to the message-sending tool
+    - Returns only basic channel properties (ID, display name, web URL); does not read channel messages
+
 - **`offline_access`** - Maintain authentication session
     - Allows the bot to save investigation outputs without requiring re-authentication for each request
 
@@ -77,6 +86,7 @@ Delegated permissions require an admin to complete a one-time OAuth flow. These 
 | Send and update bot's own response messages | Only when replying to user | Bot Framework Connector API |
 | Discover SharePoint document library location | Only when saving investigation results | `Sites.ReadWrite.All` (read portion) |
 | Create investigation log file | Only when saving investigation results | `Sites.ReadWrite.All` (write portion) |
+| Resolve a team/channel name to its conversation ID | Only when a workflow/user posts to a channel by name | `Team.ReadBasic.All` + `Channel.ReadBasic.All` (read-only) |
 
 ### What the Bot Does NOT Do
 


### PR DESCRIPTION
## What

Documents the two new **delegated** Microsoft Graph scopes the Platform MCP `lookup_teams_channel` tool relies on, and how they're used.

Supports [ROB-386](https://linear.app/robusta/issue/ROB-386) (relay: robusta-dev/relay#615).

## Changes

`docs/reference/teams-permissions.md`:
- New entries under **Delegated (OAuth) Permissions**:
  - **`Team.ReadBasic.All`** — read-only listing of the user's teams to resolve a team's display **name** → ID.
  - **`Channel.ReadBasic.All`** — read-only listing of channels to resolve a channel **name** → `conversation_id`, so you can reference a Teams channel by name in alert-triage workflows instead of pasting a raw ID.
- Added a matching row to the Security Summary table.

Both are framed as read-only (basic properties only — no message/content access), consistent with the existing doc's tone. These are tenant-wide `.All` scopes, so they're granted through the same admin-consent OAuth flow already described for `Sites.ReadWrite.All`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Teams bot permissions guidance with two additional delegated permissions for resolving team and channel names to IDs.
  * Clarified that these read-only permissions support name-based alert triage workflows and do not grant access to messages or settings.
  * Expanded the security summary to explain when name-to-conversation ID resolution occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->