### PR TITLE
feat(toolsets): add quickwit/logs toolset implementing the unified fetch_pod_logs API

### DIFF
--- a/docs/data-sources/builtin-toolsets/.nav.yml
+++ b/docs/data-sources/builtin-toolsets/.nav.yml
@@ -45,6 +45,7 @@ nav:
   - PostgreSQL: database-postgresql.md
   - Prometheus: prometheus.md
   - Prefect (MCP): prefect-mcp.md
+  - Quickwit: quickwit.md
   - RabbitMQ: rabbitmq.md
   - Robusta: robusta.md
   - Sentry (MCP): sentry-mcp.md

--- a/docs/data-sources/builtin-toolsets/index.md
+++ b/docs/data-sources/builtin-toolsets/index.md
@@ -29,6 +29,7 @@ HolmesGPT includes pre-built integrations for popular monitoring and observabili
 -   [:simple-splunk:{ .lg .middle } **Splunk (MCP)**](splunk-mcp.md)
 -   [:simple-grafana:{ .lg .middle } **Tempo**](grafanatempo.md)
 -   [:material-bug:{ .lg .middle } **Sentry (MCP)**](sentry-mcp.md)
+-   [:material-file-search:{ .lg .middle } **Quickwit**](quickwit.md)
 -   [:simple-victoriametrics:{ .lg .middle } **VictoriaLogs**](victorialogs.md)
 -   [:material-monitor-dashboard:{ .lg .middle } **Zabbix**](zabbix.md)
 

--- a/docs/data-sources/builtin-toolsets/quickwit.md
+++ b/docs/data-sources/builtin-toolsets/quickwit.md
@@ -52,9 +52,3 @@ Dotted paths are resolved against nested JSON documents.
 - The time range is passed as `start_timestamp`/`end_timestamp` (unix seconds) and results are requested newest-first, so high-volume periods cannot rotate recent lines out of the window.
 - `filter`/`exclude_filter` are applied as case-insensitive regexes in code (a malformed regex degrades to a literal match), and rows with an empty message field (common for noisy sidecars) are dropped before the limit is applied.
 - When more lines match than the limit, the response says so explicitly (`[showing the N most recent of M matching lines]`) instead of truncating silently.
-
-## Capabilities
-
-| Tool Name | Description |
-|-----------|-------------|
-| fetch_pod_logs | Fetch logs for a Kubernetes pod from Quickwit with regex filtering, exclusion patterns and time ranges |

