### PR TITLE
fix: preserve last non-empty answer when closing turn is empty (#2185)

### DIFF
--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -1056,6 +1056,7 @@ class ToolCallingLLM:
 
         self._request_context = request_context
         all_tool_calls: list[dict] = []
+        _last_non_empty_content: Optional[str] = None  # fallback for empty closing turns (#2185)
 
         # Process tool decisions if provided (approval resume)
         if msgs and tool_decisions:
@@ -1259,10 +1260,17 @@ class ToolCallingLLM:
                         metadata["finish_reason"] = fr
                 except (AttributeError, IndexError, TypeError):
                     pass
+                # Fall back to the last non-empty assistant text if the
+                # terminating turn is empty. Some providers (e.g. claude-sonnet-4-6
+                # via litellm) emit the real answer in a turn that also carries a
+                # trailing tool call, then close the loop with an empty turn.
+                # Without this fallback that empty content silently replaces the
+                # answer the model already produced. See issue #2185.
+                final_content = response_message.content or _last_non_empty_content
                 yield StreamMessage(
                     event=StreamEvents.ANSWER_END,
                     data={
-                        "content": response_message.content,
+                        "content": final_content,
                         "messages": messages,
                         "metadata": metadata,
                         "tool_calls": all_tool_calls,
@@ -1276,6 +1284,10 @@ class ToolCallingLLM:
             reasoning = getattr(response_message, "reasoning_content", None)
             message = response_message.content
             if reasoning or message:
+                # Track last non-empty assistant text for fallback on empty
+                # closing turns (see issue #2185).
+                if message and message.strip():
+                    _last_non_empty_content = message
                 yield StreamMessage(
                     event=StreamEvents.AI_MESSAGE,
                     data={

--- a/tests/test_tool_calling_llm.py
+++ b/tests/test_tool_calling_llm.py
@@ -1702,3 +1702,81 @@ class TestFrontendNoopToolFlow:
         tool_names = [t["function"]["name"] for t in tools_sent]
         assert "kubectl_get" in tool_names, "Backend tool should be included"
         assert "navigate_to_page" in tool_names, "Noop tool should be included"
+
+
+# ---------------------------------------------------------------------------
+# Issue #2185: empty closing turn should not erase the real answer
+# ---------------------------------------------------------------------------
+
+class TestEmptyClosingTurnFallback:
+    """When the model emits its answer in a turn that also carries a trailing
+    tool call, then closes the loop with an empty turn, the real answer must
+    not be lost (issue #2185)."""
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_empty_closing_turn_falls_back_to_last_non_empty(self, _mock_limit, make_ai, mock_llm):
+        """call_stream ANSWER_END content falls back to the last non-empty
+        AI_MESSAGE content when the terminating turn is empty."""
+        tool_call = _make_mock_tool_call()
+
+        # Turn 1: real answer + trailing tool call
+        turn1 = _make_llm_response(
+            content="## Summary\nThe pod is crash-looping due to OOM.",
+            tool_calls=[tool_call],
+        )
+        turn1.choices[0].finish_reason = "tool_calls"
+
+        # Turn 2: empty closing turn (no content, no tool calls)
+        turn2 = _make_llm_response(content=None, tool_calls=None)
+        turn2.choices[0].message.content = None
+        turn2.choices[0].finish_reason = "stop"
+
+        _mock_limit.side_effect = _make_context_limiter_passthrough
+        mock_llm.completion.side_effect = [turn1, turn2]
+
+        ai = make_ai(tools=[])
+        messages = [{"role": "user", "content": "Why is my pod crashing?"}]
+
+        events = _collect_stream_events(ai.call_stream(msgs=messages))
+        answer_ends = _events_of_type(events, StreamEvents.ANSWER_END)
+
+        assert len(answer_ends) == 1
+        assert answer_ends[0].data["content"] == "## Summary\nThe pod is crash-looping due to OOM."
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_non_empty_closing_turn_is_used_directly(self, _mock_limit, make_ai, mock_llm):
+        """When the terminating turn has content, it is used as-is (no fallback)."""
+        turn1 = _make_llm_response(content="The answer is here.", tool_calls=None)
+        turn1.choices[0].finish_reason = "stop"
+
+        _mock_limit.side_effect = _make_context_limiter_passthrough
+        mock_llm.completion.side_effect = [turn1]
+
+        ai = make_ai(tools=[])
+        messages = [{"role": "user", "content": "Simple question"}]
+
+        events = _collect_stream_events(ai.call_stream(msgs=messages))
+        answer_ends = _events_of_type(events, StreamEvents.ANSWER_END)
+
+        assert len(answer_ends) == 1
+        assert answer_ends[0].data["content"] == "The answer is here."
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_truly_empty_response_returns_none(self, _mock_limit, make_ai, mock_llm):
+        """When there is no prior non-empty content and the final turn is empty,
+        content is None (no invented fallback)."""
+        turn1 = _make_llm_response(content=None, tool_calls=None)
+        turn1.choices[0].message.content = None
+        turn1.choices[0].finish_reason = "stop"
+
+        _mock_limit.side_effect = _make_context_limiter_passthrough
+        mock_llm.completion.side_effect = [turn1]
+
+        ai = make_ai(tools=[])
+        messages = [{"role": "user", "content": "Simple question"}]
+
+        events = _collect_stream_events(ai.call_stream(msgs=messages))
+        answer_ends = _events_of_type(events, StreamEvents.ANSWER_END)
+
+        assert len(answer_ends) == 1
+        assert not answer_ends[0].data["content"]


### PR DESCRIPTION
## Problem

`call_stream` returns `terminal_data["content"]` — the content of the LLM's **final** turn — as the answer. Some providers (observed with `claude-sonnet-4-6` via litellm) emit the real answer in a turn that also carries a trailing tool call, then close the loop with an empty turn (`content=None`, no tool calls). The loop terminates on that empty turn, so the empty content is returned and **the real answer is silently dropped**.

This is the same family as #1676. #1789 stopped the empty content from crashing `/api/chat` (analysis is now `""` instead of a 500), but the answer is still lost.

## Fix

Track `_last_non_empty_content` across `AI_MESSAGE` events in `call_stream`. When `ANSWER_END` fires with empty content, fall back to the last non-empty assistant text. When no prior non-empty content exists, behaviour is unchanged.

## Tests

Three new tests in `TestEmptyClosingTurnFallback`:
- Empty closing turn falls back to last non-empty `AI_MESSAGE` content
- Non-empty closing turn is used directly (no fallback)
- Truly empty response (no prior content) returns `None` as before

Closes #2185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed responses now preserve the last meaningful assistant reply when a final closing turn is empty.
  * If the final turn includes text, that text is still shown as expected.
  * If no prior reply text exists, the end result remains empty.
* **Tests**
  * Added coverage for streamed tool-use conversations to verify the updated end-of-response behavior, including a fallback for empty closing turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->