### PR TITLE
fix(tests): flip first char in tampered-signature test, not last

### DIFF
--- a/tests/test_approval_tokens.py
+++ b/tests/test_approval_tokens.py
@@ -113,7 +113,10 @@ def test_verify_attaches_specific_reason_for_server_logs(token_arg, call_id, nam
 def test_verify_rejects_tampered_signature():
     token = approval_tokens.mint_token("call_1", "bash", '{"command":"ls"}')
     header, payload, sig = token.split(".")
-    flipped = sig[:-1] + ("A" if sig[-1] != "A" else "B")
+    # Flip the first char, not the last: base64url's final char of a 32-byte HMAC
+    # only carries 4 significant bits (2 padding bits), so different chars can
+    # decode to the same signature bytes and produce a non-tampered "tamper".
+    flipped = ("A" if sig[0] != "A" else "B") + sig[1:]
     with pytest.raises(approval_tokens.ApprovalTokenError):
         approval_tokens.verify_token(
             ".".join([header, payload, flipped]),


### PR DESCRIPTION
## Summary
- `test_verify_rejects_tampered_signature` flipped the **last** base64url char of the HMAC signature. The last char of a 32-byte signature only carries 4 significant bits (2 padding bits), so a flip can decode to the **same** signature bytes — the "tampered" token verifies fine and the test fails intermittently.
- Flip the first char instead — every bit there is load-bearing — and add a one-line comment explaining why.

## Test plan
- [x] `poetry run pytest tests/test_approval_tokens.py::test_verify_rejects_tampered_signature --no-cov` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved token tampering coverage to better ensure modified signatures are rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->