--- a/docs/data-sources/builtin-toolsets/quickwit.md
+++ b/docs/data-sources/builtin-toolsets/quickwit.md
@@ -1,0 +1,60 @@
+# Quickwit
+
+Connect HolmesGPT to [Quickwit](https://quickwit.io/) for Kubernetes pod log analysis. Implements the unified `fetch_pod_logs` API: the model supplies typed parameters (pod, namespace, filter, time range) and the toolset builds the Quickwit query deterministically — no query language is exposed to the LLM, so malformed queries, unsupported wildcards, or quoting issues cannot silently return empty results.
+
+## When to Use This
+
+- ✅ You ship Kubernetes pod logs into a Quickwit index (e.g. via Vector or Fluent Bit)
+- ✅ You want HolmesGPT to read pod logs from Quickwit instead of `kubectl logs`
+- ✅ Your log documents carry pod/namespace/container metadata fields
+
+## Prerequisites
+
+- A reachable Quickwit HTTP endpoint (default port: `7280`)
+- An index whose documents include the log message, a unix-seconds timestamp, and Kubernetes metadata fields (defaults match Vector's `kubernetes_logs` source: `kubernetes.pod_name`, `kubernetes.pod_namespace`, `kubernetes.container_name`)
+
+--8<-- "snippets/toolsets_that_provide_logging.md"
+
+## Configuration
+
+```yaml-toolset-config
+toolsets:
+  quickwit/logs:
+    enabled: true
+    config:
+      api_url: http://quickwit.monitoring.svc:7280
+      index: k8s-logs
+```
+
+### Field mapping
+
+If your index uses different field names, override the defaults:
+
+```yaml-toolset-config
+toolsets:
+  quickwit/logs:
+    enabled: true
+    config:
+      api_url: http://quickwit.monitoring.svc:7280
+      index: k8s-logs
+      timestamp_field: timestamp
+      message_field: message
+      namespace_field: kubernetes.pod_namespace
+      pod_field: kubernetes.pod_name
+      container_field: kubernetes.container_name
+```
+
+Dotted paths are resolved against nested JSON documents.
+
+## How it works
+
+- The query is built from exact field terms only (`<namespace_field>:<ns> AND <pod_field>:<pod>`); identifiers are sanitized to the DNS-1123 character set, so model-supplied values can never alter the query structure.
+- The time range is passed as `start_timestamp`/`end_timestamp` (unix seconds) and results are requested newest-first, so high-volume periods cannot rotate recent lines out of the window.
+- `filter`/`exclude_filter` are applied as case-insensitive regexes in code (a malformed regex degrades to a literal match), and rows with an empty message field (common for noisy sidecars) are dropped before the limit is applied.
+- When more lines match than the limit, the response says so explicitly (`[showing the N most recent of M matching lines]`) instead of truncating silently.
+
+## Capabilities
+
+| Tool Name | Description |
+|-----------|-------------|
+| fetch_pod_logs | Fetch logs for a Kubernetes pod from Quickwit with regex filtering, exclusion patterns and time ranges |

--- a/docs/snippets/toolsets_that_provide_logging.md
+++ b/docs/snippets/toolsets_that_provide_logging.md
@@ -7,3 +7,4 @@
     - **[Elasticsearch / OpenSearch](elasticsearch.md)** - Logs from Elasticsearch/OpenSearch
     - **[Coralogix](coralogix-logs.md)** - Logs via Coralogix platform
     - **[DataDog](datadog.md)** - Logs from DataDog
+    - **[Quickwit](quickwit.md)** - Logs from a Quickwit index

--- a/holmes/plugins/toolsets/__init__.py
+++ b/holmes/plugins/toolsets/__init__.py
@@ -56,6 +56,7 @@ from holmes.plugins.toolsets.investigator.core_investigation import (
 from holmes.plugins.toolsets.kafka import KafkaToolset
 from holmes.plugins.toolsets.kubectl_run.kubectl_run_toolset import KubectlRunToolset
 from holmes.plugins.toolsets.kubernetes_logs import KubernetesLogsToolset
+from holmes.plugins.toolsets.quickwit.quickwit import QuickwitLogsToolset
 from holmes.plugins.toolsets.mcp.toolset_mcp import RemoteMCPToolset
 from holmes.plugins.toolsets.multi_instance import multi_instance
 from holmes.plugins.toolsets.newrelic.newrelic import NewRelicToolset
@@ -140,6 +141,8 @@ def load_python_toolsets(
 
     if not USE_LEGACY_KUBERNETES_LOGS:
         toolsets.append(KubernetesLogsToolset())
+
+    toolsets.append(QuickwitLogsToolset())
 
     platform_mcp = make_robusta_platform_mcp_toolset(dal)
     if platform_mcp is not None:

--- a/holmes/plugins/toolsets/logging_utils/logging_api.py
+++ b/holmes/plugins/toolsets/logging_utils/logging_api.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from math import ceil
-from typing import TYPE_CHECKING, Optional
+from typing import Optional, Protocol
 
 from pydantic import BaseModel, field_validator
 
@@ -15,8 +15,13 @@ from holmes.core.tools import (
 from holmes.core.tools_utils.token_counting import count_tool_response_tokens
 from holmes.plugins.toolsets.utils import get_param_or_raise
 
-if TYPE_CHECKING:
-    from holmes.plugins.toolsets.kubernetes_logs import KubernetesLogsToolset
+class PodLoggingToolset(Protocol):
+    """Structural interface for toolsets that back the unified fetch_pod_logs tool."""
+
+    name: str
+
+    def fetch_pod_logs(self, params: "FetchPodLogsParams") -> StructuredToolResult: ...
+
 
 # Default values for log fetching
 DEFAULT_LOG_LIMIT = 100
@@ -124,7 +129,7 @@ def truncate_logs(
 class PodLoggingTool(Tool):
     """Tool for fetching Kubernetes pod logs"""
 
-    def __init__(self, toolset: "KubernetesLogsToolset"):
+    def __init__(self, toolset: "PodLoggingToolset"):
         toolset_name = toolset.name if toolset.name else "logging backend"
         description = (
             f"Fetch logs for a Kubernetes pod from {toolset_name}"

--- a/holmes/plugins/toolsets/quickwit/quickwit.py
+++ b/holmes/plugins/toolsets/quickwit/quickwit.py
@@ -1,0 +1,255 @@
+"""Quickwit pod-logging toolset implementing the unified fetch_pod_logs API.
+
+The model never writes a Quickwit query: it supplies typed parameters (namespace, pod_name,
+filter, time range) and this toolset builds the query deterministically — exact field terms
+only (no wildcards, which Quickwit silently ignores), identifiers sanitized so quoting can
+never corrupt the query, sidecar noise with empty messages dropped before the limit is
+applied, and regex filtering done in code rather than pushed to the query language.
+"""
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, ClassVar, Dict, Tuple, Type
+
+import requests  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field
+
+from holmes.utils.pydantic_utils import ToolsetConfig
+
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    Toolset,
+    ToolsetTag,
+)
+from holmes.plugins.toolsets.logging_utils.logging_api import (
+    DEFAULT_LOG_LIMIT,
+    DEFAULT_TIME_SPAN_SECONDS,
+    FetchPodLogsParams,
+    PodLoggingTool,
+)
+from holmes.plugins.toolsets.utils import process_timestamps_to_int
+
+# fetch generously before code-side filtering/dropping so high-volume sidecars can't
+# starve the interesting container's lines out of the window
+FETCH_HITS = 1000
+
+# k8s object names are DNS-1123 (alphanumerics, '-', '.'); everything else is stripped so a
+# crafted identifier can never alter the query structure
+_IDENTIFIER_SAFE = re.compile(r"[^A-Za-z0-9_.\-]")
+
+
+class QuickwitConfig(ToolsetConfig):
+    """Configuration for Quickwit API access.
+
+    Example configuration:
+    ```yaml
+    api_url: "http://quickwit.monitoring.svc:7280"
+    index: "k8s-logs"
+    ```
+    """
+
+    api_url: str = Field(
+        title="API URL",
+        description="Base URL of the Quickwit server (without trailing slash).",
+        examples=["http://quickwit.monitoring.svc:7280"],
+    )
+    index: str = Field(
+        title="Index ID",
+        description="Quickwit index holding the Kubernetes logs.",
+        examples=["k8s-logs"],
+    )
+    timestamp_field: str = Field(
+        default="timestamp",
+        title="Timestamp Field",
+        description="Document field holding the event time (unix seconds).",
+    )
+    message_field: str = Field(
+        default="message",
+        title="Message Field",
+        description="Document field holding the log line text (dotted paths supported).",
+    )
+    namespace_field: str = Field(
+        default="kubernetes.pod_namespace",
+        title="Namespace Field",
+        description="Document field holding the pod namespace (dotted paths supported).",
+    )
+    pod_field: str = Field(
+        default="kubernetes.pod_name",
+        title="Pod Field",
+        description="Document field holding the pod name (dotted paths supported).",
+    )
+    container_field: str = Field(
+        default="kubernetes.container_name",
+        title="Container Field",
+        description="Document field holding the container name (dotted paths supported).",
+    )
+    timeout_seconds: int = Field(
+        default=30,
+        title="Timeout Seconds",
+        description="Request timeout in seconds.",
+    )
+
+
+def _sanitize(value: str) -> str:
+    return _IDENTIFIER_SAFE.sub("", value or "")
+
+
+def _dotted_get(obj: Dict[str, Any], dotted: str) -> Any:
+    cur: Any = obj
+    for part in dotted.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def _compile_or_literal(pattern: str) -> re.Pattern:
+    """Filters are advertised as regex; a malformed pattern degrades to a literal match."""
+    try:
+        return re.compile(pattern, re.IGNORECASE)
+    except re.error:
+        return re.compile(re.escape(pattern), re.IGNORECASE)
+
+
+class QuickwitLogsToolset(Toolset):
+    """Fetch pod logs from a Quickwit index via the unified fetch_pod_logs API."""
+
+    config_classes: ClassVar[list[Type[BaseModel]]] = [QuickwitConfig]
+
+    def __init__(self):
+        super().__init__(
+            name="quickwit/logs",
+            description="Read Kubernetes pod logs stored in Quickwit using a unified API",
+            docs_url="https://quickwit.io/docs/reference/rest-api",
+            icon_url="https://avatars.githubusercontent.com/u/74226539?s=200&v=4",
+            prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
+            tools=[],
+            tags=[ToolsetTag.CORE],
+        )
+        self.tools = [PodLoggingTool(self)]
+
+    def prerequisites_callable(self, config: Dict[str, Any]) -> Tuple[bool, str]:
+        if not config:
+            return False, "quickwit/logs requires config with api_url and index"
+        try:
+            self.config = QuickwitConfig(**config)
+        except Exception as e:
+            return False, f"Failed to validate Quickwit configuration: {e}"
+        return self._health_check()
+
+    @property
+    def quickwit_config(self) -> QuickwitConfig:
+        return self.config  # type: ignore[return-value]
+
+    def _health_check(self) -> Tuple[bool, str]:
+        cfg = self.quickwit_config
+        url = f"{cfg.api_url.rstrip('/')}/health/livez"
+        try:
+            response = requests.get(url, timeout=min(cfg.timeout_seconds, 10))
+            response.raise_for_status()
+            return True, f"Connected to Quickwit at {cfg.api_url}"
+        except Exception as e:
+            return False, f"Quickwit health check failed for {url}: {e}"
+
+    def fetch_pod_logs(self, params: FetchPodLogsParams) -> StructuredToolResult:
+        cfg = self.quickwit_config
+        start_unix, end_unix = process_timestamps_to_int(
+            start=params.start_time,
+            end=params.end_time,
+            default_time_span_seconds=DEFAULT_TIME_SPAN_SECONDS,
+        )
+        limit = params.limit or DEFAULT_LOG_LIMIT
+
+        namespace = _sanitize(params.namespace)
+        pod_name = _sanitize(params.pod_name)
+        query = f"{cfg.namespace_field}:{namespace} AND {cfg.pod_field}:{pod_name}"
+
+        request_params: Dict[str, Any] = {
+            "query": query,
+            "max_hits": FETCH_HITS,
+            # newest-first so a large result set can never rotate the recent lines out
+            "sort_by": f"-{cfg.timestamp_field}",
+        }
+        request_params["start_timestamp"] = start_unix
+        request_params["end_timestamp"] = end_unix
+
+        url = f"{cfg.api_url.rstrip('/')}/api/v1/{cfg.index}/search"
+        try:
+            response = requests.get(
+                url, params=request_params, timeout=cfg.timeout_seconds
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as e:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    f"Quickwit search failed for {url} "
+                    f"(params={json.dumps(request_params, default=str)}): {e}"
+                ),
+                params=params.model_dump(),
+            )
+
+        include = _compile_or_literal(params.filter) if params.filter else None
+        exclude = (
+            _compile_or_literal(params.exclude_filter)
+            if params.exclude_filter
+            else None
+        )
+
+        rows = []
+        for hit in payload.get("hits") or []:
+            message = _dotted_get(hit, cfg.message_field)
+            if not message:
+                continue  # high-volume sidecars whose lines carry no message are pure noise
+            if include and not include.search(message):
+                continue
+            if exclude and exclude.search(message):
+                continue
+            rows.append(
+                (
+                    _dotted_get(hit, cfg.timestamp_field) or 0,
+                    _dotted_get(hit, cfg.container_field) or "?",
+                    message,
+                )
+            )
+
+        rows.sort(key=lambda r: r[0])
+        total_matched = len(rows)
+        rows = rows[-limit:]  # keep the most recent lines, chronological order
+
+        if not rows:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.NO_DATA,
+                data=(
+                    f"No logs found for pod {params.pod_name} in namespace {params.namespace} "
+                    f"between {start_unix} and {end_unix} (unix seconds)"
+                    + (f" matching filter '{params.filter}'" if params.filter else "")
+                    + f" (query: {query})."
+                ),
+                params=params.model_dump(),
+            )
+
+        lines = []
+        if total_matched > len(rows):
+            lines.append(
+                f"[showing the {len(rows)} most recent of {total_matched} matching lines]"
+            )
+        for ts, container, message in rows:
+            iso = (
+                datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+                if isinstance(ts, (int, float)) and ts
+                else "?"
+            )
+            lines.append(f"{iso} {container} {message}")
+
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS,
+            data="\n".join(lines),
+            params=params.model_dump(),
+        )

--- a/holmes/plugins/toolsets/quickwit/quickwit.py
+++ b/holmes/plugins/toolsets/quickwit/quickwit.py
@@ -151,6 +151,12 @@ class QuickwitLogsToolset(Toolset):
             response = requests.get(url, timeout=min(cfg.timeout_seconds, 10))
             response.raise_for_status()
             return True, f"Connected to Quickwit at {cfg.api_url}"
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "?"
+            body = e.response.text[:1000] if e.response is not None else ""
+            return False, (
+                f"Quickwit health check failed for {url}: HTTP {status}. Response: {body}"
+            )
         except Exception as e:
             return False, f"Quickwit health check failed for {url}: {e}"
 
@@ -183,12 +189,34 @@ class QuickwitLogsToolset(Toolset):
             )
             response.raise_for_status()
             payload = response.json()
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "?"
+            body = e.response.text[:1000] if e.response is not None else ""
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    f"Quickwit search failed for {url} with HTTP {status} "
+                    f"(params={json.dumps(request_params, default=str)}). "
+                    f"Response: {body}"
+                ),
+                params=params.model_dump(),
+            )
         except Exception as e:
             return StructuredToolResult(
                 status=StructuredToolResultStatus.ERROR,
                 error=(
                     f"Quickwit search failed for {url} "
                     f"(params={json.dumps(request_params, default=str)}): {e}"
+                ),
+                params=params.model_dump(),
+            )
+
+        if not isinstance(payload, dict):
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    f"Quickwit search for {url} returned an unexpected response shape "
+                    f"(expected a JSON object): {str(payload)[:500]}"
                 ),
                 params=params.model_dump(),
             )

