### PR TITLE
helm: add backwards-compatible multi-account (multi-tenant) Azure MCP

### DIFF
--- a/docs/data-sources/builtin-toolsets/azure-mcp.md
+++ b/docs/data-sources/builtin-toolsets/azure-mcp.md
@@ -294,6 +294,92 @@ Choose an authentication method based on your environment:
 
 Holmes can automatically discover and switch between subscriptions within the same tenant. Just ensure your identity has the appropriate roles in each subscription.
 
+## Multi-Account Setup (Multiple Tenants)
+
+If a single Holmes agent needs to query Azure resources across **multiple separate accounts (different Entra ID tenants)** — not just multiple subscriptions in one tenant — use the multi-account setup instead of the single-account setup above.
+
+When multi-account mode is enabled, the chart switches to the multi-account image (`multi-azure-cli-mcp`), mounts an `accounts.yaml` config, and projects a federated token. On startup the server logs into every configured account (no secrets — each tenant's identity is federated to the Holmes service account) so one instance can reach all of them.
+
+### Step 1: Set up the identities and federation
+
+Run the multi-account setup script against each target tenant. It creates a managed identity + federated credential (trusting your AKS OIDC issuer and the Holmes service account) and assigns the "Azure MCP Reader" role, then emits the `accounts.yaml` values you paste into Helm.
+
+```bash
+# Requires yq and az access to each target tenant
+curl -O https://raw.githubusercontent.com/robusta-dev/holmes-mcp-integrations/master/servers/azure-multi-account/setup-azure-identity.sh
+curl -O https://raw.githubusercontent.com/robusta-dev/holmes-mcp-integrations/master/servers/azure-multi-account/accounts-config-example.yaml
+chmod +x setup-azure-identity.sh
+
+# Edit accounts-config-example.yaml with your tenants, then:
+./setup-azure-identity.sh \
+  --auth-method multi-account \
+  --resource-group YOUR_AKS_RG \
+  --aks-cluster YOUR_AKS_CLUSTER \
+  --accounts-file accounts-config-example.yaml
+```
+
+The script fails fast if the config is malformed or any tenant isn't logged in. To remove everything it created, re-run with `--teardown`.
+
+### Step 2: Enable multi-account mode in Helm
+
+=== "Holmes Helm Chart"
+
+    Add the following to your `values.yaml`:
+
+    ```yaml
+    mcpAddons:
+      azure:
+        enabled: true
+
+        # Multi-account (multiple tenants) configuration
+        multiAccount:
+          enabled: true
+          accounts:
+            dev:
+              tenant_id: "11111111-1111-1111-1111-111111111111"
+              client_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"   # managed identity in that tenant
+            prod:
+              tenant_id: "22222222-2222-2222-2222-222222222222"
+              client_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+          # Tell the model which subscription belongs to which account
+          llm_account_descriptions: |
+            You must pass --subscription <id> to target an account.
+            dev tenant 11111111-...: subscriptions [aaaa-1111, aaaa-2222] - development resources
+            prod tenant 22222222-...: subscriptions [bbbb-1111] - production resources
+
+        # The service account uses token projection; workload-identity annotations are ignored.
+        serviceAccount:
+          create: true
+    ```
+
+=== "Robusta Helm Chart"
+
+    Add the same block nested under `holmes:`:
+
+    ```yaml
+    holmes:
+      mcpAddons:
+        azure:
+          enabled: true
+          multiAccount:
+            enabled: true
+            accounts:
+              dev:
+                tenant_id: "11111111-1111-1111-1111-111111111111"
+                client_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+              prod:
+                tenant_id: "22222222-2222-2222-2222-222222222222"
+                client_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+            llm_account_descriptions: |
+              You must pass --subscription <id> to target an account.
+              dev tenant 11111111-...: subscriptions [aaaa-1111, aaaa-2222] - development resources
+              prod tenant 22222222-...: subscriptions [bbbb-1111] - production resources
+          serviceAccount:
+            create: true
+    ```
+
+**Limitations:** Azure CLI targets a subscription id, not a tenant id — every query must include the specific `--subscription`; if omitted it falls back to an arbitrary default account and returns misleading results. A tenant can have multiple subscriptions with different data, and there is no way to query a whole account or all accounts at once — each subscription is queried individually.
+
 ### Troubleshooting
 
 ```bash

--- a/helm/holmes/templates/mcp-servers/azure/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/azure/_helpers.tpl
@@ -204,4 +204,12 @@ az resource list --query "[].{Name:name, Type:type, ResourceGroup:resourceGroup}
 
 Remember: Many Kubernetes issues have Azure infrastructure as the root cause. Always investigate both layers.
 {{- end -}}
+{{- if and .Values.mcpAddons.azure.multiAccount.enabled .Values.mcpAddons.azure.multiAccount.llm_account_descriptions }}
+
+## Multiple Azure Accounts
+
+This MCP is configured with multiple Azure accounts (tenants). Azure CLI selects an account by subscription id, not tenant id: pass the matching `--subscription <id>` on every command (e.g. `az vm list --subscription <id>`). If you omit `--subscription`, the call falls back to an arbitrary default account and returns misleading results. A tenant can contain multiple subscriptions, each with different resources, and there is no way to query all accounts or a whole account at once — query each subscription individually.
+
+{{ .Values.mcpAddons.azure.multiAccount.llm_account_descriptions }}
+{{- end -}}
 {{- end }}

--- a/helm/holmes/templates/mcp-servers/azure/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/deployment.yaml
@@ -21,6 +21,15 @@ data:
   AZURE_SUBSCRIPTION_ID: {{ .Values.mcpAddons.azure.config.subscriptionId | quote }}
   AZ_AUTH_METHOD: {{ .Values.mcpAddons.azure.config.authMethod | default "workload-identity" | quote }}
   READ_ONLY_MODE: {{ .Values.mcpAddons.azure.config.readOnlyMode | default "true" | quote }}
+  {{- if and .Values.mcpAddons.azure.multiAccount.enabled .Values.mcpAddons.azure.multiAccount.accounts }}
+  accounts.yaml: |
+    accounts:
+      {{- range $name, $config := .Values.mcpAddons.azure.multiAccount.accounts }}
+      - name: {{ $name | quote }}
+        tenant_id: {{ $config.tenant_id | quote }}
+        client_id: {{ $config.client_id | quote }}
+      {{- end }}
+  {{- end }}
 ---
 {{- if .Values.mcpAddons.azure.serviceAccount.create }}
 apiVersion: v1
@@ -35,7 +44,7 @@ metadata:
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" . | nindent 4 }}
-    {{- if eq .Values.mcpAddons.azure.config.authMethod "workload-identity" }}
+    {{- if and (not .Values.mcpAddons.azure.multiAccount.enabled) (eq .Values.mcpAddons.azure.config.authMethod "workload-identity") }}
     azure.workload.identity/use: "true"
     {{- end }}
   {{- $ann := dict -}}
@@ -83,7 +92,7 @@ spec:
         app.kubernetes.io/component: mcp-server
         app.kubernetes.io/part-of: holmes
         {{- include "holmes.commonLabels" . | nindent 8 }}
-        {{- if eq .Values.mcpAddons.azure.config.authMethod "workload-identity" }}
+        {{- if and (not .Values.mcpAddons.azure.multiAccount.enabled) (eq .Values.mcpAddons.azure.config.authMethod "workload-identity") }}
         azure.workload.identity/use: "true"
         {{- end }}
       annotations:
@@ -95,11 +104,32 @@ spec:
       {{- if or .Values.mcpAddons.azure.serviceAccount.create .Values.mcpAddons.azure.serviceAccount.name }}
       serviceAccountName: {{ .Values.mcpAddons.azure.serviceAccount.name }}
       {{- end }}
+      {{- if and .Values.mcpAddons.azure.multiAccount.enabled .Values.mcpAddons.azure.multiAccount.accounts }}
+      volumes:
+      - name: azure-accounts
+        configMap:
+          name: {{ .Release.Name }}-azure-mcp-config
+          items:
+          - key: accounts.yaml
+            path: accounts.yaml
+      - name: azure-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: azure-identity-token
+              expirationSeconds: 3600
+              audience: api://AzureADTokenExchange
+      {{- end }}
       containers:
       - name: azure-mcp
+        {{- if and .Values.mcpAddons.azure.multiAccount.enabled .Values.mcpAddons.azure.multiAccount.image }}
+        image: {{ .Values.mcpAddons.azure.registry }}/{{ .Values.mcpAddons.azure.multiAccount.image }}
+        {{- else }}
         image: {{ .Values.mcpAddons.azure.registry }}/{{ .Values.mcpAddons.azure.image }}
+        {{- end }}
         imagePullPolicy: {{ .Values.mcpAddons.azure.imagePullPolicy | default "IfNotPresent" }}
 
+        {{- if not .Values.mcpAddons.azure.multiAccount.enabled }}
         args:
           - "--transport"
           - "streamable-http"
@@ -117,6 +147,7 @@ spec:
           - "--timeout"
           - {{ .Values.mcpAddons.azure.config.timeout | quote }}
           {{- end }}
+        {{- end }}
 
         ports:
         - name: http
@@ -124,6 +155,14 @@ spec:
           protocol: TCP
 
         env:
+        {{- if and .Values.mcpAddons.azure.multiAccount.enabled .Values.mcpAddons.azure.multiAccount.accounts }}
+        # Multi-account: the wrapper logs into every account listed in accounts.yaml.
+        # Both paths below match the wrapper defaults; set explicitly for clarity.
+        - name: AZURE_ACCOUNTS_FILE
+          value: "/etc/azure/accounts.yaml"
+        - name: AZURE_FEDERATED_TOKEN_FILE
+          value: "/var/run/secrets/azure/tokens/azure-identity-token"
+        {{- else }}
         - name: AZURE_TENANT_ID
           valueFrom:
             configMapKeyRef:
@@ -159,8 +198,19 @@ spec:
         - name: AZURE_CLIENT_ID
           value: {{ .Values.mcpAddons.azure.config.clientId | quote }}
         {{- end }}
+        {{- end }}
         {{- if .Values.mcpAddons.azure.additionalEnvVars }}
         {{- toYaml .Values.mcpAddons.azure.additionalEnvVars | nindent 8 }}
+        {{- end }}
+
+        {{- if and .Values.mcpAddons.azure.multiAccount.enabled .Values.mcpAddons.azure.multiAccount.accounts }}
+        volumeMounts:
+        - name: azure-accounts
+          mountPath: /etc/azure
+          readOnly: true
+        - name: azure-token
+          mountPath: /var/run/secrets/azure/tokens
+          readOnly: true
         {{- end }}
 
         resources:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -395,6 +395,29 @@ mcpAddons:
       timeout: "120"                    # Command execution timeout in seconds
       namespace: ""                     # MCP installation namespace (defaults to release namespace if empty)
 
+    # Multi-account (multiple tenants) configuration.
+    # When multiAccount.enabled is true with accounts defined, the chart switches
+    # to the multi-account image and projects a federated token so the server logs
+    # into every configured account (tenant) on startup. Account selection at query
+    # time is by subscription id (az ... --subscription <id>).
+    # See docs/data-sources/builtin-toolsets/azure-mcp.md for setup.
+    multiAccount:
+      enabled: false                              # Set to true to enable multi-account (multi-tenant) access
+      image: "multi-azure-cli-mcp:1.1.0"
+      # Each entry is one account/tenant. name -> {tenant_id, client_id}, where
+      # client_id is the managed identity in that tenant federated to this
+      # service account (created by setup-azure-identity.sh --auth-method multi-account).
+      accounts: {}
+        # dev:
+        #   tenant_id: "11111111-1111-1111-1111-111111111111"
+        #   client_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        # prod:
+        #   tenant_id: "22222222-2222-2222-2222-222222222222"
+        #   client_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+      # LLM instructions describing which subscription belongs to which account,
+      # appended to the Azure MCP instructions so the model targets --subscription correctly.
+      llm_account_descriptions: ""
+
     # Secret name for service principal authentication (if using service-principal auth)
     secretName: "azure-mcp-creds"
 

--- a/tests/test_azure_mcp_helm.py
+++ b/tests/test_azure_mcp_helm.py
@@ -1,0 +1,71 @@
+"""Regression checks for the Azure MCP multi-account Helm wiring.
+
+These assert the chart values/templates encode multi-account (multi-tenant)
+support while staying backwards compatible, without needing the `helm` binary:
+the single-account path is unchanged (workload-identity label + `--readonly`
+args), and multi-account switches the image, mounts `accounts.yaml` plus a
+projected federated token, and appends the multi-account LLM instructions.
+"""
+
+from pathlib import Path
+
+import yaml
+
+HELM_DIR = Path(__file__).resolve().parents[1] / "helm" / "holmes"
+TEMPLATE_DIR = HELM_DIR / "templates" / "mcp-servers" / "azure"
+
+
+def _azure_values() -> dict:
+    with open(HELM_DIR / "values.yaml") as f:
+        return yaml.safe_load(f)["mcpAddons"]["azure"]
+
+
+def test_multi_account_defaults_are_backwards_compatible():
+    v = _azure_values()
+    # Opt-in: default deployment behaves exactly as before.
+    assert v["multiAccount"]["enabled"] is False
+    assert v["multiAccount"]["image"] == "multi-azure-cli-mcp:1.1.0"
+    assert v["multiAccount"]["accounts"] == {}
+    # Single-account image/config still present and unchanged.
+    assert v["image"] == "azure-cli-mcp:1.0.2"
+    assert v["config"]["readOnlyMode"] is True
+    assert v["config"]["authMethod"] == "workload-identity"
+
+
+def test_deployment_single_account_path_unchanged():
+    text = (TEMPLATE_DIR / "deployment.yaml").read_text()
+    # Single-account args block (read-only guardrail) still rendered.
+    assert '"--readonly"' in text
+    # workload-identity label is gated so it only renders in single-account mode.
+    assert (
+        'if and (not .Values.mcpAddons.azure.multiAccount.enabled) '
+        '(eq .Values.mcpAddons.azure.config.authMethod "workload-identity")' in text
+    )
+    # Single-account image selection is the fallback branch.
+    assert "{{ .Values.mcpAddons.azure.registry }}/{{ .Values.mcpAddons.azure.image }}" in text
+
+
+def test_deployment_multi_account_path_wired():
+    text = (TEMPLATE_DIR / "deployment.yaml").read_text()
+    # accounts.yaml projected into the ConfigMap from the accounts map.
+    assert "accounts.yaml: |" in text
+    assert "range $name, $config := .Values.mcpAddons.azure.multiAccount.accounts" in text
+    # Wrapper env pointing at the mounted config + projected token.
+    assert "AZURE_ACCOUNTS_FILE" in text
+    assert "AZURE_FEDERATED_TOKEN_FILE" in text
+    # Projected serviceAccountToken volume for federation.
+    assert "serviceAccountToken:" in text
+    assert "api://AzureADTokenExchange" in text
+    # Multi-account image selection branch.
+    assert "{{ .Values.mcpAddons.azure.registry }}/{{ .Values.mcpAddons.azure.multiAccount.image }}" in text
+
+
+def test_helpers_append_multi_account_instructions():
+    text = (TEMPLATE_DIR / "_helpers.tpl").read_text()
+    assert "## Multiple Azure Accounts" in text
+    # Gated on both the toggle and the descriptions being provided.
+    assert (
+        "if and .Values.mcpAddons.azure.multiAccount.enabled "
+        ".Values.mcpAddons.azure.multiAccount.llm_account_descriptions" in text
+    )
+    assert "{{ .Values.mcpAddons.azure.multiAccount.llm_account_descriptions }}" in text


### PR DESCRIPTION
## What

Adds an opt-in `mcpAddons.azure.multiAccount` mode to the Azure MCP Helm addon so a single Holmes deployment can investigate resources across **multiple separate Entra ID tenants**. Previously the Azure MCP could authenticate to only one identity/tenant.

## How it works

When `multiAccount.enabled: true`, the chart:
- Switches to the `multi-azure-cli-mcp` wrapper image.
- Projects a federated `serviceAccountToken` (`api://AzureADTokenExchange`) — no secrets; each tenant's managed identity is federated to the Holmes service account.
- Mounts an `accounts.yaml` (name → `tenant_id`/`client_id`) so the server logs into every configured tenant on startup.
- Appends a "Multiple Azure Accounts" section (plus operator-supplied `llm_account_descriptions`) to the Azure LLM instructions, so the model targets the correct `--subscription <id>`.

## Backwards compatibility

With `multiAccount.enabled: false` (the default), the chart renders **exactly as before**: single `azure-cli-mcp` image, `--readonly` args, `azure.workload.identity/use` label, env from the ConfigMap. Verified via `helm template` in both modes and `helm lint`.

## Tests

Adds `tests/test_azure_mcp_helm.py` — a binary-free Helm-wiring regression test (mirrors `test_kubernetes_remediation_helm.py`) asserting the unchanged single-account path and the multi-account wiring. 4/4 pass.

## Docs

New "Multi-Account Setup (Multiple Tenants)" section in `docs/data-sources/builtin-toolsets/azure-mcp.md` with setup script, Helm + Robusta chart examples, and limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure MCP multi-account setup, including tenant-specific configuration, federated login, and per-account access details.
  * Multi-account mode now uses a dedicated image path and mounts the required account and token files automatically.

* **Documentation**
  * Expanded Azure MCP setup guidance with step-by-step multi-tenant configuration examples and Helm values for supported chart options.

* **Tests**
  * Added coverage to verify both single-account and multi-account behavior, including template rendering and configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->