### PR TITLE
ROB-602 Langfuse support in OpenTelemetry tracing

### DIFF
--- a/docs/reference/opentelemetry.md
+++ b/docs/reference/opentelemetry.md
@@ -244,6 +244,7 @@ echo -n "pk-lf-xxxx:sk-lf-xxxx" | base64
 
 **What `HOLMES_LANGFUSE_ATTRIBUTES=true` adds** (all under the `langfuse.*` namespace):
 
+- **Trace-level input/output** — the user's question (input) and Holmes's final answer (output) on the `holmesgpt.investigation` root, so the top of the trace shows the prompt and the answer at a glance.
 - **Observation input/output** — the prompt messages, the assistant's response, its `reasoning` (thinking), and the tool calls it chose (on `gen_ai.chat` spans); tool arguments and results (on `holmesgpt.tool.*` spans).
 - **Trace user & session** — `langfuse.user.id` (initiating user, falling back through user id → email → account id) and `langfuse.session.id` (the conversation id), powering Langfuse's Users and Sessions views.
 - **Trace tags** — `source:<request_source>`, `cluster:<cluster>`, `model:<model>`.

--- a/docs/reference/opentelemetry.md
+++ b/docs/reference/opentelemetry.md
@@ -42,6 +42,8 @@ additionalEnvVars:
 | `OTEL_SERVICE_NAME` | Service name in traces/metrics | `holmesgpt` |
 | `OTEL_EXPORTER_OTLP_HEADERS` | Headers for OTLP exporter (e.g., auth tokens) | *(none)* |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Override metrics endpoint (if different from traces) | *(uses OTEL_EXPORTER_OTLP_ENDPOINT)* |