--- a/tests/plugins/toolsets/test_quickwit.py
+++ b/tests/plugins/toolsets/test_quickwit.py
@@ -1,8 +1,9 @@
 """Tests for the Quickwit pod-logging toolset (unified fetch_pod_logs API)."""
 
-from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
+import responses
 
 from holmes.core.tools import StructuredToolResultStatus
 from holmes.plugins.toolsets.logging_utils.logging_api import FetchPodLogsParams
@@ -12,6 +13,8 @@ from holmes.plugins.toolsets.quickwit.quickwit import (
 )
 
 TS = 1783432000  # base unix seconds for fixture hits
+API_URL = "http://quickwit.monitoring.svc:7280"
+SEARCH_URL = f"{API_URL}/api/v1/stage-zksync-os-stage/search"
 
 
 def _hit(t, container, msg, pod="app-1-abc", ns="prod"):
@@ -26,57 +29,47 @@ def _hit(t, container, msg, pod="app-1-abc", ns="prod"):
     }
 
 
-def _response(hits):
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"num_hits": len(hits), "hits": hits}
-    resp.raise_for_status.return_value = None
-    return resp
-
-
 @pytest.fixture()
 def toolset():
     ts = QuickwitLogsToolset()
-    ts.config = QuickwitConfig(
-        api_url="http://quickwit.monitoring.svc:7280",
-        index="stage-zksync-os-stage",
-    )
+    ts.config = QuickwitConfig(api_url=API_URL, index="stage-zksync-os-stage")
     return ts
 
 
 def _fetch(toolset, hits, **param_overrides):
