### PR TITLE
Add EmpirioLabs AI provider docs

### DIFF
--- a/docs/ai-providers/empiriolabs.md
+++ b/docs/ai-providers/empiriolabs.md
@@ -1,0 +1,74 @@
+# EmpirioLabs AI
+
+Configure HolmesGPT to use [EmpirioLabs AI](https://empiriolabs.ai/) through its OpenAI-compatible API.
+
+## Quick Start
+
+Use the OpenAI-compatible provider and set the EmpirioLabs base URL:
+
+=== "Holmes CLI"
+
+    ```bash
+    export OPENAI_API_KEY="sk-empiriolabs-..."
+    export OPENAI_API_BASE="https://api.empiriolabs.ai/v1"
+
+    holmes ask "what pods are failing?" --model="openai/qwen3-max"
+    ```
+
+=== "Holmes Helm Chart"
+
+    ```yaml
+    # values.yaml
+    additionalEnvVars:
+      - name: OPENAI_API_BASE
+        value: "https://api.empiriolabs.ai/v1"
+      - name: OPENAI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: holmes-secrets
+            key: empirio-api-key
+
+    modelList:
+      empirio-qwen:
+        api_key: "{{ env.OPENAI_API_KEY }}"
+        api_base: "{{ env.OPENAI_API_BASE }}"
+        model: openai/qwen3-max
+        temperature: 1
+
+    config:
+      model: "empirio-qwen"
+    ```
+
+=== "Robusta Helm Chart"
+
+    ```yaml
+    # values.yaml
+    holmes:
+      additionalEnvVars:
+        - name: OPENAI_API_BASE
+          value: "https://api.empiriolabs.ai/v1"
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: robusta-holmes-secret
+              key: empirio-api-key
+
+      modelList:
+        empirio-qwen:
+          api_key: "{{ env.OPENAI_API_KEY }}"
+          api_base: "{{ env.OPENAI_API_BASE }}"
+          model: openai/qwen3-max
+          temperature: 1
+
+      config:
+        model: "empirio-qwen"
+    ```
+
+## Models
+
+Use any chat model available in your EmpirioLabs account. See the [EmpirioLabs model catalog](https://empiriolabs.ai/models) for current model IDs, then prefix the model with `openai/` in HolmesGPT.
+
+## Notes
+
+- EmpirioLabs uses an OpenAI-compatible `/v1` endpoint.
+- HolmesGPT requires models that support function calling for tool use.

--- a/docs/ai-providers/index.md
+++ b/docs/ai-providers/index.md
@@ -13,6 +13,7 @@ HolmesGPT supports multiple AI providers, giving you flexibility in choosing the
 -   [:simple-ollama:{ .lg .middle } **Ollama**](ollama.md)
 -   [:fontawesome-brands-openai:{ .lg .middle } **OpenAI**](openai.md)
 -   [:material-api:{ .lg .middle } **OpenAI-Compatible** (LiteLLM Proxy, etc.)](openai-compatible.md)
+-   [:material-api:{ .lg .middle } **EmpirioLabs AI**](empiriolabs.md)
 -   [:material-earth:{ .lg .middle } **OpenRouter**](openrouter.md)
 -   [:material-robot:{ .lg .middle } **Robusta AI**](robusta-ai.md)
 -   [:material-layers-triple:{ .lg .middle } **Using Multiple Providers**](using-multiple-providers.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
           - OpenRouter: ai-providers/openrouter.md
           - OpenAI: ai-providers/openai.md
           - "OpenAI-Compatible": ai-providers/openai-compatible.md
+          - "EmpirioLabs AI": ai-providers/empiriolabs.md
           - Other: ai-providers/other.md
           - "Robusta AI": ai-providers/robusta-ai.md
           - "Using Multiple Providers": ai-providers/using-multiple-providers.md


### PR DESCRIPTION
Summary:
- add an EmpirioLabs AI provider page
- include CLI and Helm examples for the OpenAI-compatible endpoint
- add the page to the AI providers index and navigation

Testing:
- Not run, docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new AI provider guide for EmpirioLabs AI, including quick start steps, configuration examples, model selection guidance, and endpoint notes.
  * Added EmpirioLabs AI to the AI providers documentation index and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->