### PR TITLE
Support multiple Azure MCP accounts with different credentials

### DIFF
--- a/docs/data-sources/builtin-toolsets/azure-mcp.md
+++ b/docs/data-sources/builtin-toolsets/azure-mcp.md
@@ -294,6 +294,44 @@ Choose an authentication method based on your environment:
 
 Holmes can automatically discover and switch between subscriptions within the same tenant. Just ensure your identity has the appropriate roles in each subscription.
 
+### Multiple Accounts (Different Credentials)
+
+When you need to reach several Azure accounts, tenants, or subscriptions that use **different credentials** (for example a separate service principal per environment, or accounts in different tenants), define them under `accounts`. Each entry deploys its own Azure MCP server (Deployment, Service, ConfigMap, ServiceAccount, and NetworkPolicy) and is exposed to Holmes as a dedicated toolset named `azure_api_<accountName>`.
+
+Every account inherits the top-level `azure` settings (`image`, `registry`, `resources`, `service`, `networkPolicy`, etc.) as defaults and overrides only what it sets:
+
+```yaml
+mcpAddons:
+  azure:
+    enabled: true
+    # Shared defaults inherited by every account below
+    config:
+      readOnlyMode: true
+      authMethod: "workload-identity"
+    accounts:
+      prod:
+        config:
+          tenantId: "PROD_TENANT_ID"
+          subscriptionId: "PROD_SUBSCRIPTION_ID"
+          clientId: "PROD_CLIENT_ID"
+        serviceAccount:
+          annotations:
+            azure.workload.identity/client-id: "PROD_CLIENT_ID"
+            azure.workload.identity/tenant-id: "PROD_TENANT_ID"
+      dev:
+        config:
+          tenantId: "DEV_TENANT_ID"
+          subscriptionId: "DEV_SUBSCRIPTION_ID"
+          authMethod: "service-principal"
+        secretName: "azure-mcp-creds-dev"   # must contain AZURE_CLIENT_ID / AZURE_CLIENT_SECRET
+```
+
+Notes:
+
+- Resources for a named account are suffixed with `-<accountName>` (e.g. `RELEASE_NAME-azure-mcp-server-prod`), and the ServiceAccount defaults to `RELEASE_NAME-azure-mcp-sa-<accountName>` unless you set `serviceAccount.name` explicitly.
+- For `service-principal` accounts, create a distinct secret per account (`secretName`) holding `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`.
+- Leaving `accounts` empty keeps the previous single-server behavior unchanged (one `azure_api` toolset), so existing installs need no changes.
+
 ### Troubleshooting
 
 ```bash

--- a/helm/holmes/templates/mcp-servers/azure/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/azure/_helpers.tpl
@@ -1,9 +1,53 @@
 {{/*
-Define the LLM instructions for Azure MCP
+Normalize the Azure MCP config into a list of accounts so that a single set of
+templates can render one Deployment/Service/ConfigMap/ServiceAccount per account.
+
+Backwards compatible: when `azure.accounts` is not set, a single account is
+synthesized from the top-level `azure` fields and its resource names are left
+unsuffixed (`<release>-azure-mcp-server`, mcp key `azure_api`, etc.) so existing
+installs are unchanged. When `azure.accounts` (a map keyed by account name) is
+set, each entry inherits the top-level fields as defaults and overrides them,
+and every resource is suffixed with `-<accountName>`.
+
+Each returned account carries three resolved helper keys:
+  _suffix  - "" for the legacy account, "-<name>" for named accounts
+  _mcpKey  - "azure_api" for the legacy account, "azure_api_<name>" otherwise
+  _saName  - resolved ServiceAccount name (unique per named account)
+
+Usage: {{- range include "holmes.azureMcp.accounts" . | fromYamlArray }}
+*/}}
+{{- define "holmes.azureMcp.accounts" -}}
+{{- $root := .Values.mcpAddons.azure -}}
+{{- $out := list -}}
+{{- if $root.accounts -}}
+{{- $defaults := omit $root "accounts" "enabled" -}}
+{{- range $name, $acct := $root.accounts -}}
+{{- $acct = default (dict) $acct -}}
+{{- $merged := merge (deepCopy $acct) (deepCopy $defaults) -}}
+{{- $_ := set $merged "_suffix" (printf "-%s" $name) -}}
+{{- $_ := set $merged "_mcpKey" (printf "azure_api_%s" $name) -}}
+{{- $sa := default (dict) $acct.serviceAccount -}}
+{{- $_ := set $merged "_saName" (default (printf "%s-azure-mcp-sa-%s" $.Release.Name $name) $sa.name) -}}
+{{- $out = append $out $merged -}}
+{{- end -}}
+{{- else -}}
+{{- $merged := deepCopy (omit $root "accounts") -}}
+{{- $_ := set $merged "_suffix" "" -}}
+{{- $_ := set $merged "_mcpKey" "azure_api" -}}
+{{- $_ := set $merged "_saName" $root.serviceAccount.name -}}
+{{- $out = append $out $merged -}}
+{{- end -}}
+{{- $out | toYaml -}}
+{{- end -}}
+
+{{/*
+Define the LLM instructions for Azure MCP.
+Accepts the account dict as the context (falls back to root when rendered
+without an account) so a per-account `llmInstructions` override wins.
 */}}
 {{- define "holmes.azureMcp.llmInstructions" -}}
-{{- if .Values.mcpAddons.azure.llmInstructions -}}
-{{ .Values.mcpAddons.azure.llmInstructions }}
+{{- if .llmInstructions -}}
+{{ .llmInstructions }}
 {{- else -}}
 IMPORTANT: When investigating Kubernetes issues, ALWAYS check if Azure infrastructure could be the root cause. Many K8s problems originate from Azure-level configurations.
 IMPORTANT: Always use paging, where possible, to avoid reaching the size limit. Use pagination parameters like  --max-items and --next-token or similar.

--- a/helm/holmes/templates/mcp-servers/azure/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/deployment.yaml
@@ -1,48 +1,55 @@
 {{- if .Values.mcpAddons.azure.enabled }}
+{{- $root := . }}
+{{- range $account := include "holmes.azureMcp.accounts" . | fromYamlArray }}
+{{- $suffix := $account._suffix }}
+{{- $ns := $account.config.namespace | default $root.Release.Namespace }}
+{{- $name := printf "%s-azure-mcp%s" $root.Release.Name $suffix }}
+{{- $cmName := printf "%s-azure-mcp-config%s" $root.Release.Name $suffix }}
+{{- $serverName := printf "%s-azure-mcp-server%s" $root.Release.Name $suffix }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-azure-mcp-config
-  namespace: {{ .Values.mcpAddons.azure.config.namespace | default .Release.Namespace }}
+  name: {{ $cmName }}
+  namespace: {{ $ns }}
   labels:
-    app: {{ .Release.Name }}-azure-mcp
+    app: {{ $name }}
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
-    {{- include "holmes.commonLabels" . | nindent 4 }}
-  {{- with (include "holmes.commonAnnotations" .) }}
+    {{- include "holmes.commonLabels" $root | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $root) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
 data:
-  AZURE_TENANT_ID: {{ .Values.mcpAddons.azure.config.tenantId | quote }}
-  AZURE_SUBSCRIPTION_ID: {{ .Values.mcpAddons.azure.config.subscriptionId | quote }}
-  AZ_AUTH_METHOD: {{ .Values.mcpAddons.azure.config.authMethod | default "workload-identity" | quote }}
-  READ_ONLY_MODE: {{ .Values.mcpAddons.azure.config.readOnlyMode | default "true" | quote }}
+  AZURE_TENANT_ID: {{ $account.config.tenantId | quote }}
+  AZURE_SUBSCRIPTION_ID: {{ $account.config.subscriptionId | quote }}
+  AZ_AUTH_METHOD: {{ $account.config.authMethod | default "workload-identity" | quote }}
+  READ_ONLY_MODE: {{ $account.config.readOnlyMode | default "true" | quote }}
 ---
-{{- if .Values.mcpAddons.azure.serviceAccount.create }}
+{{- if $account.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.mcpAddons.azure.serviceAccount.name }}
-  namespace: {{ .Values.mcpAddons.azure.config.namespace | default .Release.Namespace }}
+  name: {{ $account._saName }}
+  namespace: {{ $ns }}
   labels:
-    app: {{ .Release.Name }}-azure-mcp
+    app: {{ $name }}
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
-    {{- include "holmes.commonLabels" . | nindent 4 }}
-    {{- if eq .Values.mcpAddons.azure.config.authMethod "workload-identity" }}
+    {{- include "holmes.commonLabels" $root | nindent 4 }}
+    {{- if eq $account.config.authMethod "workload-identity" }}
     azure.workload.identity/use: "true"
     {{- end }}
   {{- $ann := dict -}}
-  {{- with (include "holmes.commonAnnotations" . | fromYaml) -}}
+  {{- with (include "holmes.commonAnnotations" $root | fromYaml) -}}
   {{- $ann = mergeOverwrite $ann . -}}
   {{- end -}}
-  {{- with .Values.mcpAddons.azure.serviceAccount.annotations -}}
+  {{- with $account.serviceAccount.annotations -}}
   {{- $ann = mergeOverwrite $ann . -}}
   {{- end -}}
   {{- if $ann }}
@@ -54,16 +61,16 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-azure-mcp-server
-  namespace: {{ .Values.mcpAddons.azure.config.namespace | default .Release.Namespace }}
+  name: {{ $serverName }}
+  namespace: {{ $ns }}
   labels:
-    app: {{ .Release.Name }}-azure-mcp
+    app: {{ $name }}
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
-    {{- include "holmes.commonLabels" . | nindent 4 }}
-  {{- with (include "holmes.commonAnnotations" .) }}
+    {{- include "holmes.commonLabels" $root | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $root) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
@@ -71,34 +78,34 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-azure-mcp
+      app: {{ $name }}
       app.kubernetes.io/name: azure-mcp-server
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ $root.Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-azure-mcp
+        app: {{ $name }}
         app.kubernetes.io/name: azure-mcp-server
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ $root.Release.Name }}
         app.kubernetes.io/component: mcp-server
         app.kubernetes.io/part-of: holmes
-        {{- include "holmes.commonLabels" . | nindent 8 }}
-        {{- if eq .Values.mcpAddons.azure.config.authMethod "workload-identity" }}
+        {{- include "holmes.commonLabels" $root | nindent 8 }}
+        {{- if eq $account.config.authMethod "workload-identity" }}
         azure.workload.identity/use: "true"
         {{- end }}
       annotations:
-        {{- with (include "holmes.commonAnnotations" .) }}
+        {{- with (include "holmes.commonAnnotations" $root) }}
           {{- . | nindent 8 }}
         {{- end }}
-        checksum/config: {{ .Values.mcpAddons.azure | toYaml | sha256sum }}
+        checksum/config: {{ $account | toYaml | sha256sum }}
     spec:
-      {{- if or .Values.mcpAddons.azure.serviceAccount.create .Values.mcpAddons.azure.serviceAccount.name }}
-      serviceAccountName: {{ .Values.mcpAddons.azure.serviceAccount.name }}
+      {{- if or $account.serviceAccount.create $account._saName }}
+      serviceAccountName: {{ $account._saName }}
       {{- end }}
       containers:
       - name: azure-mcp
-        image: {{ .Values.mcpAddons.azure.registry }}/{{ .Values.mcpAddons.azure.image }}
-        imagePullPolicy: {{ .Values.mcpAddons.azure.imagePullPolicy | default "IfNotPresent" }}
+        image: {{ $account.registry }}/{{ $account.image }}
+        imagePullPolicy: {{ $account.imagePullPolicy | default "IfNotPresent" }}
 
         args:
           - "--transport"
@@ -107,15 +114,15 @@ spec:
           - "0.0.0.0"
           - "--port"
           - "8000"
-          {{- if .Values.mcpAddons.azure.config.readOnlyMode }}
+          {{- if $account.config.readOnlyMode }}
           - "--readonly"
           {{- end }}
-          {{- if .Values.mcpAddons.azure.config.enableSecurityPolicy }}
+          {{- if $account.config.enableSecurityPolicy }}
           - "--enable-security-policy"
           {{- end }}
-          {{- if .Values.mcpAddons.azure.config.timeout }}
+          {{- if $account.config.timeout }}
           - "--timeout"
-          - {{ .Values.mcpAddons.azure.config.timeout | quote }}
+          - {{ $account.config.timeout | quote }}
           {{- end }}
 
         ports:
@@ -127,44 +134,44 @@ spec:
         - name: AZURE_TENANT_ID
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-azure-mcp-config
+              name: {{ $cmName }}
               key: AZURE_TENANT_ID
         - name: AZURE_SUBSCRIPTION_ID
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-azure-mcp-config
+              name: {{ $cmName }}
               key: AZURE_SUBSCRIPTION_ID
         - name: AZ_AUTH_METHOD
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-azure-mcp-config
+              name: {{ $cmName }}
               key: AZ_AUTH_METHOD
-        {{- if eq .Values.mcpAddons.azure.config.authMethod "workload-identity" }}
+        {{- if eq $account.config.authMethod "workload-identity" }}
         - name: AZURE_CLIENT_ID
-          value: {{ .Values.mcpAddons.azure.config.clientId | quote }}
+          value: {{ $account.config.clientId | quote }}
         {{- end }}
-        {{- if eq .Values.mcpAddons.azure.config.authMethod "service-principal" }}
+        {{- if eq $account.config.authMethod "service-principal" }}
         - name: AZURE_CLIENT_ID
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.mcpAddons.azure.secretName | default "azure-mcp-creds" }}
+              name: {{ $account.secretName | default "azure-mcp-creds" }}
               key: AZURE_CLIENT_ID
         - name: AZURE_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.mcpAddons.azure.secretName | default "azure-mcp-creds" }}
+              name: {{ $account.secretName | default "azure-mcp-creds" }}
               key: AZURE_CLIENT_SECRET
         {{- end }}
-        {{- if eq .Values.mcpAddons.azure.config.authMethod "managed-identity" }}
+        {{- if eq $account.config.authMethod "managed-identity" }}
         - name: AZURE_CLIENT_ID
-          value: {{ .Values.mcpAddons.azure.config.clientId | quote }}
+          value: {{ $account.config.clientId | quote }}
         {{- end }}
-        {{- if .Values.mcpAddons.azure.additionalEnvVars }}
-        {{- toYaml .Values.mcpAddons.azure.additionalEnvVars | nindent 8 }}
+        {{- if $account.additionalEnvVars }}
+        {{- toYaml $account.additionalEnvVars | nindent 8 }}
         {{- end }}
 
         resources:
-          {{- toYaml .Values.mcpAddons.azure.resources | nindent 10 }}
+          {{- toYaml $account.resources | nindent 10 }}
 
         livenessProbe:
           httpGet:
@@ -185,44 +192,45 @@ spec:
           successThreshold: 1
           failureThreshold: 3
 
-      {{- if .Values.mcpAddons.azure.nodeSelector }}
+      {{- if $account.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.mcpAddons.azure.nodeSelector | nindent 8 }}
+        {{- toYaml $account.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.mcpAddons.azure.tolerations }}
+      {{- if $account.tolerations }}
       tolerations:
-        {{- toYaml .Values.mcpAddons.azure.tolerations | nindent 8 }}
+        {{- toYaml $account.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.mcpAddons.azure.affinity }}
+      {{- if $account.affinity }}
       affinity:
-        {{- toYaml .Values.mcpAddons.azure.affinity | nindent 8 }}
+        {{- toYaml $account.affinity | nindent 8 }}
       {{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-azure-mcp-server
-  namespace: {{ .Values.mcpAddons.azure.config.namespace | default .Release.Namespace }}
+  name: {{ $serverName }}
+  namespace: {{ $ns }}
   labels:
-    app: {{ .Release.Name }}-azure-mcp
+    app: {{ $name }}
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
-    {{- include "holmes.commonLabels" . | nindent 4 }}
-  {{- with (include "holmes.commonAnnotations" .) }}
+    {{- include "holmes.commonLabels" $root | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $root) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP
   selector:
-    app: {{ .Release.Name }}-azure-mcp
+    app: {{ $name }}
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
   ports:
   - name: http
     port: 8000
     targetPort: http
     protocol: TCP
+{{- end }}
 {{- end }}

--- a/helm/holmes/templates/mcp-servers/azure/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/networkpolicy.yaml
@@ -1,27 +1,34 @@
-{{- if and .Values.mcpAddons.azure.enabled .Values.mcpAddons.azure.networkPolicy.enabled }}
+{{- if .Values.mcpAddons.azure.enabled }}
+{{- $root := . }}
+{{- range $account := include "holmes.azureMcp.accounts" . | fromYamlArray }}
+{{- if $account.networkPolicy.enabled }}
+{{- $suffix := $account._suffix }}
+{{- $ns := $account.config.namespace | default $root.Release.Namespace }}
+{{- $name := printf "%s-azure-mcp%s" $root.Release.Name $suffix }}
+{{- $serverName := printf "%s-azure-mcp-server%s" $root.Release.Name $suffix }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-azure-mcp-server
-  namespace: {{ .Values.mcpAddons.azure.config.namespace | default .Release.Namespace }}
+  name: {{ $serverName }}
+  namespace: {{ $ns }}
   labels:
-    app: {{ .Release.Name }}-azure-mcp
+    app: {{ $name }}
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
-    {{- include "holmes.commonLabels" . | nindent 4 }}
-  {{- with (include "holmes.commonAnnotations" .) }}
+    {{- include "holmes.commonLabels" $root | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $root) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ .Release.Name }}-azure-mcp
+      app: {{ $name }}
       app.kubernetes.io/name: azure-mcp-server
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ $root.Release.Name }}
   policyTypes:
   - Ingress
   - Egress
@@ -31,13 +38,13 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: holmes
-          app.kubernetes.io/instance: {{ .Release.Name }}
+          app.kubernetes.io/instance: {{ $root.Release.Name }}
     # Allow traffic from pods with specific label
     - podSelector:
         matchLabels:
           holmes.mcp.client: "true"
-    {{- if .Values.mcpAddons.azure.networkPolicy.additionalIngressRules }}
-    {{- toYaml .Values.mcpAddons.azure.networkPolicy.additionalIngressRules | nindent 4 }}
+    {{- if $account.networkPolicy.additionalIngressRules }}
+    {{- toYaml $account.networkPolicy.additionalIngressRules | nindent 4 }}
     {{- end }}
     ports:
     - protocol: TCP
@@ -58,7 +65,9 @@ spec:
     ports:
     - protocol: TCP
       port: 443
-  {{- if .Values.mcpAddons.azure.networkPolicy.additionalEgressRules }}
-  {{- toYaml .Values.mcpAddons.azure.networkPolicy.additionalEgressRules | nindent 2 }}
+  {{- if $account.networkPolicy.additionalEgressRules }}
+  {{- toYaml $account.networkPolicy.additionalEgressRules | nindent 2 }}
   {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -35,17 +35,25 @@ data:
     {{- $mcpServers = merge $mcpServers $awsMcpServers }}
     {{- end }}
     {{- if .Values.mcpAddons.azure.enabled }}
-    {{- $azureMcpServers := dict "azure_api" (dict
-        "description" "Azure API MCP Server - comprehensive Azure service access. Execute any Azure CLI commands."
+    {{- $azureRoot := . }}
+    {{- range $account := include "holmes.azureMcp.accounts" . | fromYamlArray }}
+    {{- $azureNs := $account.config.namespace | default $azureRoot.Release.Namespace }}
+    {{- $azureDesc := "Azure API MCP Server - comprehensive Azure service access. Execute any Azure CLI commands." }}
+    {{- if $account._suffix }}
+    {{- $azureDesc = printf "%s (account: %s)" $azureDesc (trimPrefix "-" $account._suffix) }}
+    {{- end }}
+    {{- $azureMcpServers := dict $account._mcpKey (dict
+        "description" $azureDesc
         "config" (dict
-          "url" (printf "http://%s-azure-mcp-server.%s.svc.cluster.local:8000/mcp" .Release.Name (.Values.mcpAddons.azure.config.namespace | default .Release.Namespace))
+          "url" (printf "http://%s-azure-mcp-server%s.%s.svc.cluster.local:8000/mcp" $azureRoot.Release.Name $account._suffix $azureNs)
           "mode" "streamable-http"
           "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/microsoft-azure.svg"
         )
-        "llm_instructions" (include "holmes.azureMcp.llmInstructions" . | trim)
+        "llm_instructions" (include "holmes.azureMcp.llmInstructions" $account | trim)
       )
     }}
     {{- $mcpServers = merge $mcpServers $azureMcpServers }}
+    {{- end }}
     {{- end }}
     {{- if .Values.mcpAddons.mariadb.enabled }}
     {{- $mariadbMcpServers := dict "mariadb" (dict

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -421,6 +421,38 @@ mcpAddons:
     # Custom LLM instructions (optional) - leave empty to use default
     llmInstructions: ""
 
+    # Multiple accounts (optional).
+    # By default the single set of fields above deploys ONE Azure MCP server
+    # (backwards compatible - resource names and the `azure_api` toolset are
+    # unchanged). To connect Holmes to several Azure accounts/subscriptions
+    # with different credentials, list them here. Each entry gets its own
+    # Deployment, Service, ConfigMap, ServiceAccount and NetworkPolicy, plus a
+    # dedicated toolset named `azure_api_<accountName>`.
+    #
+    # Every entry inherits the fields above (image, registry, resources,
+    # service, networkPolicy, etc.) as defaults and overrides only what it
+    # sets. Resources for a named account are suffixed with `-<accountName>`
+    # (e.g. `<release>-azure-mcp-server-prod`), and the ServiceAccount defaults
+    # to `<release>-azure-mcp-sa-<accountName>` unless you set
+    # `serviceAccount.name` explicitly.
+    accounts: {}
+      # prod:
+      #   config:
+      #     tenantId: "prod-tenant-id"
+      #     subscriptionId: "prod-subscription-id"
+      #     clientId: "prod-client-id"
+      #     authMethod: "workload-identity"
+      #   serviceAccount:
+      #     annotations:
+      #       azure.workload.identity/client-id: "prod-client-id"
+      #       azure.workload.identity/tenant-id: "prod-tenant-id"
+      # dev:
+      #   config:
+      #     tenantId: "dev-tenant-id"
+      #     subscriptionId: "dev-subscription-id"
+      #     authMethod: "service-principal"
+      #   secretName: "azure-mcp-creds-dev"   # must contain AZURE_CLIENT_ID / AZURE_CLIENT_SECRET
+
   # GitHub MCP Server Configuration
   # Provides access to GitHub repositories, pull requests, issues, and GitHub Actions
   #


### PR DESCRIPTION
## What

Makes the Azure MCP Helm addon support **multiple accounts with different credentials**, while remaining fully backwards compatible.

Previously `mcpAddons.azure` deployed a single Azure MCP server. Now you can define an `accounts` map to connect Holmes to several Azure accounts / tenants / subscriptions that use **different credentials** (e.g. a separate service principal per environment, or accounts in different tenants).

## How

- New `mcpAddons.azure.accounts` map (keyed by account name). Each entry deploys its **own** Deployment, Service, ConfigMap, ServiceAccount, and NetworkPolicy, and is exposed to Holmes as a dedicated toolset `azure_api_<accountName>`.
- Each account inherits the top-level `azure` fields (`image`, `registry`, `resources`, `service`, `networkPolicy`, `config`, etc.) as defaults and overrides only what it sets.
- Named-account resources are suffixed `-<accountName>` (e.g. `RELEASE-azure-mcp-server-prod`); the ServiceAccount defaults to `RELEASE-azure-mcp-sa-<accountName>` unless `serviceAccount.name` is set.
- A new `holmes.azureMcp.accounts` template helper normalizes config into a list of accounts, so a single set of templates renders one instance per account.

### Backwards compatibility

With `accounts` unset (the default), a single account is synthesized from the existing top-level fields with **unsuffixed** names — identical to before (`RELEASE-azure-mcp-server`, `azure_api` toolset, `azure-api-mcp-sa`). Existing installs need no changes.

## Example

```yaml
mcpAddons:
  azure:
    enabled: true
    config:
      authMethod: "workload-identity"
    accounts:
      prod:
        config: { tenantId: "...", subscriptionId: "...", clientId: "..." }
        serviceAccount:
          annotations:
            azure.workload.identity/client-id: "..."
      dev:
        config: { tenantId: "...", subscriptionId: "...", authMethod: "service-principal" }
        secretName: "azure-mcp-creds-dev"
```

## Testing

Verified with `helm template` in legacy (single), multi-account, and disabled modes — all render without errors. Confirmed per-account inheritance/override (shared defaults applied, per-account overrides win), distinct resource/SA/toolset names, and that legacy names are unchanged.

## Files

- `helm/holmes/templates/mcp-servers/azure/_helpers.tpl` — `holmes.azureMcp.accounts` normalization helper; per-account `llmInstructions`
- `helm/holmes/templates/mcp-servers/azure/deployment.yaml` — ranges over accounts
- `helm/holmes/templates/mcp-servers/azure/networkpolicy.yaml` — one policy per account
- `helm/holmes/templates/toolset-config.yaml` — one MCP toolset per account
- `helm/holmes/values.yaml` — documented `accounts`
- `docs/data-sources/builtin-toolsets/azure-mcp.md` — new "Multiple Accounts" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple Azure accounts, with each account getting its own dedicated toolset and separate Kubernetes resources.
  * Toolset entries now reflect account-specific names, namespaces, and connection settings.

* **Documentation**
  * Expanded Azure setup guidance with multi-account examples, override behavior, and naming conventions.
  * Updated configuration examples to show how to keep the existing single-account setup or enable multiple accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->