+    """Run fetch_pod_logs against a mocked Quickwit; returns (result, sent query params)."""
     kwargs = {"namespace": "prod", "pod_name": "app-1-abc", **param_overrides}
     params = FetchPodLogsParams(**kwargs)
-    with patch(
-        "holmes.plugins.toolsets.quickwit.quickwit.requests.get",
-        return_value=_response(hits),
-    ) as mock_get:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            SEARCH_URL,
+            json={"num_hits": len(hits), "hits": hits},
+            status=200,
+        )
         result = toolset.fetch_pod_logs(params)
-    return result, mock_get
+        url = urlparse(rsps.calls[0].request.url)
+        query = {k: v[0] for k, v in parse_qs(url.query).items()}
+    return result, query
 
 
 def test_builds_exact_term_query_with_time_range(toolset):
-    result, mock_get = _fetch(toolset, [_hit(TS, "server", "boom")])
+    result, query = _fetch(toolset, [_hit(TS, "server", "boom")])
 
     assert result.status == StructuredToolResultStatus.SUCCESS
-    url = (
-        mock_get.call_args.args[0]
-        if mock_get.call_args.args
-        else mock_get.call_args.kwargs["url"]
-    )
-    assert "/api/v1/stage-zksync-os-stage/search" in url
-    q = mock_get.call_args.kwargs["params"]
     assert (
-        q["query"] == "kubernetes.pod_namespace:prod AND kubernetes.pod_name:app-1-abc"
+        query["query"]
+        == "kubernetes.pod_namespace:prod AND kubernetes.pod_name:app-1-abc"
     )
