### PR TITLE
fix: two-phase HealthCheck execution so tool calls aren't skipped (#2031)

### DIFF
--- a/holmes/checks/checks.py
+++ b/holmes/checks/checks.py
@@ -70,13 +70,53 @@ def _get_check_prompt() -> str:
 
 
 def _execute_ai_check(check: Check, ai: ToolCallingLLM) -> LLMResult:
+    """Run a health check in two phases.
+
+    Phase 1 investigates using tools, with no response_format set. Some
+    models (e.g. Qwen served via vLLM) will satisfy a strict
+    response_format schema immediately instead of calling tools first when
+    both tools and response_format are present on the same call - see
+    https://github.com/HolmesGPT/holmesgpt/issues/2031. The CLI ask/
+    investigate flows never hit this because they don't set
+    response_format, so phase 1 mirrors that by omitting it.
+
+    Phase 2 classifies the investigation's findings into the required
+    pass/fail schema. No tools are relevant to this call - the model only
+    needs to read the investigation result and decide - so response_format
+    is safe to set here without risking a premature, tool-less answer.
+    """
     system_message = _get_check_prompt()
     messages = [
         {"role": "system", "content": system_message},
         {"role": "user", "content": check.query},
     ]
-    response: LLMResult = ai.call(messages, response_format=CHECK_RESPONSE_FORMAT)
-    return response
+    investigation: LLMResult = ai.call(messages)
+
+    classification_messages = [
+        {
+            "role": "system",
+            "content": (
+                "You already completed an investigation for a health check. "
+                "Based solely on the investigation result below, decide "
+                "whether the check passes or fails."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Original check query:\n{check.query}\n\n"
+                f"Investigation result:\n{investigation.result or ''}"
+            ),
+        },
+    ]
+    classification: LLMResult = ai.call(
+        classification_messages, response_format=CHECK_RESPONSE_FORMAT
+    )
+    classification.num_llm_calls = (investigation.num_llm_calls or 0) + (
+        classification.num_llm_calls or 0
+    )
+    classification += investigation
+    return classification
 
 
 def _parse_check_response(response: LLMResult) -> CheckResponse:

--- a/tests/checks/test_checks_cli.py
+++ b/tests/checks/test_checks_cli.py
@@ -64,7 +64,8 @@ def test_checks_cli_monitor_mode(mock_create_toolcalling_llm):
         assert "PASS" in result.output
 
         # Verify LLM was called
-        mock_ai.call.assert_called_once()
+        # Two-phase execution (#2031): investigation call + classification call.
+        assert mock_ai.call.call_count == 2
 
 
 @patch("holmes.config.Config.create_toolcalling_llm")
@@ -110,4 +111,70 @@ def test_checks_cli_inline_check(mock_create_toolcalling_llm):
     assert "FAIL" in result.output
 
     # Verify LLM was called
-    mock_ai.call.assert_called_once()
+    # Two-phase execution (#2031): investigation call + classification call.
+    assert mock_ai.call.call_count == 2
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+def test_checks_cli_two_phase_no_response_format_on_investigation_call(
+    mock_create_toolcalling_llm,
+):
+    """Phase 1 (investigation) must NOT set response_format - see #2031.
+
+    Setting response_format alongside tool availability causes some models
+    (Qwen via vLLM) to satisfy the schema immediately instead of calling
+    tools first, so the investigation call must omit it entirely.
+    """
+    mock_ai = MagicMock()
+    mock_ai.llm.model = "gpt-4"
+    mock_ai.call.return_value = LLMResult(
+        result=json.dumps({"passed": True, "rationale": "All good."}),
+        tool_calls=[],
+    )
+    mock_create_toolcalling_llm.return_value = mock_ai
+
+    result = runner.invoke(
+        app,
+        ["checks", "run", "-c", "Are all pods healthy?", "--mode", "monitor"],
+    )
+
+    assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+    assert mock_ai.call.call_count == 2
+
+    first_call_kwargs = mock_ai.call.call_args_list[0].kwargs
+    assert first_call_kwargs.get("response_format") is None
+
+    second_call_kwargs = mock_ai.call.call_args_list[1].kwargs
+    assert second_call_kwargs.get("response_format") is not None
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+def test_checks_cli_classification_includes_investigation_result(
+    mock_create_toolcalling_llm,
+):
+    """Phase 2's prompt must include phase 1's investigation findings."""
+    mock_ai = MagicMock()
+    mock_ai.llm.model = "gpt-4"
+
+    investigation_text = "Found 3 pods in CrashLoopBackOff in namespace prod."
+    investigation_response = LLMResult(result=investigation_text, tool_calls=[])
+    classification_response = LLMResult(
+        result=json.dumps(
+            {"passed": False, "rationale": "3 pods are crash-looping."}
+        ),
+        tool_calls=[],
+    )
+    mock_ai.call.side_effect = [investigation_response, classification_response]
+    mock_create_toolcalling_llm.return_value = mock_ai
+
+    result = runner.invoke(
+        app,
+        ["checks", "run", "-c", "Are all pods healthy?", "--mode", "monitor"],
+    )
+
+    assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+    assert "FAIL" in result.output
+
+    second_call_messages = mock_ai.call.call_args_list[1].args[0]
+    combined_text = " ".join(m["content"] for m in second_call_messages)
+    assert investigation_text in combined_text

--- a/tests/checks/test_checks_cli.py
+++ b/tests/checks/test_checks_cli.py
@@ -172,7 +172,9 @@ def test_checks_cli_classification_includes_investigation_result(
         ["checks", "run", "-c", "Are all pods healthy?", "--mode", "monitor"],
     )
 
-    assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+    # Exit code 1 because the check failed, matching the existing
+    # failing-check assertion pattern in this file.
+    assert result.exit_code == 1, f"CLI failed unexpectedly with output: {result.output}"
     assert "FAIL" in result.output
 
     second_call_messages = mock_ai.call.call_args_list[1].args[0]


### PR DESCRIPTION
## Problem

`HealthCheck`/`ScheduledHealthCheck` call the LLM once with both tools available and `response_format` set to a strict pass/fail schema. Some models (Qwen via vLLM, per the issue) satisfy the schema immediately instead of calling any tools first when both are present on the same request - the CLI `ask`/`investigate` flows never hit this because they never set `response_format`.

## Fix

Split `_execute_ai_check` into two calls:
1. **Investigation** - no `response_format`, tools used freely, exactly like the working CLI flow
2. **Classification** - given the investigation's findings as context, classify into the required `{rationale, passed}` schema. No tools are relevant to this call, so `response_format` is safe here.

Cost/token stats are merged across both calls via `RequestStats.__iadd__` so usage reporting stays accurate.

## Testing

Added two new tests verifying:
- The investigation call has no `response_format`, the classification call does
- The investigation's result text is actually included in the classification prompt

Updated the two existing CLI tests that asserted `ai.call` ran exactly once, since it now runs twice by design.

Closes #2031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI-driven health check execution by splitting it into two phases: an initial investigation followed by strict pass/fail classification.
  * The final results now include the investigation details in addition to the classification, with combined usage tracking.
* **Tests**
  * Updated CLI tests to expect two LLM calls per check run.
  * Added coverage to ensure the first phase omits response formatting, the second phase applies the strict format, and the classification prompt includes the investigation output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->