### PR TITLE
feat: inject Anthropic Tool Search Tool for Claude models (#2107)

### DIFF
--- a/holmes/checks/checks.py
+++ b/holmes/checks/checks.py
@@ -70,13 +70,53 @@ def _get_check_prompt() -> str:
 
 
 def _execute_ai_check(check: Check, ai: ToolCallingLLM) -> LLMResult:
+    """Run a health check in two phases.
+
+    Phase 1 investigates using tools, with no response_format set. Some
+    models (e.g. Qwen served via vLLM) will satisfy a strict
+    response_format schema immediately instead of calling tools first when
+    both tools and response_format are present on the same call - see
+    https://github.com/HolmesGPT/holmesgpt/issues/2031. The CLI ask/
+    investigate flows never hit this because they don't set
+    response_format, so phase 1 mirrors that by omitting it.
+
+    Phase 2 classifies the investigation's findings into the required
+    pass/fail schema. No tools are relevant to this call - the model only
+    needs to read the investigation result and decide - so response_format
+    is safe to set here without risking a premature, tool-less answer.
+    """
     system_message = _get_check_prompt()
     messages = [
         {"role": "system", "content": system_message},
         {"role": "user", "content": check.query},
     ]
-    response: LLMResult = ai.call(messages, response_format=CHECK_RESPONSE_FORMAT)
-    return response
+    investigation: LLMResult = ai.call(messages)
+
+    classification_messages = [
+        {
+            "role": "system",
+            "content": (
+                "You already completed an investigation for a health check. "
+                "Based solely on the investigation result below, decide "
+                "whether the check passes or fails."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Original check query:\n{check.query}\n\n"
+                f"Investigation result:\n{investigation.result or ''}"
+            ),
+        },
+    ]
+    classification: LLMResult = ai.call(
+        classification_messages, response_format=CHECK_RESPONSE_FORMAT
+    )
+    classification.num_llm_calls = (investigation.num_llm_calls or 0) + (
+        classification.num_llm_calls or 0
+    )
+    classification += investigation
+    return classification
 
 
 def _parse_check_response(response: LLMResult) -> CheckResponse:

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -560,7 +560,7 @@ class ToolCallingLLM:
 
         return messages, events
 
-    def _get_tools(self) -> list:
+    def _get_tools(self, request_context: Optional[Dict[str, Any]] = None) -> list:
         """Get the tools list in OpenAI format.
 
         If a user_id is available (from request_context), per-user OAuth tools
@@ -570,8 +570,13 @@ class ToolCallingLLM:
         all user-defined tools with defer_loading=True so Claude can
         dynamically discover tools on-demand instead of loading every
         definition into the context window upfront (see issue #2107).
+
+        request_context is passed explicitly (not read from self) because
+        this class is shared/stateless across requests; caching it on self
+        would let concurrent requests race and leak each other's
+        OAuth-expanded tool lists.
         """
-        user_id = (self._request_context or {}).get("user_id") if hasattr(self, "_request_context") else None
+        user_id = (request_context or {}).get("user_id")
         tools = self.tool_executor.get_all_tools_openai_format(
             user_id=user_id,
         )
@@ -598,8 +603,8 @@ class ToolCallingLLM:
             "name": "tool_search_tool_regex",
         }
         deferred_tools = []
-        for tool in tools:
-            deferred = dict(tool)
+        for tool_def in tools:
+            deferred = dict(tool_def)
             deferred["defer_loading"] = True
             deferred_tools.append(deferred)
         return [tool_search_tool] + deferred_tools
@@ -1087,7 +1092,6 @@ class ToolCallingLLM:
         if trace_span is None:
             trace_span = DummySpan()
 
-        self._request_context = request_context
         all_tool_calls: list[dict] = []
 
         # Process tool decisions if provided (approval resume)
@@ -1123,7 +1127,7 @@ class ToolCallingLLM:
 
         messages: list[dict] = list(msgs) if msgs else []
         tool_calls: list[dict] = []
