### PR TITLE
ROB-589 Steer call_aws JSON-argument commands to the reliable no-JSON path (cut ~87s of retries)

### DIFF
--- a/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
@@ -9,13 +9,12 @@ IMPORTANT: When investigating issues related to AWS resources or Kubernetes work
 
 ## Cost Explorer and other JSON-argument commands (READ THIS FIRST)
 
-call_aws tokenizes the command with shell rules and has NO writable filesystem, which makes inline JSON arguments (Cost Explorer `--filter`, `--cli-input-json`, CloudWatch `--metric-data-queries`, etc.) unreliable — double quotes inside an unquoted JSON value get stripped and AWS receives invalid JSON. Follow this order:
+call_aws tokenizes the command with shell rules, which makes inline JSON arguments (Cost Explorer `--filter`, `--cli-input-json`, CloudWatch `--metric-data-queries`, etc.) unreliable — double quotes inside an unquoted JSON value get stripped and AWS receives invalid JSON. Follow this order:
 
 1. **Avoid inline JSON — prefer shorthand that needs no JSON.** For a breakdown by a dimension use `--group-by Type=DIMENSION,Key=SERVICE` (no quotes to lose), then filter/aggregate the results yourself in your analysis (e.g. keep only the row whose service key is "Amazon Bedrock"). This is the most reliable approach and sidesteps the quoting problem entirely. Example:
    `aws ce get-cost-and-usage --time-period Start=2026-01-01,End=2026-08-01 --granularity MONTHLY --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE`
-2. **Do NOT try to work around it with the filesystem.** call_aws cannot `mkdir`, `echo`/redirect to a file, or use `--filter file://...` — there is no writable filesystem. Repeated file/redirect attempts will only waste steps.
-3. **Only if you truly need a JSON argument**, wrap the ENTIRE value in single quotes (not double quotes, and do not backslash-escape the inner double quotes): `--filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}'`. If a single-quoted attempt still fails, do not keep retrying variations — fall back to option 1 (`--group-by` + client-side filtering).
-4. When unsure of the exact syntax, call `suggest_aws_commands` first, then run the suggested command with call_aws.
+2. **Only if you truly need a JSON argument**, wrap the ENTIRE value in single quotes (not double quotes, and do not backslash-escape the inner double quotes): `--filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}'`. If a single-quoted attempt still fails, do not keep retrying variations — fall back to option 1 (`--group-by` + client-side filtering).
+3. When unsure of the exact syntax, call `suggest_aws_commands` first, then run the suggested command with call_aws.
 
 ## Investigation Principles
 

--- a/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
@@ -7,6 +7,20 @@ Define the LLM instructions for AWS MCP
 {{- else -}}
 IMPORTANT: When investigating issues related to AWS resources or Kubernetes workloads running on AWS, you MUST actively use this MCP server to gather data rather than providing manual instructions to the user.
 
+## Passing JSON arguments to call_aws (READ THIS FIRST)
+
+call_aws runs the command you give it through shell-style tokenization. Any argument whose value is JSON — Cost Explorer `--filter`, `--cli-input-json`, CloudWatch `--metric-data-queries`, etc. — MUST be wrapped in **single quotes** so its inner double quotes survive. Single quotes ARE supported; use them.
+
+- WRONG — unquoted JSON: the double quotes are stripped and AWS receives invalid JSON like `{Dimensions:{Key:SERVICE,Values:[Amazon Bedrock]}}`:
+  `aws ce get-cost-and-usage ... --filter {"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}`
+- RIGHT — single-quote the whole JSON value:
+  `aws ce get-cost-and-usage --time-period Start=2026-01-01,End=2026-07-08 --granularity MONTHLY --metrics UnblendedCost --filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}'`
+
+More guidance for JSON-heavy commands:
+- Do NOT try to write the JSON to a file or create a directory first — call_aws has no writable filesystem and cannot run shell file/redirect/`mkdir` operations. Put the JSON inline in single quotes.
+- When you only need a breakdown by a dimension, prefer shorthand syntax, which has no quotes to lose: `--group-by Type=DIMENSION,Key=SERVICE`. Fetch the grouped result and aggregate/filter client-side rather than fighting a JSON `--filter`.
+- If you are unsure of the exact syntax, call `suggest_aws_commands` first to get a validated command, then run it with call_aws.
+
 ## Investigation Principles
 
 **ALWAYS follow this investigation flow:**

--- a/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
@@ -7,19 +7,15 @@ Define the LLM instructions for AWS MCP
 {{- else -}}
 IMPORTANT: When investigating issues related to AWS resources or Kubernetes workloads running on AWS, you MUST actively use this MCP server to gather data rather than providing manual instructions to the user.
 
-## Passing JSON arguments to call_aws (READ THIS FIRST)
+## Cost Explorer and other JSON-argument commands (READ THIS FIRST)
 
-call_aws runs the command you give it through shell-style tokenization. Any argument whose value is JSON — Cost Explorer `--filter`, `--cli-input-json`, CloudWatch `--metric-data-queries`, etc. — MUST be wrapped in **single quotes** so its inner double quotes survive. Single quotes ARE supported; use them.
+call_aws tokenizes the command with shell rules and has NO writable filesystem, which makes inline JSON arguments (Cost Explorer `--filter`, `--cli-input-json`, CloudWatch `--metric-data-queries`, etc.) unreliable — double quotes inside an unquoted JSON value get stripped and AWS receives invalid JSON. Follow this order:
 
