### PR TITLE
ROB-411: allow env var templating in MCP OAuth URLs

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -300,6 +300,8 @@ class Config(RobustaBaseConfig):
         if skill_paths:
             kwargs["custom_skill_paths"] = skill_paths
         kwargs["cluster_name"] = Config.__get_cluster_name()
+        if kwargs["cluster_name"] and not os.environ.get("CLUSTER_NAME"):
+            os.environ["CLUSTER_NAME"] = kwargs["cluster_name"]
         kwargs["should_try_robusta_ai"] = True
         result = cls(**kwargs)
         if "model" in kwargs:

--- a/holmes/core/oauth_config.py
+++ b/holmes/core/oauth_config.py
@@ -157,16 +157,15 @@ class MCPOAuthConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def render_client_secret_env_template(self):
-        """Substitute ``{{ env.X }}`` references in ``client_secret`` at load time.
+    def render_env_templates(self):
+        """Substitute ``{{ env.X }}`` references in OAuth fields at load time.
 
-        Keeps the secret out of YAML by reading it from an environment variable
-        (typically injected from a Kubernetes Secret) — same Jinja syntax the
-        headers code path already supports.
+        Keeps secrets and per-env URLs out of YAML by reading them from
+        environment variables (typically injected from a Kubernetes Secret) —
+        same Jinja syntax the headers code path already supports.
         """
-   
-
-        self.client_secret = render_env_template(self.client_secret, "MCPOAuthConfig.client_secret")
+        for field in ("client_secret", "authorization_url", "token_url", "client_id", "registration_endpoint"):
+            setattr(self, field, render_env_template(getattr(self, field), f"MCPOAuthConfig.{field}"))
         return self
 
 


### PR DESCRIPTION
## Summary
- Extend the `{{ env.X }}` substitution already supported for `client_secret` to `authorization_url`, `token_url`, `client_id`, and `registration_endpoint` on `MCPOAuthConfig`.
- When the Holmes pod resolves `cluster_name` from Robusta's `global_config` (because `CLUSTER_NAME` was not set), export it into `os.environ` so OAuth URL templates like `{{ env.CLUSTER_NAME }}` resolve at toolset load time.

## Use case
Some IdPs (and our own OAuth-fronted MCP servers) expose per-cluster authorization/token endpoints — e.g. `https://auth.example.com/{cluster}/oauth/authorize`. Previously the only env-templated OAuth field was `client_secret`, so the URLs had to be hardcoded per cluster in the toolset YAML. With this change a single shared YAML works across clusters:

```yaml
oauth:
  authorization_url: "https://auth.example.com/{{ env.CLUSTER_NAME }}/oauth/authorize"
  token_url:         "https://auth.example.com/{{ env.CLUSTER_NAME }}/oauth/token"
  client_id:         "{{ env.OAUTH_CLIENT_ID }}"
  client_secret:     "{{ env.OAUTH_CLIENT_SECRET }}"
```

The CLUSTER_NAME export piece is what makes the `{{ env.CLUSTER_NAME }}` case actually work on the pod — without it, users who configured `cluster_name` only in Robusta's global_config (the common path) would have to redundantly set `CLUSTER_NAME` as a pod env var just to satisfy the template.

## Test plan
- [ ] Toolset YAML with `{{ env.CLUSTER_NAME }}` in `authorization_url` resolves on pod boot when `CLUSTER_NAME` is unset but `cluster_name` is in Robusta's global_config
- [ ] `{{ env.X }}` in `token_url` / `client_id` / `registration_endpoint` resolves the same way as `client_secret` already does
- [ ] CLI path (`load_from_file`) does not export `CLUSTER_NAME` into the parent process env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth settings now support environment-variable placeholders in more fields, including client ID, secrets, and endpoint URLs.
  * The configured cluster name is now exposed as an environment variable when available.

* **Bug Fixes**
  * Improved startup configuration handling so values derived from config or CLI are consistently available to other components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->