-    assert isinstance(q["start_timestamp"], int) and isinstance(q["end_timestamp"], int)
-    assert q["end_timestamp"] > q["start_timestamp"]
+    assert int(query["end_timestamp"]) > int(query["start_timestamp"])
+    assert query["sort_by"] == "-timestamp"
 
 
 def test_query_values_are_sanitized_against_injection(toolset):
-    """Quotes/parens in identifiers must not reach the Quickwit query string."""
-    result, mock_get = _fetch(toolset, [], namespace="prod'", pod_name='app OR *"')
-    q = mock_get.call_args.kwargs["params"]["query"]
+    """Quotes/spaces/wildcards in identifiers must not reach the Quickwit query string."""
+    result, query = _fetch(toolset, [], namespace="prod'", pod_name='app OR *"')
+
+    q = query["query"]
     assert "'" not in q and '"' not in q and "*" not in q
     # spaces are stripped, so the injected ` OR ` cannot become a query operator: the pod
     # value collapses into one harmless term and the query keeps exactly one AND
@@ -86,7 +79,7 @@ def test_query_values_are_sanitized_against_injection(toolset):
 
 def test_log_lines_include_container_and_drop_empty_messages(toolset):
     hits = [
-        _hit(TS + 1, "anvil", ""),  # noisy sidecar line with empty message → dropped
+        _hit(TS + 1, "anvil", ""),  # noisy sidecar line with empty message -> dropped
         _hit(TS + 2, "server", "CRITICAL: failed to reach http://127.0.0.1:19545"),
         _hit(TS + 3, "anvil", ""),
     ]
