### PR TITLE
Expand namespace-scoped access documentation with Helm approach

### DIFF
--- a/docs/installation/namespace-scoped-access.md
+++ b/docs/installation/namespace-scoped-access.md
@@ -1,16 +1,66 @@
 # Limiting Holmes to a Namespace
 
-By default, the Holmes Helm chart creates a cluster-wide, read-only `ClusterRole` so Holmes can investigate resources across the whole cluster. This guide explains how to instead restrict Holmes to a single namespace.
+By default, the Holmes Helm chart creates a cluster-wide, read-only `ClusterRole` so Holmes can investigate resources across the whole cluster. This guide explains how to instead restrict Holmes to specific namespaces.
 
 ## What to Expect
 
-When Holmes is scoped to one namespace, it can only see resources in that namespace. Tools that query cluster-scoped resources (nodes, persistent volumes, storage classes, CRDs) or that list across all namespaces (`kubectl get ... --all-namespaces`, `kubectl top pods -A`) will return `forbidden` errors. Holmes keeps running and simply reports those errors, but investigations are limited to the target namespace.
+When Holmes is scoped to specific namespaces, it can only see resources in those namespaces. Tools that query cluster-scoped resources (nodes, persistent volumes, storage classes, CRDs) or that list across all namespaces (`kubectl get ... --all-namespaces`, `kubectl top pods -A`) will return `forbidden` errors. Holmes keeps running and simply reports those errors, but investigations are limited to the target namespaces.
 
 ## Configuration
 
-Point Holmes at your own service account instead of the chart-managed cluster-wide one.
+There are two approaches to scope Holmes to specific namespaces:
 
-Set the following in your Helm values:
+1. **Helm Configuration** (recommended) — Let the Helm chart automatically create the necessary RBAC resources
+2. **Manual YAML** — Create custom `Role` and `RoleBinding` resources yourself
+
+### Approach 1: Helm Configuration (Recommended)
+
+Use the `roleBindingNamespaces` value in your Helm chart to automatically create namespaced `RoleBindings` instead of a cluster-wide `ClusterRoleBinding`.
+
+Set the following in your Helm `values.yaml`:
+
+```yaml
+# List the namespaces where Holmes should have access
+roleBindingNamespaces:
+  - monitoring
+  - production
+  - staging
+```
+
+That's it! The Helm chart will:
+- Keep the cluster-wide `ClusterRole` for consistency
+- Create `RoleBinding` resources in each specified namespace, binding Holmes' `ClusterRole` to those namespace-scoped service accounts
+- Automatically set `createServiceAccount: true` so Holmes has the necessary permissions in those namespaces
+
+When you upgrade Holmes, it will automatically create the necessary `RoleBindings` in each namespace listed.
+
+**To grant access to additional namespaces** later, simply add them to the list and re-run `helm upgrade`:
+
+```bash
+helm upgrade holmes robusta/holmes -f values.yaml
+```
+
+**To verify the configuration:**
+
+```bash
+# Check RoleBindings in your target namespaces
+kubectl get rolebinding -n monitoring
+kubectl get rolebinding -n production
+kubectl get rolebinding -n staging
+
+# Confirm Holmes can access resources in these namespaces
+kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:holmes:holmes
+kubectl auth can-i list pods -n production --as=system:serviceaccount:holmes:holmes
+
+# Confirm Holmes cannot access other namespaces
+kubectl auth can-i list pods -n default --as=system:serviceaccount:holmes:holmes  # expected: no
+```
+
+### Approach 2: Manual YAML Configuration
+
+Use this approach if you need to customize the permissions or use a different service account name.
+
+First, set the following in your Helm `values.yaml` to skip the chart-managed RBAC resources:
 
 ```yaml
 # Don't let the chart create its cluster-wide ClusterRole/ClusterRoleBinding
@@ -19,7 +69,7 @@ createServiceAccount: false
 customServiceAccountName: holmes
 ```
 
