### PR TITLE
Remove deprecated Tool._is_restricted() mechanism

### DIFF
--- a/holmes/core/conversations_worker/tool_call_worker.py
+++ b/holmes/core/conversations_worker/tool_call_worker.py
@@ -270,8 +270,6 @@ class ToolCallWorker:
             return _error_response(
                 f"toolset '{toolset.name}' is not exposed for remote execution"
             )
-        if tool._is_restricted():
-            return _error_response(f"tool '{tool_name}' is restricted")
 
         # Instance resolution: given -> must be exposed; omitted with exactly
         # one exposed instance -> default; omitted with several -> error.

--- a/holmes/utils/holmes_sync_toolsets.py
+++ b/holmes/utils/holmes_sync_toolsets.py
@@ -31,9 +31,9 @@ def build_remote_tools_meta(toolset: Toolset) -> Any:
     None when the toolset must not be published (not exposed, is_core, not
     enabled, or no publishable tools).
 
-    Excluded tools: restricted tools and tools that as a whole match
-    approval_required_tools patterns (bash is NOT excluded — its approval
-    decision is per command and enforced at execution time)."""
+    Excluded tools: tools that as a whole match approval_required_tools
+    patterns (bash is NOT excluded — its approval decision is per command
+    and enforced at execution time)."""
     if not toolset.expose_remotely or toolset.is_core:
         return None
     if toolset.status != ToolsetStatusEnum.ENABLED:
@@ -49,8 +49,7 @@ def build_remote_tools_meta(toolset: Toolset) -> Any:
     tools = [
         tool.get_openai_format()
         for tool in toolset.tools
-        if not tool._is_restricted()
-        and not _tool_requires_approval(tool.name, toolset.approval_required_tools)
+        if not _tool_requires_approval(tool.name, toolset.approval_required_tools)
     ]
     if not tools:
         return None

--- a/tests/core/conversations_worker/test_tool_call_worker.py
+++ b/tests/core/conversations_worker/test_tool_call_worker.py
@@ -75,9 +75,8 @@ def test_incompressible_result_stays_plain():
 
 
 def _make_tool(instance_echo=True):
-    tool = MagicMock(name="tool", spec=["name", "_is_restricted", "_get_approval_requirement", "invoke"])
+    tool = MagicMock(name="tool", spec=["name", "_get_approval_requirement", "invoke"])
     tool.name = "probe"
-    tool._is_restricted.return_value = False
     tool._get_approval_requirement.return_value = None
 
     def _invoke(params, context):

--- a/tests/test_holmes_sync_toolsets.py
+++ b/tests/test_holmes_sync_toolsets.py
@@ -18,7 +18,10 @@ from holmes.core.tools import (
 )
 from holmes.plugins.toolsets import load_builtin_toolsets
 from holmes.plugins.toolsets.mcp.toolset_mcp import RemoteMCPToolset
-from holmes.utils.holmes_sync_toolsets import holmes_sync_toolsets_status
+from holmes.utils.holmes_sync_toolsets import (
+    build_remote_tools_meta,
+    holmes_sync_toolsets_status,
+)
 from tests.utils.bad_toolset_example import BadTool, BadToolset
 from tests.utils.toolsets import callable_success, failing_callable_for_test
 
@@ -405,6 +408,54 @@ def test_toolsets_dumpable(mock_dal, mock_config):
     -> ToolsetDBModel -> dal.sync_toolsets() for sending to database.
     """
     holmes_sync_toolsets_status(mock_dal, mock_config)
+
+
+def _exposed_toolset(approval_required_tools=None):
+    ts = SampleToolset(
+        name="remote-toolset",
+        description="Remotely exposed toolset",
+        enabled=True,
+        tools=[
+            YAMLTool(name="list_buckets", description="List", command="echo a"),
+            YAMLTool(name="delete_bucket", description="Delete", command="echo b"),
+        ],
+        tags=[ToolsetTag.CLUSTER],
+        expose_remotely=True,
+        approval_required_tools=approval_required_tools or [],
+    )
+    ts.check_prerequisites()
+    assert ts.status == ToolsetStatusEnum.ENABLED
+    return ts
+
+
+def test_build_remote_tools_meta_publishes_yaml_tools():
+    """Regression: build_remote_tools_meta must not call removed Tool._is_restricted().
+
+    The restricted_tools mechanism was removed in favor of approval_required_tools;
+    a stale reference here raised AttributeError on YAMLTool at toolset-sync time.
+    """
+    meta = build_remote_tools_meta(_exposed_toolset())
+
+    assert meta is not None
+    tool_names = {t["function"]["name"] for t in meta["tools"]}
+    assert tool_names == {"list_buckets", "delete_bucket"}
+
+
+def test_build_remote_tools_meta_excludes_approval_required_tools():
+    meta = build_remote_tools_meta(
+        _exposed_toolset(approval_required_tools=["delete_*"])
+    )
+
+    assert meta is not None
+    tool_names = {t["function"]["name"] for t in meta["tools"]}
+    assert tool_names == {"list_buckets"}
+
+
+def test_build_remote_tools_meta_none_when_not_exposed():
+    ts = _exposed_toolset()
+    ts.expose_remotely = False
+
+    assert build_remote_tools_meta(ts) is None
 
 
 def _mock_get_server_tools(mock_tools_result):


### PR DESCRIPTION
## Summary
Removes the deprecated `_is_restricted()` method from the tool restriction mechanism, which has been superseded by the `approval_required_tools` pattern. This cleanup eliminates stale references that were causing `AttributeError` when syncing toolsets with YAML-based tools.

## Changes
- **holmes/utils/holmes_sync_toolsets.py**: Removed the `tool._is_restricted()` check from `build_remote_tools_meta()` and updated docstring to reflect that only `approval_required_tools` patterns are used for exclusion
- **holmes/core/conversations_worker/tool_call_worker.py**: Removed the `_is_restricted()` check from tool execution validation
- **tests/test_holmes_sync_toolsets.py**: 
  - Added import for `build_remote_tools_meta` function
  - Added three new regression tests covering:
    - Publishing YAML tools without calling removed `_is_restricted()` method
    - Excluding tools matching `approval_required_tools` patterns
    - Returning `None` for non-exposed toolsets
- **tests/core/conversations_worker/test_tool_call_worker.py**: Removed `_is_restricted` from mock tool spec

## Implementation Details
The `approval_required_tools` mechanism (which uses glob patterns to match tool names) is now the sole method for controlling tool access. The removed `_is_restricted()` method was a legacy approach that only applied to certain tool types and was causing issues with YAML-based tools that don't implement this method.

https://claude.ai/code/session_017mvo4K4WG7HkpyKE7v94i7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote tool publishing so only tools matching approval-required patterns are excluded from shared metadata.
  * Clarified handling for tools that are approved per command, ensuring they remain available in published tool lists when appropriate.
  * Corrected the tool execution flow so remote-access checks return the proper error response before later validation steps.
  
* **Tests**
  * Added regression coverage for remote tool metadata generation and exposure settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->