### PR TITLE
Update github-app-mcp image to 1.0.7

### DIFF
--- a/docs/data-sources/builtin-toolsets/github-mcp.md
+++ b/docs/data-sources/builtin-toolsets/github-mcp.md
@@ -337,7 +337,7 @@ Find the **App ID** on the App's settings page (under "About").
         spec:
           containers:
           - name: github-mcp
-            image: us-central1-docker.pkg.dev/genuine-flight-317411/mcp/github-app-mcp:1.0.0
+            image: us-central1-docker.pkg.dev/genuine-flight-317411/mcp/github-app-mcp:1.0.7
             ports:
             - containerPort: 8000
             args:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -460,7 +460,7 @@ mcpAddons:
       #     -n <NAMESPACE>
       githubApp:
         secretName: ""                                          # Name of K8s secret containing GitHub App credentials
-        image: "github-app-mcp:1.0.3"                          # Image with GitHub App token management
+        image: "github-app-mcp:1.0.7"                          # Image with GitHub App token management
         registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
 
     config:


### PR DESCRIPTION
## Summary

Bumps the `github-app-mcp` image to `us-central1-docker.pkg.dev/genuine-flight-317411/mcp/github-app-mcp:1.0.7`.

## Changes

- `helm/holmes/values.yaml`: GitHub App MCP image tag `1.0.3` → `1.0.7` (registry unchanged: `us-central1-docker.pkg.dev/genuine-flight-317411/mcp`)
- `docs/data-sources/builtin-toolsets/github-mcp.md`: deployment example image `1.0.0` → `1.0.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3zMrGrzzTreqTSLHxpgXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3zMrGrzzTreqTSLHxpgXQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub App MCP container image version to a newer release in deployment examples and default Helm values.
  * This keeps the documented and packaged setup aligned with the latest available image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->