### PR TITLE
Fix issue when using operator with vertex

### DIFF
--- a/holmes/checks/checks.py
+++ b/holmes/checks/checks.py
@@ -5,7 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 import requests  # type:ignore
 import yaml
@@ -32,28 +32,11 @@ from holmes.core.usage_recorder import (
 from holmes.plugins.destinations.pagerduty.plugin import PagerDutyDestination
 from holmes.plugins.destinations.slack.plugin import SlackDestination
 
-CHECK_RESPONSE_FORMAT = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "check_response",
-        "strict": True,
-        "schema": {
-            "type": "object",
-            "properties": {
-                "rationale": {
-                    "type": "string",
-                    "description": "First, explain what you found and your reasoning",
-                },
-                "passed": {
-                    "type": "boolean",
-                    "description": "Based on your rationale above, does the check pass (true) or fail (false)?",
-                },
-            },
-            "required": ["rationale", "passed"],
-            "additionalProperties": False,
-        },
-    },
-}
+# Use the CheckResponse Pydantic model as response_format so litellm can translate
+# it correctly for each provider (OpenAI json_schema, Vertex AI responseSchema, etc.).
+# Passing a raw OpenAI-format dict with "type": "json_schema" / "strict": True
+# causes Vertex AI / Gemini to return INVALID_ARGUMENT.
+CHECK_RESPONSE_FORMAT: Type[CheckResponse] = CheckResponse
 CHECK_PROMPT_TEMPLATE_PATH = Path(__file__).parent / "check_system_prompt.jinja2"
 
 CHECK_STATUS_COLOR = {
@@ -75,7 +58,7 @@ def _execute_ai_check(check: Check, ai: ToolCallingLLM) -> LLMResult:
         {"role": "system", "content": system_message},
         {"role": "user", "content": check.query},
     ]
-    response: LLMResult = ai.call(messages, response_format=CHECK_RESPONSE_FORMAT)
+    response: LLMResult = ai.call(messages, response_format=CheckResponse)
     return response
 
 

--- a/holmes/checks/checks.py
+++ b/holmes/checks/checks.py
@@ -58,7 +58,7 @@ def _execute_ai_check(check: Check, ai: ToolCallingLLM) -> LLMResult:
         {"role": "system", "content": system_message},
         {"role": "user", "content": check.query},
     ]
-    response: LLMResult = ai.call(messages, response_format=CheckResponse)
+    response: LLMResult = ai.call(messages, response_format=CHECK_RESPONSE_FORMAT)
     return response
 
 

--- a/tests/checks/test_checks_cli.py
+++ b/tests/checks/test_checks_cli.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from holmes.main import app
 from holmes.checks.models import CheckResponse
+from holmes.checks.checks import CHECK_RESPONSE_FORMAT
 from holmes.core.tool_calling_llm import LLMResult
 
 
@@ -154,11 +155,13 @@ def test_checks_response_format_is_pydantic_model(mock_create_toolcalling_llm):
 
         assert result.exit_code == 0, f"CLI failed with output: {result.output}"
 
-    # The critical assertion: response_format must be the CheckResponse Pydantic class,
-    # NOT a raw dict (which breaks Vertex AI / Gemini with INVALID_ARGUMENT).
+    # The critical assertion: response_format must be CHECK_RESPONSE_FORMAT (the
+    # CheckResponse Pydantic model class), NOT a raw dict (which breaks Vertex AI /
+    # Gemini with INVALID_ARGUMENT).
     call_kwargs = mock_ai.call.call_args.kwargs
