### PR TITLE
ROB-485

### DIFF
--- a/tests/test_approval_tokens.py
+++ b/tests/test_approval_tokens.py
@@ -4,6 +4,7 @@ Closes the forgery primitive from GHSA-6m4w-cmhp-f95f. Replay protection is
 out of scope.
 """
 
+import base64
 import time
 
 import jwt
@@ -113,7 +114,14 @@ def test_verify_attaches_specific_reason_for_server_logs(token_arg, call_id, nam
 def test_verify_rejects_tampered_signature():
     token = approval_tokens.mint_token("call_1", "bash", '{"command":"ls"}')
     header, payload, sig = token.split(".")
-    flipped = sig[:-1] + ("A" if sig[-1] != "A" else "B")
+    # Tamper the signature at the byte level. Flipping a base64url *character*
+    # is flaky: the final char of a 32-byte HMAC signature carries 2 unused
+    # padding bits that base64 decoding discards, so e.g. 'A'->'B' decodes to
+    # identical bytes (~1/16 of tokens) and the "tampered" signature still
+    # verifies. XOR-ing a raw HMAC byte guarantees the signature changes.
+    raw = base64.urlsafe_b64decode(sig + "=" * (-len(sig) % 4))
+    tampered = bytes([raw[0] ^ 0xFF]) + raw[1:]
+    flipped = base64.urlsafe_b64encode(tampered).rstrip(b"=").decode("ascii")
     with pytest.raises(approval_tokens.ApprovalTokenError):
         approval_tokens.verify_token(
             ".".join([header, payload, flipped]),


### PR DESCRIPTION
## Summary

Fixes the intermittently-failing `test_verify_rejects_tampered_signature` in `tests/test_approval_tokens.py`.

### Root cause

The test tampered with the JWT signature by flipping its **last base64url character**:

```python
flipped = sig[:-1] + ("A" if sig[-1] != "A" else "B")
```

A 256-bit HMAC-SHA256 signature base64url-encodes to 43 characters, but only 256 of those 258 encoded bits are significant — the **last character carries 2 unused padding bits that base64 decoding discards**. When the flip (`'A'`↔`'B'`) only changes those padding bits, the decoded signature is byte-for-byte identical, so the "tampered" token still verifies and `verify_token` does not raise — the test fails with `DID NOT RAISE ApprovalTokenError`.

### Measured flakiness

Over 100,000 freshly-minted tokens:

| Tampering logic | Pass (detected) | Fail (missed) | Fail rate |
|---|---|---|---|
| Original (flip last char) | 93,922 | 6,078 | **~6.08%** (≈ 1 in 16) |
| New (byte-level XOR) | 100,000 | 0 | **0%** |

Every one of the 6,078 failures occurred when the signature's last character was `'A'`, exactly the padding-bit collision described above.

### Fix

Tamper at the byte level so the signature is *always* genuinely altered: decode the base64url signature, XOR the first raw HMAC byte with `0xFF`, and re-encode. Verified deterministic over 100,000 runs (0 failures).

### Tracking

[ROB-485](https://linear.app/robusta/issue/ROB-485/fix-flaky-approval-token-tampered-signature-test)

Slack thread: https://robustaco.slack.com/archives/C047B4M8Y7K/p1782390156829299?thread_ts=1782389959.450839&cid=C047B4M8Y7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeMqTEvWa2RoGeW4tiybiK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for tampered approval token handling.
  * Made the verification test more reliable by ensuring signature corruption is consistently detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->