### PR TITLE
fix(SC-022): Load secrets from projected volume files

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -86,6 +86,69 @@ def _toolset_tools_changed(
     return False
 
 
+def load_secrets_from_files(secret_dir: str = "/etc/holmes/secrets") -> dict:
+    """
+    Load secrets from projected volume files instead of environment variables.
+
+    Each file in the secret directory is read and its content stored as a secret.
+    This prevents secrets from being exposed as plaintext environment variables,
+    addressing security compliance SC-022.
+
+    Args:
+        secret_dir: Path to directory containing secret files (default: /etc/holmes/secrets)
+
+    Returns:
+        Dictionary mapping secret names (uppercase) to their values
+    """
+    secrets = {}
+    secret_path = Path(secret_dir)
+
+    if secret_path.exists():
+        try:
+            for secret_file in secret_path.iterdir():
+                if secret_file.is_file():
+                    try:
+                        with open(secret_file, 'r') as f:
+                            value = f.read().strip()
+                            if value:
+                                secret_name = secret_file.name.upper()
+                                secrets[secret_name] = value
+                                display_logger.debug(f"Loaded secret from file: {secret_file.name}")
+                    except (IOError, OSError) as e:
+                        display_logger.warning(f"Could not read secret file {secret_file}: {e}")
+        except (OSError) as e:
+            display_logger.warning(f"Could not read secret directory {secret_dir}: {e}")
+    else:
+        display_logger.debug(
+            f"Secret directory not found: {secret_dir} "
+            "(expected for non-Kubernetes deployments)"
+        )
+
+    return secrets
+
+
+def initialize_secrets_from_files():
+    """
+    Initialize configuration by loading secrets from projected volume files.
+
+    This function:
+    1. Loads all secrets from /etc/holmes/secrets/ (if it exists)
+    2. Sets them as environment variables so the Config class can access them
+    3. Logs which secrets were loaded
+
+    Security Note:
+    This function is called BEFORE any logging of environment variables.
+    Secrets are only exposed in memory, not in pod environment inspection.
+    """
+    file_secrets = load_secrets_from_files()
+
+    if file_secrets:
+        display_logger.info(f"Loaded {len(file_secrets)} secrets from /etc/holmes/secrets/")
+
+    for secret_name, secret_value in file_secrets.items():
+        os.environ[secret_name] = secret_value
+
+
 class SupportedTicketSources(str, Enum):
     JIRA_SERVICE_MANAGEMENT = "jira-service-management"
     PAGERDUTY = "pagerduty"

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -86,7 +86,7 @@ def _toolset_tools_changed(
     return False
 
 
-def load_secrets_from_files(secret_dir: str = "/etc/holmes/secrets") -> dict:
+def load_secrets_from_files(secret_dir: str = "/etc/holmes/secrets") -> dict[str, str]:
     """
     Load secrets from projected volume files instead of environment variables.
 
@@ -109,7 +109,7 @@ def load_secrets_from_files(secret_dir: str = "/etc/holmes/secrets") -> dict:
                 if secret_file.is_file():
                     try:
                         with open(secret_file, 'r') as f:
-                            value = f.read().strip()
+                            value = f.read().rstrip('\n\r')
                             if value:
                                 secret_name = secret_file.name.upper()
                                 secrets[secret_name] = value
@@ -127,7 +127,7 @@ def load_secrets_from_files(secret_dir: str = "/etc/holmes/secrets") -> dict:
     return secrets
 
 
-def initialize_secrets_from_files():
+def initialize_secrets_from_files() -> None:
     """
     Initialize configuration by loading secrets from projected volume files.
 

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -110,10 +110,9 @@ def load_secrets_from_files(secret_dir: str = "/etc/holmes/secrets") -> dict[str
                     try:
                         with open(secret_file, 'r') as f:
                             value = f.read().rstrip('\n\r')
-                            if value:
-                                secret_name = secret_file.name.upper()
-                                secrets[secret_name] = value
-                                display_logger.debug(f"Loaded secret from file: {secret_file.name}")
+                            secret_name = secret_file.name.upper()
+                            secrets[secret_name] = value
+                            display_logger.debug(f"Loaded secret from file: {secret_file.name}")
                     except (IOError, OSError) as e:
                         display_logger.warning(f"Could not read secret file {secret_file}: {e}")
         except (OSError) as e:

--- a/server.py
+++ b/server.py
@@ -43,7 +43,7 @@ from holmes.common.env_vars import (
     TOOLSET_STATUS_REFRESH_INTERVAL_SECONDS,
     TRACE_TOKEN_USAGE,
 )
-from holmes.config import DEFAULT_CONFIG_LOCATION, Config
+from holmes.config import DEFAULT_CONFIG_LOCATION, Config, initialize_secrets_from_files
 from holmes.core.conversations import (
     build_chat_messages,
 )
@@ -155,6 +155,11 @@ def open_experiment_from_request(http_request: Request) -> None:
 
 if ENABLE_CONNECTION_KEEPALIVE:
     patch_socket_create_connection()
+
+
+# Load secrets from projected volume files (SC-022: prevent env var exposure)
+# This must run BEFORE init_config() so Config.load_from_env() can access the secrets
+initialize_secrets_from_files()
 
 
 def init_config():


### PR DESCRIPTION
Add secret file loading capability to prevent plaintext exposure of API keys and datasource credentials in pod environment variables.

Changes:
- Add load_secrets_from_files() function to read secrets from /etc/holmes/secrets/
- Add initialize_secrets_from_files() to set loaded secrets as env vars in memory
- Call initialize_secrets_from_files() in server.py before config loading
- Maintains backward compatibility with existing env var configurations

Security: Secrets are loaded from file paths, not exposed in pod environment to kubectl inspect (addresses SC-022 compliance requirement).

Non-breaking: Falls back gracefully if secret directory doesn't exist (for non-Kubernetes deployments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secrets can now be loaded from files in a mounted secrets directory during startup.
  * Loaded secrets are injected into environment variables early, allowing configuration to read them.
* **Bug Fixes**
  * Startup tolerates a missing secrets directory.
  * Issues while iterating or reading individual secret files are handled gracefully with warnings, avoiding initialization failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->