### PR TITLE
ROB-597 AWS MCP: steer call_aws JSON args to escaped double quotes

### DIFF
--- a/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/aws/_helpers.tpl
@@ -13,7 +13,7 @@ call_aws tokenizes the command with shell rules, which makes inline JSON argumen
 
 1. **Avoid inline JSON — prefer shorthand that needs no JSON.** For a breakdown by a dimension use `--group-by Type=DIMENSION,Key=SERVICE` (no quotes to lose), then filter/aggregate the results yourself in your analysis (e.g. keep only the row whose service key is "Amazon Bedrock"). This is the most reliable approach and sidesteps the quoting problem entirely. Example:
    `aws ce get-cost-and-usage --time-period Start=2026-01-01,End=2026-08-01 --granularity MONTHLY --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE`
-2. **Only if you truly need a JSON argument**, wrap the ENTIRE value in single quotes (not double quotes, and do not backslash-escape the inner double quotes): `--filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Bedrock"]}}'`. If a single-quoted attempt still fails, do not keep retrying variations — fall back to option 1 (`--group-by` + client-side filtering).
+2. **If you truly need a JSON argument**, wrap the ENTIRE value in double quotes and backslash-escape every inner double quote: `--filter "{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"Amazon Bedrock\"]}}"`. This escaped double-quoted form is the one that survives the shell tokenizer with the JSON intact. Do NOT leave the inner double quotes unescaped (`"{"Dimensions":...}"` — the quotes get stripped and AWS receives invalid JSON). If an escaped attempt still fails, do not keep retrying variations — fall back to option 1 (`--group-by` + client-side filtering).
 3. When unsure of the exact syntax, call `suggest_aws_commands` first, then run the suggested command with call_aws.
 
 ## Investigation Principles


### PR DESCRIPTION
Follow-up to #2270.

The single-quote guidance for `call_aws` JSON arguments (Cost Explorer `--filter`, `--cli-input-json`, CloudWatch `--metric-data-queries`, etc.) didn't hold up in practice — the model second-guessed it and flailed, still producing invalid JSON.

This switches the AWS MCP `llm_instructions` (option 2 of the "READ THIS FIRST" section) to recommend **escaped double-quoted** JSON — the shlex-valid form models emit most reliably:

```
--filter "{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"Amazon Bedrock\"]}}"
```

It also explicitly warns against the unescaped `"{"Dimensions":...}"` form (quotes get stripped). `--group-by` + client-side aggregation stays as the primary/most-reliable option 1.

Linear: https://linear.app/robusta/issue/ROB-597/aws-mcp-steer-call-aws-json-args-to-escaped-double-quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance for entering JSON arguments in AWS-related commands so values are passed correctly and avoid parsing errors.
  * Clarified the required quoting format for JSON input to help prevent shell-related quote stripping issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->