+| `HOLMES_LANGFUSE_ATTRIBUTES` | Emit Langfuse-specific span attributes (prompts, tool I/O, thinking, user/session, tags). See [Langfuse](#langfuse). | `false` |
+| `HOLMES_OTEL_MAX_ATTR_CHARS` | Max characters for the input/output attributes emitted when `HOLMES_LANGFUSE_ATTRIBUTES` is enabled | `100000` |
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` is **not** set, HolmesGPT uses a no-op `DummyTracer` with zero overhead.
 
@@ -192,6 +194,62 @@ additionalEnvVars:
   - name: OTEL_EXPORTER_OTLP_HEADERS
     value: "Authorization=Basic BASE64_ENCODED_INSTANCE:TOKEN"
 ```
+
+### Langfuse
+
+[Langfuse](https://langfuse.com/) is an LLM-observability platform that ingests OpenTelemetry traces natively. HolmesGPT can export each investigation to Langfuse as a full audit trail — the initiating user, the prompts sent to the LLM, the model's thinking/reasoning, the tools it called with their arguments and outputs, and the final answer.
+
+**Two things are required:**
+
+1. Point the OTLP exporter at your Langfuse project's OTLP endpoint over **HTTP** (Langfuse does not support gRPC), authenticated with a Basic-auth header of `base64(<public-key>:<secret-key>)`.
+2. Set **`HOLMES_LANGFUSE_ATTRIBUTES=true`**. This is opt-in and **off by default** because it emits Langfuse-vendor-specific span attributes (`langfuse.*`) that would be noise for a generic OTel backend. Without it, Holmes exports only vendor-neutral OTel/`gen_ai.*` spans and the Langfuse Input/Output panels stay empty.
+
+Generate the Basic-auth value:
+
+```bash
+echo -n "pk-lf-xxxx:sk-lf-xxxx" | base64
+```
+
+=== "Holmes CLI"
+
+    ```bash
+    export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"
+    export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+    export OTEL_SERVICE_NAME="holmesgpt"
+    export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(public:secret)>"
+    export HOLMES_LANGFUSE_ATTRIBUTES="true"
+    holmes ask "Why is my pod crashing?"
+    ```
+
+=== "Helm / Kubernetes"
+
+    Store the Basic-auth value in a secret, then:
+
+    ```yaml
+    additionalEnvVars:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "https://cloud.langfuse.com/api/public/otel"  # or your EU / self-hosted host
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: "http/protobuf"
+      - name: OTEL_SERVICE_NAME
+        value: "holmesgpt"
+      - name: HOLMES_LANGFUSE_ATTRIBUTES
+        value: "true"
+      - name: OTEL_EXPORTER_OTLP_HEADERS
+        valueFrom:
+          secretKeyRef:
+            name: holmes-langfuse-otlp
+            key: OTEL_EXPORTER_OTLP_HEADERS   # value: "Authorization=Basic <base64(public:secret)>"
+    ```
+
+**What `HOLMES_LANGFUSE_ATTRIBUTES=true` adds** (all under the `langfuse.*` namespace):
+
+- **Observation input/output** — the prompt messages, the assistant's response, its `reasoning` (thinking), and the tool calls it chose (on `gen_ai.chat` spans); tool arguments and results (on `holmesgpt.tool.*` spans).
+- **Trace user & session** — `langfuse.user.id` (initiating user, falling back through user id → email → account id) and `langfuse.session.id` (the conversation id), powering Langfuse's Users and Sessions views.
+- **Trace tags** — `source:<request_source>`, `cluster:<cluster>`, `model:<model>`.
+- **Filterable trace metadata** — `user_id`, `user_email`, `conversation_id`, `account_id`, `cluster_id`, `model`, `request_source`.
+
+Since Holmes emits OTel **metrics** as well and Langfuse ingests **traces only**, metric exports to the Langfuse endpoint are rejected harmlessly (traces are unaffected). To avoid that noise entirely, route Holmes through an OTel Collector and forward only traces to Langfuse.
 
 ## Architecture
 

--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -42,7 +42,7 @@ from holmes.core.tools_utils.frontend_tools import (
     FrontendToolCollisionError,
     inject_frontend_tools,
 )
-from holmes.core.tracing import TracingFactory
+from holmes.core.tracing import TracingFactory, langfuse_trace_attributes
 from holmes.core.usage_recorder import (
     build_chat_recorder_state,
     stream_with_usage_recording,
@@ -874,6 +874,18 @@ class ConversationWorker:
                     "holmesgpt.investigation.question": chat_request.ask[:1024],
                     "holmesgpt.investigation.stream": True,
                     "holmesgpt.conversation_id": task.conversation_id,
+                    # Langfuse trace-level attributes (initiating user, session,
+                    # filterable metadata) read from the root span.
+                    **langfuse_trace_attributes(
+                        chat_request.ask,
+                        user_id=chat_request.user_id,
+                        user_email=chat_request.user_email,
+                        account_id=task.account_id,
+                        session_id=task.conversation_id,
+                        cluster_id=task.cluster_id,
+                        model=chat_request.model,
+                        request_source=chat_request.request_source,
+                    ),
                 }
             )
 

--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -875,8 +875,7 @@ class ConversationWorker:
                     "holmesgpt.investigation.question": chat_request.ask[:1024],
                     "holmesgpt.investigation.stream": True,
                     "holmesgpt.conversation_id": task.conversation_id,
-                    # Langfuse trace-level attributes (initiating user, session,
-                    # filterable metadata) read from the root span.
+                    # Langfuse trace-level attributes (user, session, metadata).
                     **langfuse_trace_attributes(
                         chat_request.ask,
                         user_id=chat_request.user_id,

--- a/holmes/core/conversations_worker/worker.py
+++ b/holmes/core/conversations_worker/worker.py
@@ -870,6 +870,7 @@ class ConversationWorker:
             # Write an initial ai_message event (optional) - skip; call_stream will emit events
             trace_span = server_tracer.start_trace("holmesgpt.investigation")
             trace_span.log(
+                input=chat_request.ask,
                 metadata={
                     "holmesgpt.investigation.question": chat_request.ask[:1024],
                     "holmesgpt.investigation.stream": True,

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -299,7 +299,7 @@ class OTelSpan:
                 )
         if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
             for k, v in kwargs["metadata"].items():
-                if isinstance(v, bool) or isinstance(v, (int, float)):
+                if isinstance(v, (int, float, bool)):
                     self._span.set_attribute(k, v)
                 elif isinstance(v, str):
                     # cap free-text metadata

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -18,11 +18,17 @@ Dynatrace, Grafana and Prometheus which normalise dots to underscores.
 Two sets of constants are provided below to keep the distinction explicit.
 """
 
+import json
 import logging
 import os
 from typing import Any, Dict, Optional
 
-from holmes.core.tracing import DummySpan, SpanType, TracingFactory
+from holmes.core.tracing import (
+    DummySpan,
+    SpanType,
+    TracingFactory,
+    langfuse_attributes_enabled,
+)
 
 try:
     from opentelemetry import context as otel_context
@@ -35,6 +41,12 @@ try:
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     from opentelemetry.sdk.metrics.view import View
     from opentelemetry.trace import StatusCode
+    from opentelemetry.sdk.trace.sampling import (
+        ALWAYS_ON,
+        Decision,
+        Sampler,
+        SamplingResult,
+    )
 
     OTEL_AVAILABLE = True
 except ImportError:
@@ -72,6 +84,71 @@ logger = logging.getLogger(__name__)
 # Default OTLP endpoints per protocol (OTel spec: gRPC uses 4317, HTTP uses 4318)
 DEFAULT_GRPC_ENDPOINT = "http://localhost:4317"
 DEFAULT_HTTP_ENDPOINT = "http://localhost:4318"
+
+# Max characters for input/output span attributes. Prompts + tool outputs can be
+# large; the default is generous so a full interaction audit isn't truncated, but
+# still bounded to stay within OTLP/backend attribute limits. Override via env.
+_MAX_ATTR_CHARS = int(os.environ.get("HOLMES_OTEL_MAX_ATTR_CHARS", "100000"))
+
+
+def _to_attr_str(value: Any) -> str:
+    """Render a span attribute value as a (bounded) string.
+
+    Strings are used verbatim; everything else is JSON-encoded (falling back to
+    ``str`` for non-serializable objects). The result is truncated to
+    ``_MAX_ATTR_CHARS``. Used for the Langfuse ``input``/``output`` attributes,
+    which Langfuse parses as JSON when possible and otherwise shows as text.
+    """
+    if isinstance(value, str):
+        rendered = value
+    else:
+        try:
+            rendered = json.dumps(value, default=str, ensure_ascii=False)
+        except (TypeError, ValueError):
+            rendered = str(value)
+    return rendered[:_MAX_ATTR_CHARS]
+
+
+# HTTP method names used by the httpx auto-instrumentation as span names.
+_HTTP_METHOD_SPAN_NAMES = {
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE",
+}
+
+if OTEL_AVAILABLE:
+
+    class _DropOrphanHttpSampler(Sampler):
+        """Drop root spans created by httpx auto-instrumentation.
+
+        Holmes auto-instruments httpx so that HTTP calls made *inside* an
+        investigation nest under the tool/LLM spans. But every background HTTP
+        call the server makes *outside* an investigation (health checks, platform
+        polling, etc.) also becomes a span — and with no parent it lands as its
+        own root trace, flooding the backend and burying the real
+        ``holmesgpt.investigation`` traces.
+
+        This sampler drops a span only when it is BOTH a root (no valid parent)
+        AND named like a bare HTTP method. httpx spans that have a parent (i.e.
+        created within an investigation) and all Holmes spans are unaffected.
+        """
+
+        def __init__(self, delegate: "Sampler" = ALWAYS_ON):
+            self._delegate = delegate
+
+        def should_sample(
+            self, parent_context, trace_id, name, kind=None,
+            attributes=None, links=None, trace_state=None,
+        ) -> "SamplingResult":
+            parent_span = trace.get_current_span(parent_context)
+            parent_ctx = parent_span.get_span_context() if parent_span else None
+            is_root = not (parent_ctx and parent_ctx.is_valid)
+            if is_root and name in _HTTP_METHOD_SPAN_NAMES:
+                return SamplingResult(Decision.DROP, attributes, trace_state)
+            return self._delegate.should_sample(
+                parent_context, trace_id, name, kind, attributes, links, trace_state
+            )
+
+        def get_description(self) -> str:
+            return f"DropOrphanHttp({self._delegate.get_description()})"
 
 # ---------------------------------------------------------------------------
 # OTel GenAI semantic convention — span attribute names (dot-delimited)
@@ -223,23 +300,43 @@ class OTelSpan:
         """Log attributes to the span.
 
         Supported keyword arguments:
-            input: Stored as the ``input`` span attribute (truncated to 4096 chars).
-            output: Stored as the ``output`` span attribute (truncated to 4096 chars).
+            input: Stored as the ``langfuse.observation.input`` span attribute
+                (JSON-encoded if not a string, truncated to ``_MAX_ATTR_CHARS``).
+            output: Stored as the ``langfuse.observation.output`` span attribute
+                (same encoding). Langfuse reads these to populate the observation
+                Input/Output panels.
+            error: When truthy, marks the observation as an error via
+                ``langfuse.observation.level`` / ``.status_message``.
             metadata: A ``dict`` whose entries are set as individual span attributes.
             metrics: A ``dict`` of numeric values set as span attributes; names
                 with a GenAI semantic convention equivalent (e.g. ``prompt_tokens``)
                 are renamed to it.
         """
-        if "input" in kwargs:
-            val = str(kwargs["input"])
-            self._span.set_attribute("input", val[:4096])
-        if "output" in kwargs:
-            val = str(kwargs["output"])
-            self._span.set_attribute("output", val[:4096])
+        # input/output/error map to Langfuse-vendor-specific attributes; only emit
+        # them when Langfuse enrichment is enabled (off by default).
+        if langfuse_attributes_enabled():
+            if "input" in kwargs:
+                self._span.set_attribute(
+                    "langfuse.observation.input", _to_attr_str(kwargs["input"])
+                )
+            if "output" in kwargs:
+                self._span.set_attribute(
+                    "langfuse.observation.output", _to_attr_str(kwargs["output"])
+                )
+            if kwargs.get("error"):
+                self._span.set_attribute("langfuse.observation.level", "ERROR")
+                self._span.set_attribute(
+                    "langfuse.observation.status_message", _to_attr_str(kwargs["error"])
+                )
         if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
             for k, v in kwargs["metadata"].items():
                 if isinstance(v, (str, int, float, bool)):
                     self._span.set_attribute(k, v)
+                elif isinstance(v, (list, tuple)) and all(
+                    isinstance(e, str) for e in v
+                ):
+                    # native OTel string-array attribute (e.g. langfuse.trace.tags)
+                    self._span.set_attribute(k, list(v))
                 else:
                     self._span.set_attribute(k, str(v))
         if "metrics" in kwargs and isinstance(kwargs["metrics"], dict):
@@ -343,7 +440,11 @@ class OpenTelemetryTracer:
         )
 
         # --- Traces ---
-        trace_provider = TracerProvider(resource=resource)
+        # Drop orphan httpx root spans (background HTTP calls) so they don't
+        # flood the backend and bury real investigation traces.
+        trace_provider = TracerProvider(
+            resource=resource, sampler=_DropOrphanHttpSampler()
+        )
         trace_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
         trace.set_tracer_provider(trace_provider)
         self._tracer = trace.get_tracer("holmesgpt", "0.1.0")

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -85,14 +85,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_GRPC_ENDPOINT = "http://localhost:4317"
 DEFAULT_HTTP_ENDPOINT = "http://localhost:4318"
 
-# Max characters for input/output span attributes. Prompts + tool outputs can be
-# large; the default is generous so a full interaction audit isn't truncated, but
-# still bounded to stay within OTLP/backend attribute limits. Override via env.
+# Max chars for input/output span attributes; bounded for OTLP limits. Override via env.
 def _int_env(name: str, default: int) -> int:
-    """Parse an int env var, falling back to ``default`` on missing/invalid value.
-
-    Guarded so a bad ``HOLMES_OTEL_MAX_ATTR_CHARS`` can't crash import/startup.
-    """
+    """Parse an int env var; fall back to ``default`` on missing/invalid value."""
     try:
         return int(os.environ[name])
     except (KeyError, ValueError):
@@ -103,13 +98,7 @@ _MAX_ATTR_CHARS = _int_env("HOLMES_OTEL_MAX_ATTR_CHARS", 100000)
 
 
 def _to_attr_str(value: Any) -> str:
-    """Render a span attribute value as a (bounded) string.
-
-    Strings are used verbatim; everything else is JSON-encoded (falling back to
-    ``str`` for non-serializable objects). The result is truncated to
-    ``_MAX_ATTR_CHARS``. Used for the Langfuse ``input``/``output`` attributes,
-    which Langfuse parses as JSON when possible and otherwise shows as text.
-    """
+    """Render a value as a bounded string: verbatim if str, else JSON, truncated."""
     if isinstance(value, str):
         rendered = value
     else:
@@ -128,18 +117,10 @@ _HTTP_METHOD_SPAN_NAMES = {
 if OTEL_AVAILABLE:
 
     class _DropOrphanHttpSampler(Sampler):
-        """Drop root spans created by httpx auto-instrumentation.
+        """Drop root httpx spans (background HTTP calls) that would bury real investigation traces.
 
-        Holmes auto-instruments httpx so that HTTP calls made *inside* an
-        investigation nest under the tool/LLM spans. But every background HTTP
-        call the server makes *outside* an investigation (health checks, platform
-        polling, etc.) also becomes a span — and with no parent it lands as its
-        own root trace, flooding the backend and burying the real
-        ``holmesgpt.investigation`` traces.
-
-        This sampler drops a span only when it is BOTH a root (no valid parent)
-        AND named like a bare HTTP method. httpx spans that have a parent (i.e.
-        created within an investigation) and all Holmes spans are unaffected.
+        Only drops spans that are both a root (no parent) and named like a bare
+        HTTP method; httpx spans nested in an investigation are kept.
         """
 
         def __init__(self, delegate: "Sampler" = ALWAYS_ON):
@@ -308,23 +289,8 @@ class OTelSpan:
     }
 
     def log(self, *args: Any, **kwargs: Any) -> None:
-        """Log attributes to the span.
-
-        Supported keyword arguments:
-            input: Stored as the ``langfuse.observation.input`` span attribute
-                (JSON-encoded if not a string, truncated to ``_MAX_ATTR_CHARS``).
-            output: Stored as the ``langfuse.observation.output`` span attribute
-                (same encoding). Langfuse reads these to populate the observation
-                Input/Output panels.
-            error: When truthy, marks the observation as an error via
-                ``langfuse.observation.level`` / ``.status_message``.
-            metadata: A ``dict`` whose entries are set as individual span attributes.
-            metrics: A ``dict`` of numeric values set as span attributes; names
-                with a GenAI semantic convention equivalent (e.g. ``prompt_tokens``)
-                are renamed to it.
-        """
-        # input/output/error map to Langfuse-vendor-specific attributes; only emit
-        # them when Langfuse enrichment is enabled (off by default).
+        """Set span attributes from input/output/error (Langfuse, gated), metadata, and metrics."""
+        # Langfuse-specific input/output/error; gated (off by default).
         if HOLMES_LANGFUSE_ATTRIBUTES:
             if "input" in kwargs:
                 self._span.set_attribute(
@@ -344,12 +310,12 @@ class OTelSpan:
                 if isinstance(v, bool) or isinstance(v, (int, float)):
                     self._span.set_attribute(k, v)
                 elif isinstance(v, str):
-                    # cap free-text metadata (e.g. langfuse.trace.input) like input/output
+                    # cap free-text metadata
                     self._span.set_attribute(k, v[:_MAX_ATTR_CHARS])
                 elif isinstance(v, (list, tuple)) and all(
                     isinstance(e, str) for e in v
                 ):
-                    # native OTel string-array attribute (e.g. langfuse.trace.tags)
+                    # string-array attribute (e.g. tags)
                     self._span.set_attribute(k, list(v))
                 else:
                     self._span.set_attribute(k, str(v)[:_MAX_ATTR_CHARS])
@@ -364,24 +330,12 @@ class OTelSpan:
         self._span.end()
 
     def _safe_detach(self) -> None:
-        """Detach our context token, but only when it's safe (in LIFO order).
-
-        OpenTelemetry's ``context.detach()`` does NOT re-raise on failure — it
-        catches the error and logs ``Failed to detach context`` at ERROR (with a
-        ``ValueError: <Token ...> was created in a different Context`` traceback).
-        That fires routinely for Holmes' long-lived spans that wrap streaming
-        generators / cross thread boundaries, where the token is detached from a
-        different execution context than the one it was attached in (ROB-278).
-
-        A plain ``try/except`` around ``detach()`` can't suppress it (the error is
-        already swallowed and logged inside OTel). Instead we only detach when our
-        span is still the current one — i.e. the detach would be in order.
-        Otherwise we skip it; the contextvar is reset when its execution unit
-        ends, and export is unaffected either way.
-        """
+        """Detach our context token only when in LIFO order, else skip (ROB-278)."""
         if self._token is None:
             return
         token, self._token = self._token, None
+        # Out-of-order detach makes OTel log "Failed to detach context" (it swallows
+        # the error, so try/except can't help); only detach when our span is current.
         if trace.get_current_span() is self._span:
             otel_context.detach(token)
         else:
@@ -465,8 +419,7 @@ class OpenTelemetryTracer:
         )
 
         # --- Traces ---
-        # Drop orphan httpx root spans (background HTTP calls) so they don't
-        # flood the backend and bury real investigation traces.
+        # Drop orphan httpx root spans so they don't bury real investigation traces.
         trace_provider = TracerProvider(
             resource=resource, sampler=_DropOrphanHttpSampler()
         )

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -86,15 +86,7 @@ DEFAULT_GRPC_ENDPOINT = "http://localhost:4317"
 DEFAULT_HTTP_ENDPOINT = "http://localhost:4318"
 
 # Max chars for input/output span attributes; bounded for OTLP limits. Override via env.
-def _int_env(name: str, default: int) -> int:
-    """Parse an int env var; fall back to ``default`` on missing/invalid value."""
-    try:
-        return int(os.environ[name])
-    except (KeyError, ValueError):
-        return default
-
-
-_MAX_ATTR_CHARS = _int_env("HOLMES_OTEL_MAX_ATTR_CHARS", 100000)
+_MAX_ATTR_CHARS = int(os.environ.get("HOLMES_OTEL_MAX_ATTR_CHARS", 100000))
 
 
 def _to_attr_str(value: Any) -> str:

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -88,7 +88,18 @@ DEFAULT_HTTP_ENDPOINT = "http://localhost:4318"
 # Max characters for input/output span attributes. Prompts + tool outputs can be
 # large; the default is generous so a full interaction audit isn't truncated, but
 # still bounded to stay within OTLP/backend attribute limits. Override via env.
-_MAX_ATTR_CHARS = int(os.environ.get("HOLMES_OTEL_MAX_ATTR_CHARS", "100000"))
+def _int_env(name: str, default: int) -> int:
+    """Parse an int env var, falling back to ``default`` on missing/invalid value.
+
+    Guarded so a bad ``HOLMES_OTEL_MAX_ATTR_CHARS`` can't crash import/startup.
+    """
+    try:
+        return int(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+_MAX_ATTR_CHARS = _int_env("HOLMES_OTEL_MAX_ATTR_CHARS", 100000)
 
 
 def _to_attr_str(value: Any) -> str:
@@ -330,15 +341,18 @@ class OTelSpan:
                 )
         if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
             for k, v in kwargs["metadata"].items():
-                if isinstance(v, (str, int, float, bool)):
+                if isinstance(v, bool) or isinstance(v, (int, float)):
                     self._span.set_attribute(k, v)
+                elif isinstance(v, str):
+                    # cap free-text metadata (e.g. langfuse.trace.input) like input/output
+                    self._span.set_attribute(k, v[:_MAX_ATTR_CHARS])
                 elif isinstance(v, (list, tuple)) and all(
                     isinstance(e, str) for e in v
                 ):
                     # native OTel string-array attribute (e.g. langfuse.trace.tags)
                     self._span.set_attribute(k, list(v))
                 else:
-                    self._span.set_attribute(k, str(v))
+                    self._span.set_attribute(k, str(v)[:_MAX_ATTR_CHARS])
         if "metrics" in kwargs and isinstance(kwargs["metrics"], dict):
             for k, v in kwargs["metrics"].items():
                 if isinstance(v, (int, float)):

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -364,17 +364,28 @@ class OTelSpan:
         self._span.end()
 
     def _safe_detach(self) -> None:
-        """Detach context token, tolerating cross-context calls (generators/threads)."""
-        if self._token is not None:
-            try:
-                otel_context.detach(self._token)
-            except ValueError:
-                # Token created in a different context (e.g., streaming generator
-                # yielding across thread/coroutine boundaries). This is expected
-                # for long-lived spans that wrap generators. The span still exports
-                # correctly; we just can't restore the previous context.
-                logger.debug("Context detach skipped (cross-context span lifecycle)")
-            self._token = None
+        """Detach our context token, but only when it's safe (in LIFO order).
+
+        OpenTelemetry's ``context.detach()`` does NOT re-raise on failure — it
+        catches the error and logs ``Failed to detach context`` at ERROR (with a
+        ``ValueError: <Token ...> was created in a different Context`` traceback).
+        That fires routinely for Holmes' long-lived spans that wrap streaming
+        generators / cross thread boundaries, where the token is detached from a
+        different execution context than the one it was attached in (ROB-278).
+
+        A plain ``try/except`` around ``detach()`` can't suppress it (the error is
+        already swallowed and logged inside OTel). Instead we only detach when our
+        span is still the current one — i.e. the detach would be in order.
+        Otherwise we skip it; the contextvar is reset when its execution unit
+        ends, and export is unaffected either way.
+        """
+        if self._token is None:
+            return
+        token, self._token = self._token, None
+        if trace.get_current_span() is self._span:
+            otel_context.detach(token)
+        else:
+            logger.debug("Context detach skipped (cross-context span lifecycle)")
 
     def set_attributes(self, name: Optional[str] = None, span_type: Optional[str] = None, span_attributes: Optional[Dict[str, Any]] = None) -> None:
         """Update the span's name and/or set additional attributes.

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -24,10 +24,10 @@ import os
 from typing import Any, Dict, Optional
 
 from holmes.core.tracing import (
+    HOLMES_LANGFUSE_ATTRIBUTES,
     DummySpan,
     SpanType,
     TracingFactory,
-    langfuse_attributes_enabled,
 )
 
 try:
@@ -325,7 +325,7 @@ class OTelSpan:
         """
         # input/output/error map to Langfuse-vendor-specific attributes; only emit
         # them when Langfuse enrichment is enabled (off by default).
-        if langfuse_attributes_enabled():
+        if HOLMES_LANGFUSE_ATTRIBUTES:
             if "input" in kwargs:
                 self._span.set_attribute(
                     "langfuse.observation.input", _to_attr_str(kwargs["input"])

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -57,7 +57,11 @@ from holmes.core.otel_tracing import (
     DIM_GEN_AI_TOKEN_TYPE,
     DIM_TOOL_NAME,
 )
-from holmes.core.tracing import DummySpan, TracingFactory
+from holmes.core.tracing import (
+    HOLMES_LANGFUSE_ATTRIBUTES,
+    DummySpan,
+    TracingFactory,
+)
 from holmes.core.truncation.input_context_window_limiter import (
     CompactionInsufficientError,
     check_compaction_needed,
@@ -1209,28 +1213,22 @@ class ToolCallingLLM:
                 })
 
                 # Log prompt (input) + response content/reasoning/tool_calls (output).
-                # Must stay inside the `with` block.
-                _resp_msg = full_response.choices[0].message  # type: ignore
-                _reasoning = getattr(_resp_msg, "reasoning_content", None)
-                _raw_tool_calls = getattr(_resp_msg, "tool_calls", None) or []
-                _tool_calls_out = []
-                for _tc in _raw_tool_calls:
-                    _dump = getattr(_tc, "model_dump", None)
-                    if callable(_dump):
-                        try:
-                            _tool_calls_out.append(_dump())
-                        except Exception:
-                            _tool_calls_out.append(str(_tc))
-                    else:
-                        _tool_calls_out.append(str(_tc))
-                llm_span.log(
-                    input=messages,
-                    output={
-                        "content": getattr(_resp_msg, "content", None),
-                        "reasoning": _reasoning,
-                        "tool_calls": _tool_calls_out,
-                    },
-                )
+                # Only needed when Langfuse enrichment is on. Must stay in the `with` block.
+                if HOLMES_LANGFUSE_ATTRIBUTES:
+                    _resp_msg = full_response.choices[0].message  # type: ignore
+                    _raw_tool_calls = getattr(_resp_msg, "tool_calls", None) or []
+                    _tool_calls_out = []
+                    for _tc in _raw_tool_calls:
+                        _dump = getattr(_tc, "model_dump", None)
+                        _tool_calls_out.append(_dump() if callable(_dump) else str(_tc))
+                    llm_span.log(
+                        input=messages,
+                        output={
+                            "content": getattr(_resp_msg, "content", None),
+                            "reasoning": getattr(_resp_msg, "reasoning_content", None),
+                            "tool_calls": _tool_calls_out,
+                        },
+                    )
 
               # catch a known error that occurs with Azure and replace the error message with something more obvious to the user
               except BadRequestError as e:

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -1286,6 +1286,12 @@ class ToolCallingLLM:
                         metadata["finish_reason"] = fr
                 except (AttributeError, IndexError, TypeError):
                     pass
+                # Record the final answer as the investigation's top-level output
+                # so Langfuse shows the answer at the trace root (not only on the
+                # gen_ai.chat child). The prompt is set as the root input by the
+                # caller. Both go through the gated log().
+                if response_message.content:
+                    trace_span.log(output=response_message.content)
                 yield StreamMessage(
                     event=StreamEvents.ANSWER_END,
                     data={

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -1208,6 +1208,33 @@ class ToolCallingLLM:
                     "holmesgpt.iteration": i,
                 })
 
+                # Capture the prompt (input) and the assistant response — content,
+                # thinking/reasoning, and chosen tool calls — (output) on the same
+                # span so Langfuse shows a full audit of this LLM interaction.
+                # Must happen inside the `with` block (it closes before
+                # response_message is re-read below).
+                _resp_msg = full_response.choices[0].message  # type: ignore
+                _reasoning = getattr(_resp_msg, "reasoning_content", None)
+                _raw_tool_calls = getattr(_resp_msg, "tool_calls", None) or []
+                _tool_calls_out = []
+                for _tc in _raw_tool_calls:
+                    _dump = getattr(_tc, "model_dump", None)
+                    if callable(_dump):
+                        try:
+                            _tool_calls_out.append(_dump())
+                        except Exception:
+                            _tool_calls_out.append(str(_tc))
+                    else:
+                        _tool_calls_out.append(str(_tc))
+                llm_span.log(
+                    input=messages,
+                    output={
+                        "content": getattr(_resp_msg, "content", None),
+                        "reasoning": _reasoning,
+                        "tool_calls": _tool_calls_out,
+                    },
+                )
+
               # catch a known error that occurs with Azure and replace the error message with something more obvious to the user
               except BadRequestError as e:
                 if "Unrecognized request arguments supplied: tool_choice, tools" in str(

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -1208,11 +1208,8 @@ class ToolCallingLLM:
                     "holmesgpt.iteration": i,
                 })
 
-                # Capture the prompt (input) and the assistant response — content,
-                # thinking/reasoning, and chosen tool calls — (output) on the same
-                # span so Langfuse shows a full audit of this LLM interaction.
-                # Must happen inside the `with` block (it closes before
-                # response_message is re-read below).
+                # Log prompt (input) + response content/reasoning/tool_calls (output).
+                # Must stay inside the `with` block.
                 _resp_msg = full_response.choices[0].message  # type: ignore
                 _reasoning = getattr(_resp_msg, "reasoning_content", None)
                 _raw_tool_calls = getattr(_resp_msg, "tool_calls", None) or []
@@ -1286,10 +1283,7 @@ class ToolCallingLLM:
                         metadata["finish_reason"] = fr
                 except (AttributeError, IndexError, TypeError):
                     pass
-                # Record the final answer as the investigation's top-level output
-                # so Langfuse shows the answer at the trace root (not only on the
-                # gen_ai.chat child). The prompt is set as the root input by the
-                # caller. Both go through the gated log().
+                # Final answer as the trace root output (prompt set as root input by caller).
                 if response_message.content:
                     trace_span.log(output=response_message.content)
                 yield StreamMessage(

--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -120,6 +120,86 @@ class SpanType(Enum):
     TOOL = "tool"
 
 
+def langfuse_attributes_enabled() -> bool:
+    """Whether to emit Langfuse-vendor-specific span attributes (``langfuse.*``).
+
+    Off by default: these attributes are proprietary to Langfuse and would be
+    noise for a vendor-neutral OTel backend. Enable with
+    ``HOLMES_LANGFUSE_ATTRIBUTES=true`` when exporting to Langfuse to get the
+    full audit (input/output content, initiating user, session, tags, metadata).
+    """
+    return os.environ.get("HOLMES_LANGFUSE_ATTRIBUTES", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def langfuse_trace_attributes(
+    ask: Optional[str],
+    *,
+    user_id: Optional[str] = None,
+    user_email: Optional[str] = None,
+    account_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+    model: Optional[str] = None,
+    request_source: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build Langfuse trace-level span attributes for an investigation root span.
+
+    Langfuse reads these from the trace's root span to populate the trace name,
+    input, the initiating user, the session grouping, tags, and filterable
+    metadata. Only non-empty values are included (empty attributes add UI noise).
+    Returns ``{}`` unless :func:`langfuse_attributes_enabled` is true.
+    Pass the result as ``trace_span.log(metadata=...)``.
+    """
+    if not langfuse_attributes_enabled():
+        return {}
+
+    # Trace name = "Holmes: <question>" so the Langfuse trace list is scannable.
+    # The observation name stays "holmesgpt.investigation" (filterable), and the
+    # question is also surfaced as the trace input.
+    ask = ask or ""
+    attrs: Dict[str, Any] = {
+        "langfuse.trace.name": f"Holmes: {ask[:80]}",
+        "langfuse.trace.input": ask,
+    }
+    # user id (Langfuse "Users" view) with fallback; email/user shown separately too.
+    uid = user_id or user_email or account_id
+    if uid:
+        attrs["langfuse.user.id"] = uid
+    # session grouping (Langfuse "Sessions" view). In Holmes this is the conversation id.
+    if session_id:
+        attrs["langfuse.session.id"] = session_id
+    # Filterable trace metadata (only "langfuse.trace.metadata.*" keys are top-level filterable).
+    for key, val in (
+        ("user_id", user_id),
+        ("user_email", user_email),
+        ("conversation_id", session_id),
+        ("account_id", account_id),
+        ("cluster_id", cluster_id),
+        ("model", model),
+        ("request_source", request_source),
+    ):
+        if val:
+            attrs[f"langfuse.trace.metadata.{key}"] = val
+    # Trace tags (Langfuse "Trace Tags" facet). Native string-array attribute.
+    tags = [
+        f"{label}:{val}"
+        for label, val in (
+            ("source", request_source),
+            ("cluster", cluster_id),
+            ("model", model),
+        )
+        if val
+    ]
+    if tags:
+        attrs["langfuse.trace.tags"] = tags
+    return attrs
+
+
 class DummySpan:
     """A no-op span implementation for when tracing is disabled."""
 

--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -120,20 +120,13 @@ class SpanType(Enum):
     TOOL = "tool"
 
 
-def langfuse_attributes_enabled() -> bool:
-    """Whether to emit Langfuse-vendor-specific span attributes (``langfuse.*``).
-
-    Off by default: these attributes are proprietary to Langfuse and would be
-    noise for a vendor-neutral OTel backend. Enable with
-    ``HOLMES_LANGFUSE_ATTRIBUTES=true`` when exporting to Langfuse to get the
-    full audit (input/output content, initiating user, session, tags, metadata).
-    """
-    return os.environ.get("HOLMES_LANGFUSE_ATTRIBUTES", "false").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
+# Whether to emit Langfuse-vendor-specific span attributes (``langfuse.*``).
+# Off by default: these are proprietary to Langfuse and would be noise for a
+# vendor-neutral OTel backend. Enable with ``HOLMES_LANGFUSE_ATTRIBUTES=true``
+# to get the full audit (input/output, initiating user, session, tags, metadata).
+HOLMES_LANGFUSE_ATTRIBUTES = (
+    os.environ.get("HOLMES_LANGFUSE_ATTRIBUTES", "false").lower() == "true"
+)
 
 
 def langfuse_trace_attributes(
@@ -152,10 +145,10 @@ def langfuse_trace_attributes(
     Langfuse reads these from the trace's root span to populate the trace name,
     input, the initiating user, the session grouping, tags, and filterable
     metadata. Only non-empty values are included (empty attributes add UI noise).
-    Returns ``{}`` unless :func:`langfuse_attributes_enabled` is true.
+    Returns ``{}`` unless :data:`HOLMES_LANGFUSE_ATTRIBUTES` is true.
     Pass the result as ``trace_span.log(metadata=...)``.
     """
-    if not langfuse_attributes_enabled():
+    if not HOLMES_LANGFUSE_ATTRIBUTES:
         return {}
 
     # Trace name = "Holmes: <question>" so the Langfuse trace list is scannable.

--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -141,12 +141,13 @@ def langfuse_trace_attributes(
     if not HOLMES_LANGFUSE_ATTRIBUTES:
         return {}
 
-    # Trace name "Holmes: <question>"; observation name stays holmesgpt.investigation.
     ask = ask or ""
     attrs: Dict[str, Any] = {
-        "langfuse.trace.name": f"Holmes: {ask[:80]}",
         "langfuse.trace.input": ask,
     }
+    # trace name = conversation id (short + filterable; prompt is in trace.input)
+    if session_id:
+        attrs["langfuse.trace.name"] = session_id
     # user id (Users view) with fallback
     uid = user_id or user_email or account_id
     if uid:

--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -120,10 +120,7 @@ class SpanType(Enum):
     TOOL = "tool"
 
 
-# Whether to emit Langfuse-vendor-specific span attributes (``langfuse.*``).
-# Off by default: these are proprietary to Langfuse and would be noise for a
-# vendor-neutral OTel backend. Enable with ``HOLMES_LANGFUSE_ATTRIBUTES=true``
-# to get the full audit (input/output, initiating user, session, tags, metadata).
+# Emit Langfuse-vendor-specific ``langfuse.*`` span attributes. Off by default.
 HOLMES_LANGFUSE_ATTRIBUTES = (
     os.environ.get("HOLMES_LANGFUSE_ATTRIBUTES", "false").lower() == "true"
 )
@@ -140,33 +137,24 @@ def langfuse_trace_attributes(
     model: Optional[str] = None,
     request_source: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Build Langfuse trace-level span attributes for an investigation root span.
-
-    Langfuse reads these from the trace's root span to populate the trace name,
-    input, the initiating user, the session grouping, tags, and filterable
-    metadata. Only non-empty values are included (empty attributes add UI noise).
-    Returns ``{}`` unless :data:`HOLMES_LANGFUSE_ATTRIBUTES` is true.
-    Pass the result as ``trace_span.log(metadata=...)``.
-    """
+    """Build Langfuse trace-level root-span attributes; ``{}`` unless enrichment is enabled."""
     if not HOLMES_LANGFUSE_ATTRIBUTES:
         return {}
 
-    # Trace name = "Holmes: <question>" so the Langfuse trace list is scannable.
-    # The observation name stays "holmesgpt.investigation" (filterable), and the
-    # question is also surfaced as the trace input.
+    # Trace name "Holmes: <question>"; observation name stays holmesgpt.investigation.
     ask = ask or ""
     attrs: Dict[str, Any] = {
         "langfuse.trace.name": f"Holmes: {ask[:80]}",
         "langfuse.trace.input": ask,
     }
-    # user id (Langfuse "Users" view) with fallback; email/user shown separately too.
+    # user id (Users view) with fallback
     uid = user_id or user_email or account_id
     if uid:
         attrs["langfuse.user.id"] = uid
-    # session grouping (Langfuse "Sessions" view). In Holmes this is the conversation id.
+    # session grouping (Sessions view) = conversation id
     if session_id:
         attrs["langfuse.session.id"] = session_id
-    # Filterable trace metadata (only "langfuse.trace.metadata.*" keys are top-level filterable).
+    # filterable metadata (only langfuse.trace.metadata.* is filterable)
     for key, val in (
         ("user_id", user_id),
         ("user_email", user_email),
@@ -178,7 +166,7 @@ def langfuse_trace_attributes(
     ):
         if val:
             attrs[f"langfuse.trace.metadata.{key}"] = val
-    # Trace tags (Langfuse "Trace Tags" facet). Native string-array attribute.
+    # trace tags (Trace Tags facet)
     tags = [
         f"{label}:{val}"
         for label, val in (

--- a/server.py
+++ b/server.py
@@ -622,7 +622,7 @@ def chat(chat_request: ChatRequest, http_request: Request):
         if chat_request.stream:
             # Create root investigation span for streaming (same as non-streaming)
             trace_span = server_tracer.start_trace("holmesgpt.investigation")
-            trace_span.log(metadata={
+            trace_span.log(input=chat_request.ask, metadata={
                 "holmesgpt.investigation.question": chat_request.ask[:1024],
                 "holmesgpt.investigation.stream": True,
                 **langfuse_trace_attributes(
@@ -678,7 +678,7 @@ def chat(chat_request: ChatRequest, http_request: Request):
                     trace_span = server_tracer.start_trace(
                         "holmesgpt.investigation",
                     )
-                    trace_span.log(metadata={
+                    trace_span.log(input=chat_request.ask, metadata={
                         "holmesgpt.investigation.question": chat_request.ask[:1024],
                         **langfuse_trace_attributes(
                             chat_request.ask,

--- a/server.py
+++ b/server.py
@@ -90,7 +90,7 @@ from holmes.core.tools_utils.frontend_tools import (
     FrontendToolCollisionError,
     inject_frontend_tools,
 )
-from holmes.core.tracing import TracingFactory
+from holmes.core.tracing import TracingFactory, langfuse_trace_attributes
 from holmes.core.usage_recorder import (
     build_chat_recorder_state,
     record_error,
@@ -625,6 +625,16 @@ def chat(chat_request: ChatRequest, http_request: Request):
             trace_span.log(metadata={
                 "holmesgpt.investigation.question": chat_request.ask[:1024],
                 "holmesgpt.investigation.stream": True,
+                **langfuse_trace_attributes(
+                    chat_request.ask,
+                    user_id=chat_request.user_id,
+                    user_email=chat_request.user_email,
+                    account_id=dal.account_id,
+                    session_id=chat_request.conversation_id,
+                    cluster_id=config.cluster_name,
+                    model=chat_request.model or config.model,
+                    request_source=chat_request.request_source,
+                ),
             })
             otel_metrics = TracingFactory.get_metrics()
             if otel_metrics:
@@ -670,6 +680,16 @@ def chat(chat_request: ChatRequest, http_request: Request):
                     )
                     trace_span.log(metadata={
                         "holmesgpt.investigation.question": chat_request.ask[:1024],
+                        **langfuse_trace_attributes(
+                            chat_request.ask,
+                            user_id=chat_request.user_id,
+                            user_email=chat_request.user_email,
+                            account_id=dal.account_id,
+                            session_id=chat_request.conversation_id,
+                            cluster_id=config.cluster_name,
+                            model=chat_request.model or config.model,
+                            request_source=chat_request.request_source,
+                        ),
                     })
 
                 _inv_start = time.time()

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -80,20 +80,96 @@ class TestOTelSpan:
         mock_span.set_attribute.assert_any_call("key1", "value1")
         mock_span.set_attribute.assert_any_call("key2", 42)
 
-    def test_otel_span_log_input_output_truncated(self):
-        """OTelSpan.log() truncates input/output to 4096 chars."""
+    def test_otel_span_log_input_output_langfuse_attrs(self):
+        """OTelSpan.log() stores input/output under the Langfuse-read attrs."""
         from holmes.core.otel_tracing import OTelSpan
 
         mock_span = MagicMock()
-        mock_tracer = MagicMock()
-        otel_span = OTelSpan(mock_span, mock_tracer)
+        otel_span = OTelSpan(mock_span, MagicMock())
 
-        long_string = "x" * 10000
-        otel_span.log(input=long_string, output=long_string)
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            otel_span.log(input="the prompt", output="the answer")
 
-        calls = mock_span.set_attribute.call_args_list
-        for call in calls:
-            assert len(call[0][1]) <= 4096
+        mock_span.set_attribute.assert_any_call(
+            "langfuse.observation.input", "the prompt"
+        )
+        mock_span.set_attribute.assert_any_call(
+            "langfuse.observation.output", "the answer"
+        )
+
+    def test_otel_span_log_input_output_disabled_by_default(self):
+        """Without the env flag, input/output are NOT emitted (vendor-neutral)."""
+        from holmes.core.otel_tracing import OTelSpan
+
+        mock_span = MagicMock()
+        otel_span = OTelSpan(mock_span, MagicMock())
+
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "false"}):
+            otel_span.log(input="the prompt", output="the answer", error="x")
+
+        keys = [c[0][0] for c in mock_span.set_attribute.call_args_list]
+        assert not any(k.startswith("langfuse.observation.") for k in keys)
+
+    def test_otel_span_log_input_output_truncated(self):
+        """OTelSpan.log() truncates input/output to _MAX_ATTR_CHARS."""
+        from holmes.core.otel_tracing import _MAX_ATTR_CHARS, OTelSpan
+
+        mock_span = MagicMock()
+        otel_span = OTelSpan(mock_span, MagicMock())
+
+        long_string = "x" * (_MAX_ATTR_CHARS + 5000)
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            otel_span.log(input=long_string, output=long_string)
+
+        for call in mock_span.set_attribute.call_args_list:
+            assert len(call[0][1]) <= _MAX_ATTR_CHARS
+
+    def test_otel_span_log_input_output_json_encoded(self):
+        """Non-string input/output is JSON-encoded (so Langfuse renders it)."""
+        import json
+
+        from holmes.core.otel_tracing import OTelSpan
+
+        mock_span = MagicMock()
+        otel_span = OTelSpan(mock_span, MagicMock())
+
+        payload = {"content": "hi", "reasoning": "because", "tool_calls": []}
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            otel_span.log(input=[{"role": "user", "content": "q"}], output=payload)
+
+        recorded = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
+        assert json.loads(recorded["langfuse.observation.input"]) == [
+            {"role": "user", "content": "q"}
+        ]
+        assert json.loads(recorded["langfuse.observation.output"]) == payload
+
+    def test_otel_span_log_error_sets_level(self):
+        """A truthy error= marks the observation as ERROR for Langfuse."""
+        from holmes.core.otel_tracing import OTelSpan
+
+        mock_span = MagicMock()
+        otel_span = OTelSpan(mock_span, MagicMock())
+
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            otel_span.log(output="partial", error="boom failed")
+
+        mock_span.set_attribute.assert_any_call("langfuse.observation.level", "ERROR")
+        mock_span.set_attribute.assert_any_call(
+            "langfuse.observation.status_message", "boom failed"
+        )
+
+    def test_otel_span_log_tags_as_string_array(self):
+        """List metadata values (e.g. langfuse.trace.tags) set as native arrays."""
+        from holmes.core.otel_tracing import OTelSpan
+
+        mock_span = MagicMock()
+        otel_span = OTelSpan(mock_span, MagicMock())
+
+        otel_span.log(metadata={"langfuse.trace.tags": ["source:alert", "cluster:x"]})
+
+        mock_span.set_attribute.assert_any_call(
+            "langfuse.trace.tags", ["source:alert", "cluster:x"]
+        )
 
     def test_otel_span_set_attributes(self):
         """OTelSpan.set_attributes() updates span name and attributes."""
@@ -110,6 +186,74 @@ class TestOTelSpan:
 
         mock_span.update_name.assert_called_once_with("new_name")
         mock_span.set_attribute.assert_called_once_with("attr1", "val1")
+
+
+class TestLangfuseTraceAttributes:
+    """Test the langfuse_trace_attributes helper used on root spans."""
+
+    def test_disabled_by_default(self):
+        """Returns {} unless HOLMES_LANGFUSE_ATTRIBUTES is enabled."""
+        from holmes.core.tracing import langfuse_trace_attributes
+
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "false"}):
+            assert langfuse_trace_attributes("q", user_id="u1", session_id="c1") == {}
+
+    def test_full_attrs(self):
+        from holmes.core.tracing import langfuse_trace_attributes
+
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            attrs = langfuse_trace_attributes(
+                "why is my pod crashing?",
+                user_id="u123",
+                user_email="a@b.com",
+                account_id="acct1",
+                session_id="conv1",
+                cluster_id="clusterA",
+                model="anthropic/claude",
+                request_source="alert_investigation",
+            )
+        assert attrs["langfuse.user.id"] == "u123"  # user_id wins
+        assert attrs["langfuse.session.id"] == "conv1"
+        assert attrs["langfuse.trace.name"] == "Holmes: why is my pod crashing?"
+        assert attrs["langfuse.trace.input"] == "why is my pod crashing?"
+        # explicit identity metadata
+        assert attrs["langfuse.trace.metadata.user_id"] == "u123"
+        assert attrs["langfuse.trace.metadata.user_email"] == "a@b.com"
+        assert attrs["langfuse.trace.metadata.conversation_id"] == "conv1"
+        assert attrs["langfuse.trace.metadata.account_id"] == "acct1"
+        assert attrs["langfuse.trace.metadata.model"] == "anthropic/claude"
+        # tags as a string array
+        assert attrs["langfuse.trace.tags"] == [
+            "source:alert_investigation",
+            "cluster:clusterA",
+            "model:anthropic/claude",
+        ]
+
+    def test_user_id_fallback_chain(self):
+        from holmes.core.tracing import langfuse_trace_attributes
+
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            assert (
+                langfuse_trace_attributes("q", user_email="a@b.com")["langfuse.user.id"]
+                == "a@b.com"
+            )
+            assert (
+                langfuse_trace_attributes("q", account_id="acct1")["langfuse.user.id"]
+                == "acct1"
+            )
+
+    def test_empty_values_omitted(self):
+        from holmes.core.tracing import langfuse_trace_attributes
+
+        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+            attrs = langfuse_trace_attributes("q")
+        # no user/session/metadata/tags keys when nothing is provided
+        assert "langfuse.user.id" not in attrs
+        assert "langfuse.session.id" not in attrs
+        assert "langfuse.trace.tags" not in attrs
+        assert not any(k.startswith("langfuse.trace.metadata.") for k in attrs)
+        # name/input are always present
+        assert attrs["langfuse.trace.input"] == "q"
 
 
 class TestSpanHierarchy:

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -87,7 +87,7 @@ class TestOTelSpan:
         mock_span = MagicMock()
         otel_span = OTelSpan(mock_span, MagicMock())
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.otel_tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             otel_span.log(input="the prompt", output="the answer")
 
         mock_span.set_attribute.assert_any_call(
@@ -104,7 +104,7 @@ class TestOTelSpan:
         mock_span = MagicMock()
         otel_span = OTelSpan(mock_span, MagicMock())
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "false"}):
+        with patch("holmes.core.otel_tracing.HOLMES_LANGFUSE_ATTRIBUTES", False):
             otel_span.log(input="the prompt", output="the answer", error="x")
 
         keys = [c[0][0] for c in mock_span.set_attribute.call_args_list]
@@ -118,7 +118,7 @@ class TestOTelSpan:
         otel_span = OTelSpan(mock_span, MagicMock())
 
         long_string = "x" * (_MAX_ATTR_CHARS + 5000)
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.otel_tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             otel_span.log(input=long_string, output=long_string)
 
         for call in mock_span.set_attribute.call_args_list:
@@ -134,7 +134,7 @@ class TestOTelSpan:
         otel_span = OTelSpan(mock_span, MagicMock())
 
         payload = {"content": "hi", "reasoning": "because", "tool_calls": []}
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.otel_tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             otel_span.log(input=[{"role": "user", "content": "q"}], output=payload)
 
         recorded = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
@@ -150,7 +150,7 @@ class TestOTelSpan:
         mock_span = MagicMock()
         otel_span = OTelSpan(mock_span, MagicMock())
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.otel_tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             otel_span.log(output="partial", error="boom failed")
 
         mock_span.set_attribute.assert_any_call("langfuse.observation.level", "ERROR")
@@ -217,13 +217,13 @@ class TestLangfuseTraceAttributes:
         """Returns {} unless HOLMES_LANGFUSE_ATTRIBUTES is enabled."""
         from holmes.core.tracing import langfuse_trace_attributes
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "false"}):
+        with patch("holmes.core.tracing.HOLMES_LANGFUSE_ATTRIBUTES", False):
             assert langfuse_trace_attributes("q", user_id="u1", session_id="c1") == {}
 
     def test_full_attrs(self):
         from holmes.core.tracing import langfuse_trace_attributes
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             attrs = langfuse_trace_attributes(
                 "why is my pod crashing?",
                 user_id="u123",
@@ -254,7 +254,7 @@ class TestLangfuseTraceAttributes:
     def test_user_id_fallback_chain(self):
         from holmes.core.tracing import langfuse_trace_attributes
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             assert (
                 langfuse_trace_attributes("q", user_email="a@b.com")["langfuse.user.id"]
                 == "a@b.com"
@@ -267,7 +267,7 @@ class TestLangfuseTraceAttributes:
     def test_empty_values_omitted(self):
         from holmes.core.tracing import langfuse_trace_attributes
 
-        with patch.dict(os.environ, {"HOLMES_LANGFUSE_ATTRIBUTES": "true"}):
+        with patch("holmes.core.tracing.HOLMES_LANGFUSE_ATTRIBUTES", True):
             attrs = langfuse_trace_attributes("q")
         # no user/session/metadata/tags keys when nothing is provided
         assert "langfuse.user.id" not in attrs

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -228,6 +228,50 @@ class TestOTelSpan:
         detach.assert_not_called()
         assert otel_span._token is None  # token cleared either way
 
+    def test_rob278_reproduce_bug_then_verify_fix(self, in_memory_exporter, caplog):
+        """Reproduce the real ROB-278 error, then prove _safe_detach avoids it.
+
+        The error ("Token was created in a different Context") happens when a
+        context token is attached in one contextvars.Context and detached in
+        another — exactly what happens when Holmes' span wraps a streaming
+        generator and is ended from the caller's context. We reproduce it by
+        attaching here and detaching inside a fresh contextvars.Context (where
+        our span is NOT the current one).
+        """
+        import contextvars
+        import logging
+
+        from opentelemetry import context as otel_context
+        from opentelemetry import trace as _trace
+
+        from holmes.core.otel_tracing import OTelSpan
+
+        tracer = _trace.get_tracer("test")
+        span_a = tracer.start_span("a")
+        token_a = otel_context.attach(_trace.set_span_in_context(span_a))
+        try:
+            # 1) Naive detach in a DIFFERENT context reproduces the OTel error.
+            def naive_detach():
+                otel_context.detach(token_a)
+
+            caplog.clear()
+            with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+                contextvars.Context().run(naive_detach)
+            assert "Failed to detach context" in caplog.text
+
+            # 2) _safe_detach in that same cross-context situation stays silent:
+            #    span_a is not current there, so it skips the detach.
+            def safe_detach():
+                OTelSpan(span_a, tracer, token_a)._safe_detach()
+
+            caplog.clear()
+            with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+                contextvars.Context().run(safe_detach)
+            assert "Failed to detach context" not in caplog.text
+        finally:
+            # in-order detach in the original context — clean, no error
+            otel_context.detach(token_a)
+
     def test_otel_span_set_attributes(self):
         """OTelSpan.set_attributes() updates span name and attributes."""
         from holmes.core.otel_tracing import OTelSpan

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -170,16 +170,6 @@ class TestOTelSpan:
         recorded = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
         assert len(recorded["langfuse.trace.input"]) == _MAX_ATTR_CHARS
 
-    def test_int_env_invalid_falls_back(self):
-        """A non-numeric HOLMES_OTEL_MAX_ATTR_CHARS doesn't crash; uses default."""
-        from holmes.core.otel_tracing import _int_env
-
-        with patch.dict(os.environ, {"X_TEST_INT": "not-a-number"}):
-            assert _int_env("X_TEST_INT", 4242) == 4242
-        with patch.dict(os.environ, {"X_TEST_INT": "77"}):
-            assert _int_env("X_TEST_INT", 4242) == 77
-        assert _int_env("X_TEST_INT_MISSING", 4242) == 4242
-
     def test_otel_span_log_tags_as_string_array(self):
         """List metadata values (e.g. langfuse.trace.tags) set as native arrays."""
         from holmes.core.otel_tracing import OTelSpan

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -158,6 +158,28 @@ class TestOTelSpan:
             "langfuse.observation.status_message", "boom failed"
         )
 
+    def test_otel_span_log_metadata_string_truncated(self):
+        """Free-text metadata values are capped to _MAX_ATTR_CHARS."""
+        from holmes.core.otel_tracing import _MAX_ATTR_CHARS, OTelSpan
+
+        mock_span = MagicMock()
+        otel_span = OTelSpan(mock_span, MagicMock())
+
+        otel_span.log(metadata={"langfuse.trace.input": "y" * (_MAX_ATTR_CHARS + 10)})
+
+        recorded = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
+        assert len(recorded["langfuse.trace.input"]) == _MAX_ATTR_CHARS
+
+    def test_int_env_invalid_falls_back(self):
+        """A non-numeric HOLMES_OTEL_MAX_ATTR_CHARS doesn't crash; uses default."""
+        from holmes.core.otel_tracing import _int_env
+
+        with patch.dict(os.environ, {"X_TEST_INT": "not-a-number"}):
+            assert _int_env("X_TEST_INT", 4242) == 4242
+        with patch.dict(os.environ, {"X_TEST_INT": "77"}):
+            assert _int_env("X_TEST_INT", 4242) == 77
+        assert _int_env("X_TEST_INT_MISSING", 4242) == 4242
+
     def test_otel_span_log_tags_as_string_array(self):
         """List metadata values (e.g. langfuse.trace.tags) set as native arrays."""
         from holmes.core.otel_tracing import OTelSpan

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -293,7 +293,7 @@ class TestLangfuseTraceAttributes:
             )
         assert attrs["langfuse.user.id"] == "u123"  # user_id wins
         assert attrs["langfuse.session.id"] == "conv1"
-        assert attrs["langfuse.trace.name"] == "Holmes: why is my pod crashing?"
+        assert attrs["langfuse.trace.name"] == "conv1"  # conversation id, not the prompt
         assert attrs["langfuse.trace.input"] == "why is my pod crashing?"
         # explicit identity metadata
         assert attrs["langfuse.trace.metadata.user_id"] == "u123"

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -193,6 +193,41 @@ class TestOTelSpan:
             "langfuse.trace.tags", ["source:alert", "cluster:x"]
         )
 
+    def test_safe_detach_detaches_when_in_order(self):
+        """When our span is current, detach happens normally."""
+        from holmes.core.otel_tracing import OTelSpan
+
+        span = MagicMock()
+        token = object()
+        otel_span = OTelSpan(span, MagicMock(), token)
+
+        with patch(
+            "holmes.core.otel_tracing.trace.get_current_span", return_value=span
+        ), patch("holmes.core.otel_tracing.otel_context.detach") as detach:
+            otel_span._safe_detach()
+
+        detach.assert_called_once_with(token)
+
+    def test_safe_detach_skips_when_out_of_order(self):
+        """When a different span is current (cross-context), detach is skipped.
+
+        This is the ROB-278 case: calling OTel detach out of LIFO order makes it
+        log "Failed to detach context" at ERROR. Skipping avoids that entirely.
+        """
+        from holmes.core.otel_tracing import OTelSpan
+
+        span = MagicMock()
+        otel_span = OTelSpan(span, MagicMock(), object())
+
+        with patch(
+            "holmes.core.otel_tracing.trace.get_current_span",
+            return_value=MagicMock(),  # some other span is current
+        ), patch("holmes.core.otel_tracing.otel_context.detach") as detach:
+            otel_span._safe_detach()
+
+        detach.assert_not_called()
+        assert otel_span._token is None  # token cleared either way
+
     def test_otel_span_set_attributes(self):
         """OTelSpan.set_attributes() updates span name and attributes."""
         from holmes.core.otel_tracing import OTelSpan

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -209,11 +209,7 @@ class TestOTelSpan:
         detach.assert_called_once_with(token)
 
     def test_safe_detach_skips_when_out_of_order(self):
-        """When a different span is current (cross-context), detach is skipped.
-
-        This is the ROB-278 case: calling OTel detach out of LIFO order makes it
-        log "Failed to detach context" at ERROR. Skipping avoids that entirely.
-        """
+        """Out-of-order (cross-context) detach is skipped — the ROB-278 case."""
         from holmes.core.otel_tracing import OTelSpan
 
         span = MagicMock()
@@ -229,15 +225,7 @@ class TestOTelSpan:
         assert otel_span._token is None  # token cleared either way
 
     def test_rob278_reproduce_bug_then_verify_fix(self, in_memory_exporter, caplog):
-        """Reproduce the real ROB-278 error, then prove _safe_detach avoids it.
-
-        The error ("Token was created in a different Context") happens when a
-        context token is attached in one contextvars.Context and detached in
-        another — exactly what happens when Holmes' span wraps a streaming
-        generator and is ended from the caller's context. We reproduce it by
-        attaching here and detaching inside a fresh contextvars.Context (where
-        our span is NOT the current one).
-        """
+        """Reproduce the real ROB-278 detach error, then prove _safe_detach avoids it."""
         import contextvars
         import logging
 


### PR DESCRIPTION
## ROB-602

Adds **opt-in Langfuse support** to Holmes' existing OpenTelemetry tracing, so each investigation shows up in Langfuse as a full audit: the initiating **user**, the **prompts**, the **tools called** with their **arguments and outputs**, the model's **thinking/reasoning**, and the final answer.

### What changed
- **`OTelSpan.log()`** now emits `langfuse.observation.input` / `output` (JSON, bounded by `HOLMES_OTEL_MAX_ATTR_CHARS`, default 100k) and marks failures via `langfuse.observation.level`. Langfuse reads these; the previous plain `input`/`output` attributes it ignored.
- **`gen_ai.chat`** spans log the prompt messages (input) and the assistant response as `{content, reasoning, tool_calls}` (output).
- **Investigation root spans** carry `langfuse.user.id`, `langfuse.session.id`, `langfuse.trace.tags`, and filterable `langfuse.trace.metadata.*` (user id/email, conversation id, account, cluster, model, request source) via a shared `langfuse_trace_attributes()` helper, wired into both the conversations-worker and server chat paths.
- **Env gate:** all `langfuse.*` enrichment is behind **`HOLMES_LANGFUSE_ATTRIBUTES`** (default **false**). When off, output is unchanged vendor-neutral OTel/`gen_ai.*` — clean for non-Langfuse backends.
- **Noise fix:** a sampler drops orphan httpx root spans (background HTTP calls made outside an investigation) so real `holmesgpt.investigation` traces aren't buried in the backend. httpx spans *inside* an investigation keep their parent and are unaffected.
- **Docs:** `docs/reference/opentelemetry.md` gets a Langfuse section (CLI + Helm) and the two new env vars.

### Enabling
Point the OTLP exporter at Langfuse's OTLP endpoint over HTTP with a Basic-auth header, and set `HOLMES_LANGFUSE_ATTRIBUTES=true`. See the Langfuse section in `docs/reference/opentelemetry.md`.

### Tests
Extended `tests/test_otel_tracing.py` (attribute mapping, JSON encoding, error level, tags array, the env gate on/off, and the enriched trace attributes). Non-LLM suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in Langfuse trace/observation attributes with structured investigation input/output, tool-call logging, and final answer visibility at the trace root.
  * Added environment controls to enable Langfuse vendor attributes and cap maximum span attribute length.
  * Added optional custom TLS certificate support via `CERTIFICATE`.
* **Documentation**
  * Expanded OpenTelemetry/Langfuse backend examples, including OTLP over HTTP with Basic auth and collector guidance.
* **Bug Fixes**
  * Reduced tracing noise by filtering orphan HTTP spans and improving span attribute truncation/type handling.
* **Tests**
  * Expanded coverage for Langfuse gating, truncation, JSON encoding, error reporting, tag formatting, and env parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->