### PR TITLE
ROB-591 Prevent filesystem-write flailing across all tools

### DIFF
--- a/holmes/plugins/prompts/generic_ask.jinja2
+++ b/holmes/plugins/prompts/generic_ask.jinja2
@@ -332,6 +332,7 @@ If during the investigation you encounter a permissions error (e.g., `Error from
 You are able to make tool calls / function calls. Recognise when a tool has already been called and reuse its result.
 If a tool call returns nothing, modify the parameters as required instead of repeating the tool call.
 When searching for resources in specific namespaces, test a cluster level tool to find the resource(s) and identify what namespace they are part of.
+Tools run in isolated, ephemeral containers with no writable or shared filesystem. Do NOT create files or directories, redirect command output to files (`>`, `>>`, `tee`), or try to pass data between tools via files (e.g. `--filter file://...`). Keep intermediate data in your reasoning/context and pass values inline. If a tool needs a file path that does not exist, do not attempt to create it — restructure the call to avoid files.
 {% endif %}
 
 {% if style_guide_enabled %}

--- a/holmes/plugins/toolsets/bash/bash_instructions.jinja2
+++ b/holmes/plugins/toolsets/bash/bash_instructions.jinja2
@@ -4,6 +4,8 @@ Use the `bash` tool to execute shell commands. You must provide:
 1. `command`: The bash command to execute
 2. `suggested_prefixes`: Array of prefixes, one per command segment
 
+The filesystem is ephemeral and not shared between tools. Filesystem-writing commands (`mkdir`, `touch`, `tee`, `cp`, `mv`, ...) and output redirection to a file (`>`, `>>`) are rejected unless explicitly allow-listed — redirecting to `/dev/null` is fine. Do not try to persist data to files or pass it between tools via files; keep intermediate data in your context.
+
 ## Supported Command Types
 
 **Auto-approved** (if prefix is in the allow list):

--- a/holmes/plugins/toolsets/bash/bash_toolset.py
+++ b/holmes/plugins/toolsets/bash/bash_toolset.py
@@ -281,6 +281,9 @@ class RunBashCommand(Tool):
         elif validation_result.deny_reason == DenyReason.PREFIX_NOT_IN_COMMAND:
             return f"Invalid prefix: {validation_result.message}"
 
+        elif validation_result.deny_reason == DenyReason.FILESYSTEM_WRITE:
+            return validation_result.message or "Command blocked: filesystem is read-only."
+
         else:
             return validation_result.message or "Command denied."
 

--- a/holmes/plugins/toolsets/bash/validation.py
+++ b/holmes/plugins/toolsets/bash/validation.py
@@ -43,6 +43,68 @@ class DenyReason(Enum):
     HARDCODED_BLOCK = "hardcoded_block"
     DENY_LIST = "deny_list"
     PREFIX_NOT_IN_COMMAND = "fabricated_prefix"
+    FILESYSTEM_WRITE = "filesystem_write"
+
+
+# Commands whose purpose is to write to / mutate the filesystem. Holmes runs tools in
+# ephemeral, isolated containers with no writable or shared filesystem, so these never
+# work and files cannot be passed between tool calls. Denying them with a clear message
+# stops the model from repeatedly retrying file-based workarounds.
+FILESYSTEM_WRITE_COMMANDS: List[str] = [
+    "mkdir",
+    "rmdir",
+    "touch",
+    "tee",
+    "cp",
+    "mv",
+    "rm",
+    "ln",
+    "dd",
+    "install",
+    "truncate",
+    "mktemp",
+]
+
+# Output redirection to a real file (`>`, `>>`, optionally fd-prefixed like `1>`).
+# The negative lookahead skips fd duplications (`2>&1`) and the whitespace that would
+# precede a bare target; each captured target is then checked against the /dev/ allowlist.
+_FILE_REDIRECT_RE = re.compile(r"\d*>>?\s*(?![&\s])(\S+)")
+
+# Redirect targets that are not real files and are safe to allow (e.g. `2>/dev/null`).
+_REDIRECT_TARGET_ALLOWLIST_PREFIX = "/dev/"
+
+FILESYSTEM_WRITE_MESSAGE = (
+    "This tool runs in an ephemeral, isolated container with no writable or shared "
+    "filesystem. Writing files does not work and files cannot be passed between tool "
+    "calls. Do not create files or directories, redirect output to a file (`>`, `>>`, "
+    "`tee`), or reference files you tried to write (e.g. `--filter file://...`). Keep "
+    "intermediate data in your reasoning/context and pass values inline instead."
+)
+
+
+def check_filesystem_write(segment: str) -> Optional[str]:
+    """
+    Detect an attempt to write to the filesystem in a command segment.
+
+    Returns a short human-readable description of the offending part if the segment
+    redirects output to a real file, None otherwise. The command-name check (mkdir,
+    tee, cp, ...) is handled separately so that an explicit user allow-list entry can
+    still take precedence; file redirection is never legitimate for read-only
+    investigation and is checked regardless.
+    """
+    for match in _FILE_REDIRECT_RE.finditer(segment):
+        target = match.group(1)
+        if not target.startswith(_REDIRECT_TARGET_ALLOWLIST_PREFIX):
+            return f"output redirection to '{target}'"
+    return None
+
+
+def check_filesystem_write_command(segment: str) -> Optional[str]:
+    """Return the write command name if the segment starts with one, None otherwise."""
+    for cmd in FILESYSTEM_WRITE_COMMANDS:
+        if match_prefix(segment, cmd):
+            return cmd
+    return None
 
 
 @dataclass
@@ -280,12 +342,34 @@ def validate_segment(
                 message=f"Command matches deny list pattern '{deny_prefix}'. This command is blocked by configuration.",
             )
 
-    # Step 3: Check allow list
+    # Step 3: File redirection to a real file is never valid on the ephemeral filesystem.
+    # Checked before the allow list because the base command (e.g. `kubectl get`) may be
+    # allow-listed while the `> file` redirect still attempts a write.
+    redirect = check_filesystem_write(segment)
+    if redirect:
+        return ValidationResult(
+            status=ValidationStatus.DENIED,
+            deny_reason=DenyReason.FILESYSTEM_WRITE,
+            message=f"Command uses {redirect}. {FILESYSTEM_WRITE_MESSAGE}",
+        )
+
+    # Step 4: Check allow list (an explicit allow-list entry wins over the write-command
+    # check below, so users who intentionally allow e.g. `mkdir` keep that ability).
     for allow_prefix in allow_list:
         if match_prefix(segment, allow_prefix):
             return ValidationResult(status=ValidationStatus.ALLOWED)
 
-    # Step 4: Not in any list -> needs approval
+    # Step 5: Filesystem-mutating commands (mkdir, tee, cp, ...) that were not explicitly
+    # allow-listed -> deny with a clear message instead of a vague approval prompt.
+    write_cmd = check_filesystem_write_command(segment)
+    if write_cmd:
+        return ValidationResult(
+            status=ValidationStatus.DENIED,
+            deny_reason=DenyReason.FILESYSTEM_WRITE,
+            message=f"Command '{write_cmd}' writes to the filesystem. {FILESYSTEM_WRITE_MESSAGE}",
+        )
+
+    # Step 6: Not in any list -> needs approval
     return ValidationResult(
         status=ValidationStatus.APPROVAL_REQUIRED,
         message=f"Command segment '{segment}' is not in the allow list.",
@@ -337,6 +421,13 @@ def validate_command(
                 status=ValidationStatus.DENIED,
                 deny_reason=DenyReason.DENY_LIST,
                 message=f"Command matches deny list pattern '{denied}'. This command is blocked by configuration.",
+            )
+        redirect = check_filesystem_write(command)
+        if redirect:
+            return ValidationResult(
+                status=ValidationStatus.DENIED,
+                deny_reason=DenyReason.FILESYSTEM_WRITE,
+                message=f"Command uses {redirect}. {FILESYSTEM_WRITE_MESSAGE}",
             )
         return ValidationResult(
             status=ValidationStatus.APPROVAL_REQUIRED,

--- a/holmes/plugins/toolsets/bash/validation.py
+++ b/holmes/plugins/toolsets/bash/validation.py
@@ -321,8 +321,10 @@ def validate_segment(
     Validation order:
     1. Hardcoded blocks -> DENIED
     2. Deny list -> DENIED
-    3. Allow list -> ALLOWED
-    4. Neither -> APPROVAL_REQUIRED
+    3. File redirection to a real file -> DENIED (filesystem write)
+    4. Allow list -> ALLOWED
+    5. Filesystem-mutating command (mkdir, tee, ...) not allow-listed -> DENIED
+    6. Neither -> APPROVAL_REQUIRED
     """
     # Step 1: Check hardcoded blocks
     blocked = check_hardcoded_blocks(segment)
@@ -428,6 +430,13 @@ def validate_command(
                 status=ValidationStatus.DENIED,
                 deny_reason=DenyReason.FILESYSTEM_WRITE,
                 message=f"Command uses {redirect}. {FILESYSTEM_WRITE_MESSAGE}",
+            )
+        write_cmd = check_filesystem_write_command(command)
+        if write_cmd:
+            return ValidationResult(
+                status=ValidationStatus.DENIED,
+                deny_reason=DenyReason.FILESYSTEM_WRITE,
+                message=f"Command '{write_cmd}' writes to the filesystem. {FILESYSTEM_WRITE_MESSAGE}",
             )
         return ValidationResult(
             status=ValidationStatus.APPROVAL_REQUIRED,

--- a/tests/test_bash_session_prefix_flow.py
+++ b/tests/test_bash_session_prefix_flow.py
@@ -644,7 +644,7 @@ class TestCrossConversationIsolation:
         )
 
         # Verify shared config was never modified
-        assert "rm" not in shared_config.allow, (
+        assert "kubectl delete" not in shared_config.allow, (
             f"Shared config should not have been mutated. "
             f"shared_config.allow={shared_config.allow}"
         )

--- a/tests/test_bash_session_prefix_flow.py
+++ b/tests/test_bash_session_prefix_flow.py
@@ -581,9 +581,9 @@ class TestCrossConversationIsolation:
         """Test that prefixes approved in one conversation don't affect new conversations.
 
         Scenario:
-        1. Conversation A: User approves 'rm' command → prefix saved in session
+        1. Conversation A: User approves 'kubectl delete' command → prefix saved in session
         2. Conversation B: New conversation with same toolset config
-        3. Conversation B should NOT have 'rm' approved (no prefix in its history)
+        3. Conversation B should NOT have 'kubectl delete' approved (no prefix in its history)
         """
         from holmes.plugins.toolsets.bash.common.config import BashExecutorConfig
         from holmes.plugins.toolsets.bash.validation import (
@@ -603,37 +603,43 @@ class TestCrossConversationIsolation:
         # Get effective lists for conversation A
         allow_list_a, deny_list_a = get_effective_lists(shared_config)
 
-        # 'rm' command should require approval (not in allow list)
-        result_a1 = validate_command("rm /tmp/test", ["rm"], allow_list_a, deny_list_a)
+        # 'kubectl delete' command should require approval (not in allow list)
+        result_a1 = validate_command(
+            "kubectl delete pod my-pod", ["kubectl delete"], allow_list_a, deny_list_a
+        )
         assert (
             result_a1.status == ValidationStatus.APPROVAL_REQUIRED
-        ), "rm should require approval in conversation A"
+        ), "kubectl delete should require approval in conversation A"
 
         # User approves - simulate by adding to LOCAL allow list (not shared config)
         # This mimics what session_approved_prefixes does
-        allow_list_a.append("rm")
+        allow_list_a.append("kubectl delete")
 
-        # Now 'rm' works in conversation A
-        result_a2 = validate_command("rm /tmp/test", ["rm"], allow_list_a, deny_list_a)
+        # Now 'kubectl delete' works in conversation A
+        result_a2 = validate_command(
+            "kubectl delete pod my-pod", ["kubectl delete"], allow_list_a, deny_list_a
+        )
         assert (
             result_a2.status == ValidationStatus.ALLOWED
-        ), "rm should be allowed after session approval in conversation A"
+        ), "kubectl delete should be allowed after session approval in conversation A"
 
         # ===== CONVERSATION B (NEW) =====
         # Get FRESH effective lists for conversation B (separate conversation)
         allow_list_b, deny_list_b = get_effective_lists(shared_config)
 
-        # Key assertion: 'rm' should NOT be in conversation B's allow list
+        # Key assertion: 'kubectl delete' should NOT be in conversation B's allow list
         # (the shared config should not have been mutated)
-        assert "rm" not in allow_list_b, (
-            f"rm should NOT be in new conversation's allow list. "
+        assert "kubectl delete" not in allow_list_b, (
+            f"kubectl delete should NOT be in new conversation's allow list. "
             f"Cross-conversation leak detected! allow_list_b={allow_list_b}"
         )
 
-        # 'rm' should require approval again in conversation B
-        result_b = validate_command("rm /tmp/test", ["rm"], allow_list_b, deny_list_b)
+        # 'kubectl delete' should require approval again in conversation B
+        result_b = validate_command(
+            "kubectl delete pod my-pod", ["kubectl delete"], allow_list_b, deny_list_b
+        )
         assert result_b.status == ValidationStatus.APPROVAL_REQUIRED, (
-            "rm should require approval in conversation B (new conversation). "
+            "kubectl delete should require approval in conversation B (new conversation). "
             "Cross-conversation leak detected if this fails!"
         )
 

--- a/tests/test_bash_toolset_validation.py
+++ b/tests/test_bash_toolset_validation.py
@@ -22,6 +22,8 @@ from holmes.plugins.toolsets.bash.validation import (
     DenyReason,
     ValidationStatus,
     check_blocked_in_raw_command,
+    check_filesystem_write,
+    check_filesystem_write_command,
     check_hardcoded_blocks,
     get_effective_lists,
     match_prefix,
@@ -1135,3 +1137,93 @@ class TestRequiresApprovalPrefixesToSave:
         }
         result = tool.requires_approval(params, context)
         assert result is None
+
+
+class TestFilesystemWriteDetection:
+    """Tests for the no-shared-filesystem guard (ROB-591)."""
+
+    @pytest.mark.parametrize(
+        "segment,expected",
+        [
+            ("kubectl get pods > out.json", "out.json"),
+            ("kubectl get pods >> log.txt", "log.txt"),
+            ("cat file 1>/tmp/o", "/tmp/o"),
+            # /dev/ targets are legitimate and must not be flagged
+            ("kubectl get pods 2>/dev/null", None),
+            ("cmd > /dev/null", None),
+            ("cmd &>/dev/null", None),
+            # fd duplication is not a file write
+            ("kubectl get pods 2>&1", None),
+            ("echo hi", None),
+        ],
+    )
+    def test_check_filesystem_write_redirect(self, segment, expected):
+        result = check_filesystem_write(segment)
+        if expected is None:
+            assert result is None
+        else:
+            assert result is not None and expected in result
+
+    @pytest.mark.parametrize(
+        "segment,expected",
+        [
+            ("mkdir -p /tmp/x", "mkdir"),
+            ("tee results.txt", "tee"),
+            ("cp a b", "cp"),
+            ("mv a b", "mv"),
+            ("touch f", "touch"),
+            ("rm -rf /tmp/x", "rm"),
+            ("kubectl get pods", None),
+            ("grep error", None),
+        ],
+    )
+    def test_check_filesystem_write_command(self, segment, expected):
+        assert check_filesystem_write_command(segment) == expected
+
+    def test_redirect_to_file_denied_even_when_base_command_allowed(self):
+        """A redirect to a real file is denied even if the base command is allow-listed."""
+        result = validate_segment(
+            "kubectl get pods > out.json",
+            allow_list=["kubectl get"],
+            deny_list=[],
+        )
+        assert result.status == ValidationStatus.DENIED
+        assert result.deny_reason == DenyReason.FILESYSTEM_WRITE
+
+    def test_redirect_to_devnull_allowed(self):
+        result = validate_segment(
+            "kubectl get pods 2>/dev/null",
+            allow_list=["kubectl get"],
+            deny_list=[],
+        )
+        assert result.status == ValidationStatus.ALLOWED
+
+    def test_write_command_denied_by_default(self):
+        result = validate_segment(
+            "mkdir -p /tmp/data",
+            allow_list=["kubectl get"],
+            deny_list=[],
+        )
+        assert result.status == ValidationStatus.DENIED
+        assert result.deny_reason == DenyReason.FILESYSTEM_WRITE
+
+    def test_explicit_allow_list_entry_wins_over_write_guard(self):
+        """A user who explicitly allow-lists a write command keeps that ability."""
+        result = validate_segment(
+            "mkdir -p /tmp/data",
+            allow_list=["mkdir"],
+            deny_list=[],
+        )
+        assert result.status == ValidationStatus.ALLOWED
+
+    def test_full_command_pipe_to_tee_denied(self):
+        config = BashExecutorConfig(allow=["kubectl get"])
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(
+            "kubectl get pods | tee results.txt",
+            ["kubectl get", "tee"],
+            allow_list,
+            deny_list,
+        )
+        assert result.status == ValidationStatus.DENIED
+        assert result.deny_reason == DenyReason.FILESYSTEM_WRITE

--- a/tests/test_bash_toolset_validation.py
+++ b/tests/test_bash_toolset_validation.py
@@ -1227,3 +1227,12 @@ class TestFilesystemWriteDetection:
         )
         assert result.status == ValidationStatus.DENIED
         assert result.deny_reason == DenyReason.FILESYSTEM_WRITE
+
+    def test_unparseable_write_command_denied(self):
+        """A write command that fails to parse still gets a clear filesystem denial."""
+        config = BashExecutorConfig(allow=["kubectl get"])
+        allow_list, deny_list = get_effective_lists(config)
+        # trailing pipe makes bashlex fail -> unparseable fallback path
+        result = validate_command("mkdir foo |", [], allow_list, deny_list)
+        assert result.status == ValidationStatus.DENIED
+        assert result.deny_reason == DenyReason.FILESYSTEM_WRITE


### PR DESCRIPTION
## Problem

Holmes runs each tool in an ephemeral, isolated container with **no writable or shared filesystem**. Tools cannot create files/directories or pass data to each other via files. Despite this, the model repeatedly tries file-based workarounds — `mkdir`, output redirection (`>`, `>>`, `tee`), and things like AWS `call_aws --filter file://...` — and then burns turns retrying when a write silently fails or comes back as a vague *"command requires approval"* message.

This showed up concretely in production Ask-Holmes traces (e.g. AWS Cost Explorer investigations), where the model spent many seconds cycling on `Thinking: The directory doesn't exist...` and similar. It is **not** AWS-specific — it's a general, cross-toolset failure mode.

## Fix

Two complementary, tool-agnostic changes:

**1. Core system prompt (`generic_ask.jinja2`)** — add an explicit statement in the "Tool/function calls" section that tools run in isolated containers with no writable/shared filesystem, and to keep intermediate data in context instead of writing files or passing data via files (`--filter file://...`). This applies to **every** toolset, not just one integration.

**2. Bash toolset validation** — deny filesystem-mutating commands and file redirection with a clear, actionable message instead of a vague approval prompt the model retries against:
- Filesystem-mutating commands (`mkdir`, `rmdir`, `touch`, `tee`, `cp`, `mv`, `rm`, `ln`, `dd`, `install`, `truncate`, `mktemp`).
- Output redirection to a real file (`>`, `>>`, incl. fd-prefixed like `1>`).
- Redirection to `/dev/null` (and other `/dev/*`) stays allowed, and fd duplication (`2>&1`) is **not** treated as a file write.
- An explicit user allow-list entry (e.g. adding `mkdir`) still wins, so intentional local/CLI use is preserved. Redirects are checked before the allow list so an allow-listed base command (`kubectl get`) can't smuggle a `> file` write.
- `bash_instructions.jinja2` documents the constraint.

## Tests

- New `TestFilesystemWriteDetection` covering redirect detection (incl. `/dev/null` and `2>&1` negatives), write-command detection, allow-list precedence, and the pipe-to-`tee` case.
- Updated the cross-conversation isolation test to use `kubectl delete` (still approval-requiring) now that `rm` is denied by default.
- Full bash test suite green (156 passed).

## Notes

- This is the global counterpart to the AWS-MCP-specific instruction cleanup; with this in place the AWS instructions no longer need to carry their own filesystem-workaround guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FonHqnDVjnkM9qoa7gdM9v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stronger safeguards for shell commands run in isolated, ephemeral environments.
  * Blocking now covers common filesystem-writing actions and output redirection by default, with clearer denial messaging.

* **Bug Fixes**
  * Improved command validation so filesystem-write attempts are consistently denied, including in piped and unparseable/fallback parsing cases.
  * Prevented approval settings from leaking between separate conversations (updated regression coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->