### PR TITLE
Add RBAC cluster filtering to robusta toolset

### DIFF
--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -84,6 +84,10 @@ HOLMES_USAGE_EVENTS_TABLE = "HolmesUsageEvents"
 ENRICHMENT_BLACKLIST = ["text_file", "graph", "ai_analysis", "holmes"]
 ENRICHMENT_BLACKLIST_SET = set(ENRICHMENT_BLACKLIST)
 
+# RBAC permission action that grants a user access to a cluster via Holmes chat.
+# Used to filter which clusters' data a user is allowed to read.
+HOLMES_CHAT_ACTION = "MA_HOLMES_CHAT"
+
 
 logging.getLogger(__name__).debug("Patching supabase_request_builder.pre_select")
 original_pre_select = supabase_request_builder.pre_select
@@ -766,6 +770,80 @@ class SupabaseDal:
             issue_data["end_timestamp_millis"] = int(end_timestamp.timestamp() * 1000)
 
         return issue_data
+
+    def is_account_regular_user(self, user_id: str) -> bool:
+        """Return True if the user is a regular account user (full platform access).
+
+        Regular account users are not subject to RBAC permission-group filtering,
+        so callers can skip per-cluster filtering for them. Mirrors relay's
+        ``RBACClient.is_account_regular_user`` and relies on the ``is_relay()``
+        server-side guard of the ``relay_is_account_user`` RPC.
+        """
+        if not self.enabled or not user_id:
+            return False
+        res = self.client.rpc(
+            "relay_is_account_user",
+            {"_account_id": self.account_id, "_user_id": user_id},
+        ).execute()
+        data = res.data
+        if isinstance(data, list):
+            data = data[0] if data else False
+        return bool(data)
+
+    def get_user_permissions(self, user_id: str) -> Dict:
+        """Fetch the RBAC permissions map for a specific user.
+
+        Returns a dict of the form
+        ``{"MA_HOLMES_CHAT": {"cluster_a": ["*"], "cluster_b": ["ns1"]}, ...}``
+        mapping each permission action to the clusters (and namespaces) the user
+        is granted it on. Returns an empty dict when nothing is granted.
+        """
+        if not self.enabled or not user_id:
+            return {}
+        res = self.client.rpc(
+            "relay_get_user_permissions",
+            {"_account_id": self.account_id, "_user_id": user_id},
+        ).execute()
+        data = res.data
+        if isinstance(data, list):
+            data = data[0] if data else None
+        return data or {}
+
+    def get_holmes_chat_allowed_clusters(
+        self, user_id: Optional[str]
+    ) -> Optional[List[str]]:
+        """Return the clusters a user may access via Holmes chat (MA_HOLMES_CHAT).
+
+        The return value follows relay's RBAC contract:
+
+          * ``None``    – the user is a regular account user: full access, no
+            cluster filtering should be applied.
+          * ``[]``      – the user is RBAC-restricted and has no authorized
+            clusters: every cluster-scoped request must be denied.
+          * ``[names]`` – the user is limited to exactly these clusters.
+
+        Fails closed (returns ``[]``) when the user id is missing or the
+        permission lookup fails, so an error can never widen a user's access.
+        """
+        if not user_id:
+            return []
+        if not self.enabled:
+            # No platform connection means there is no cross-cluster data to
+            # protect here; leave any filtering to the individual data fetchers.
+            return None
+        try:
+            if self.is_account_regular_user(user_id):
+                return None
+            permissions = self.get_user_permissions(user_id)
+            return list(permissions.get(HOLMES_CHAT_ACTION, {}).keys())
+        except Exception:
+            logging.warning(
+                "Failed to resolve MA_HOLMES_CHAT clusters for user %s; "
+                "denying cross-cluster access",
+                user_id,
+                exc_info=True,
+            )
+            return []
 
     def get_skill_catalog(self) -> Optional[List[RobustaSkillInstruction]]:
         if not self.enabled:

--- a/holmes/plugins/toolsets/robusta/robusta.py
+++ b/holmes/plugins/toolsets/robusta/robusta.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from holmes.core.supabase_dal import FindingType, SupabaseDal
 from holmes.core.tools import (
@@ -52,9 +52,19 @@ class FetchRobustaFinding(Tool):
 
     def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
         finding_id = params[PARAM_FINDING_ID]
+        user_id = (context.request_context or {}).get("user_id")
         try:
             finding = self._fetch_finding(finding_id)
             if finding:
+                rbac_error = _check_finding_cluster_access(
+                    finding, self._dal, user_id
+                )
+                if rbac_error:
+                    return StructuredToolResult(
+                        status=StructuredToolResultStatus.ERROR,
+                        error=rbac_error,
+                        params=params,
+                    )
                 return StructuredToolResult(
                     status=StructuredToolResultStatus.SUCCESS,
                     data=finding,
@@ -97,6 +107,73 @@ def _parse_cluster_scope(params: Dict) -> Optional[List[str]]:
         return ["*"]
     # else: None means current cluster only
     return None
+
+
+def _resolve_authorized_clusters(
+    params: Dict,
+    dal: Optional[SupabaseDal],
+    user_id: Optional[str],
+) -> Tuple[Optional[List[str]], Optional[str]]:
+    """Build the cluster scope from tool params and enforce MA_HOLMES_CHAT RBAC.
+
+    The returned cluster list uses the DAL contract (``None`` = current cluster
+    only, ``["*"]`` = every cluster in the account, ``[names]`` = an explicit
+    subset). When the request must be denied, the second tuple element is a
+    user-facing message and the first is ``None``.
+
+    RBAC filtering is only applied to user-scoped requests: when no ``user_id``
+    is supplied (internal / CLI calls) the raw scope is returned unchanged.
+    """
+    clusters = _parse_cluster_scope(params)
+
+    if not user_id or dal is None or not dal.enabled:
+        return clusters, None
+
+    allowed = dal.get_holmes_chat_allowed_clusters(user_id)
+    if allowed is None:
+        # Regular account user: unrestricted access.
+        return clusters, None
+
+    allowed_set = set(allowed)
+    if not allowed_set:
+        return None, "You are not authorized to access any cluster with Holmes."
+
+    # Resolve the requested scope to a concrete cluster list before filtering.
+    if clusters is None:
+        requested = [dal.cluster]
+    elif clusters == ["*"]:
+        requested = allowed
+    else:
+        requested = clusters
+
+    authorized = [c for c in requested if c in allowed_set]
+    if not authorized:
+        return None, "You are not authorized to access the requested cluster(s)."
+    return authorized, None
+
+
+def _check_finding_cluster_access(
+    finding: Optional[Dict],
+    dal: Optional[SupabaseDal],
+    user_id: Optional[str],
+) -> Optional[str]:
+    """Enforce MA_HOLMES_CHAT RBAC on a single finding fetched by id.
+
+    Returns a user-facing denial message when the user is not authorized to see
+    the finding's cluster, or ``None`` when access is allowed.
+    """
+    if not user_id or dal is None or not dal.enabled or not finding:
+        return None
+
+    allowed = dal.get_holmes_chat_allowed_clusters(user_id)
+    if allowed is None:
+        # Regular account user: unrestricted access.
+        return None
+
+    cluster = finding.get("cluster")
+    if cluster in set(allowed):
+        return None
+    return "You are not authorized to access this finding's cluster."
 
 
 class FetchResourceRecommendation(Tool):
@@ -188,7 +265,9 @@ class FetchResourceRecommendation(Tool):
         )
         self._dal = dal
 
-    def _fetch_recommendations(self, params: Dict) -> Optional[List[Dict]]:
+    def _fetch_recommendations(
+        self, params: Dict, clusters: Optional[List[str]]
+    ) -> Optional[List[Dict]]:
         if self._dal and self._dal.enabled:
             # Set default values and enforce max limit
             limit = min(
@@ -196,8 +275,6 @@ class FetchResourceRecommendation(Tool):
                 MAX_LIMIT_KRR_ROWS,
             )
             sort_by = params.get("sort_by") or "cpu_total"
-
-            clusters = _parse_cluster_scope(params)
 
             return self._dal.get_resource_recommendation(
                 limit=limit,
@@ -211,8 +288,18 @@ class FetchResourceRecommendation(Tool):
         return None
 
     def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        user_id = (context.request_context or {}).get("user_id")
+        clusters, rbac_error = _resolve_authorized_clusters(
+            params, self._dal, user_id
+        )
+        if rbac_error:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=rbac_error,
+                params=params,
+            )
         try:
-            recommendations = self._fetch_recommendations(params)
+            recommendations = self._fetch_recommendations(params, clusters)
             if recommendations:
                 return StructuredToolResult(
                     status=StructuredToolResultStatus.SUCCESS,
@@ -324,11 +411,10 @@ class FetchConfigurationChangesMetadata(Tool):
     def _fetch_issues(
         self,
         params: Dict,
+        clusters: Optional[List[str]],
         finding_type: FindingType = FindingType.CONFIGURATION_CHANGE,
     ) -> Optional[List[Dict]]:
         if self._dal and self._dal.enabled:
-            clusters = _parse_cluster_scope(params)
-
             # Default include_external to True
             include_external = params.get("include_external")
             if include_external is None:
@@ -350,8 +436,18 @@ class FetchConfigurationChangesMetadata(Tool):
         return None
 
     def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        user_id = (context.request_context or {}).get("user_id")
+        clusters, rbac_error = _resolve_authorized_clusters(
+            params, self._dal, user_id
+        )
+        if rbac_error:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=rbac_error,
+                params=params,
+            )
         try:
-            changes = self._fetch_issues(params)
+            changes = self._fetch_issues(params, clusters)
             if changes:
                 return StructuredToolResult(
                     status=StructuredToolResultStatus.SUCCESS,
@@ -446,10 +542,10 @@ class FetchResourceIssuesMetadata(Tool):
         )
         self._dal = dal
 
-    def _fetch_issues(self, params: Dict) -> Optional[List[Dict]]:
+    def _fetch_issues(
+        self, params: Dict, clusters: Optional[List[str]]
+    ) -> Optional[List[Dict]]:
         if self._dal and self._dal.enabled:
-            clusters = _parse_cluster_scope(params)
-
             return self._dal.get_issues_metadata(
                 start_datetime=params["start_datetime"],
                 end_datetime=params["end_datetime"],
@@ -466,8 +562,18 @@ class FetchResourceIssuesMetadata(Tool):
         return None
 
     def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        user_id = (context.request_context or {}).get("user_id")
+        clusters, rbac_error = _resolve_authorized_clusters(
+            params, self._dal, user_id
+        )
+        if rbac_error:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=rbac_error,
+                params=params,
+            )
         try:
-            issues = self._fetch_issues(params)
+            issues = self._fetch_issues(params, clusters)
             if issues:
                 return StructuredToolResult(
                     status=StructuredToolResultStatus.SUCCESS,

--- a/tests/core/test_supabase_dal.py
+++ b/tests/core/test_supabase_dal.py
@@ -802,3 +802,88 @@ class TestGetResourceRecommendation:
         assert results[0]["namespace"] == "production"
         assert results[0]["kind"] == "Deployment"
         assert results[0]["container"] == "main"
+
+
+class TestGetHolmesChatAllowedClusters:
+    """Tests for the MA_HOLMES_CHAT RBAC cluster resolution used to filter
+    which clusters' data a user may read through the robusta toolset."""
+
+    @pytest.fixture
+    def mock_dal(self):
+        with patch("holmes.core.supabase_dal.create_client"):
+            dal = SupabaseDal(cluster="test-cluster")
+            dal.enabled = True
+            dal.account_id = "test-account"
+            dal.client = Mock()
+            return dal
+
+    def _set_rpc(self, mock_dal, responses: dict):
+        """Route client.rpc(name, params).execute().data based on function name."""
+
+        def rpc_side_effect(name, params):
+            chain = Mock()
+            res = Mock()
+            res.data = responses.get(name)
+            chain.execute.return_value = res
+            return chain
+
+        mock_dal.client.rpc.side_effect = rpc_side_effect
+
+    def test_missing_user_id_denies_all(self, mock_dal):
+        # No user id -> fail closed with an empty list (deny all clusters).
+        assert mock_dal.get_holmes_chat_allowed_clusters(None) == []
+        mock_dal.client.rpc.assert_not_called()
+
+    def test_disabled_dal_returns_none(self, mock_dal):
+        mock_dal.enabled = False
+        assert mock_dal.get_holmes_chat_allowed_clusters("user-1") is None
+
+    def test_regular_account_user_gets_full_access(self, mock_dal):
+        # Regular account users are not RBAC-filtered -> None means "no filtering".
+        self._set_rpc(mock_dal, {"relay_is_account_user": True})
+        assert mock_dal.get_holmes_chat_allowed_clusters("user-1") is None
+
+    def test_restricted_user_returns_allowed_clusters(self, mock_dal):
+        self._set_rpc(
+            mock_dal,
+            {
+                "relay_is_account_user": False,
+                "relay_get_user_permissions": {
+                    "MA_HOLMES_CHAT": {"cluster-a": ["*"], "cluster-b": ["ns1"]},
+                    "MA_HOLMES_INVESTIGATE": {"cluster-c": ["*"]},
+                },
+            },
+        )
+        allowed = mock_dal.get_holmes_chat_allowed_clusters("user-1")
+        assert sorted(allowed) == ["cluster-a", "cluster-b"]
+
+    def test_restricted_user_without_chat_permission_returns_empty(self, mock_dal):
+        self._set_rpc(
+            mock_dal,
+            {
+                "relay_is_account_user": False,
+                "relay_get_user_permissions": {
+                    "MA_HOLMES_INVESTIGATE": {"cluster-c": ["*"]}
+                },
+            },
+        )
+        assert mock_dal.get_holmes_chat_allowed_clusters("user-1") == []
+
+    def test_list_wrapped_rpc_responses_are_unwrapped(self, mock_dal):
+        # PostgREST sometimes wraps scalar / json results in a single-row list.
+        self._set_rpc(
+            mock_dal,
+            {
+                "relay_is_account_user": [False],
+                "relay_get_user_permissions": [
+                    {"MA_HOLMES_CHAT": {"cluster-a": ["*"]}}
+                ],
+            },
+        )
+        assert mock_dal.get_holmes_chat_allowed_clusters("user-1") == ["cluster-a"]
+
+    def test_lookup_error_fails_closed(self, mock_dal):
+        chain = Mock()
+        chain.execute.side_effect = Exception("boom")
+        mock_dal.client.rpc.return_value = chain
+        assert mock_dal.get_holmes_chat_allowed_clusters("user-1") == []

--- a/tests/plugins/toolsets/test_robusta_rbac.py
+++ b/tests/plugins/toolsets/test_robusta_rbac.py
@@ -1,0 +1,196 @@
+"""Tests for MA_HOLMES_CHAT RBAC cluster filtering in the robusta toolset.
+
+PR #1478 added cross-cluster access to the robusta tools (all_clusters / clusters
+params, plus fetch_finding_by_id which looks up a finding regardless of cluster).
+These tests verify that when a request carries a user id, the tools only ever
+touch clusters the user has MA_HOLMES_CHAT permission on.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from holmes.core.tools import StructuredToolResultStatus
+from holmes.plugins.toolsets.robusta.robusta import (
+    FetchConfigurationChangesMetadata,
+    FetchResourceIssuesMetadata,
+    FetchResourceRecommendation,
+    FetchRobustaFinding,
+    _check_finding_cluster_access,
+    _resolve_authorized_clusters,
+)
+
+
+def _dal(allowed, cluster="current"):
+    """A mock DAL whose get_holmes_chat_allowed_clusters returns `allowed`."""
+    dal = Mock()
+    dal.enabled = True
+    dal.cluster = cluster
+    dal.get_holmes_chat_allowed_clusters.return_value = allowed
+    return dal
+
+
+def _ctx(user_id):
+    return SimpleNamespace(request_context={"user_id": user_id} if user_id else {})
+
+
+class TestResolveAuthorizedClusters:
+    def test_no_user_id_skips_filtering(self):
+        dal = _dal(allowed=[])  # would deny everything if consulted
+        clusters, err = _resolve_authorized_clusters(
+            {"all_clusters": True}, dal, user_id=None
+        )
+        assert err is None
+        assert clusters == ["*"]
+        dal.get_holmes_chat_allowed_clusters.assert_not_called()
+
+    def test_regular_user_full_access(self):
+        dal = _dal(allowed=None)  # None => regular account user
+        clusters, err = _resolve_authorized_clusters(
+            {"all_clusters": True}, dal, user_id="u1"
+        )
+        assert err is None
+        assert clusters == ["*"]
+
+    def test_no_allowed_clusters_denied(self):
+        dal = _dal(allowed=[])
+        clusters, err = _resolve_authorized_clusters(
+            {"all_clusters": True}, dal, user_id="u1"
+        )
+        assert clusters is None
+        assert err is not None
+
+    def test_all_clusters_narrowed_to_allowed(self):
+        dal = _dal(allowed=["a", "b"])
+        clusters, err = _resolve_authorized_clusters(
+            {"all_clusters": True}, dal, user_id="u1"
+        )
+        assert err is None
+        assert clusters == ["a", "b"]
+
+    def test_explicit_clusters_intersected(self):
+        dal = _dal(allowed=["a", "b"])
+        clusters, err = _resolve_authorized_clusters(
+            {"clusters": ["a", "c"]}, dal, user_id="u1"
+        )
+        assert err is None
+        assert clusters == ["a"]
+
+    def test_explicit_clusters_all_unauthorized_denied(self):
+        dal = _dal(allowed=["a", "b"])
+        clusters, err = _resolve_authorized_clusters(
+            {"clusters": ["c", "d"]}, dal, user_id="u1"
+        )
+        assert clusters is None
+        assert err is not None
+
+    def test_current_cluster_allowed(self):
+        dal = _dal(allowed=["current", "a"], cluster="current")
+        clusters, err = _resolve_authorized_clusters({}, dal, user_id="u1")
+        assert err is None
+        assert clusters == ["current"]
+
+    def test_current_cluster_not_allowed_denied(self):
+        dal = _dal(allowed=["a"], cluster="current")
+        clusters, err = _resolve_authorized_clusters({}, dal, user_id="u1")
+        assert clusters is None
+        assert err is not None
+
+
+class TestCheckFindingClusterAccess:
+    def test_no_user_id_allows(self):
+        dal = _dal(allowed=[])
+        assert _check_finding_cluster_access({"cluster": "a"}, dal, None) is None
+
+    def test_regular_user_allows(self):
+        dal = _dal(allowed=None)
+        assert _check_finding_cluster_access({"cluster": "a"}, dal, "u1") is None
+
+    def test_authorized_cluster_allows(self):
+        dal = _dal(allowed=["a", "b"])
+        assert _check_finding_cluster_access({"cluster": "a"}, dal, "u1") is None
+
+    def test_unauthorized_cluster_denied(self):
+        dal = _dal(allowed=["a"])
+        assert _check_finding_cluster_access({"cluster": "b"}, dal, "u1") is not None
+
+    def test_external_finding_denied_for_restricted_user(self):
+        dal = _dal(allowed=["a"])
+        assert _check_finding_cluster_access({"cluster": None}, dal, "u1") is not None
+
+
+class TestToolInvokeEnforcement:
+    """End-to-end style checks that the tool _invoke methods deny unauthorized
+    cross-cluster requests before hitting the DAL data fetchers."""
+
+    def test_issues_tool_denies_unauthorized_cluster(self):
+        dal = _dal(allowed=["a"])
+        tool = FetchResourceIssuesMetadata(dal)
+        result = tool._invoke(
+            {
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-02T00:00:00Z",
+                "clusters": ["b"],
+            },
+            context=_ctx("u1"),
+        )
+        assert result.status == StructuredToolResultStatus.ERROR
+        dal.get_issues_metadata.assert_not_called()
+
+    def test_issues_tool_filters_all_clusters(self):
+        dal = _dal(allowed=["a", "b"])
+        dal.get_issues_metadata.return_value = [{"id": "1"}]
+        tool = FetchResourceIssuesMetadata(dal)
+        result = tool._invoke(
+            {
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-02T00:00:00Z",
+                "all_clusters": True,
+            },
+            context=_ctx("u1"),
+        )
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        _, kwargs = dal.get_issues_metadata.call_args
+        assert kwargs["clusters"] == ["a", "b"]
+
+    def test_config_changes_tool_denies_unauthorized_cluster(self):
+        dal = _dal(allowed=["a"])
+        tool = FetchConfigurationChangesMetadata(dal)
+        result = tool._invoke(
+            {
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-02T00:00:00Z",
+                "clusters": ["b"],
+            },
+            context=_ctx("u1"),
+        )
+        assert result.status == StructuredToolResultStatus.ERROR
+        dal.get_issues_metadata.assert_not_called()
+
+    def test_recommendation_tool_denies_unauthorized_cluster(self):
+        dal = _dal(allowed=["a"])
+        tool = FetchResourceRecommendation(dal)
+        result = tool._invoke({"clusters": ["b"]}, context=_ctx("u1"))
+        assert result.status == StructuredToolResultStatus.ERROR
+        dal.get_resource_recommendation.assert_not_called()
+
+    def test_finding_tool_denies_unauthorized_finding(self):
+        dal = _dal(allowed=["a"])
+        dal.enabled = True
+        dal.get_issue_data.return_value = {"id": "f1", "cluster": "b"}
+        tool = FetchRobustaFinding(dal)
+        result = tool._invoke({"id": "f1"}, context=_ctx("u1"))
+        assert result.status == StructuredToolResultStatus.ERROR
+
+    def test_finding_tool_allows_authorized_finding(self):
+        dal = _dal(allowed=["a"])
+        dal.enabled = True
+        dal.get_issue_data.return_value = {"id": "f1", "cluster": "a"}
+        tool = FetchRobustaFinding(dal)
+        result = tool._invoke({"id": "f1"}, context=_ctx("u1"))
+        assert result.status == StructuredToolResultStatus.SUCCESS
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements role-based access control (RBAC) for the robusta toolset to enforce MA_HOLMES_CHAT permissions on cross-cluster data access. When a request includes a user ID, the tools now verify that the user has permission to access the requested clusters before fetching data.

## Key Changes

- **New RBAC helper functions** in `robusta.py`:
  - `_resolve_authorized_clusters()`: Filters requested clusters against user's MA_HOLMES_CHAT permissions, supporting `all_clusters`, explicit `clusters` list, and current cluster defaults
  - `_check_finding_cluster_access()`: Validates single finding access by cluster

- **Updated tool implementations** to enforce RBAC:
  - `FetchRobustaFinding`: Checks cluster access before returning finding data
  - `FetchResourceRecommendation`: Filters clusters before fetching recommendations
  - `FetchConfigurationChangesMetadata`: Filters clusters before fetching config changes
  - `FetchResourceIssuesMetadata`: Filters clusters before fetching issues
  - All tools extract `user_id` from request context and deny access with user-facing error messages when unauthorized

- **New DAL methods** in `supabase_dal.py`:
  - `is_account_regular_user()`: Checks if user has full platform access (no RBAC filtering needed)
  - `get_user_permissions()`: Fetches user's permission map from relay RPC
  - `get_holmes_chat_allowed_clusters()`: Returns allowed clusters for a user, with three-state return value (None = full access, [] = no access, [names] = restricted list)

- **Comprehensive test coverage** in new `test_robusta_rbac.py`:
  - Tests for `_resolve_authorized_clusters()` covering all cluster scope combinations
  - Tests for `_check_finding_cluster_access()` with various permission states
  - End-to-end tool invocation tests verifying RBAC enforcement before DAL calls
  - Tests for `get_holmes_chat_allowed_clusters()` covering regular users, restricted users, and error handling

## Implementation Details

- RBAC filtering only applies to user-scoped requests (when `user_id` is present); internal/CLI calls bypass filtering
- Fails closed: permission lookup errors return empty cluster list, denying access
- Supports PostgREST response unwrapping (scalar results wrapped in single-row lists)
- Error messages are user-facing and indicate authorization denial without exposing internal details
- Cluster filtering happens before DAL data fetchers are called, preventing unnecessary queries

https://claude.ai/code/session_011Zrr7rSyj2kRJbEhP2Qwcn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Holmes chat access scoping for cluster-based permissions.
  * Multi-cluster Robusta tools now respect user-specific access limits and only return allowed clusters.

* **Bug Fixes**
  * Unauthorized cluster access now fails closed and returns a clear error for denied requests.
  * Permission lookups now safely handle missing user IDs, disabled access control, and lookup failures.

* **Tests**
  * Added coverage for Holmes chat cluster resolution and RBAC filtering across Robusta tool flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->