-    assert call_kwargs.get("response_format") is CheckResponse, (
-        "response_format must be the CheckResponse Pydantic model class so litellm "
-        "can translate it correctly for each provider (Vertex AI, Gemini, etc.). "
+    assert call_kwargs.get("response_format") is CHECK_RESPONSE_FORMAT, (
+        "response_format must be CHECK_RESPONSE_FORMAT (the CheckResponse Pydantic "
+        "model class) so litellm can translate it correctly for each provider "
+        "(Vertex AI, Gemini, etc.). "
         f"Got: {call_kwargs.get('response_format')!r}"
     )

--- a/tests/checks/test_checks_cli.py
+++ b/tests/checks/test_checks_cli.py
@@ -7,6 +7,7 @@ import yaml
 from typer.testing import CliRunner
 
 from holmes.main import app
+from holmes.checks.models import CheckResponse
 from holmes.core.tool_calling_llm import LLMResult
 
 
@@ -111,3 +112,53 @@ def test_checks_cli_inline_check(mock_create_toolcalling_llm):
 
     # Verify LLM was called
     mock_ai.call.assert_called_once()
+
+
+@patch("holmes.config.Config.create_toolcalling_llm")
+def test_checks_response_format_is_pydantic_model(mock_create_toolcalling_llm):
+    """Verify ai.call() receives CheckResponse (Pydantic model) as response_format.
+
+    Passing a raw OpenAI-format dict with "type": "json_schema" / "strict": True
+    causes Vertex AI / Gemini to return INVALID_ARGUMENT. litellm can only translate
+    the format correctly per-provider when given a Pydantic model class.
+    """
+    mock_ai = MagicMock()
+    mock_ai.llm.model = "vertex_ai/gemini-pro"
+
+    mock_response = LLMResult(
+        result=json.dumps({"passed": True, "rationale": "Everything looks healthy."}),
+        tool_calls=[],
+    )
+    mock_ai.call.return_value = mock_response
+    mock_create_toolcalling_llm.return_value = mock_ai
+
+    checks_config = {
+        "version": 1,
+        "checks": [
+            {
+                "name": "vertex-compat-check",
+                "query": "Are all pods running?",
+                "description": "Vertex AI compatibility check",
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+        yaml.dump(checks_config, f)
+        checks_file = Path(f.name)
+
+        result = runner.invoke(
+            app,
+            ["checks", "run", "--checks-file", str(checks_file), "--mode", "monitor"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+
+    # The critical assertion: response_format must be the CheckResponse Pydantic class,
+    # NOT a raw dict (which breaks Vertex AI / Gemini with INVALID_ARGUMENT).
+    call_kwargs = mock_ai.call.call_args.kwargs
+    assert call_kwargs.get("response_format") is CheckResponse, (
+        "response_format must be the CheckResponse Pydantic model class so litellm "
+        "can translate it correctly for each provider (Vertex AI, Gemini, etc.). "
+        f"Got: {call_kwargs.get('response_format')!r}"
+    )

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -7,6 +7,7 @@ import threading
 import time
 import unittest
 from io import StringIO
+from typing import Optional
 from unittest.mock import Mock, patch
 
 from rich.console import Console
@@ -1123,6 +1124,14 @@ class TestRendererEndToEnd(unittest.TestCase):
         renderer = AgenticProgressRenderer(console, tool_number_offset=0)
         root = logging.getLogger()
 
+        # In xdist workers the root logger may have no handlers, which means the
+        # filter would be installed on nothing and the buffer would stay empty.
+        # Add a temporary NullHandler to guarantee the filter has somewhere to sit.
+        temp_handler: Optional[logging.Handler] = None
+        if not root.handlers:
+            temp_handler = logging.NullHandler()
+            root.addHandler(temp_handler)
+
         # Install filter on all handlers (matches production behavior)
         for handler in root.handlers:
             handler.addFilter(renderer._log_filter)
@@ -1138,6 +1147,8 @@ class TestRendererEndToEnd(unittest.TestCase):
             for handler in root.handlers:
                 handler.removeFilter(renderer._log_filter)
             renderer._log_buffer.clear()
+            if temp_handler is not None:
+                root.removeHandler(temp_handler)
 
     def test_start_installs_log_filter_on_handlers(self):
         """start() should install the log filter on root logger's handlers."""


### PR DESCRIPTION
[Issue Addressed](https://github.com/HolmesGPT/holmesgpt/issues/2188)

Fix(checks): use Pydantic model as response_format to fix Vertex AI /Gemini compatibility

Passing a raw OpenAI-format dict with type: json_schema / strict: True as the response_format causes Vertex AI and Gemini to return INVALID_ARGUMENT, breaking the holmesgpt-operator when using those providers.

Replace CHECK_RESPONSE_FORMAT (a hardcoded dict) with the CheckResponse Pydantic model class directly. litellm translates a Pydantic model into the correct structured-output schema for each provider — OpenAI json_schema, Vertex AI responseSchema, etc. — whereas the raw dict was OpenAI-specific.

Tests:
- Add test_checks_response_format_is_pydantic_model to assert ai.call() receives CheckResponse (the Pydantic class) rather than a raw dict, catching any future regression on non-OpenAI providers.
- Fix test_log_buffering_filter flake under pytest-xdist: in some workers the root logger has no handlers, so the log filter was installed on nothing and the buffer stayed empty. Add a temporary NullHandler when needed so the filter has somewhere to sit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI-powered check execution by standardizing the structured response format used across providers.
  * Reduced the likelihood of check-run failures caused by mismatched response-format expectations.
  * Strengthened logging behavior during interactive usage to prevent missing-handler issues.
* **Tests**
  * Added coverage to ensure the CLI passes the expected structured response format during monitor-mode runs.
  * Updated interactive logging test setup to be resilient in parallelized environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->