-Create the service account, `Role`, and `RoleBinding` (`holmes-namespace-scoped.yaml`). Replace `monitoring` with the namespace you want Holmes to investigate, and `holmes` with the namespace Holmes is installed in:
+Then, create the service account, `Role`, and `RoleBinding` resources manually. Create a file called `holmes-namespace-scoped.yaml`. Replace `monitoring` with the namespace you want Holmes to investigate, and `holmes` with the namespace Holmes is installed in:
 
 ```yaml
 apiVersion: v1
@@ -86,15 +136,45 @@ subjects:
     namespace: holmes
 ```
 
-Apply it, then upgrade Holmes with the values above:
+Apply the resources:
 
 ```bash
 kubectl apply -f holmes-namespace-scoped.yaml
 ```
 
-To grant access to more than one namespace, create an additional `Role` + `RoleBinding` in each namespace, all bound to the same `holmes` service account.
+Then upgrade Holmes with the values above:
+
+```bash
+helm upgrade holmes robusta/holmes -f values.yaml
+```
+
+To grant access to more than one namespace, create an additional `Role` + `RoleBinding` in each namespace, all bound to the same `holmes` service account. Or, switch to **Approach 1** for easier multi-namespace management.
+
+## Comparison
+
+| Aspect | Helm Configuration | Manual YAML |
+|--------|-------------------|------------|
+| **Setup** | Add `roleBindingNamespaces` to values | Create custom YAML files |
+| **Namespaces** | Specify in list, auto-creates RoleBindings | Create Role+RoleBinding per namespace |
+| **Updates** | `helm upgrade` manages all namespaces | Manual updates to YAML |
+| **Customization** | Uses standard ClusterRole | Can customize permissions |
+| **Recommended for** | Most deployments | Advanced custom permission needs |
 
 ## Verify the Configuration
+
+For **Helm Configuration** approach:
+
+```bash
+# Confirm RoleBindings are in each namespace
+kubectl get rolebinding -n monitoring
+kubectl get rolebinding -n production
+
+# Check what the service account can and cannot do
+kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:holmes:holmes
+kubectl auth can-i list nodes --as=system:serviceaccount:holmes:holmes  # expected: no
+```
+
+For **Manual YAML** approach:
 
 ```bash
 # Confirm the Role and binding exist in the target namespace


### PR DESCRIPTION
## Summary

Expanded the namespace-scoped access documentation to provide two distinct approaches for limiting Holmes to specific namespaces, with the Helm configuration method as the recommended approach for most users.

## Key Changes

- **Added Helm Configuration approach** (recommended): Introduced `roleBindingNamespaces` Helm value that automatically creates namespaced `RoleBinding` resources, allowing users to easily specify multiple namespaces without manual YAML creation
- **Reorganized Manual YAML approach**: Moved the existing manual configuration method to a secondary approach for advanced use cases
- **Added verification commands**: Provided `kubectl auth can-i` examples to help users verify their configuration works correctly
- **Added comparison table**: Created a side-by-side comparison of both approaches to help users choose the right method
- **Improved clarity**: Updated language from "single namespace" to "specific namespaces" throughout to reflect multi-namespace support
- **Enhanced workflow documentation**: Added step-by-step instructions for both approaches, including how to grant access to additional namespaces later

## Notable Details

- The Helm approach leverages the existing `ClusterRole` but creates namespace-scoped `RoleBinding` resources, providing a cleaner upgrade path
- Both approaches are fully documented with complete YAML examples and verification steps
- The documentation now clearly explains the trade-offs between convenience (Helm) and customization (Manual YAML)

https://claude.ai/code/session_01LbstYMmYGuKaZq2muqZHwa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote the namespace-scoped access guide with clearer setup steps and verification commands.
  * Added two setup paths: a recommended Helm-based configuration and a manual YAML-based option.
  * Expanded guidance for granting access to multiple namespaces and keeping access limited elsewhere.
  * Updated the comparison and validation sections to make it easier to confirm the configuration is working as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->