### PR TITLE
feat: support pre-acquired AZURE_AD_TOKEN for Entra ID auth

### DIFF
--- a/holmes/core/azure_token.py
+++ b/holmes/core/azure_token.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import threading
 import time
 from typing import Optional
@@ -19,10 +20,19 @@ _token_timestamp: float = 0.0
 def get_azure_ad_token() -> str:
     """Return a cached Azure AD bearer token, refreshing if expired.
 
-    The token is obtained via ``get_bearer_token_provider(DefaultAzureCredential(), ...)``
+    If the ``AZURE_AD_TOKEN`` environment variable is set, its value is
+    returned directly.  This allows callers to inject a pre-acquired
+    short-lived token into ephemeral pods that have no Azure identity
+    of their own.
+
+    Otherwise the token is obtained via ``get_bearer_token_provider(DefaultAzureCredential(), ...)``
     and cached for up to TOKEN_EXPIRY_SECONDS (1 hour).
     """
     global _cached_token, _token_timestamp
+
+    pre_acquired = os.environ.get("AZURE_AD_TOKEN")
+    if pre_acquired:
+        return pre_acquired
 
     with _lock:
         now = time.monotonic()

--- a/tests/core/test_azure_token.py
+++ b/tests/core/test_azure_token.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.core import azure_token
+from holmes.core.azure_token import get_azure_ad_token
+
+
+@pytest.fixture(autouse=True)
+def reset_token_cache():
+    """Reset the module-level token cache between tests."""
+    azure_token._cached_token = None
+    azure_token._token_timestamp = 0.0
+    yield
+    azure_token._cached_token = None
+    azure_token._token_timestamp = 0.0
+
+
+class TestGetAzureAdToken:
+    def test_returns_pre_acquired_token_from_env(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AD_TOKEN", "my-pre-acquired-token")
+        assert get_azure_ad_token() == "my-pre-acquired-token"
+
+    @patch("holmes.core.azure_token.get_bearer_token_provider")
+    @patch("holmes.core.azure_token.DefaultAzureCredential")
+    def test_falls_back_to_default_credential_when_env_not_set(
+        self, mock_cred_cls, mock_provider_fn, monkeypatch
+    ):
+        monkeypatch.delenv("AZURE_AD_TOKEN", raising=False)
+        mock_provider_fn.return_value = lambda: "credential-token"
+
+        token = get_azure_ad_token()
+
+        assert token == "credential-token"
+        mock_cred_cls.assert_called_once()
+        mock_provider_fn.assert_called_once()
+
+    def test_pre_acquired_token_skips_default_credential(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AD_TOKEN", "injected-token")
+        with patch("holmes.core.azure_token.DefaultAzureCredential") as mock_cred:
+            token = get_azure_ad_token()
+            assert token == "injected-token"
+            mock_cred.assert_not_called()
+
+    def test_empty_env_var_falls_back_to_default_credential(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AD_TOKEN", "")
+        with patch("holmes.core.azure_token.DefaultAzureCredential"):
+            with patch("holmes.core.azure_token.get_bearer_token_provider") as mock_provider:
+                mock_provider.return_value = lambda: "fallback-token"
+                token = get_azure_ad_token()
+                assert token == "fallback-token"


### PR DESCRIPTION
## Summary

- When `AZURE_AD_TOKEN` environment variable is set, `get_azure_ad_token()` returns its value directly instead of acquiring a token via `DefaultAzureCredential`
- `DefaultAzureCredential` remains the fallback when `AZURE_AD_TOKEN` is not set
- No changes to the existing `AZURE_AD_TOKEN_AUTH` flow — this simply adds a short-circuit for pre-acquired tokens

## Motivation

ARO-RP runs HolmesGPT investigation pods on a Hive AKS cluster that has no Azure identity of its own. The RP acquires a short-lived Entra ID token via its own MSI and injects it into the pod as `AZURE_AD_TOKEN`. Without this change, the pod falls back to `DefaultAzureCredential` which fails because the pod has no credentials.

The token is valid for ~1 hour, and investigation pods time out at 10 minutes, so the pre-acquired token is always valid for the lifetime of the pod.

## Test plan

- [ ] Verified `AZURE_AD_TOKEN` env var is used when set
- [ ] Verified `DefaultAzureCredential` fallback works when `AZURE_AD_TOKEN` is not set
- [ ] Tested end-to-end with ARO-RP investigation pods on Hive AKS cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using a pre-acquired Azure AD token via the `AZURE_AD_TOKEN` environment variable.
  * When `AZURE_AD_TOKEN` is set and non-empty, it’s used immediately; otherwise, the app continues existing token acquisition and cache refresh.

* **Documentation**
  * Updated Azure token authentication documentation to include the `AZURE_AD_TOKEN` option.

* **Tests**
  * Added tests covering environment override behavior (including empty-string fallback) and cache reset between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->