### PR TITLE
Additional configurations for Helm chart: `command` and probes

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -103,9 +103,9 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         command: ["python3", "-u", "server.py"]
-        {{- if .Values.args }}
+        {{- with .Values.args }}
         args:
-        {{- toYaml .Values.args | nindent 8 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: 5050

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -102,7 +102,10 @@ spec:
           {{- with .Values.containerSecurityContext }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-        command: ["python3", "-u", "server.py"]
+        {{- with .Values.command }}
+        command:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.args }}
         args:
           {{- toYaml . | nindent 10 }}

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -113,6 +113,7 @@ spec:
         ports:
         - containerPort: 5050
           name: http
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           {{- if and $tls.enabled $tls.caCertsSecretKey }}
           # mTLS requires a client cert; kubelet httpGet probes can't present one,
@@ -127,10 +128,12 @@ spec:
             scheme: HTTPS
             {{- end }}
           {{- end }}
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 10
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           {{- if and $tls.enabled $tls.caCertsSecretKey }}
           # mTLS requires a client cert; kubelet httpGet probes can't present one,
@@ -145,10 +148,11 @@ spec:
             scheme: HTTPS
             {{- end }}
           {{- end }}
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         env:
           - name: LOG_LEVEL
             value: {{ .Values.logLevel }}

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -195,6 +195,20 @@ args: []
 
 priorityClassName: ""
 
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
 # List of Kubernetes Secret names whose keys are auto-mounted as env vars on
 # the Holmes pod via `envFrom`. Use this together with the `envRef:` sugar
 # below to avoid repeating each API key in `additionalEnvVars`. Every listed

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -181,6 +181,12 @@ additionalVolumeMounts: []
 #         mountPath: /shared
 initContainers: []
 
+# Override command used to launch the Holmes server
+# Use it to try out experimental features or for custom configurations
+# Example:
+# command: ["python3", "-u", "experimental/ag-ui/server-agui.py"]
+command: ["python3", "-u", "server.py"]
+
 # Additional arguments to pass to the Holmes server
 # Example:
 # args:


### PR DESCRIPTION
Hi folks! I'm testing Holmes out with the [AI Assistant](https://github.com/headlamp-k8s/plugins/tree/b84332fea79153187dd218ebce874f39a6929a60/ai-assistant) plugin for Headlamp. The setup needed for this plugin is quite specific and involves the use of features like the experimental server:

> ### 3. Render and Patch the Helm Template
>
> Holmes requires enabling the AG-UI server for the AI Assistant to communicate with it. Render the template and update the container command:
>
> ```bash
> helm template holmesgpt robusta/holmes -f values.yaml > rendered.yaml
> ```
>
> In `rendered.yaml`, find the container command and change it to:
>
> ```yaml
> command: ['python3', '-u', '/app/experimental/ag-ui/server-agui.py']
> ```

It's currently not possible to tweak the container `command` in the chart. Furthermore, the experimental server doesn't provide the same endpoints that the liveness/readyness probes rely on, which leads to restart loops.

Right now, one would either have to do as the guide suggests or use techniques like applying [Kustomize patches via Helm hooks](https://austindewey.com/2020/07/27/patch-any-helm-chart-template-using-a-kustomize-post-renderer/). I'm not particularly fond of either approach. To that end, I've just introduced some values that allow you to override the `command` and disable the probes for the `Deployment`.

This way, consumers can:

- Customize whether they want to use the vanilla or experimental version.
- Tweak or even remove the probes based on the version they are using.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable container startup commands and arguments through Helm chart values.
  * Added configurable liveness and readiness probes, including enablement, timing, and failure thresholds.
  * Probes remain enabled by default and can be disabled through chart configuration.

* **Improvements**
  * Health check settings can now be tuned for different deployment environments instead of relying solely on fixed defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->