@@ -127,9 +120,7 @@ def test_limit_keeps_most_recent_lines_in_chronological_order(toolset):
     lines = result.data.strip().splitlines()
     assert "most recent of 10" in lines[0]  # the model is TOLD results were capped
     assert len(lines) == 4  # banner + 3 log lines
-    assert (
-        "line-7" in lines[1] and "line-9" in lines[3]
-    )  # oldest→newest, most recent kept
+    assert "line-7" in lines[1] and "line-9" in lines[3]  # oldest->newest, recent kept
 
 
 def test_zero_hits_returns_no_data_with_context(toolset):
@@ -138,18 +129,64 @@ def test_zero_hits_returns_no_data_with_context(toolset):
     assert "app-1-abc" in str(result.data)
 
 
-def test_http_error_returns_error_result_never_raises(toolset):
+def test_http_error_surfaces_status_and_response_body(toolset):
+    """Quickwit puts the actionable detail (e.g. malformed query, unknown field) in the
+    response body — the error result must include it for LLM self-correction."""
     params = FetchPodLogsParams(namespace="prod", pod_name="app-1-abc")
-    with patch(
-        "holmes.plugins.toolsets.quickwit.quickwit.requests.get",
-        side_effect=Exception("connection refused"),
-    ):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            SEARCH_URL,
+            body='{"message": "field does not exist: `kubernetes.pod_nam`"}',
+            status=400,
+        )
+        result = toolset.fetch_pod_logs(params)
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "HTTP 400" in result.error
+    assert "field does not exist" in result.error
+
+
+def test_connection_error_returns_error_result_never_raises(toolset):
+    params = FetchPodLogsParams(namespace="prod", pod_name="app-1-abc")
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            SEARCH_URL,
+            body=ConnectionError("connection refused"),
+        )
         result = toolset.fetch_pod_logs(params)
     assert result.status == StructuredToolResultStatus.ERROR
     assert "connection refused" in result.error
+
+
+def test_non_dict_response_returns_error_not_attributeerror(toolset):
+    """A 200 with a JSON array body must produce a clean ERROR result."""
+    params = FetchPodLogsParams(namespace="prod", pod_name="app-1-abc")
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, SEARCH_URL, json=["unexpected", "array"], status=200)
+        result = toolset.fetch_pod_logs(params)
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "unexpected response shape" in result.error
 
 
 def test_prerequisites_fail_cleanly_without_config():
     ts = QuickwitLogsToolset()
     ok, msg = ts.prerequisites_callable({})
     assert ok is False and msg
+
+
+def test_health_check_error_includes_response_body():
+    ts = QuickwitLogsToolset()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            f"{API_URL}/health/livez",
+            body="service unavailable: searcher not ready",
+            status=503,
+        )
+        ok, msg = ts.prerequisites_callable(
+            {"api_url": API_URL, "index": "stage-zksync-os-stage"}
+        )
+    assert ok is False
+    assert "HTTP 503" in msg
+    assert "searcher not ready" in msg