-- WRONG — unquoted JSON: the double quotes are stripped and AWS receives invalid JSON like `{Dimensions:{Key:SERVICE,Values:[Amazon Bedrock]}}`:
-  `aws ce get-cost-and-usage ... --filter {"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}`
-- RIGHT — single-quote the whole JSON value:
-  `aws ce get-cost-and-usage --time-period Start=2026-01-01,End=2026-07-08 --granularity MONTHLY --metrics UnblendedCost --filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}'`
-
-More guidance for JSON-heavy commands:
-- Do NOT try to write the JSON to a file or create a directory first — call_aws has no writable filesystem and cannot run shell file/redirect/`mkdir` operations. Put the JSON inline in single quotes.
-- When you only need a breakdown by a dimension, prefer shorthand syntax, which has no quotes to lose: `--group-by Type=DIMENSION,Key=SERVICE`. Fetch the grouped result and aggregate/filter client-side rather than fighting a JSON `--filter`.
-- If you are unsure of the exact syntax, call `suggest_aws_commands` first to get a validated command, then run it with call_aws.
+1. **Avoid inline JSON — prefer shorthand that needs no JSON.** For a breakdown by a dimension use `--group-by Type=DIMENSION,Key=SERVICE` (no quotes to lose), then filter/aggregate the results yourself in your analysis (e.g. keep only the row whose service key is "Amazon Bedrock"). This is the most reliable approach and sidesteps the quoting problem entirely. Example:
+   `aws ce get-cost-and-usage --time-period Start=2026-01-01,End=2026-08-01 --granularity MONTHLY --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE`
+2. **Do NOT try to work around it with the filesystem.** call_aws cannot `mkdir`, `echo`/redirect to a file, or use `--filter file://...` — there is no writable filesystem. Repeated file/redirect attempts will only waste steps.
+3. **Only if you truly need a JSON argument**, wrap the ENTIRE value in single quotes (not double quotes, and do not backslash-escape the inner double quotes): `--filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}'`. If a single-quoted attempt still fails, do not keep retrying variations — fall back to option 1 (`--group-by` + client-side filtering).
+4. When unsure of the exact syntax, call `suggest_aws_commands` first, then run the suggested command with call_aws.
 
 ## Investigation Principles
 


### PR DESCRIPTION
## Problem

In a real Ask-Holmes investigation ("show me graphs of AWS Bedrock spend mom…"), the model burned **~87 s (54% of the turn's LLM time)** fighting the `call_aws` tool before it could retrieve any AWS Cost Explorer data. **Reproduced live on production (Opus 4.6) — see the trace below.**

The flailing sequence (baseline, without this change):
1. `aws ce get-cost-and-usage … --filter <inline JSON>` → error (⚠️)
2. retry → error
3. `echo '{...}' > /tmp/aws-api-mcp/workdir/bedrock.json` → error (no writable filesystem)
4. `mkdir -p /tmp/aws-api-mcp/workdir && echo …` → error
5. another `--filter` attempt → error; reasoning: *"the tool is stripping double quotes from the JSON"*
6. a single-quote attempt → still error
7. eventually falls back to a dimension/`--query` approach and gets data

Root cause: the AWS API MCP server (`aws-api-mcp-server`, upstream `awslabs.aws-api-mcp-server`) tokenizes the command with `shlex.split()`. Unquoted JSON loses its double quotes. But the repro shows single-quoting alone isn't a dependable fix in practice — the model also wastes steps on filesystem workarounds and quote-variation retries. Not an awslabs code bug (standard shell tokenization) — a usage/guidance problem.

## Fix

Rewrite the AWS MCP default `llm_instructions` (`helm/holmes/templates/mcp-servers/aws/_helpers.tpl`) to steer toward the **reliable no-JSON path**, in priority order:

1. **Prefer shorthand that needs no JSON** — `--group-by Type=DIMENSION,Key=SERVICE` and filter/aggregate client-side. Sidesteps the quoting problem entirely; this is what the model eventually fell back to anyway.
2. **Do NOT attempt filesystem workarounds** (`mkdir`/`echo`/redirect/`file://`) — the MCP sandbox is read-only. (Directly kills steps 3–4 above.)
3. **Only if a JSON arg is truly needed**, single-quote the whole value (no double quotes, no backslash-escaping); if it still fails, fall back to #1 instead of retrying variations.
4. Use `suggest_aws_commands` when unsure.

No MCP server code change — model guidance only.

## Validation status (honest)

The behavior is **confirmed reproduced on production** (baseline). A controlled sandbox harness under-reproduced it (current Opus single-quotes fine in a minimal setup), so the reliable test for this change is **deploying it and re-running the same prompt** — the shorthand-first guidance should eliminate the flailing. Not yet re-run with the change applied.

## Context

Linear: ROB-589. One of two independent slowdowns found in one slow chat: ~87 s AWS-tool friction (this PR) and a ~30–60 s visualization retry loop (fixed in robusta-frontend#3369 / FRO-175, which has a deterministic client-side repair).

## Follow-up (upstream DX, out of scope)

`awslabs/mcp` `call_aws` could add a single-quoting hint to its tool description or return an actionable error on bare-JSON tokens. Draft note prepared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new AWS MCP instruction block with guidance for using JSON arguments reliably, including required single-quote wrapping rules and avoidance of double-quotes/backslash escaping.
  * Provided an example using a JSON-based `--filter`.
  * Clarified a safer decision flow: prefer shorthand options and client-side filtering/aggregation, use command suggestions first when unsure, and only then execute via `call_aws`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->