### PR TITLE
Add support for multiple Azure MCP instances with backward compatibility

### DIFF
--- a/docs/data-sources/builtin-toolsets/azure-mcp.md
+++ b/docs/data-sources/builtin-toolsets/azure-mcp.md
@@ -309,7 +309,7 @@ When you need to connect to multiple Azure tenants or subscriptions with differe
 
 #### Example 1: Multiple Instances with Workload Identity (AKS - No Secrets Required)
 
-Use this for AKS clusters with Workload Identity enabled. No secrets are needed.
+Use this for AKS clusters with Workload Identity enabled. No secrets are needed. Each instance can have its own custom LLM instructions to guide Holmes' investigation behavior.
 
 ```yaml
 mcpAddons:
@@ -353,7 +353,23 @@ mcpAddons:
       networkPolicy:
         enabled: false
 
-      llmInstructions: ""
+      # Custom instructions for production investigations
+      llmInstructions: |
+        ## Production Azure Investigation Guidelines
+        
+        **CRITICAL**: You are investigating PRODUCTION resources. Exercise extreme caution.
+        
+        **Before making any changes:**
+        1. Check Azure Activity Log for recent changes (last 24 hours)
+        2. Verify change windows and maintenance schedules
+        3. Always report findings to the on-call engineer before suggesting fixes
+        4. For critical systems, request approval before proceeding
+        
+        **Focus areas for prod:**
+        - Check Azure Monitor alerts and metrics
+        - Review cost anomalies (may indicate issues)
+        - Verify RBAC role assignments haven't been modified
+        - Check for service outages in Activity Log
 
     - name: "staging"
       enabled: true
@@ -389,7 +405,23 @@ mcpAddons:
       networkPolicy:
         enabled: false
 
-      llmInstructions: ""
+      # Custom instructions for staging investigations
+      llmInstructions: |
+        ## Staging Azure Investigation Guidelines
+        
+        **SAFE TO EXPERIMENT**: You are investigating STAGING resources. 
+        
+        **Investigation approach:**
+        1. Feel free to gather detailed diagnostics and check configurations
+        2. You can safely query resources without worry of impacting production
+        3. Focus on testing, validation, and reproducing issues
+        4. Check Azure Monitor for metrics and diagnostics
+        
+        **Use for:**
+        - Testing Azure configurations before production deployment
+        - Reproducing reported issues in a safe environment
+        - Validating fixes and changes
+        - Learning Azure resource behavior
 ```
 
 #### Example 2: Multiple Instances with Service Principal (Non-AKS Clusters - Secrets Required)
@@ -452,6 +484,24 @@ mcpAddons:
       networkPolicy:
         enabled: false
 
+      # Custom instructions for production investigations
+      llmInstructions: |
+        ## Production Azure Investigation Guidelines
+        
+        **CRITICAL**: You are investigating PRODUCTION resources. Exercise extreme caution.
+        
+        **Before making any changes:**
+        1. Check Azure Activity Log for recent changes (last 24 hours)
+        2. Verify change windows and maintenance schedules
+        3. Always report findings to the on-call engineer before suggesting fixes
+        4. For critical systems, request approval before proceeding
+        
+        **Focus areas for prod:**
+        - Check Azure Monitor alerts and metrics
+        - Review cost anomalies (may indicate issues)
+        - Verify RBAC role assignments haven't been modified
+        - Check for service outages in Activity Log
+
     - name: "staging"
       enabled: true
 
@@ -483,11 +533,29 @@ mcpAddons:
 
       networkPolicy:
         enabled: false
+
+      # Custom instructions for staging investigations
+      llmInstructions: |
+        ## Staging Azure Investigation Guidelines
+        
+        **SAFE TO EXPERIMENT**: You are investigating STAGING resources. 
+        
+        **Investigation approach:**
+        1. Feel free to gather detailed diagnostics and check configurations
+        2. You can safely query resources without worry of impacting production
+        3. Focus on testing, validation, and reproducing issues
+        4. Check Azure Monitor for metrics and diagnostics
+        
+        **Use for:**
+        - Testing Azure configurations before production deployment
+        - Reproducing reported issues in a safe environment
+        - Validating fixes and changes
+        - Learning Azure resource behavior
 ```
 
 #### Example 3: Mixed Setup (Workload Identity + Service Principal)
 
-Use this when you have multiple clusters or authentication methods.
+Use this when you have multiple clusters or authentication methods. Each instance maintains its own custom LLM instructions.
 
 ```yaml
 mcpAddons:
@@ -515,6 +583,18 @@ mcpAddons:
       service:
         port: 8000
 
+      llmInstructions: |
+        ## Production AKS on Azure Investigation
+        
+        You have access to a production AKS cluster running on Azure.
+        Be cautious - focus on diagnostics, not changes.
+        
+        Priority checks:
+        - Node health and capacity
+        - Pod resource constraints
+        - Network connectivity issues
+        - Azure storage and networking
+
     # Non-AKS cluster with Service Principal - requires secret
     - name: "staging-on-prem"
       enabled: true
@@ -532,6 +612,18 @@ mcpAddons:
 
       service:
         port: 8001
+
+      llmInstructions: |
+        ## Staging On-Premises Azure Investigation
+        
+        You have access to on-premises staging infrastructure integrated with Azure.
+        This is a lower-risk environment - safe to investigate thoroughly.
+        
+        Investigation focus:
+        - Azure-to-on-prem connectivity
+        - Hybrid network configuration
+        - Resource synchronization
+        - Staging test results
 ```
 
 **Secret Creation for Mixed Setup:**
@@ -543,6 +635,39 @@ kubectl create secret generic azure-staging-mcp-creds \
   --from-literal=AZURE_CLIENT_SECRET=staging-client-secret \
   -n YOUR_NAMESPACE
 ```
+
+#### Custom LLM Instructions Per Instance
+
+Each Azure instance can have its own custom `llmInstructions` field to guide Holmes' investigation behavior. This is optional — if omitted, Holmes uses the default Azure MCP instructions.
+
+**Use custom instructions to:**
+- **Distinguish environments**: Tell Holmes if it's investigating production vs staging
+- **Set investigation scope**: Limit what Holmes should investigate per tenant
+- **Define escalation paths**: Specify when to report findings vs making changes
+- **Provide context**: Include environment-specific priorities and known issues
+
+**Example: Production vs Staging Instructions**
+
+```yaml
+azureInstances:
+  - name: "prod"
+    # ... config ...
+    llmInstructions: |
+      # CRITICAL: Production environment
+      - Always verify changes in Activity Log first
+      - Report findings before taking action
+      - Check maintenance windows before suggesting changes
+  
+  - name: "staging"
+    # ... config ...
+    llmInstructions: |
+      # SAFE: Staging environment  
+      - Feel free to investigate thoroughly
+      - Safe to gather detailed diagnostics
+      - No approval needed for diagnostics
+```
+
+If you omit `llmInstructions`, Holmes uses the default Azure MCP instructions (which cover general Azure investigation patterns).
 
 #### When to Use Each Authentication Method
 

--- a/docs/data-sources/builtin-toolsets/azure-mcp.md
+++ b/docs/data-sources/builtin-toolsets/azure-mcp.md
@@ -294,6 +294,108 @@ Choose an authentication method based on your environment:
 
 Holmes can automatically discover and switch between subscriptions within the same tenant. Just ensure your identity has the appropriate roles in each subscription.
 
+### Multiple Azure MCP Instances
+
+When you need to connect to multiple Azure tenants or subscriptions with different credentials, deploy multiple Azure MCP instances. Each instance runs in its own pod with its own configuration, service account, and network policies.
+
+**Example: Connecting to Two Azure Tenants**
+
+```yaml
+mcpAddons:
+  # Disable the single instance (backward compatible)
+  azure:
+    enabled: false
+
+  # Configure multiple instances
+  azureInstances:
+    - name: "prod"
+      enabled: true
+
+      serviceAccount:
+        create: true
+        name: "azure-prod-mcp-sa"
+        annotations:
+          azure.workload.identity/client-id: "prod-client-id"
+          azure.workload.identity/tenant-id: "prod-tenant-id"
+
+      image: "azure-cli-mcp:1.0.2"
+      registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
+
+      config:
+        tenantId: "prod-tenant-id"
+        subscriptionId: "prod-subscription-id"
+        clientId: "prod-client-id"
+        authMethod: "workload-identity"
+        readOnlyMode: true
+        timeout: "120"
+
+      service:
+        port: 8000
+
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "512Mi"
+
+      networkPolicy:
+        enabled: false
+
+      llmInstructions: ""
+
+    - name: "staging"
+      enabled: true
+
+      serviceAccount:
+        create: true
+        name: "azure-staging-mcp-sa"
+        annotations:
+          azure.workload.identity/client-id: "staging-client-id"
+          azure.workload.identity/tenant-id: "staging-tenant-id"
+
+      image: "azure-cli-mcp:1.0.2"
+      registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
+
+      config:
+        tenantId: "staging-tenant-id"
+        subscriptionId: "staging-subscription-id"
+        clientId: "staging-client-id"
+        authMethod: "workload-identity"
+        readOnlyMode: true
+        timeout: "120"
+
+      service:
+        port: 8001  # Each instance needs a unique port
+
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "512Mi"
+
+      networkPolicy:
+        enabled: false
+
+      llmInstructions: ""
+```
+
+**Key Points for Multiple Instances:**
+
+- **Instance Name**: The `name` field must be unique across all instances (used for resource naming)
+- **Unique Ports**: Each instance must have a unique `service.port` to avoid conflicts
+- **Unique Service Accounts**: Recommended to use unique service account names per instance
+- **Unique Credentials**: Each instance can have its own tenant ID, subscription ID, and credentials
+- **Backward Compatible**: The single `azure` configuration still works — you only need `azureInstances` when deploying multiple instances
+
+When using multiple instances, Holmes will route requests to the appropriate instance based on the context (tenant/subscription). You can specify which instance to use in your investigation prompt:
+
+```
+"List all resource groups in the prod tenant"
+"Get VM details from the staging subscription"
+```
+
 ### Troubleshooting
 
 ```bash

--- a/docs/data-sources/builtin-toolsets/azure-mcp.md
+++ b/docs/data-sources/builtin-toolsets/azure-mcp.md
@@ -298,7 +298,18 @@ Holmes can automatically discover and switch between subscriptions within the sa
 
 When you need to connect to multiple Azure tenants or subscriptions with different credentials, deploy multiple Azure MCP instances. Each instance runs in its own pod with its own configuration, service account, and network policies.
 
-**Example: Connecting to Two Azure Tenants**
+**Key Points for Multiple Instances:**
+
+- **Instance Name**: The `name` field must be unique across all instances (used for resource naming)
+- **Unique Ports**: Each instance must have a unique `service.port` to avoid conflicts
+- **Unique Service Accounts**: Recommended to use unique service account names per instance
+- **Unique Credentials**: Each instance can have its own tenant ID, subscription ID, and credentials
+- **Backward Compatible**: The single `azure` configuration still works — you only need `azureInstances` when deploying multiple instances
+- **Secrets are Optional**: Secrets are only required when using `service-principal` authentication. For `workload-identity` and `managed-identity`, no secrets are needed.
+
+#### Example 1: Multiple Instances with Workload Identity (AKS - No Secrets Required)
+
+Use this for AKS clusters with Workload Identity enabled. No secrets are needed.
 
 ```yaml
 mcpAddons:
