### PR TITLE
helm: skip get_me health check for GitHub App auth

### DIFF
--- a/helm/holmes/templates/mcp-servers/github/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/github/deployment.yaml
@@ -18,7 +18,12 @@ metadata:
   {{- end }}
 data:
   {{- if .Values.mcpAddons.github.config.toolsets }}
-  GITHUB_TOOLSETS: {{ .Values.mcpAddons.github.config.toolsets | quote }}
+  {{- $toolsets := .Values.mcpAddons.github.config.toolsets }}
+  {{- if .Values.mcpAddons.github.auth.githubApp.secretName }}
+  {{/* App installation tokens 403 on /user. Drop 'context' so get_me isn't advertised — Holmes then auto-skips its auth health check instead of disabling the toolset. */}}
+  {{- $toolsets = join "," (without (splitList "," $toolsets) "context") }}
+  {{- end }}
+  GITHUB_TOOLSETS: {{ $toolsets | quote }}
   {{- end }}
   {{- if .Values.mcpAddons.github.config.tools }}
   GITHUB_TOOLS: {{ .Values.mcpAddons.github.config.tools | quote }}

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -103,11 +103,11 @@ data:
     {{- end }}
     {{- if .Values.mcpAddons.github.enabled }}
     {{- if .Values.mcpAddons.github.auth.githubApp.secretName }}
+    {{/* No health_check_tool: App installation tokens 403 on /user, so get_me is not a valid auth probe. Combined with the deployment.yaml change that strips 'context' from GITHUB_TOOLSETS, Holmes auto-detect finds no identity tool and skips the auth health check. */}}
     {{- $githubConfig := dict
         "url" (printf "http://%s-github-mcp-server.%s.svc.cluster.local:8000/mcp" .Release.Name .Release.Namespace)
         "mode" "streamable-http"
         "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/github.svg"
-        "health_check_tool" "get_me"
     }}
     {{- $githubMcpServers := dict "github" (dict
         "description" "GitHub MCP Server - access repositories, pull requests, issues, and GitHub Actions. Debug CI failures, search code, and delegate tasks to Copilot."

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -480,6 +480,8 @@ mcpAddons:
       # 'context' exposes the read-only get_me tool, which Holmes uses to validate
       # the GitHub token at startup (a bad PAT marks the toolset disabled instead of
       # appearing connected). Keep 'context' enabled unless you have a reason not to.
+      # Note: when using GitHub App auth, 'context' is automatically stripped — App
+      # installation tokens 403 on GET /user, so get_me is not a valid auth probe.
       # Ignored when `tools` below is set (tools takes precedence as a hard allowlist).
       toolsets: "repos,issues,pull_requests,actions,context"
 


### PR DESCRIPTION
## Summary

GitHub App installation tokens 403 on `GET /user`, so the `get_me` health check added in #2118 always fails for the `github-app-mcp` addon. Holmes then disables the toolset on startup — making the GitHub App MCP unusable since 2026-06-03.

This PR fixes it on the chart side, scoped to the App-auth branch:

- `helm/holmes/templates/toolset-config.yaml`: drop the hardcoded `health_check_tool: get_me` for the App-auth `$githubConfig`.
- `helm/holmes/templates/mcp-servers/github/deployment.yaml`: strip `context` from `GITHUB_TOOLSETS` so the upstream server doesn't advertise `get_me` to Holmes auto-detect.
- `helm/holmes/values.yaml`: comment note that 'context' is auto-stripped for App auth.

Net effect for App auth: Holmes auto-detect finds no identity tool, skips the auth health check (`holmes/plugins/toolsets/mcp/toolset_mcp.py:1004-1010`), and the toolset comes up enabled.

PAT auth is untouched — `get_me` is a valid token-validity probe there and is preserved.

## Why a values.yaml workaround alone doesn't work

I initially suggested dropping `context` via a values override. That doesn't fix it: the chart hardcodes `health_check_tool: get_me`, which then fails with "tool not found" instead of 403 — toolset still disabled. The hardcoded health_check_tool also can't be set to empty from values: sprig `merge` treats `""` as unset, so the chart value wins.

The chart fix is the only working path.

## Test plan

- [x] `helm template` renders correctly for App auth (no `context`, no `health_check_tool`)
- [x] `helm template` renders correctly for PAT auth (context preserved, `health_check_tool: get_me` preserved)
- [x] Edge case: `toolsets: "repos,context,issues"` for App auth renders cleanly as `"repos,issues"` (no double comma)
- [x] End-to-end reproduction on a real cluster using a junk PAT + default chart: Holmes logs `❌ Toolset github: ... health check failed (tool: get_me): ... 401 Bad credentials` and lists `github` in Disabled toolsets — same Holmes codepath the customer hits with 403
- [x] End-to-end fix verified on the same cluster by patching the in-cluster ConfigMaps to simulate the chart change: Holmes logs `✅ Toolset github`, `github` moves to Enabled toolsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub addon configuration by automatically cleaning the selected toolsets before applying them, avoiding invalid combinations.
  * Skips an auth health check that isn’t supported for GitHub App authentication, reducing avoidable 403 errors during startup or validation.

* **Documentation**
  * Updated the Helm values notes to clarify that, with GitHub App auth, the `context` toolset is automatically stripped and why the `get_me` probe is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->