-        tools: Optional[list] = self._get_tools()
+        tools: Optional[list] = self._get_tools(request_context)
         max_steps = self.max_steps
         metadata: Dict[Any, Any] = {}
         stats = RequestStats()
@@ -1481,9 +1485,17 @@ class ToolCallingLLM:
 
                 # Re-fetch tools if the tool list changed (skill activation, OAuth tool discovery, etc.)
                 if tools is not None:
-                    new_tools = self._get_tools()
-                    old_names = {t["function"]["name"] for t in tools}
-                    new_names = {t["function"]["name"] for t in new_tools}
+                    new_tools = self._get_tools(request_context)
+                    old_names = {
+                        t["function"]["name"]
+                        for t in tools
+                        if t.get("type") == "function"
+                    }
+                    new_names = {
+                        t["function"]["name"]
+                        for t in new_tools
+                        if t.get("type") == "function"
+                    }
                     if old_names != new_names:
                         logging.warning(
                             f"Tool list changed - refreshing ({len(tools)} -> {len(new_tools)} tools)"

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -565,11 +565,44 @@ class ToolCallingLLM:
 
         If a user_id is available (from request_context), per-user OAuth tools
         replace _connect placeholders for authenticated users.
+
+        For Anthropic/Claude models, injects the Tool Search Tool and marks
+        all user-defined tools with defer_loading=True so Claude can
+        dynamically discover tools on-demand instead of loading every
+        definition into the context window upfront (see issue #2107).
         """
         user_id = (self._request_context or {}).get("user_id") if hasattr(self, "_request_context") else None
-        return self.tool_executor.get_all_tools_openai_format(
+        tools = self.tool_executor.get_all_tools_openai_format(
             user_id=user_id,
         )
+        if tools and self.llm._is_anthropic_model():
+            tools = self._apply_tool_search(tools)
+        return tools
+
+    def _apply_tool_search(self, tools: list) -> list:
+        """Wrap tools with Anthropic Tool Search for Claude models.
+
+        Prepends the regex-variant Tool Search Tool and marks every
+        user-defined tool with defer_loading=True. This lets Claude
+        search and load only the tools it needs per turn, avoiding
+        context-window bloat when many toolsets are enabled.
+
+        Supported by litellm for all Anthropic-compatible providers
+        (direct API, Bedrock, Vertex AI). BM25 variant is not used
+        because it is not supported on Bedrock.
+
+        See: https://docs.litellm.ai/docs/providers/anthropic_tool_search
+        """
+        tool_search_tool = {
+            "type": "tool_search_tool_regex_20251119",
+            "name": "tool_search_tool_regex",
+        }
+        deferred_tools = []
+        for tool in tools:
+            deferred = dict(tool)
+            deferred["defer_loading"] = True
+            deferred_tools.append(deferred)
+        return [tool_search_tool] + deferred_tools
 
     @sentry_sdk.trace
     def call(  # type: ignore

--- a/tests/checks/test_checks_cli.py
+++ b/tests/checks/test_checks_cli.py
@@ -64,7 +64,8 @@ def test_checks_cli_monitor_mode(mock_create_toolcalling_llm):
         assert "PASS" in result.output
 
         # Verify LLM was called
-        mock_ai.call.assert_called_once()
+        # Two-phase execution (#2031): investigation call + classification call.
+        assert mock_ai.call.call_count == 2
 
 
 @patch("holmes.config.Config.create_toolcalling_llm")
@@ -110,4 +111,70 @@ def test_checks_cli_inline_check(mock_create_toolcalling_llm):
     assert "FAIL" in result.output
 
     # Verify LLM was called
-    mock_ai.call.assert_called_once()
+    # Two-phase execution (#2031): investigation call + classification call.
+    assert mock_ai.call.call_count == 2
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+def test_checks_cli_two_phase_no_response_format_on_investigation_call(
+    mock_create_toolcalling_llm,
+):
+    """Phase 1 (investigation) must NOT set response_format - see #2031.
+
+    Setting response_format alongside tool availability causes some models
+    (Qwen via vLLM) to satisfy the schema immediately instead of calling
+    tools first, so the investigation call must omit it entirely.
+    """
+    mock_ai = MagicMock()
+    mock_ai.llm.model = "gpt-4"
+    mock_ai.call.return_value = LLMResult(
+        result=json.dumps({"passed": True, "rationale": "All good."}),
+        tool_calls=[],
+    )
+    mock_create_toolcalling_llm.return_value = mock_ai
+
+    result = runner.invoke(
+        app,
+        ["checks", "run", "-c", "Are all pods healthy?", "--mode", "monitor"],
+    )
+
+    assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+    assert mock_ai.call.call_count == 2
+
+    first_call_kwargs = mock_ai.call.call_args_list[0].kwargs
+    assert first_call_kwargs.get("response_format") is None
+
+    second_call_kwargs = mock_ai.call.call_args_list[1].kwargs
+    assert second_call_kwargs.get("response_format") is not None
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+def test_checks_cli_classification_includes_investigation_result(
+    mock_create_toolcalling_llm,
+):
+    """Phase 2's prompt must include phase 1's investigation findings."""
+    mock_ai = MagicMock()
+    mock_ai.llm.model = "gpt-4"
+
+    investigation_text = "Found 3 pods in CrashLoopBackOff in namespace prod."
+    investigation_response = LLMResult(result=investigation_text, tool_calls=[])
+    classification_response = LLMResult(
+        result=json.dumps(
+            {"passed": False, "rationale": "3 pods are crash-looping."}
+        ),
+        tool_calls=[],
+    )
+    mock_ai.call.side_effect = [investigation_response, classification_response]
+    mock_create_toolcalling_llm.return_value = mock_ai
+
+    result = runner.invoke(
+        app,
+        ["checks", "run", "-c", "Are all pods healthy?", "--mode", "monitor"],
+    )
+
+    assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+    assert "FAIL" in result.output
+
+    second_call_messages = mock_ai.call.call_args_list[1].args[0]
+    combined_text = " ".join(m["content"] for m in second_call_messages)
+    assert investigation_text in combined_text

--- a/tests/checks/test_checks_cli.py
+++ b/tests/checks/test_checks_cli.py
@@ -172,7 +172,9 @@ def test_checks_cli_classification_includes_investigation_result(
         ["checks", "run", "-c", "Are all pods healthy?", "--mode", "monitor"],
     )
 
-    assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+    # Exit code 1 because the check failed, matching the existing
+    # failing-check assertion pattern in this file.
+    assert result.exit_code == 1, f"CLI failed unexpectedly with output: {result.output}"
     assert "FAIL" in result.output
 
     second_call_messages = mock_ai.call.call_args_list[1].args[0]

--- a/tests/test_tool_calling_llm.py
+++ b/tests/test_tool_calling_llm.py
@@ -1702,3 +1702,90 @@ class TestFrontendNoopToolFlow:
         tool_names = [t["function"]["name"] for t in tools_sent]
         assert "kubectl_get" in tool_names, "Backend tool should be included"
         assert "navigate_to_page" in tool_names, "Noop tool should be included"
+
+
+# ---------------------------------------------------------------------------
+# Issue #2107: Anthropic Tool Search Tool injection
+# ---------------------------------------------------------------------------
+
+class TestApplyToolSearch:
+    """_apply_tool_search() prepends the Tool Search Tool and marks all
+    user-defined tools with defer_loading=True for Anthropic models."""
+
+    def _make_tool(self, name: str) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Tool {name}",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_apply_tool_search_prepends_search_tool(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        tools = [self._make_tool("kubectl_get"), self._make_tool("kubectl_describe")]
+        result = ai._apply_tool_search(tools)
+
+        assert result[0]["type"] == "tool_search_tool_regex_20251119"
+        assert result[0]["name"] == "tool_search_tool_regex"
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_apply_tool_search_marks_defer_loading(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        tools = [self._make_tool("kubectl_get"), self._make_tool("kubectl_describe")]
+        result = ai._apply_tool_search(tools)
+
+        for tool in result[1:]:
+            assert tool.get("defer_loading") is True
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_apply_tool_search_preserves_tool_count(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        tools = [self._make_tool(f"tool_{i}") for i in range(5)]
+        result = ai._apply_tool_search(tools)
+
+        # 1 search tool + 5 user tools
+        assert len(result) == 6
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_apply_tool_search_does_not_mutate_original(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        tools = [self._make_tool("kubectl_get")]
+        _ = ai._apply_tool_search(tools)
+
+        assert "defer_loading" not in tools[0]
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_get_tools_applies_search_for_anthropic(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        ai.llm._is_anthropic_model = MagicMock(return_value=True)
+        ai.tool_executor.get_all_tools_openai_format = MagicMock(
+            return_value=[self._make_tool("kubectl_get")]
+        )
+        result = ai._get_tools()
+
+        assert result[0]["type"] == "tool_search_tool_regex_20251119"
+        assert result[1].get("defer_loading") is True
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_get_tools_skips_search_for_non_anthropic(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        ai.llm._is_anthropic_model = MagicMock(return_value=False)
+        ai.tool_executor.get_all_tools_openai_format = MagicMock(
+            return_value=[self._make_tool("kubectl_get")]
+        )
+        result = ai._get_tools()
+
+        assert result[0]["type"] == "function"
+        assert "defer_loading" not in result[0]
+
+    @patch("holmes.core.tool_calling_llm.compact_if_necessary")
+    def test_get_tools_skips_search_when_no_tools(self, _mock_limit, make_ai, mock_llm):
+        ai = make_ai(tools=[])
+        ai.llm._is_anthropic_model = MagicMock(return_value=True)
+        ai.tool_executor.get_all_tools_openai_format = MagicMock(return_value=[])
+        result = ai._get_tools()
+
+        assert result == []


### PR DESCRIPTION
## Summary

Closes #2107

When HolmesGPT runs on an Anthropic/Claude model, all tool definitions are currently serialized into every LLM call. With rich toolsets (Kafka, RDS, Grafana, Kubernetes, etc.) this bloats the context window significantly, causes truncation, and wastes Claude's context budget.

This PR integrates Anthropic's Tool Search Tool via litellm so Claude can dynamically discover and load only the tools it needs per turn.

## How it works

`_get_tools()` now detects Anthropic models via the existing `self.llm._is_anthropic_model()` helper and calls `_apply_tool_search()` which:

1. Prepends `tool_search_tool_regex_20251119` to the tools list
2. Marks every user-defined tool with `defer_loading=True`

Claude then searches the tool catalog on-demand rather than loading every definition upfront. The regex variant is used (not BM25) because BM25 is not supported on Bedrock.

All Anthropic-compatible providers are covered: direct API, Bedrock, Vertex AI — via litellm's existing tool search support.

## Tests

7 new tests in `TestApplyToolSearch`:
- Search tool is prepended
- All user tools get `defer_loading=True`
- Tool count is correct (1 search + N user tools)
- Original tool list is not mutated
- `_get_tools()` applies search for Anthropic models
- `_get_tools()` skips search for non-Anthropic models
- `_get_tools()` skips search when tool list is empty

## References
- litellm tool search docs: https://docs.litellm.ai/docs/providers/anthropic_tool_search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI health checks now use a two-phase flow: an initial investigation call (no structured response format) followed by a classification call with strict structured output.
  * Anthropic/Claude tool selection is now request-context-aware, enabling Anthropic tool-search wrapping and deferred tool loading per turn, with consistent tool refresh after activations/OAuth discovery.
* **Tests**
  * Updated checks CLI tests for two LLM calls and assertions that structured response formatting applies only during classification.
  * Added unit tests covering tool-search injection, deferred-loading behavior, tool-count preservation, and non-mutation of original tool definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->