@@ -306,7 +317,7 @@ mcpAddons:
   azure:
     enabled: false
 
-  # Configure multiple instances
+  # Configure multiple instances with Workload Identity
   azureInstances:
     - name: "prod"
       enabled: true
@@ -381,13 +392,165 @@ mcpAddons:
       llmInstructions: ""
 ```
 
-**Key Points for Multiple Instances:**
+#### Example 2: Multiple Instances with Service Principal (Non-AKS Clusters - Secrets Required)
 
-- **Instance Name**: The `name` field must be unique across all instances (used for resource naming)
-- **Unique Ports**: Each instance must have a unique `service.port` to avoid conflicts
-- **Unique Service Accounts**: Recommended to use unique service account names per instance
-- **Unique Credentials**: Each instance can have its own tenant ID, subscription ID, and credentials
-- **Backward Compatible**: The single `azure` configuration still works — you only need `azureInstances` when deploying multiple instances
+Use this for non-AKS clusters or when you prefer service principal authentication. **Requires creating secrets.**
+
+**Step 1: Create secrets for each instance**
+
+```bash
+# Create secret for prod instance
+kubectl create secret generic azure-prod-mcp-creds \
+  --from-literal=AZURE_CLIENT_ID=prod-client-id \
+  --from-literal=AZURE_CLIENT_SECRET=prod-client-secret \
+  -n YOUR_NAMESPACE
+
+# Create secret for staging instance
+kubectl create secret generic azure-staging-mcp-creds \
+  --from-literal=AZURE_CLIENT_ID=staging-client-id \
+  --from-literal=AZURE_CLIENT_SECRET=staging-client-secret \
+  -n YOUR_NAMESPACE
+```
+
+**Step 2: Configure Helm chart**
+
+```yaml
+mcpAddons:
+  azure:
+    enabled: false
+
+  azureInstances:
+    - name: "prod"
+      enabled: true
+
+      serviceAccount:
+        create: true
+        name: "azure-prod-mcp-sa"
+
+      image: "azure-cli-mcp:1.0.2"
+      registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
+
+      config:
+        tenantId: "prod-tenant-id"
+        subscriptionId: "prod-subscription-id"
+        authMethod: "service-principal"
+        readOnlyMode: true
+        timeout: "120"
+
+      secretName: "azure-prod-mcp-creds"  # Secret created in Step 1
+
+      service:
+        port: 8000
+
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "512Mi"
+
+      networkPolicy:
+        enabled: false
+
+    - name: "staging"
+      enabled: true
+
+      serviceAccount:
+        create: true
+        name: "azure-staging-mcp-sa"
+
+      image: "azure-cli-mcp:1.0.2"
+      registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
+
+      config:
+        tenantId: "staging-tenant-id"
+        subscriptionId: "staging-subscription-id"
+        authMethod: "service-principal"
+        readOnlyMode: true
+        timeout: "120"
+
+      secretName: "azure-staging-mcp-creds"  # Secret created in Step 1
+
+      service:
+        port: 8001
+
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "512Mi"
+
+      networkPolicy:
+        enabled: false
+```
+
+#### Example 3: Mixed Setup (Workload Identity + Service Principal)
+
+Use this when you have multiple clusters or authentication methods.
+
+```yaml
+mcpAddons:
+  azure:
+    enabled: false
+
+  azureInstances:
+    # AKS cluster with Workload Identity - no secret
+    - name: "prod-aks"
+      enabled: true
+
+      serviceAccount:
+        create: true
+        annotations:
+          azure.workload.identity/client-id: "prod-client-id"
+          azure.workload.identity/tenant-id: "prod-tenant-id"
+
+      config:
+        tenantId: "prod-tenant-id"
+        subscriptionId: "prod-subscription-id"
+        clientId: "prod-client-id"
+        authMethod: "workload-identity"
+        readOnlyMode: true
+
+      service:
+        port: 8000
+
+    # Non-AKS cluster with Service Principal - requires secret
+    - name: "staging-on-prem"
+      enabled: true
+
+      serviceAccount:
+        create: true
+
+      config:
+        tenantId: "staging-tenant-id"
+        subscriptionId: "staging-subscription-id"
+        authMethod: "service-principal"
+        readOnlyMode: true
+
+      secretName: "azure-staging-mcp-creds"  # Secret required for this instance
+
+      service:
+        port: 8001
+```
+
+**Secret Creation for Mixed Setup:**
+
+```bash
+# Only create secret for instances using service-principal auth
+kubectl create secret generic azure-staging-mcp-creds \
+  --from-literal=AZURE_CLIENT_ID=staging-client-id \
+  --from-literal=AZURE_CLIENT_SECRET=staging-client-secret \
+  -n YOUR_NAMESPACE
+```
+
+#### When to Use Each Authentication Method
+
+| Method | Best For | Secret Required | Example |
+|--------|----------|-----------------|---------|
+| `workload-identity` | AKS clusters | ❌ No | Production AKS environments |
+| `service-principal` | Non-AKS clusters, legacy setups | ✅ Yes | On-premises, EKS, GKE |
+| `managed-identity` | AKS with node-level managed identity | ❌ No | Simplified AKS setup |
 
 When using multiple instances, Holmes will route requests to the appropriate instance based on the context (tenant/subscription). You can specify which instance to use in your investigation prompt:
 

--- a/helm/holmes/templates/mcp-servers/azure/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/deployment.yaml
@@ -6,12 +6,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-azure-{{ .name }}-mcp-config
-  namespace: {{ .config.namespace | default .Release.Namespace }}
+  name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-config
+  namespace: {{ .config.namespace | default $.Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-azure-{{ .name }}-mcp
+    app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" $ | nindent 4 }}
@@ -241,7 +241,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-azure-mcp
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" . | nindent 4 }}
@@ -264,7 +264,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-azure-mcp
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" . | nindent 4 }}
@@ -292,7 +292,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-azure-mcp
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" . | nindent 4 }}
@@ -306,13 +306,13 @@ spec:
     matchLabels:
       app: {{ .Release.Name }}-azure-mcp
       app.kubernetes.io/name: azure-mcp-server
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
   template:
     metadata:
       labels:
         app: {{ .Release.Name }}-azure-mcp
         app.kubernetes.io/name: azure-mcp-server
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
         app.kubernetes.io/component: mcp-server
         app.kubernetes.io/part-of: holmes
         {{- include "holmes.commonLabels" . | nindent 8 }}
@@ -439,7 +439,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-azure-mcp
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" . | nindent 4 }}
@@ -452,7 +452,7 @@ spec:
   selector:
     app: {{ .Release.Name }}-azure-mcp
     app.kubernetes.io/name: azure-mcp-server
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
   ports:
   - name: http
     port: 8000

--- a/helm/holmes/templates/mcp-servers/azure/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/deployment.yaml
@@ -1,4 +1,237 @@
-{{- if .Values.mcpAddons.azure.enabled }}
+{{- /* Support for multiple Azure MCP instances */ -}}
+{{- if .Values.mcpAddons.azureInstances }}
+{{- range .Values.mcpAddons.azureInstances }}
+{{- if .enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-azure-{{ .name }}-mcp-config
+  namespace: {{ .config.namespace | default .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-azure-{{ .name }}-mcp
+    app.kubernetes.io/name: azure-mcp-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/part-of: holmes
+    {{- include "holmes.commonLabels" $ | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+data:
+  AZURE_TENANT_ID: {{ .config.tenantId | quote }}
+  AZURE_SUBSCRIPTION_ID: {{ .config.subscriptionId | quote }}
+  AZ_AUTH_METHOD: {{ .config.authMethod | default "workload-identity" | quote }}
+  READ_ONLY_MODE: {{ .config.readOnlyMode | default "true" | quote }}
+---
+{{- if .serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .serviceAccount.name | default (printf "azure-%s-mcp-sa" .name) }}
+  namespace: {{ .config.namespace | default $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+    app.kubernetes.io/name: azure-mcp-server
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/part-of: holmes
+    {{- include "holmes.commonLabels" $ | nindent 4 }}
+    {{- if eq .config.authMethod "workload-identity" }}
+    azure.workload.identity/use: "true"
+    {{- end }}
+  {{- $ann := dict -}}
+  {{- with (include "holmes.commonAnnotations" $ | fromYaml) -}}
+  {{- $ann = mergeOverwrite $ann . -}}
+  {{- end -}}
+  {{- with .serviceAccount.annotations -}}
+  {{- $ann = mergeOverwrite $ann . -}}
+  {{- end -}}
+  {{- if $ann }}
+  annotations:
+    {{- toYaml $ann | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-server
+  namespace: {{ .config.namespace | default $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+    app.kubernetes.io/name: azure-mcp-server
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/part-of: holmes
+    {{- include "holmes.commonLabels" $ | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+      app.kubernetes.io/name: azure-mcp-server
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+        app.kubernetes.io/name: azure-mcp-server
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        app.kubernetes.io/component: mcp-server
+        app.kubernetes.io/part-of: holmes
+        {{- include "holmes.commonLabels" $ | nindent 8 }}
+        {{- if eq .config.authMethod "workload-identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      annotations:
+        {{- with (include "holmes.commonAnnotations" $) }}
+          {{- . | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ . | toYaml | sha256sum }}
+    spec:
+      {{- if or .serviceAccount.create .serviceAccount.name }}
+      serviceAccountName: {{ .serviceAccount.name | default (printf "azure-%s-mcp-sa" .name) }}
+      {{- end }}
+      containers:
+      - name: azure-mcp
+        image: {{ .registry }}/{{ .image }}
+        imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
+
+        args:
+          - "--transport"
+          - "streamable-http"
+          - "--host"
+          - "0.0.0.0"
+          - "--port"
+          - {{ .service.port | default 8000 | quote }}
+          {{- if .config.readOnlyMode }}
+          - "--readonly"
+          {{- end }}
+          {{- if .config.enableSecurityPolicy }}
+          - "--enable-security-policy"
+          {{- end }}
+          {{- if .config.timeout }}
+          - "--timeout"
+          - {{ .config.timeout | quote }}
+          {{- end }}
+
+        ports:
+        - name: http
+          containerPort: {{ .service.port | default 8000 }}
+          protocol: TCP
+
+        env:
+        - name: AZURE_TENANT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-config
+              key: AZURE_TENANT_ID
+        - name: AZURE_SUBSCRIPTION_ID
+          valueFrom:
+            configMapKeyRef:
+              name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-config
+              key: AZURE_SUBSCRIPTION_ID
+        - name: AZ_AUTH_METHOD
+          valueFrom:
+            configMapKeyRef:
+              name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-config
+              key: AZ_AUTH_METHOD
+        {{- if eq .config.authMethod "workload-identity" }}
+        - name: AZURE_CLIENT_ID
+          value: {{ .config.clientId | quote }}
+        {{- end }}
+        {{- if eq .config.authMethod "service-principal" }}
+        - name: AZURE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName | default "azure-mcp-creds" }}
+              key: AZURE_CLIENT_ID
+        - name: AZURE_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName | default "azure-mcp-creds" }}
+              key: AZURE_CLIENT_SECRET
+        {{- end }}
+        {{- if eq .config.authMethod "managed-identity" }}
+        - name: AZURE_CLIENT_ID
+          value: {{ .config.clientId | quote }}
+        {{- end }}
+        {{- if .additionalEnvVars }}
+        {{- toYaml .additionalEnvVars | nindent 8 }}
+        {{- end }}
+
+        resources:
+          {{- toYaml .resources | nindent 10 }}
+
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+
+      {{- if .nodeSelector }}
+      nodeSelector:
+        {{- toYaml .nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .tolerations }}
+      tolerations:
+        {{- toYaml .tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .affinity }}
+      affinity:
+        {{- toYaml .affinity | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-server
+  namespace: {{ .config.namespace | default $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+    app.kubernetes.io/name: azure-mcp-server
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/part-of: holmes
+    {{- include "holmes.commonLabels" $ | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+    app.kubernetes.io/name: azure-mcp-server
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  ports:
+  - name: http
+    port: {{ .service.port | default 8000 }}
+    targetPort: http
+    protocol: TCP
+{{- end }}
+{{- end }}
+{{- else if .Values.mcpAddons.azure.enabled }}
+{{- /* Backward compatibility: single azure instance */ -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/holmes/templates/mcp-servers/azure/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/azure/networkpolicy.yaml
@@ -1,4 +1,73 @@
-{{- if and .Values.mcpAddons.azure.enabled .Values.mcpAddons.azure.networkPolicy.enabled }}
+{{- /* Network policies for multiple Azure MCP instances */ -}}
+{{- if .Values.mcpAddons.azureInstances }}
+{{- range .Values.mcpAddons.azureInstances }}
+{{- if and .enabled .networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $.Release.Name }}-azure-{{ .name }}-mcp-server
+  namespace: {{ .config.namespace | default $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+    app.kubernetes.io/name: azure-mcp-server
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/part-of: holmes
+    {{- include "holmes.commonLabels" $ | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" $) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $.Release.Name }}-azure-{{ .name }}-mcp
+      app.kubernetes.io/name: azure-mcp-server
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    # Allow traffic from Holmes pods
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: holmes
+          app.kubernetes.io/instance: {{ $.Release.Name }}
+    # Allow traffic from pods with specific label
+    - podSelector:
+        matchLabels:
+          holmes.mcp.client: "true"
+    {{- if .networkPolicy.additionalIngressRules }}
+    {{- toYaml .networkPolicy.additionalIngressRules | nindent 4 }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: {{ .service.port | default 8000 }}
+  egress:
+  # Allow DNS
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+  # Allow HTTPS traffic to Azure APIs
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
+  {{- if .networkPolicy.additionalEgressRules }}
+  {{- toYaml .networkPolicy.additionalEgressRules | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- else if and .Values.mcpAddons.azure.enabled .Values.mcpAddons.azure.networkPolicy.enabled }}
+{{- /* Backward compatibility: single azure instance */ -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -38,6 +38,7 @@ data:
     {{- if .Values.mcpAddons.azureInstances }}
     {{- range .Values.mcpAddons.azureInstances }}
     {{- if .enabled }}
+    {{- $llmInstructions := .llmInstructions | default (include "holmes.azureMcp.llmInstructions" $) }}
     {{- $azureInstanceMcpServers := dict (printf "azure_%s" .name) (dict
         "description" (printf "Azure API MCP Server (%s) - access to %s tenant. Execute Azure CLI commands." .name .config.tenantId)
         "config" (dict
@@ -45,7 +46,7 @@ data:
           "mode" "streamable-http"
           "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/microsoft-azure.svg"
         )
-        "llm_instructions" (if .llmInstructions (.llmInstructions | trim) else (include "holmes.azureMcp.llmInstructions" $ | trim) end)
+        "llm_instructions" ($llmInstructions | trim)
       )
     }}
     {{- $mcpServers = merge $mcpServers $azureInstanceMcpServers }}

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.toolsets | not | empty) .Values.mcpAddons.aws.enabled .Values.mcpAddons.mariadb.enabled .Values.mcpAddons.gcp.enabled .Values.mcpAddons.azure.enabled .Values.mcpAddons.github.enabled .Values.mcpAddons.gitlabMcp.enabled .Values.mcpAddons.sentry.enabled .Values.mcpAddons.prefect.enabled .Values.mcpAddons.kubernetesRemediation.enabled .Values.mcpAddons.kubernetes.enabled .Values.mcpAddons.confluenceMcp.enabled }}
+{{- if or (.Values.toolsets | not | empty) .Values.mcpAddons.aws.enabled .Values.mcpAddons.mariadb.enabled .Values.mcpAddons.gcp.enabled .Values.mcpAddons.azure.enabled .Values.mcpAddons.azureInstances .Values.mcpAddons.github.enabled .Values.mcpAddons.gitlabMcp.enabled .Values.mcpAddons.sentry.enabled .Values.mcpAddons.prefect.enabled .Values.mcpAddons.kubernetesRemediation.enabled .Values.mcpAddons.kubernetes.enabled .Values.mcpAddons.confluenceMcp.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,7 +34,25 @@ data:
     }}
     {{- $mcpServers = merge $mcpServers $awsMcpServers }}
     {{- end }}
-    {{- if .Values.mcpAddons.azure.enabled }}
+    {{- /* Multiple Azure MCP instances */ -}}
+    {{- if .Values.mcpAddons.azureInstances }}
+    {{- range .Values.mcpAddons.azureInstances }}
+    {{- if .enabled }}
+    {{- $azureInstanceMcpServers := dict (printf "azure_%s" .name) (dict
+        "description" (printf "Azure API MCP Server (%s) - access to %s tenant. Execute Azure CLI commands." .name .config.tenantId)
+        "config" (dict
+          "url" (printf "http://%s-azure-%s-mcp-server.%s.svc.cluster.local:%d/mcp" $.Release.Name .name (.config.namespace | default $.Release.Namespace) (int .service.port | default 8000))
+          "mode" "streamable-http"
+          "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/microsoft-azure.svg"
+        )
+        "llm_instructions" (if .llmInstructions (.llmInstructions | trim) else (include "holmes.azureMcp.llmInstructions" $ | trim) end)
+      )
+    }}
+    {{- $mcpServers = merge $mcpServers $azureInstanceMcpServers }}
+    {{- end }}
+    {{- end }}
+    {{- else if .Values.mcpAddons.azure.enabled }}
+    {{- /* Backward compatibility: single azure instance */ -}}
     {{- $azureMcpServers := dict "azure_api" (dict
         "description" "Azure API MCP Server - comprehensive Azure service access. Execute any Azure CLI commands."
         "config" (dict

--- a/helm/holmes/templates/validate.yaml
+++ b/helm/holmes/templates/validate.yaml
@@ -30,3 +30,67 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- /*
+  Azure instances validation.
+
+  When using multiple Azure MCP instances, validate:
+  - Each instance has a unique name
+  - Each instance has a unique service port
+  - Required fields (tenantId, subscriptionId, authMethod) are set
+  - authMethod is one of: workload-identity, managed-identity, service-principal
+  - service-principal instances have a secretName specified
+*/ -}}
+{{- if .Values.mcpAddons.azureInstances }}
+  {{- $instanceNames := list }}
+  {{- $instancePorts := list }}
+  {{- range .Values.mcpAddons.azureInstances }}
+    {{- if .enabled }}
+      {{- /* Validate required fields */ -}}
+      {{- if not .name }}
+        {{- fail "mcpAddons.azureInstances: each instance must have a 'name' field" }}
+      {{- end }}
+      {{- if not .config.tenantId }}
+        {{- fail (printf "mcpAddons.azureInstances[%s]: 'config.tenantId' is required" .name) }}
+      {{- end }}
+      {{- if not .config.subscriptionId }}
+        {{- fail (printf "mcpAddons.azureInstances[%s]: 'config.subscriptionId' is required" .name) }}
+      {{- end }}
+      {{- if not .config.authMethod }}
+        {{- fail (printf "mcpAddons.azureInstances[%s]: 'config.authMethod' is required (workload-identity, managed-identity, or service-principal)" .name) }}
+      {{- end }}
+
+      {{- /* Validate authMethod value */ -}}
+      {{- if not (has .config.authMethod (list "workload-identity" "managed-identity" "service-principal")) }}
+        {{- fail (printf "mcpAddons.azureInstances[%s]: invalid authMethod %q. Must be one of: workload-identity, managed-identity, service-principal" .name .config.authMethod) }}
+      {{- end }}
+
+      {{- /* Validate service-principal requires secretName */ -}}
+      {{- if eq .config.authMethod "service-principal" }}
+        {{- if not .secretName }}
+          {{- fail (printf "mcpAddons.azureInstances[%s]: when using authMethod 'service-principal', 'secretName' must be specified" .name) }}
+        {{- end }}
+      {{- end }}
+
+      {{- /* Validate workload-identity requires clientId */ -}}
+      {{- if eq .config.authMethod "workload-identity" }}
+        {{- if not .config.clientId }}
+          {{- fail (printf "mcpAddons.azureInstances[%s]: when using authMethod 'workload-identity', 'config.clientId' is required" .name) }}
+        {{- end }}
+      {{- end }}
+
+      {{- /* Check for duplicate names */ -}}
+      {{- if has .name $instanceNames }}
+        {{- fail (printf "mcpAddons.azureInstances: duplicate instance name %q. Each instance must have a unique name." .name) }}
+      {{- end }}
+      {{- $instanceNames = append $instanceNames .name }}
+
+      {{- /* Check for duplicate ports */ -}}
+      {{- $port := (.service.port | default 8000) | int }}
+      {{- if has $port $instancePorts }}
+        {{- fail (printf "mcpAddons.azureInstances[%s]: duplicate service port %d. Each instance must have a unique port." .name $port) }}
+      {{- end }}
+      {{- $instancePorts = append $instancePorts $port }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -417,6 +417,9 @@ mcpAddons:
       storage: ""
 
   # Azure MCP Server Configuration
+  # BACKWARD COMPATIBILITY NOTE: The single `azure` configuration below is fully supported
+  # for backward compatibility. For multiple Azure MCP instances with different credentials
+  # and tenants, use `azureInstances` below instead.
   azure:
     enabled: false
     # Service account configuration for Azure Workload Identity
@@ -466,6 +469,69 @@ mcpAddons:
 
     # Custom LLM instructions (optional) - leave empty to use default
     llmInstructions: ""
+
+  # Multiple Azure MCP Instances Configuration
+  # When you need multiple Azure MCP servers with different credentials and tenants,
+  # enable instances here. Each instance will have its own pod, service account, and configuration.
+  #
+  # Example:
+  #   azureInstances:
+  #     - name: "prod"
+  #       enabled: true
+  #       tenantId: "tenant-1"
+  #       subscriptionId: "sub-1"
+  #       ...
+  #     - name: "staging"
+  #       enabled: true
+  #       tenantId: "tenant-2"
+  #       subscriptionId: "sub-2"
+  #       ...
+  azureInstances: []
+    # - name: ""                           # Instance name (required) - used in resource naming
+    #   enabled: true
+    #
+    #   serviceAccount:
+    #     create: true
+    #     name: ""                         # Service account name (defaults to azure-<name>-mcp-sa if empty)
+    #     annotations: {}                  # Workload Identity annotations
+    #
+    #   image: "azure-cli-mcp:1.0.2"
+    #   registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
+    #   imagePullPolicy: "IfNotPresent"
+    #
+    #   config:
+    #     tenantId: ""                     # Azure tenant ID (required)
+    #     subscriptionId: ""               # Azure subscription ID
+    #     clientId: ""                     # Azure client ID
+    #     readOnlyMode: true
+    #     authMethod: "workload-identity"  # Options: workload-identity, managed-identity, service-principal
+    #     enableSecurityPolicy: false
+    #     timeout: "120"
+    #     namespace: ""                    # Kubernetes namespace
+    #
+    #   secretName: ""                     # Secret name for service-principal auth
+    #
+    #   resources:
+    #     requests:
+    #       memory: "256Mi"
+    #       cpu: "100m"
+    #     limits:
+    #       memory: "512Mi"
+    #
+    #   service:
+    #     port: 8000                       # Each instance needs a unique port
+    #
+    #   networkPolicy:
+    #     enabled: false
+    #     additionalIngressRules: []
+    #     additionalEgressRules: []
+    #
+    #   additionalEnvVars: []
+    #   nodeSelector: {}
+    #   tolerations: []
+    #   affinity: {}
+    #
+    #   llmInstructions: ""
 
   # GitHub MCP Server Configuration
   # Provides access to GitHub repositories, pull requests, issues, and GitHub Actions

--- a/holmes/core/tools_utils/tool_executor.py
+++ b/holmes/core/tools_utils/tool_executor.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Dict, List, Optional
+import re
+from typing import Dict, List, Optional, Tuple
 
 import sentry_sdk
 
@@ -12,6 +13,43 @@ from holmes.core.tools import (
 from holmes.core.tools_utils.oauth_tool_connector import OAuthToolConnector
 
 display_logger = logging.getLogger("holmes.display.tool_executor")
+
+
+def resolve_tool_name_collisions(
+    toolsets: List[Toolset],
+) -> List[Tuple[Toolset, "Tool", str]]:
+    """Resolve each tool's exposed name. An MCP tool is prefixed with its toolset
+    name (``{toolset}__{tool}``) only when its raw name collides across toolsets;
+    otherwise the raw name is kept. Pure: computes from the immutable
+    ``mcp_tool_name`` and does not mutate any tool or toolset."""
+
+    def mcp_name(tool: "Tool") -> str:
+        # Real MCP tools carry a non-empty string mcp_tool_name; anything else
+        # (builtin tools, test mocks) is treated as non-MCP.
+        mtn = getattr(tool, "mcp_tool_name", "")
+        return mtn if isinstance(mtn, str) else ""
+
+    def raw(tool: "Tool") -> str:
+        return mcp_name(tool) or tool.name
+
+    counts: Dict[str, int] = {}
+    for ts in toolsets:
+        for tool in ts.tools:
+            counts[raw(tool)] = counts.get(raw(tool), 0) + 1
+
+    resolved: List[Tuple[Toolset, "Tool", str]] = []
+    for ts in toolsets:
+        for tool in ts.tools:
+            r = raw(tool)
+            # Only MCP tools are namespaced, and only when their raw name collides.
+            if counts[r] > 1 and mcp_name(tool):
+                # Sanitize the toolset prefix so the LLM function name stays valid
+                # even if the toolset name has spaces/dashes/dots.
+                prefix = re.sub(r"[^a-zA-Z0-9]+", "_", ts.name).strip("_")
+                resolved.append((ts, tool, f"{prefix}__{r}"))
+            else:
+                resolved.append((ts, tool, r))
+    return resolved
 
 
 class ToolExecutor:
@@ -29,28 +67,45 @@ class ToolExecutor:
                 msg = f"Overriding toolset '{ts.name}'!"
                 display_logger.warning(msg)
                 if on_event is not None:
-                    on_event(StatusEvent(kind=StatusEventKind.TOOL_OVERRIDE, name=ts.name, message=msg))
+                    on_event(
+                        StatusEvent(
+                            kind=StatusEventKind.TOOL_OVERRIDE,
+                            name=ts.name,
+                            message=msg,
+                        )
+                    )
             toolsets_by_name[ts.name] = ts
 
         self.tools_by_name: dict[str, Tool] = {}
         self._tool_to_toolset: dict[str, Toolset] = {}
-        for ts in toolsets_by_name.values():
-            for tool in ts.tools:
-                if tool.icon_url is None and ts.icon_url is not None:
-                    tool.icon_url = ts.icon_url
-                if tool.name in self.tools_by_name:
-                    msg = f"Overriding existing tool '{tool.name} with new tool from {ts.name} at {ts.path}'!"
-                    display_logger.warning(msg)
-                    if on_event is not None:
-                        on_event(StatusEvent(kind=StatusEventKind.TOOL_OVERRIDE, name=tool.name, message=msg))
-                self.tools_by_name[tool.name] = tool
-                self._tool_to_toolset[tool.name] = ts
+        for ts, tool, resolved_name in resolve_tool_name_collisions(
+            list(toolsets_by_name.values())
+        ):
+            if tool.icon_url is None and ts.icon_url is not None:
+                tool.icon_url = ts.icon_url
+            if resolved_name != tool.name:
+                tool.name = resolved_name
+            if resolved_name in self.tools_by_name:
+                msg = f"Overriding existing tool '{resolved_name} with new tool from {ts.name} at {ts.path}'!"
+                display_logger.warning(msg)
+                if on_event is not None:
+                    on_event(
+                        StatusEvent(
+                            kind=StatusEventKind.TOOL_OVERRIDE,
+                            name=resolved_name,
+                            message=msg,
+                        )
+                    )
+            self.tools_by_name[resolved_name] = tool
+            self._tool_to_toolset[resolved_name] = ts
 
         self.oauth_connector = OAuthToolConnector()
 
     # ── Tool lookup ────────────────────────────────────────────────────
 
-    def get_tool_by_name(self, name: str, user_id: Optional[str] = None) -> Optional[Tool]:
+    def get_tool_by_name(
+        self, name: str, user_id: Optional[str] = None
+    ) -> Optional[Tool]:
         if name in self.tools_by_name:
             return self.tools_by_name[name]
         # Check per-user OAuth tools (registered in _tool_to_toolset but not in tools_by_name)
@@ -60,9 +115,13 @@ class ToolExecutor:
         logging.warning(f"could not find tool {name}. skipping")
         return None
 
-    def get_toolset_name(self, tool_name: str, user_id: Optional[str] = None) -> Optional[str]:
+    def get_toolset_name(
+        self, tool_name: str, user_id: Optional[str] = None
+    ) -> Optional[str]:
         """Return the toolset name that provides a given tool, or None."""
-        ts = self._tool_to_toolset.get(tool_name) or self.oauth_connector.get_toolset(tool_name, user_id)
+        ts = self._tool_to_toolset.get(tool_name) or self.oauth_connector.get_toolset(
+            tool_name, user_id
+        )
         return ts.name if ts else None
 
     def ensure_toolset_initialized(self, tool_name: str) -> Optional[str]:
@@ -80,7 +139,9 @@ class ToolExecutor:
 
         if toolset.needs_initialization:
             if not toolset.lazy_initialize():
-                error_msg = f"Toolset '{toolset.name}' failed to initialize: {toolset.error}"
+                error_msg = (
+                    f"Toolset '{toolset.name}' failed to initialize: {toolset.error}"
+                )
                 logging.error(error_msg)
                 return error_msg
         elif toolset.status == ToolsetStatusEnum.FAILED:
@@ -116,9 +177,7 @@ class ToolExecutor:
 
         for tool in extra_tools:
             if tool.name in clone.tools_by_name:
-                logging.warning(
-                    f"Frontend tool '{tool.name}' overrides existing tool"
-                )
+                logging.warning(f"Frontend tool '{tool.name}' overrides existing tool")
             clone.tools_by_name[tool.name] = tool
             # No toolset mapping — frontend tools don't belong to a toolset,
             # so ensure_toolset_initialized() returns None (no-op) for them.
@@ -139,7 +198,9 @@ class ToolExecutor:
                      user's real tools (loaded after authentication).
         """
         tools = self._get_base_tools()
-        return self.oauth_connector.apply_user_tools(tools, user_id, self._tool_to_toolset)
+        return self.oauth_connector.apply_user_tools(
+            tools, user_id, self._tool_to_toolset
+        )
 
     def _get_base_tools(self) -> list:
         """Get all tools in OpenAI format (base set, no per-user overrides)."""

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -5,12 +5,10 @@ import json
 import logging
 import os
 import threading
-import time
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional, TextIO, Tuple, Type, Union
-from urllib.parse import urlparse
 
 import httpx
 from mcp.client.session import ClientSession
@@ -18,13 +16,13 @@ from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import Tool as MCP_Tool
-from pydantic import AnyUrl, BaseModel, Field, model_validator
+from pydantic import AnyUrl, Field, model_validator
 
 from holmes.common.env_vars import MCP_TOOL_CALL_TIMEOUT_SEC, SSE_READ_TIMEOUT
+from holmes.core.config import config_path_dir
 from holmes.core.oauth_config import (
     MCPOAuthConfig,
     OAuthEndpoints,
-    OAuthTokenExchangeError,
     _get_exchange_manager,
 )
 from holmes.core.oauth_utils import (
@@ -34,7 +32,6 @@ from holmes.core.oauth_utils import (
     fetch_oauth_metadata,
     generate_pkce,
 )
-from holmes.core.config import config_path_dir
 from holmes.core.tools import (
     ApprovalRequirement,
     CallablePrerequisite,
@@ -127,12 +124,11 @@ DEFAULT_HEALTH_CHECK_TOOLS: List[str] = [
 ]
 
 
-
-
-
 class MCPConfig(ToolsetConfig):
     _name: ClassVar[Optional[str]] = "HTTP/SSE"
-    _description: ClassVar[Optional[str]] = "Connect via HTTP using SSE or Streamable HTTP transport"
+    _description: ClassVar[Optional[str]] = (
+        "Connect via HTTP using SSE or Streamable HTTP transport"
+    )
 
     mode: MCPMode = Field(
         default=MCPMode.SSE,
@@ -193,7 +189,9 @@ class MCPConfig(ToolsetConfig):
 
 class StdioMCPConfig(ToolsetConfig):
     _name: ClassVar[Optional[str]] = "Stdio"
-    _description: ClassVar[Optional[str]] = "Run MCP server as a local subprocess using stdio transport"
+    _description: ClassVar[Optional[str]] = (
+        "Run MCP server as a local subprocess using stdio transport"
+    )
 
     mode: MCPMode = Field(
         default=MCPMode.STDIO,
@@ -247,7 +245,6 @@ def _get_mcp_log_file(server_name: str) -> TextIO:
     log_path = os.path.join(log_dir, f"{server_name}.log")
     display_logger.info(f"MCP server '{server_name}' logs: {log_path}")
     return open(log_path, "w")
-
 
 
 @asynccontextmanager
@@ -319,6 +316,8 @@ async def get_initialized_mcp_session(
 
 class RemoteMCPTool(Tool):
     toolset: "RemoteMCPToolset" = Field(exclude=True)
+    # Real server-side tool name; exposed name is prefixed.
+    mcp_tool_name: str = Field(default="", exclude=True)
 
     def requires_approval(
         self, params: Dict, context: ToolInvokeContext
@@ -328,11 +327,17 @@ class RemoteMCPTool(Tool):
             return None
 
         oauth_config = self.toolset._mcp_config.oauth
-        disk_key = str(self.toolset._mcp_config.url) if isinstance(self.toolset._mcp_config, MCPConfig) else None
+        disk_key = (
+            str(self.toolset._mcp_config.url)
+            if isinstance(self.toolset._mcp_config, MCPConfig)
+            else None
+        )
 
         # Try to get a token from cache → refresh → DB → disk
         mgr = _get_token_manager()
-        token = mgr.get_access_token(oauth_config, context.request_context, disk_key=disk_key)
+        token = mgr.get_access_token(
+            oauth_config, context.request_context, disk_key=disk_key
+        )
         if token:
             logger.info("OAuth MCP %s: token available via manager", self.toolset.name)
             return None
@@ -344,7 +349,9 @@ class RemoteMCPTool(Tool):
         is_cli = context.request_context is None
         if is_cli:
             # CLI mode: run browser OAuth flow synchronously
-            logger.info("OAuth MCP %s: CLI mode, running browser OAuth flow", self.toolset.name)
+            logger.info(
+                "OAuth MCP %s: CLI mode, running browser OAuth flow", self.toolset.name
+            )
             oauth_endpoints = OAuthEndpoints(
                 authorization_url=oauth_config.authorization_url,
                 token_url=oauth_config.token_url,
@@ -356,8 +363,11 @@ class RemoteMCPTool(Tool):
             token_data = cli_oauth_flow(oauth_endpoints, self.toolset.name)
             if token_data:
                 _get_token_manager().store_token(
-                    oauth_config, token_data, context.request_context,
-                    disk_key=disk_key, store_to_disk=True,
+                    oauth_config,
+                    token_data,
+                    context.request_context,
+                    disk_key=disk_key,
+                    store_to_disk=True,
                 )
                 logger.info("OAuth MCP %s: CLI auth successful", self.toolset.name)
                 return None  # Token obtained, no approval needed
@@ -392,7 +402,7 @@ class RemoteMCPTool(Tool):
         )
 
     def _is_placeholder_connect_tool(self) -> bool:
-        return self.name == self.toolset.connect_tool_name
+        return (self.mcp_tool_name or self.name) == self.toolset.connect_tool_name
 
     def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
         try:
@@ -417,7 +427,9 @@ class RemoteMCPTool(Tool):
                 invocation=f"MCPtool {self.name} with params {params}",
             )
 
-    def _invoke_oauth_connect(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+    def _invoke_oauth_connect(
+        self, params: dict, context: ToolInvokeContext
+    ) -> StructuredToolResult:
         """Handle the OAuth placeholder tool: load real tools from the MCP server after authentication."""
         try:
             if not self.toolset._mcp_config:
@@ -425,13 +437,22 @@ class RemoteMCPTool(Tool):
 
             lock = get_server_lock(str(self.toolset._mcp_config.get_lock_string()))
             with lock:
-                tools_result = asyncio.run(self.toolset._get_server_tools_with_context(context.request_context))
+                tools_result = asyncio.run(
+                    self.toolset._get_server_tools_with_context(context.request_context)
+                )
 
-            real_tools = [RemoteMCPTool.create(tool, self.toolset) for tool in tools_result.tools]
+            real_tools = [
+                RemoteMCPTool.create(tool, self.toolset) for tool in tools_result.tools
+            ]
 
             if real_tools:
                 tool_names = [t.name for t in real_tools]
-                logger.info("OAuth MCP %s: loaded %d tools after authentication: %s", self.toolset.name, len(real_tools), tool_names)
+                logger.info(
+                    "OAuth MCP %s: loaded %d tools after authentication: %s",
+                    self.toolset.name,
+                    len(real_tools),
+                    tool_names,
+                )
                 return StructuredToolResult(
                     status=StructuredToolResultStatus.SUCCESS,
                     data=f"Successfully authenticated and discovered {len(real_tools)} tools: {', '.join(tool_names)}. You can now call these tools directly.",
@@ -440,7 +461,9 @@ class RemoteMCPTool(Tool):
                     oauth_tools=real_tools,
                 )
             else:
-                logger.warning("OAuth MCP %s: authenticated but no tools found", self.toolset.name)
+                logger.warning(
+                    "OAuth MCP %s: authenticated but no tools found", self.toolset.name
+                )
                 return StructuredToolResult(
                     status=StructuredToolResultStatus.ERROR,
                     error=f"Authenticated but no tools found on MCP server {self.toolset.name}",
@@ -449,7 +472,9 @@ class RemoteMCPTool(Tool):
                 )
         except Exception as e:
             error_detail = _extract_root_error_message(e)
-            logger.warning("OAuth MCP %s: connect failed: %s", self.toolset.name, error_detail)
+            logger.warning(
+                "OAuth MCP %s: connect failed: %s", self.toolset.name, error_detail
+            )
             return StructuredToolResult(
                 status=StructuredToolResultStatus.ERROR,
                 error=f"OAuth connect failed: {error_detail}",
@@ -503,13 +528,19 @@ class RemoteMCPTool(Tool):
                     return base64.b64decode(blob).decode("utf-8", errors="replace")
                 except (binascii.Error, ValueError):
                     pass
-            return f"[binary resource uri={uri} mimeType={mime} base64_size={len(blob)}]"
+            return (
+                f"[binary resource uri={uri} mimeType={mime} base64_size={len(blob)}]"
+            )
         if block_type == "resource_link":
             uri = getattr(block, "uri", "")
             name = getattr(block, "name", "") or ""
             title = getattr(block, "title", "") or ""
             label = title or name
-            return f"[resource_link {label}: {uri}]" if label else f"[resource_link: {uri}]"
+            return (
+                f"[resource_link {label}: {uri}]"
+                if label
+                else f"[resource_link: {uri}]"
+            )
         return ""
 
     async def _invoke_async(
@@ -518,7 +549,9 @@ class RemoteMCPTool(Tool):
         async with get_initialized_mcp_session(
             self.toolset, request_context
         ) as session:
-            tool_result = await session.call_tool(self.name, params)
+            tool_result = await session.call_tool(
+                self.mcp_tool_name or self.name, params
+            )
 
         text_chunks = [
             self._extract_text_from_content_block(c) for c in tool_result.content
@@ -556,6 +589,7 @@ class RemoteMCPTool(Tool):
         parameters = cls.parse_input_schema(tool.inputSchema)
         return cls(
             name=tool.name,
+            mcp_tool_name=tool.name,
             description=tool.description or "",
             parameters=parameters,
             toolset=toolset,
@@ -777,7 +811,11 @@ class RemoteMCPTool(Tool):
             return f"{params.get('cli_command')}"
 
         # gcloud MCP run_gcloud_command
-        if self.name == "run_gcloud_command" and params and "args" in params:
+        if (
+            (self.mcp_tool_name or self.name) == "run_gcloud_command"
+            and params
+            and "args" in params
+        ):
             args = params.get("args", [])
             if isinstance(args, list):
                 return f"gcloud {' '.join(str(arg) for arg in args)}"
@@ -801,7 +839,11 @@ class RemoteMCPToolset(Toolset):
 
     @property
     def is_oauth_enabled(self) -> bool:
-        return isinstance(self._mcp_config, MCPConfig) and bool(self._mcp_config.oauth) and self._mcp_config.oauth.enabled
+        return (
+            isinstance(self._mcp_config, MCPConfig)
+            and bool(self._mcp_config.oauth)
+            and self._mcp_config.oauth.enabled
+        )
 
     @property
     def connect_tool_name(self) -> str:
@@ -810,14 +852,22 @@ class RemoteMCPToolset(Toolset):
 
     def get_oauth_config(self) -> Optional[Dict[str, Any]]:
         """Return OAuth config dict for syncing to DB/frontend, or None if not OAuth-enabled."""
-        if not self.is_oauth_enabled or not isinstance(self._mcp_config, MCPConfig) or not self._mcp_config.oauth:
+        if (
+            not self.is_oauth_enabled
+            or not isinstance(self._mcp_config, MCPConfig)
+            or not self._mcp_config.oauth
+        ):
             return None
         return self._mcp_config.oauth.model_dump(exclude_none=True)
 
-    def _load_remote_tools(self, request_context: Optional[Dict[str, Any]] = None) -> List["RemoteMCPTool"]:
+    def _load_remote_tools(
+        self, request_context: Optional[Dict[str, Any]] = None
+    ) -> List["RemoteMCPTool"]:
         """Load tools from the MCP server and return as RemoteMCPTool instances."""
         if request_context:
-            tools_result = asyncio.run(self._get_server_tools_with_context(request_context))
+            tools_result = asyncio.run(
+                self._get_server_tools_with_context(request_context)
+            )
         else:
             tools_result = asyncio.run(self._get_server_tools())
         return [RemoteMCPTool.create(tool, self) for tool in tools_result.tools]
@@ -859,7 +909,9 @@ class RemoteMCPToolset(Toolset):
         # known — before discovery it's None and we can't look up a token yet)
         if self.is_oauth_enabled and self._mcp_config.oauth.authorization_url:
             oauth_config = self._mcp_config.oauth
-            cached_token = _get_token_manager().get_access_token(oauth_config, request_context)
+            cached_token = _get_token_manager().get_access_token(
+                oauth_config, request_context
+            )
             if cached_token:
                 final_headers["Authorization"] = f"Bearer {cached_token}"
                 logger.debug("OAuth token injected for MCP server %s", self.name)
@@ -869,7 +921,11 @@ class RemoteMCPToolset(Toolset):
                 # Strip any Authorization header coming from static `headers` /
                 # `extra_headers` so a shared service-account credential cannot
                 # silently substitute for the absent per-user OAuth token.
-                stripped = [k for k in list(final_headers.keys()) if k.lower() == "authorization"]
+                stripped = [
+                    k
+                    for k in list(final_headers.keys())
+                    if k.lower() == "authorization"
+                ]
                 for k in stripped:
                     del final_headers[k]
                 if stripped:
@@ -972,7 +1028,9 @@ class RemoteMCPToolset(Toolset):
                 or self._auto_detect_health_check_tool()
             )
             if health_check_tool_name:
-                health_check_result = self._run_health_check_tool(health_check_tool_name)
+                health_check_result = self._run_health_check_tool(
+                    health_check_tool_name
+                )
                 if not health_check_result[0]:
                     return health_check_result
 
@@ -992,7 +1050,7 @@ class RemoteMCPToolset(Toolset):
         Returns the name of the first allowlisted tool the server exposes, or
         None if it exposes none (in which case the auth health check is skipped).
         """
-        tool_names = {t.name for t in self.tools}
+        tool_names = {(t.mcp_tool_name or t.name) for t in self.tools}
         for candidate in DEFAULT_HEALTH_CHECK_TOOLS:
             if candidate in tool_names:
                 logging.info(
@@ -1020,7 +1078,9 @@ class RemoteMCPToolset(Toolset):
         GitHub token). This method calls a specified read-only tool with empty
         arguments to verify the connection is fully functional.
         """
-        matching_tools = [t for t in self.tools if t.name == tool_name]
+        matching_tools = [
+            t for t in self.tools if (t.mcp_tool_name or t.name) == tool_name
+        ]
         if not matching_tools:
             available = [t.name for t in self.tools]
             return (
@@ -1039,20 +1099,26 @@ class RemoteMCPToolset(Toolset):
                 error_text = " ".join(t for t in error_chunks if t)
                 logging.warning(
                     "MCP server %s health check failed (tool: %s): %s",
-                    self.name, tool_name, error_text or "unknown error"
+                    self.name,
+                    tool_name,
+                    error_text or "unknown error",
                 )
                 return (
                     False,
                     f"MCP server {self.name}: health check tool '{tool_name}' with params {{}} "
                     f"failed - {error_text or 'unknown error'}",
                 )
-            logging.info("MCP server %s health check passed (tool: %s)", self.name, tool_name)
+            logging.info(
+                "MCP server %s health check passed (tool: %s)", self.name, tool_name
+            )
             return (True, "")
         except Exception as e:
             error_detail = _extract_root_error_message(e)
             logging.warning(
                 "MCP server %s health check exception (tool: %s): %s",
-                self.name, tool_name, error_detail
+                self.name,
+                tool_name,
+                error_detail,
             )
             return (
                 False,
@@ -1072,8 +1138,14 @@ class RemoteMCPToolset(Toolset):
         load the real tools directly. Otherwise, auto-discover OAuth endpoints if needed,
         then register a placeholder tool that triggers the OAuth flow on first use.
         """
-        if not isinstance(self._mcp_config, MCPConfig) or self._mcp_config.oauth is None:
-            return (False, f"MCP server {self.name}: OAuth enabled but config not properly initialized")
+        if (
+            not isinstance(self._mcp_config, MCPConfig)
+            or self._mcp_config.oauth is None
+        ):
+            return (
+                False,
+                f"MCP server {self.name}: OAuth enabled but config not properly initialized",
+            )
         url = str(self._mcp_config.url).rstrip("/")
         oauth_config = self._mcp_config.oauth
 
@@ -1095,13 +1167,21 @@ class RemoteMCPToolset(Toolset):
                 pass
 
             try:
-                r2 = httpx.post(url, timeout=10, verify=self._mcp_config.verify_ssl, follow_redirects=False)
+                r2 = httpx.post(
+                    url,
+                    timeout=10,
+                    verify=self._mcp_config.verify_ssl,
+                    follow_redirects=False,
+                )
                 responses.append(r2)
             except Exception:
                 pass
 
             if not responses:
-                return (False, f"MCP server {self.name} unreachable: no HTTP response from either endpoint")
+                return (
+                    False,
+                    f"MCP server {self.name} unreachable: no HTTP response from either endpoint",
+                )
 
             # Prefer the response with a WWW-Authenticate header (needed for PRM discovery)
             response = next(
@@ -1110,13 +1190,23 @@ class RemoteMCPToolset(Toolset):
             )
 
             # Auto-discover OAuth endpoints if not configured
-            if not oauth_config.authorization_url or not oauth_config.token_url or not oauth_config.client_id:
+            if (
+                not oauth_config.authorization_url
+                or not oauth_config.token_url
+                or not oauth_config.client_id
+            ):
                 discovered = self._discover_oauth_endpoints(url, response)
                 if not discovered:
-                    return (False, f"MCP server {self.name}: OAuth enabled but auto-discovery failed. Configure authorization_url, token_url, and client_id manually.")
+                    return (
+                        False,
+                        f"MCP server {self.name}: OAuth enabled but auto-discovery failed. Configure authorization_url, token_url, and client_id manually.",
+                    )
 
         except Exception as e:
-            return (False, f"MCP server {self.name} unreachable: {_extract_root_error_message(e)}")
+            return (
+                False,
+                f"MCP server {self.name} unreachable: {_extract_root_error_message(e)}",
+            )
 
         # Register a placeholder tool that will trigger OAuth on first call.
         # After auth succeeds, _invoke will load the real tools dynamically.
@@ -1126,10 +1216,15 @@ class RemoteMCPToolset(Toolset):
             inputSchema={"type": "object", "properties": {}},
         )
         self.tools = [RemoteMCPTool.create(placeholder, self)]
-        logging.info("OAuth MCP server %s is reachable, registered placeholder tool (auth required)", self.name)
+        logging.info(
+            "OAuth MCP server %s is reachable, registered placeholder tool (auth required)",
+            self.name,
+        )
         return (True, "")
 
-    def _discover_oauth_endpoints(self, mcp_url: str, initial_response: httpx.Response) -> bool:
+    def _discover_oauth_endpoints(
+        self, mcp_url: str, initial_response: httpx.Response
+    ) -> bool:
         """Auto-discover OAuth endpoints following the MCP SDK's discovery flow.
 
         Discovery order (matching mcp.client.auth):
@@ -1140,20 +1235,28 @@ class RemoteMCPToolset(Toolset):
 
         Returns True if discovery succeeded and oauth config is fully populated.
         """
-        if not isinstance(self._mcp_config, MCPConfig) or self._mcp_config.oauth is None:
+        if (
+            not isinstance(self._mcp_config, MCPConfig)
+            or self._mcp_config.oauth is None
+        ):
             return False
         oauth_config = self._mcp_config.oauth
         verify_ssl = self._mcp_config.verify_ssl
 
         # Step 1: Find auth server via Protected Resource Metadata (RFC 9728)
         auth_server_url, prm_scopes = discover_auth_server_from_prm(
-            initial_response, mcp_url, verify_ssl, self.name,
+            initial_response,
+            mcp_url,
+            verify_ssl,
+            self.name,
         )
         if prm_scopes and not oauth_config.scopes:
             oauth_config.scopes = prm_scopes
 
         # Step 2: Fetch OAuth/OIDC metadata
-        oidc_config = fetch_oauth_metadata(auth_server_url, mcp_url, verify_ssl, self.name)
+        oidc_config = fetch_oauth_metadata(
+            auth_server_url, mcp_url, verify_ssl, self.name
+        )
         if not oidc_config:
             return False
 
@@ -1163,7 +1266,10 @@ class RemoteMCPToolset(Toolset):
             oauth_config.token_url = oidc_config.get("token_endpoint")
 
         if not oauth_config.authorization_url or not oauth_config.token_url:
-            logging.warning("OAuth discovery %s: missing authorization or token endpoint in metadata", self.name)
+            logging.warning(
+                "OAuth discovery %s: missing authorization or token endpoint in metadata",
+                self.name,
+            )
             return False
 
         if oidc_config.get("registration_endpoint"):
@@ -1172,13 +1278,21 @@ class RemoteMCPToolset(Toolset):
         # DCR deferred to runtime — we don't know redirect_uri at startup
         if not oauth_config.client_id:
             if oauth_config.registration_endpoint:
-                logging.debug("OAuth discovery %s: no client_id, DCR deferred to runtime", self.name)
+                logging.debug(
+                    "OAuth discovery %s: no client_id, DCR deferred to runtime",
+                    self.name,
+                )
             else:
-                logging.warning("OAuth discovery %s: no client_id and no DCR endpoint", self.name)
+                logging.warning(
+                    "OAuth discovery %s: no client_id and no DCR endpoint", self.name
+                )
 
         logging.debug(
             "OAuth discovery %s complete: authorization_url=%s, token_url=%s, client_id=%s",
-            self.name, oauth_config.authorization_url, oauth_config.token_url, oauth_config.client_id,
+            self.name,
+            oauth_config.authorization_url,
+            oauth_config.token_url,
+            oauth_config.client_id,
         )
         return True
 
@@ -1186,6 +1300,8 @@ class RemoteMCPToolset(Toolset):
         async with get_initialized_mcp_session(self, None) as session:
             return await session.list_tools()
 
-    async def _get_server_tools_with_context(self, request_context: Optional[Dict[str, Any]]):
+    async def _get_server_tools_with_context(
+        self, request_context: Optional[Dict[str, Any]]
+    ):
         async with get_initialized_mcp_session(self, request_context) as session:
             return await session.list_tools()

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -416,7 +416,10 @@ class TestMCPGeneral:
                     "include": ToolParameter(
                         type="array",
                         description="List of additional information to include in the response. Available options: 'users', 'services', 'assignments', 'acknowledgers', 'custom_fields', 'teams', 'escalation_policies', 'notes', 'urgencies', 'priorities'",
-                        required=False, items=ToolParameter(type="string", required=True, description=None),
+                        required=False,
+                        items=ToolParameter(
+                            type="string", required=True, description=None
+                        ),
                         json_schema_extra={"default": None},
                     ),
                 },
@@ -443,35 +446,65 @@ class TestMCPGeneral:
                             {
                                 "type": "object",
                                 "properties": {
-                                    "id": {"type": "string", "description": "The ID of the user"},
-                                    "name": {"type": "string", "description": "The name of the user"}
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the user",
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the user",
+                                    },
                                 },
-                                "required": ["id"]
+                                "required": ["id"],
                             },
                             {
                                 "type": "object",
                                 "properties": {
-                                    "email": {"type": "string", "description": "The email of the user"},
-                                    "age": {"type": "integer", "description": "The age of the user"}
+                                    "email": {
+                                        "type": "string",
+                                        "description": "The email of the user",
+                                    },
+                                    "age": {
+                                        "type": "integer",
+                                        "description": "The age of the user",
+                                    },
                                 },
-                                "required": ["email"]
-                            }
+                                "required": ["email"],
+                            },
                         ]
                     }
                 },
-                "required": ["user_data"]
+                "required": ["user_data"],
             },
             description="Update user data",
             annotations=None,
         )
 
         expected_schema = {
-            "user_data": ToolParameter(type="object", required=True, properties={
-                "id": ToolParameter(type="string", required=True, description="The ID of the user"),
-                "name": ToolParameter(type="string", required=False, description="The name of the user"),
-                "email": ToolParameter(type="string", required=True, description="The email of the user"),
-                "age": ToolParameter(type="integer", required=False, description="The age of the user"),
-            }),
+            "user_data": ToolParameter(
+                type="object",
+                required=True,
+                properties={
+                    "id": ToolParameter(
+                        type="string", required=True, description="The ID of the user"
+                    ),
+                    "name": ToolParameter(
+                        type="string",
+                        required=False,
+                        description="The name of the user",
+                    ),
+                    "email": ToolParameter(
+                        type="string",
+                        required=True,
+                        description="The email of the user",
+                    ),
+                    "age": ToolParameter(
+                        type="integer",
+                        required=False,
+                        description="The age of the user",
+                    ),
+                },
+            ),
         }
 
         mock_toolset = RemoteMCPToolset(
@@ -703,7 +736,9 @@ class TestMCPSchemaPreservation:
 
         # Verify it flows through to OpenAI format
         openai_format = tool.get_openai_format()
-        filters_schema = openai_format["function"]["parameters"]["properties"]["filters"]
+        filters_schema = openai_format["function"]["parameters"]["properties"][
+            "filters"
+        ]
         assert "additionalProperties" in filters_schema
         assert "anyOf" in filters_schema["additionalProperties"]
         assert len(filters_schema["additionalProperties"]["anyOf"]) == 2
@@ -756,10 +791,18 @@ class TestMCPSchemaPreservation:
         assert metrics_param.json_schema_extra == {"minItems": 1, "maxItems": 12}
 
         limit_param = tool.parameters["limit"]
-        assert limit_param.json_schema_extra == {"minimum": 1, "maximum": 1000, "default": 100}
+        assert limit_param.json_schema_extra == {
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 100,
+        }
 
         name_param = tool.parameters["name_pattern"]
-        assert name_param.json_schema_extra == {"pattern": "^[a-z]+$", "minLength": 1, "maxLength": 255}
+        assert name_param.json_schema_extra == {
+            "pattern": "^[a-z]+$",
+            "minLength": 1,
+            "maxLength": 255,
+        }
 
         # Verify they flow through to OpenAI format
         openai_format = tool.get_openai_format()
@@ -925,6 +968,248 @@ class TestStreamableHttp:
             "holmes.plugins.toolsets.mcp.toolset_mcp.ClientSession",
             return_value=mock_session_context,
         )
+
+    def _enabled_mcp_toolset(self, monkeypatch, name, url, tools):
+        from holmes.core.tools import ToolsetStatusEnum
+
+        ts = RemoteMCPToolset(
+            name=name,
+            description=name,
+            config={"url": url, "mode": "streamable-http"},
+        )
+
+        async def _get_tools():
+            return ListToolsResult(tools=tools)
+
+        monkeypatch.setattr(ts, "_get_server_tools", _get_tools)
+        ts.prerequisites_callable(config=ts.config)
+        ts.status = ToolsetStatusEnum.ENABLED
+        return ts
+
+    def test_colliding_mcp_tools_prefixed_and_resolve_to_correct_server(
+        self, monkeypatch, suppress_migration_warnings
+    ):
+        from holmes.core.tools_utils.tool_executor import ToolExecutor
+
+        mcp_tool = Tool(
+            name="call_az",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="run az",
+        )
+        ts_main = self._enabled_mcp_toolset(
+            monkeypatch, "azure_main", "http://main:8000/mcp", [mcp_tool]
+        )
+        ts_new = self._enabled_mcp_toolset(
+            monkeypatch, "azure_newaccount", "http://new:8001/mcp", [mcp_tool]
+        )
+
+        ex = ToolExecutor([ts_main, ts_new])
+
+        # The colliding tool is namespaced per server; the raw name is gone.
+        assert ex.tools_by_name.keys() >= {
+            "azure_main__call_az",
+            "azure_newaccount__call_az",
+        }
+        assert "call_az" not in ex.tools_by_name
+        assert ex._tool_to_toolset["azure_main__call_az"].name == "azure_main"
+        assert (
+            ex._tool_to_toolset["azure_newaccount__call_az"].name == "azure_newaccount"
+        )
+
+        # Invoking the prefixed tool routes to its own server with the RAW name.
+        tool = ex.tools_by_name["azure_newaccount__call_az"]
+        assert tool.mcp_tool_name == "call_az"
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock(return_value=None)
+        mock_session.call_tool = AsyncMock(
+            return_value=CallToolResult(
+                content=[TextContent(type="text", text="ok")],
+                isError=False,
+            )
+        )
+        c_ctx, s_ctx = self._setup_mocks(mock_session)
+        c_patch, s_patch = self._patch_clients(c_ctx, s_ctx)
+        with c_patch, s_patch:
+            result = asyncio.run(tool._invoke_async({}, None))
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        mock_session.call_tool.assert_awaited_once_with("call_az", {})
+
+    def test_single_mcp_instance_keeps_raw_tool_name(
+        self, monkeypatch, suppress_migration_warnings
+    ):
+        from holmes.core.tools_utils.tool_executor import ToolExecutor
+
+        mcp_tool = Tool(
+            name="call_az",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="run az",
+        )
+        ts = self._enabled_mcp_toolset(
+            monkeypatch, "azure", "http://a:8000/mcp", [mcp_tool]
+        )
+        ex = ToolExecutor([ts])
+        # No collision → name unchanged from the raw server name.
+        assert "call_az" in ex.tools_by_name
+        assert ex.tools_by_name["call_az"].name == "call_az"
+
+    def test_resolve_tool_name_collisions_only_prefixes_collisions(
+        self, suppress_migration_warnings
+    ):
+        from holmes.core.tools_utils.tool_executor import resolve_tool_name_collisions
+
+        def mk(name):
+            return Tool(
+                name=name,
+                inputSchema={"type": "object", "properties": {}, "required": []},
+                description="d",
+            )
+
+        ts1 = RemoteMCPToolset(
+            name="azure_main",
+            description="d",
+            config={"url": "http://a/mcp", "mode": "streamable-http"},
+        )
+        ts2 = RemoteMCPToolset(
+            name="azure_newaccount",
+            description="d",
+            config={"url": "http://b/mcp", "mode": "streamable-http"},
+        )
+        ts1.tools = [
+            RemoteMCPTool.create(mk("call_az"), ts1),
+            RemoteMCPTool.create(mk("only_here"), ts1),
+        ]
+        ts2.tools = [RemoteMCPTool.create(mk("call_az"), ts2)]
+
+        resolved = {
+            (ts.name, tool.mcp_tool_name): name
+            for ts, tool, name in resolve_tool_name_collisions([ts1, ts2])
+        }
+        assert resolved[("azure_main", "call_az")] == "azure_main__call_az"
+        assert resolved[("azure_newaccount", "call_az")] == "azure_newaccount__call_az"
+        assert (
+            resolved[("azure_main", "only_here")] == "only_here"
+        )  # no collision → raw
+
+    def test_collision_prefix_is_sanitized(self, suppress_migration_warnings):
+        # Toolset names with spaces/dashes/dots must yield valid LLM function names.
+        from holmes.core.tools_utils.tool_executor import resolve_tool_name_collisions
+
+        def mk(name):
+            return Tool(
+                name=name,
+                inputSchema={"type": "object", "properties": {}, "required": []},
+                description="d",
+            )
+
+        ts1 = RemoteMCPToolset(
+            name="azure prod.1",
+            description="d",
+            config={"url": "http://a/mcp", "mode": "streamable-http"},
+        )
+        ts2 = RemoteMCPToolset(
+            name="azure-prod 2",
+            description="d",
+            config={"url": "http://b/mcp", "mode": "streamable-http"},
+        )
+        ts1.tools = [RemoteMCPTool.create(mk("call_az"), ts1)]
+        ts2.tools = [RemoteMCPTool.create(mk("call_az"), ts2)]
+
+        names = {n for _, _, n in resolve_tool_name_collisions([ts1, ts2])}
+        assert names == {"azure_prod_1__call_az", "azure_prod_2__call_az"}
+
+    def test_oauth_connect_placeholders_do_not_collide_across_servers(
+        self, suppress_migration_warnings
+    ):
+        # Two OAuth MCP servers each expose a `<toolset>_connect` placeholder;
+        # those names are per-server unique, so there is no collision to resolve.
+        from holmes.core.tools import ToolsetStatusEnum
+        from holmes.core.tools_utils.tool_executor import ToolExecutor
+
+        def connect_placeholder(ts):
+            t = Tool(
+                name=ts.connect_tool_name,
+                inputSchema={"type": "object", "properties": {}},
+                description="connect",
+            )
+            return RemoteMCPTool.create(t, ts)
+
+        ts1 = RemoteMCPToolset(
+            name="azure_main",
+            description="d",
+            config={"url": "http://a/mcp", "mode": "streamable-http"},
+        )
+        ts2 = RemoteMCPToolset(
+            name="azure_newaccount",
+            description="d",
+            config={"url": "http://b/mcp", "mode": "streamable-http"},
+        )
+        ts1.tools = [connect_placeholder(ts1)]
+        ts2.tools = [connect_placeholder(ts2)]
+        ts1.status = ts2.status = ToolsetStatusEnum.ENABLED
+
+        ex = ToolExecutor([ts1, ts2])
+        assert "azure_main_connect" in ex.tools_by_name
+        assert "azure_newaccount_connect" in ex.tools_by_name
+        # No collision → nothing was namespaced with the `__` prefix.
+        assert not any("__" in name for name in ex.tools_by_name)
+
+    def test_mixed_only_collisions_are_renamed_and_all_resolve(
+        self, monkeypatch, suppress_migration_warnings
+    ):
+        """Two servers share `shared` (collides) and each has a unique tool.
+        Proves: non-colliding tools are untouched; colliding ones are namespaced;
+        every tool resolves to the right server and invokes with its RAW name."""
+        from holmes.core.tools_utils.tool_executor import ToolExecutor
+
+        def mk(name):
+            return Tool(
+                name=name,
+                inputSchema={"type": "object", "properties": {}, "required": []},
+                description=name,
+            )
+
+        ts_a = self._enabled_mcp_toolset(
+            monkeypatch, "svc_a", "http://a:8000/mcp", [mk("shared"), mk("only_a")]
+        )
+        ts_b = self._enabled_mcp_toolset(
+            monkeypatch, "svc_b", "http://b:8001/mcp", [mk("shared"), mk("only_b")]
+        )
+        ex = ToolExecutor([ts_a, ts_b])
+        keys = set(ex.tools_by_name)
+
+        # NO-collision tools: names unchanged (raw), never prefixed.
+        assert {"only_a", "only_b"} <= keys
+        assert ex.tools_by_name["only_a"].name == "only_a"
+        assert ex.tools_by_name["only_b"].name == "only_b"
+        assert not any(k.endswith("__only_a") or k.endswith("__only_b") for k in keys)
+
+        # COLLISION tool: raw name gone, namespaced per server, each to right server.
+        assert "shared" not in keys
+        assert {"svc_a__shared", "svc_b__shared"} <= keys
+        assert ex._tool_to_toolset["svc_a__shared"].name == "svc_a"
+        assert ex._tool_to_toolset["svc_b__shared"].name == "svc_b"
+
+        # Every tool (colliding or not) invokes its server with the RAW name.
+        for key, expected_raw in (
+            ("only_a", "only_a"),
+            ("svc_a__shared", "shared"),
+            ("svc_b__shared", "shared"),
+        ):
+            t = ex.tools_by_name[key]
+            mock_session = AsyncMock()
+            mock_session.initialize = AsyncMock(return_value=None)
+            mock_session.call_tool = AsyncMock(
+                return_value=CallToolResult(
+                    content=[TextContent(type="text", text="ok")],
+                    isError=False,
+                )
+            )
+            c_ctx, s_ctx = self._setup_mocks(mock_session)
+            c_patch, s_patch = self._patch_clients(c_ctx, s_ctx)
+            with c_patch, s_patch:
+                res = asyncio.run(t._invoke_async({}, None))
+            assert res.status == StructuredToolResultStatus.SUCCESS
+            mock_session.call_tool.assert_awaited_once_with(expected_raw, {})
 
     @pytest.mark.parametrize(
         "tool_name,tool_schema,params,response_text,expected_in_response",
@@ -1093,9 +1378,7 @@ class TestStreamableHttp:
         call_tool_result = CallToolResult(
             content=[
                 TextContent(type="text", text="Page has 1 image"),
-                ImageContent(
-                    type="image", data="iVBORw0KGgo=", mimeType="image/png"
-                ),
+                ImageContent(type="image", data="iVBORw0KGgo=", mimeType="image/png"),
             ],
             isError=False,
         )
@@ -2034,9 +2317,9 @@ class TestStdio:
             if tool.name == "get_test_image":
                 image_tool = tool
                 break
-        assert image_tool is not None, (
-            f"get_test_image tool not found. Available: {[t.name for t in toolset.tools]}"
-        )
+        assert (
+            image_tool is not None
+        ), f"get_test_image tool not found. Available: {[t.name for t in toolset.tools]}"
 
         context = ToolInvokeContext.model_construct(
             tool_number=1,
@@ -2052,7 +2335,9 @@ class TestStdio:
 
         # Core assertion: images are extracted from MCP response
         assert invoke_result.status == StructuredToolResultStatus.SUCCESS
-        assert invoke_result.images is not None, "images should not be None for MCP ImageContent"
+        assert (
+            invoke_result.images is not None
+        ), "images should not be None for MCP ImageContent"
         assert len(invoke_result.images) == 1
         assert invoke_result.images[0]["mimeType"] == "image/png"
         assert len(invoke_result.images[0]["data"]) > 0  # base64 data present
@@ -2068,12 +2353,13 @@ class TestStdio:
         )
         message = tcr.to_llm_message()
         content = message["content"]
-        assert isinstance(content, list), "Should return multimodal content list when images present"
+        assert isinstance(
+            content, list
+        ), "Should return multimodal content list when images present"
         assert content[0]["type"] == "text"
         assert "tool-image://test-img-id" in content[0]["text"]
         assert content[1]["type"] == "image_url"
         assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
-
 
 
 class TestHeaderRendering:
@@ -2608,15 +2894,21 @@ class TestMCPHealthCheckTool:
 
         # Mock _call_health_check_tool_async to return success
         async def mock_call_health_check(tool_name):
-            return CallToolResult(content=[TextContent(type="text", text='{"login": "user"}')])
+            return CallToolResult(
+                content=[TextContent(type="text", text='{"login": "user"}')]
+            )
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, msg = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True
         assert msg == ""
 
-    def test_health_check_tool_auth_failure(self, monkeypatch, suppress_migration_warnings):
+    def test_health_check_tool_auth_failure(
+        self, monkeypatch, suppress_migration_warnings
+    ):
         """When health_check_tool returns an error, prerequisites fail with clear message."""
         toolset = RemoteMCPToolset(
             name="github",
@@ -2641,22 +2933,31 @@ class TestMCPHealthCheckTool:
         async def mock_call_health_check(tool_name):
             return CallToolResult(
                 isError=True,
-                content=[TextContent(type="text", text="401 Unauthorized: Bad credentials")],
+                content=[
+                    TextContent(type="text", text="401 Unauthorized: Bad credentials")
+                ],
             )
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, msg = toolset.prerequisites_callable(config=toolset.config)
         assert ok is False
         assert "health check tool 'get_me'" in msg
         assert "401 Unauthorized" in msg
 
-    def test_health_check_tool_not_found(self, monkeypatch, suppress_migration_warnings):
+    def test_health_check_tool_not_found(
+        self, monkeypatch, suppress_migration_warnings
+    ):
         """When health_check_tool specifies a non-existent tool, prerequisites fail."""
         toolset = RemoteMCPToolset(
             name="github",
             description="GitHub MCP",
-            config={"url": "http://localhost:8000", "health_check_tool": "nonexistent_tool"},
+            config={
+                "url": "http://localhost:8000",
+                "health_check_tool": "nonexistent_tool",
+            },
         )
 
         async def mock_get_server_tools():
@@ -2678,7 +2979,9 @@ class TestMCPHealthCheckTool:
         assert "nonexistent_tool" in msg
         assert "get_me" in msg  # should list available tools
 
-    def test_health_check_tool_exception(self, monkeypatch, suppress_migration_warnings):
+    def test_health_check_tool_exception(
+        self, monkeypatch, suppress_migration_warnings
+    ):
         """When health_check_tool throws an exception, prerequisites fail with clear message."""
         toolset = RemoteMCPToolset(
             name="github",
@@ -2703,14 +3006,18 @@ class TestMCPHealthCheckTool:
         async def mock_call_health_check(tool_name):
             raise ConnectionRefusedError("Connection refused")
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, msg = toolset.prerequisites_callable(config=toolset.config)
         assert ok is False
         assert "health check tool 'get_me'" in msg
         assert "Connection refused" in msg
 
-    def test_no_health_check_tool_skips_check(self, monkeypatch, suppress_migration_warnings):
+    def test_no_health_check_tool_skips_check(
+        self, monkeypatch, suppress_migration_warnings
+    ):
         """When health_check_tool is not set and the server exposes no known
         identity tool, no additional check is performed."""
         toolset = RemoteMCPToolset(
@@ -2739,7 +3046,9 @@ class TestMCPHealthCheckTool:
             call_count["count"] += 1
             return CallToolResult(content=[])
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, _ = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True
@@ -2812,10 +3121,14 @@ class TestMCPHealthCheckTool:
             called_with["tool_name"] = tool_name
             return CallToolResult(
                 isError=True,
-                content=[TextContent(type="text", text="401 Unauthorized: Bad credentials")],
+                content=[
+                    TextContent(type="text", text="401 Unauthorized: Bad credentials")
+                ],
             )
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, msg = toolset.prerequisites_callable(config=toolset.config)
         assert ok is False
@@ -2850,9 +3163,13 @@ class TestMCPHealthCheckTool:
 
         async def mock_call_health_check(tool_name):
             called_with["tool_name"] = tool_name
-            return CallToolResult(content=[TextContent(type="text", text='{"username": "user"}')])
+            return CallToolResult(
+                content=[TextContent(type="text", text='{"username": "user"}')]
+            )
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, msg = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True
@@ -2890,15 +3207,21 @@ class TestMCPHealthCheckTool:
 
         async def mock_call_health_check(tool_name):
             called_with["tool_name"] = tool_name
-            return CallToolResult(content=[TextContent(type="text", text='{"login": "user"}')])
+            return CallToolResult(
+                content=[TextContent(type="text", text='{"login": "user"}')]
+            )
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, _ = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True
         assert called_with["tool_name"] == "get_me"
 
-    def test_health_check_tool_in_stdio_mode(self, monkeypatch, suppress_migration_warnings):
+    def test_health_check_tool_in_stdio_mode(
+        self, monkeypatch, suppress_migration_warnings
+    ):
         """Health check tool also works in stdio mode."""
         toolset = RemoteMCPToolset(
             name="github",
@@ -2925,9 +3248,13 @@ class TestMCPHealthCheckTool:
         monkeypatch.setattr(toolset, "_get_server_tools", mock_get_server_tools)
 
         async def mock_call_health_check(tool_name):
-            return CallToolResult(content=[TextContent(type="text", text='{"login": "user"}')])
+            return CallToolResult(
+                content=[TextContent(type="text", text='{"login": "user"}')]
+            )
 
-        monkeypatch.setattr(toolset, "_call_health_check_tool_async", mock_call_health_check)
+        monkeypatch.setattr(
+            toolset, "_call_health_check_tool_async", mock_call_health_check
+        )
 
         ok, _ = toolset.prerequisites_callable(config=toolset.config)
         assert ok is True


### PR DESCRIPTION
- Add azureInstances array to values.yaml for configuring multiple Azure MCP servers
- Each instance can have its own tenant ID, subscription ID, and credentials
- Each instance gets a unique pod, service account, and network policy
- Each instance requires a unique service port for isolation
- Maintain full backward compatibility with existing single azure configuration
- Update deployment template to iterate over instances or render single instance
- Update network policy template to support multiple instances
- Update documentation with multi-instance example and configuration guide

Signed-off-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and running multiple Azure MCP instances in a single Holmes deployment, each with its own port, authentication method, and settings.
  * Added per-instance Azure MCP tool naming/collision handling so colliding tools are properly namespaced and invocations reach the correct MCP server.
* **Documentation**
  * Expanded multi-instance setup guidance with examples (workload identity, service principal, mixed) and clarified per-instance behavior (including optional per-instance LLM instructions).
* **Bug Fixes**
  * Added stricter chart validation for multi-instance configs, including required fields and detection of duplicate instance names/ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->