--- a/tests/plugins/toolsets/test_quickwit.py
+++ b/tests/plugins/toolsets/test_quickwit.py
@@ -1,0 +1,155 @@
+"""Tests for the Quickwit pod-logging toolset (unified fetch_pod_logs API)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.core.tools import StructuredToolResultStatus
+from holmes.plugins.toolsets.logging_utils.logging_api import FetchPodLogsParams
+from holmes.plugins.toolsets.quickwit.quickwit import (
+    QuickwitConfig,
+    QuickwitLogsToolset,
+)
+
+TS = 1783432000  # base unix seconds for fixture hits
+
+
+def _hit(t, container, msg, pod="app-1-abc", ns="prod"):
+    return {
+        "timestamp": t,
+        "message": msg,
+        "kubernetes": {
+            "pod_name": pod,
+            "pod_namespace": ns,
+            "container_name": container,
+        },
+    }
+
+
+def _response(hits):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"num_hits": len(hits), "hits": hits}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.fixture()
+def toolset():
+    ts = QuickwitLogsToolset()
+    ts.config = QuickwitConfig(
+        api_url="http://quickwit.monitoring.svc:7280",
+        index="stage-zksync-os-stage",
+    )
+    return ts
+
+
+def _fetch(toolset, hits, **param_overrides):
+    kwargs = {"namespace": "prod", "pod_name": "app-1-abc", **param_overrides}
+    params = FetchPodLogsParams(**kwargs)
+    with patch(
+        "holmes.plugins.toolsets.quickwit.quickwit.requests.get",
+        return_value=_response(hits),
+    ) as mock_get:
+        result = toolset.fetch_pod_logs(params)
+    return result, mock_get
+
+
+def test_builds_exact_term_query_with_time_range(toolset):
+    result, mock_get = _fetch(toolset, [_hit(TS, "server", "boom")])
+
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    url = (
+        mock_get.call_args.args[0]
+        if mock_get.call_args.args
+        else mock_get.call_args.kwargs["url"]
+    )
+    assert "/api/v1/stage-zksync-os-stage/search" in url
+    q = mock_get.call_args.kwargs["params"]
+    assert (
+        q["query"] == "kubernetes.pod_namespace:prod AND kubernetes.pod_name:app-1-abc"
+    )
+    assert isinstance(q["start_timestamp"], int) and isinstance(q["end_timestamp"], int)
+    assert q["end_timestamp"] > q["start_timestamp"]
+
+
+def test_query_values_are_sanitized_against_injection(toolset):
+    """Quotes/parens in identifiers must not reach the Quickwit query string."""
+    result, mock_get = _fetch(toolset, [], namespace="prod'", pod_name='app OR *"')
+    q = mock_get.call_args.kwargs["params"]["query"]
+    assert "'" not in q and '"' not in q and "*" not in q
+    # spaces are stripped, so the injected ` OR ` cannot become a query operator: the pod
+    # value collapses into one harmless term and the query keeps exactly one AND
+    assert " OR " not in q
+    assert q == "kubernetes.pod_namespace:prod AND kubernetes.pod_name:appOR"
+
+
+def test_log_lines_include_container_and_drop_empty_messages(toolset):
+    hits = [
+        _hit(TS + 1, "anvil", ""),  # noisy sidecar line with empty message → dropped
+        _hit(TS + 2, "server", "CRITICAL: failed to reach http://127.0.0.1:19545"),
+        _hit(TS + 3, "anvil", ""),
+    ]
+    result, _ = _fetch(toolset, hits)
+
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "19545" in result.data
+    assert "server" in result.data
+    assert result.data.count("\n") == 0  # single surviving line
+
+
+def test_filter_and_exclude_filter_are_case_insensitive_regex(toolset):
+    hits = [
+        _hit(TS + 1, "server", "level=INFO healthy heartbeat"),
+        _hit(TS + 2, "server", "level=ERROR something broke"),
+        _hit(TS + 3, "server", "level=CRITICAL panic at provider"),
+    ]
+    result, _ = _fetch(
+        toolset, hits, filter="error|critical", exclude_filter="HEARTBEAT"
+    )
+
+    assert "something broke" in result.data
+    assert "panic at provider" in result.data
+    assert "heartbeat" not in result.data
+
+
+def test_invalid_filter_regex_falls_back_to_literal(toolset):
+    hits = [_hit(TS, "server", "weird [unclosed bracket in log")]
+    result, _ = _fetch(toolset, hits, filter="[unclosed")
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "unclosed bracket" in result.data
+
+
+def test_limit_keeps_most_recent_lines_in_chronological_order(toolset):
+    hits = [_hit(TS + i, "server", f"line-{i}") for i in range(10)]
+    result, _ = _fetch(toolset, hits, limit=3)
+
+    lines = result.data.strip().splitlines()
+    assert "most recent of 10" in lines[0]  # the model is TOLD results were capped
+    assert len(lines) == 4  # banner + 3 log lines
+    assert (
+        "line-7" in lines[1] and "line-9" in lines[3]
+    )  # oldest→newest, most recent kept
+
+
+def test_zero_hits_returns_no_data_with_context(toolset):
+    result, _ = _fetch(toolset, [])
+    assert result.status == StructuredToolResultStatus.NO_DATA
+    assert "app-1-abc" in str(result.data)
+
+
+def test_http_error_returns_error_result_never_raises(toolset):
+    params = FetchPodLogsParams(namespace="prod", pod_name="app-1-abc")
+    with patch(
+        "holmes.plugins.toolsets.quickwit.quickwit.requests.get",
+        side_effect=Exception("connection refused"),
+    ):
+        result = toolset.fetch_pod_logs(params)
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "connection refused" in result.error
+
+
+def test_prerequisites_fail_cleanly_without_config():
+    ts = QuickwitLogsToolset()
+    ok, msg = ts.prerequisites_callable({})
+    assert ok is False and msg


### PR DESCRIPTION
## Summary

Adds a native Quickwit backend for Kubernetes pod logs, implementing the unified `fetch_pod_logs` API: the model supplies typed parameters (pod, namespace, filter, time range) and the toolset builds the Quickwit query deterministically — no query language is exposed to the LLM.

To make this possible, `PodLoggingTool`'s toolset parameter is generalized from the concrete `KubernetesLogsToolset` to a small `PodLoggingToolset` Protocol (structural: `name` + `fetch_pod_logs`), making the unified logging API pluggable for additional backends. `KubernetesLogsToolset` satisfies it unchanged.

## Motivation

We ran Quickwit through a custom YAML `command:` toolset and hit an instructive series of failures in real investigations: the model writes wildcard queries that Quickwit silently ignores, wraps queries in quotes that break field syntax, and concludes "logs are unavailable" from false-empty results — producing confidently wrong root-cause analyses while the decisive log line sat in the index. A typed `fetch_pod_logs` implementation eliminates that failure class by construction. In our fault-injection drills, the same model (claude-haiku) went from a wrong RCA to citing the exact CRITICAL log line, at lower cost per investigation.

## Design notes

- Query is built from exact field terms only; pod/namespace identifiers are sanitized to the DNS-1123 charset, so model-supplied values cannot alter query structure.
- Time range via `start_timestamp`/`end_timestamp` (unix seconds, using the shared `process_timestamps_to_int`); results requested newest-first so busy periods can't rotate recent lines out of the window.
- `filter`/`exclude_filter` applied as case-insensitive regexes in code, with literal-match fallback on malformed patterns.
- Rows with an empty message field (common for noisy sidecars) are dropped before the limit; capping is explicit: `[showing the N most recent of M matching lines]`.
- Field mapping is configurable and defaults to Vector's `kubernetes_logs` schema (`kubernetes.pod_name` etc.).

## Testing

- 9 unit tests covering query building, injection-resistance, filtering, empty-row dropping, capping, NO_DATA/error paths, and prerequisites.
- Existing `test_logging_api.py` and kubernetes toolset tests pass unchanged (66 tests together).
- Validated end-to-end on a kind cluster (Quickwit 0.8, Vector, HolmesGPT 0.35.0 with this toolset overlaid) investigating real crashloop faults.

## Docs

Adds `docs/data-sources/builtin-toolsets/quickwit.md` (modeled on the VictoriaLogs page), wired into `.nav.yml`, the toolsets index, and the "toolsets that provide logging" snippet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Quickwit as a built-in log source with end-to-end pod log retrieval via the unified pod-log API, including configurable field mappings and newest-first time-bounded queries.
* **Documentation**
  * Updated the sidebar and “Available Log Sources”, and added a Quickwit integration guide describing setup and expected indexed fields.
* **Bug Fixes**
  * Improved robustness of filtering (safe fallback for invalid regex), dropped empty messages before applying limits, and enhanced truncation/zero-hit messaging.
* **Tests**
  * Added comprehensive Quickwit toolset tests covering query construction, sanitization, filtering, limits, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->