### PR TITLE
FRO-190 Fix wrong icon for SQL Server and other DB subtypes

### DIFF
--- a/holmes/plugins/toolsets/database/database.py
+++ b/holmes/plugins/toolsets/database/database.py
@@ -109,6 +109,31 @@ def _detect_subtype(connection_url: str) -> DatabaseSubtype:
     return info.subtype if info else DatabaseSubtype.UNKNOWN
 
 
+# Per-subtype icon URLs. Copied from the frontend data-source catalog
+# (datasource-catalog.json) so the tool-call icon matches the catalog card
+# shown on the Data Sources page. A single DatabaseToolset backs every SQL
+# subtype, so the icon must be chosen from the resolved subtype rather than
+# hardcoded (see FRO-190: SQL Server was showing the PostgreSQL icon).
+_ICON_URL_BASE = "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos"
+_SUBTYPE_ICON_URLS: Dict[DatabaseSubtype, str] = {
+    DatabaseSubtype.POSTGRESQL: f"{_ICON_URL_BASE}/postgresql.svg",
+    DatabaseSubtype.MYSQL: f"{_ICON_URL_BASE}/mysql-icon.svg",
+    DatabaseSubtype.MARIADB: f"{_ICON_URL_BASE}/mariadb-icon.svg",
+    DatabaseSubtype.MSSQL: f"{_ICON_URL_BASE}/microsoft-icon.svg",
+    DatabaseSubtype.SQLITE: "https://cdn.simpleicons.org/sqlite/003B57",
+    DatabaseSubtype.CLICKHOUSE: "https://cdn.simpleicons.org/clickhouse/FFCC01",
+}
+
+# Fallback for an unknown/undetected subtype. Matches the generic
+# "database/sql" entry in the data-source catalog.
+_DEFAULT_DATABASE_ICON_URL = f"{_ICON_URL_BASE}/mysql-icon.svg"
+
+
+def _icon_url_for_subtype(subtype: DatabaseSubtype) -> str:
+    """Return the catalog icon URL for a database subtype."""
+    return _SUBTYPE_ICON_URLS.get(subtype, _DEFAULT_DATABASE_ICON_URL)
+
+
 def _parse_clickhouse_http_url(
     url: str,
 ) -> Tuple[str, str, Optional[Tuple[str, str]]]:
@@ -349,7 +374,9 @@ class DatabaseToolset(Toolset):
             description=description,
             type=ToolsetType.DATABASE,
             docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/database/",
-            icon_url="https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/postgresql.svg",
+            # Generic placeholder; replaced per-subtype by _apply_icon_url()
+            # once the subtype is resolved (explicitly or auto-detected).
+            icon_url=_DEFAULT_DATABASE_ICON_URL,
             prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
             tools=[],
             tags=[ToolsetTag.CORE],
@@ -385,6 +412,10 @@ class DatabaseToolset(Toolset):
         # Set initial meta — updated with detected subtype in prerequisites_callable
         self.meta = {"type": "database", "subtype": self._subtype.value}
 
+        # Apply the subtype-specific icon (explicit subtype, or the generic
+        # default until auto-detection runs in prerequisites_callable).
+        self._apply_icon_url()
+
         self._user_llm_instructions = llm_instructions
         self._dialect: Optional[str] = None
         if self._user_llm_instructions:
@@ -401,9 +432,26 @@ class DatabaseToolset(Toolset):
             if self._subtype == DatabaseSubtype.UNKNOWN:
                 self._subtype = _detect_subtype(self.database_config.connection_url)
             self.meta = {"type": "database", "subtype": self._subtype.value}
+            # Re-apply the icon now that the subtype is known (covers the
+            # auto-detect path and toolsets initialized lazily from cache).
+            self._apply_icon_url()
             return self._perform_health_check()
         except Exception as e:
             return False, f"Invalid database configuration: {e}"
+
+    def _apply_icon_url(self) -> None:
+        """Set the toolset and per-tool icon based on the resolved subtype.
+
+        The tool icon is stamped onto every tool-call result (Tool.invoke sets
+        ``result.icon_url = self.icon_url``), and ToolExecutor only copies the
+        toolset icon to a tool when the tool's icon is None — so we update the
+        tools directly to also cover the lazy-initialization path, where the
+        executor has already registered the tools before this runs.
+        """
+        icon_url = _icon_url_for_subtype(self._subtype)
+        self.icon_url = icon_url
+        for tool in self.tools:
+            tool.icon_url = icon_url
 
     def _perform_health_check(self) -> Tuple[bool, str]:
         try:

--- a/holmes/plugins/toolsets/database/database.py
+++ b/holmes/plugins/toolsets/database/database.py
@@ -109,11 +109,9 @@ def _detect_subtype(connection_url: str) -> DatabaseSubtype:
     return info.subtype if info else DatabaseSubtype.UNKNOWN
 
 
-# Per-subtype icon URLs. Copied from the frontend data-source catalog
-# (datasource-catalog.json) so the tool-call icon matches the catalog card
-# shown on the Data Sources page. A single DatabaseToolset backs every SQL
-# subtype, so the icon must be chosen from the resolved subtype rather than
-# hardcoded (see FRO-190: SQL Server was showing the PostgreSQL icon).
+# Per-subtype icons, copied from the frontend data-source catalog so tool-call
+# icons match the catalog card. One DatabaseToolset backs every SQL subtype, so
+# the icon is picked from the subtype rather than hardcoded (FRO-190).
 _ICON_URL_BASE = "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos"
 _SUBTYPE_ICON_URLS: Dict[DatabaseSubtype, str] = {
     DatabaseSubtype.POSTGRESQL: f"{_ICON_URL_BASE}/postgresql.svg",
@@ -124,8 +122,7 @@ _SUBTYPE_ICON_URLS: Dict[DatabaseSubtype, str] = {
     DatabaseSubtype.CLICKHOUSE: "https://cdn.simpleicons.org/clickhouse/FFCC01",
 }
 
-# Fallback for an unknown/undetected subtype. Matches the generic
-# "database/sql" entry in the data-source catalog.
+# Fallback for an unknown subtype; matches the catalog's generic "database/sql".
 _DEFAULT_DATABASE_ICON_URL = f"{_ICON_URL_BASE}/mysql-icon.svg"
 
 
@@ -374,8 +371,7 @@ class DatabaseToolset(Toolset):
             description=description,
             type=ToolsetType.DATABASE,
             docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/database/",
-            # Generic placeholder; replaced per-subtype by _apply_icon_url()
-            # once the subtype is resolved (explicitly or auto-detected).
+            # Placeholder; replaced per-subtype by _apply_icon_url().
             icon_url=_DEFAULT_DATABASE_ICON_URL,
             prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
             tools=[],
@@ -412,8 +408,7 @@ class DatabaseToolset(Toolset):
         # Set initial meta — updated with detected subtype in prerequisites_callable
         self.meta = {"type": "database", "subtype": self._subtype.value}
 
-        # Apply the subtype-specific icon (explicit subtype, or the generic
-        # default until auto-detection runs in prerequisites_callable).
+        # Apply icon for the explicit subtype (or the default until detection).
         self._apply_icon_url()
 
         self._user_llm_instructions = llm_instructions
@@ -432,21 +427,18 @@ class DatabaseToolset(Toolset):
             if self._subtype == DatabaseSubtype.UNKNOWN:
                 self._subtype = _detect_subtype(self.database_config.connection_url)
             self.meta = {"type": "database", "subtype": self._subtype.value}
-            # Re-apply the icon now that the subtype is known (covers the
-            # auto-detect path and toolsets initialized lazily from cache).
+            # Re-apply now the subtype is known (covers auto-detect and lazy init).
             self._apply_icon_url()
             return self._perform_health_check()
         except Exception as e:
             return False, f"Invalid database configuration: {e}"
 
     def _apply_icon_url(self) -> None:
-        """Set the toolset and per-tool icon based on the resolved subtype.
+        """Set the toolset and per-tool icon from the resolved subtype.
 
-        The tool icon is stamped onto every tool-call result (Tool.invoke sets
-        ``result.icon_url = self.icon_url``), and ToolExecutor only copies the
-        toolset icon to a tool when the tool's icon is None — so we update the
-        tools directly to also cover the lazy-initialization path, where the
-        executor has already registered the tools before this runs.
+        Tools are updated directly (not just the toolset) so the correct icon is
+        stamped onto results even under lazy init, where ToolExecutor has already
+        registered the tools and won't re-copy the toolset icon.
         """
         icon_url = _icon_url_for_subtype(self._subtype)
         self.icon_url = icon_url

--- a/tests/test_database_toolset.py
+++ b/tests/test_database_toolset.py
@@ -145,18 +145,12 @@ class TestDatabaseToolset:
 
 
 class TestSubtypeIcons:
-    """Icon must match the resolved DB subtype (FRO-190).
-
-    A single DatabaseToolset backs every SQL subtype, so the icon has to be
-    chosen from the subtype rather than hardcoded to PostgreSQL.
-    """
+    """Icon must match the resolved DB subtype, not be hardcoded (FRO-190)."""
 
     def test_every_known_subtype_has_a_distinct_icon(self):
-        # Every subtype except UNKNOWN maps to an icon...
         known = [s for s in DatabaseSubtype if s is not DatabaseSubtype.UNKNOWN]
         for subtype in known:
             assert subtype in _SUBTYPE_ICON_URLS
-        # ...and each icon is distinct so subtypes are visually distinguishable.
         icons = list(_SUBTYPE_ICON_URLS.values())
         assert len(icons) == len(set(icons))
 
@@ -171,8 +165,7 @@ class TestSubtypeIcons:
         toolset = DatabaseToolset(subtype=subtype)
         expected = _SUBTYPE_ICON_URLS[DatabaseSubtype(subtype)]
         assert toolset.icon_url == expected
-        # The icon is what gets stamped onto tool-call results, so every tool
-        # must carry it too.
+        # Tools carry the icon too — it's what's stamped onto results.
         for tool in toolset.tools:
             assert tool.icon_url == expected
 
@@ -184,13 +177,8 @@ class TestSubtypeIcons:
         assert toolset.icon_url == _SUBTYPE_ICON_URLS[DatabaseSubtype.MSSQL]
 
     def test_autodetected_subtype_updates_icon(self):
-        """Icon is corrected during prerequisites even if the DB is unreachable.
-
-        _apply_icon_url() runs before the health check, so the icon reflects the
-        detected subtype regardless of whether the connection succeeds.
-        """
+        """Icon reflects the detected subtype even if the DB is unreachable."""
         toolset = DatabaseToolset()
-        # Generic default before any connection info is known.
         assert toolset.icon_url == _DEFAULT_DATABASE_ICON_URL
         toolset.prerequisites_callable(
             {"connection_url": "mssql://user:pass@unreachable-host:1433/db"}

--- a/tests/test_database_toolset.py
+++ b/tests/test_database_toolset.py
@@ -12,10 +12,13 @@ from holmes.plugins.toolsets.database.database import (  # noqa: E402
     DatabaseConfig,
     DatabaseSubtype,
     DatabaseToolset,
+    _DEFAULT_DATABASE_ICON_URL,
     _READONLY_PATTERN,
+    _SUBTYPE_ICON_URLS,
     _WRITE_ANYWHERE_PATTERN,
     _WRITE_PATTERN,
     _detect_subtype,
+    _icon_url_for_subtype,
     _lookup_driver_info,
     _normalise_url,
     _serialize_value,
@@ -139,6 +142,73 @@ class TestDatabaseToolset:
     def test_toolset_disabled_by_default(self):
         toolset = DatabaseToolset()
         assert toolset.enabled is False
+
+
+class TestSubtypeIcons:
+    """Icon must match the resolved DB subtype (FRO-190).
+
+    A single DatabaseToolset backs every SQL subtype, so the icon has to be
+    chosen from the subtype rather than hardcoded to PostgreSQL.
+    """
+
+    def test_every_known_subtype_has_a_distinct_icon(self):
+        # Every subtype except UNKNOWN maps to an icon...
+        known = [s for s in DatabaseSubtype if s is not DatabaseSubtype.UNKNOWN]
+        for subtype in known:
+            assert subtype in _SUBTYPE_ICON_URLS
+        # ...and each icon is distinct so subtypes are visually distinguishable.
+        icons = list(_SUBTYPE_ICON_URLS.values())
+        assert len(icons) == len(set(icons))
+
+    def test_icon_for_subtype_falls_back_for_unknown(self):
+        assert (
+            _icon_url_for_subtype(DatabaseSubtype.UNKNOWN)
+            == _DEFAULT_DATABASE_ICON_URL
+        )
+
+    @pytest.mark.parametrize("subtype", ["mssql", "mysql", "mariadb", "postgresql"])
+    def test_explicit_subtype_sets_icon_at_construction(self, subtype):
+        toolset = DatabaseToolset(subtype=subtype)
+        expected = _SUBTYPE_ICON_URLS[DatabaseSubtype(subtype)]
+        assert toolset.icon_url == expected
+        # The icon is what gets stamped onto tool-call results, so every tool
+        # must carry it too.
+        for tool in toolset.tools:
+            assert tool.icon_url == expected
+
+    def test_sql_server_does_not_get_postgres_icon(self):
+        """Direct regression for FRO-190."""
+        toolset = DatabaseToolset(subtype="mssql")
+        postgres_icon = _SUBTYPE_ICON_URLS[DatabaseSubtype.POSTGRESQL]
+        assert toolset.icon_url != postgres_icon
+        assert toolset.icon_url == _SUBTYPE_ICON_URLS[DatabaseSubtype.MSSQL]
+
+    def test_autodetected_subtype_updates_icon(self):
+        """Icon is corrected during prerequisites even if the DB is unreachable.
+
+        _apply_icon_url() runs before the health check, so the icon reflects the
+        detected subtype regardless of whether the connection succeeds.
+        """
+        toolset = DatabaseToolset()
+        # Generic default before any connection info is known.
+        assert toolset.icon_url == _DEFAULT_DATABASE_ICON_URL
+        toolset.prerequisites_callable(
+            {"connection_url": "mssql://user:pass@unreachable-host:1433/db"}
+        )
+        expected = _SUBTYPE_ICON_URLS[DatabaseSubtype.MSSQL]
+        assert toolset._subtype == DatabaseSubtype.MSSQL
+        assert toolset.icon_url == expected
+        for tool in toolset.tools:
+            assert tool.icon_url == expected
+
+    def test_sqlite_icon_applied_on_successful_connection(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        toolset = DatabaseToolset()
+        success, _ = toolset.prerequisites_callable(
+            {"connection_url": f"sqlite:///{db_path}"}
+        )
+        assert success is True
+        assert toolset.icon_url == _SUBTYPE_ICON_URLS[DatabaseSubtype.SQLITE]
 
 
 class TestReadOnlyValidation:


### PR DESCRIPTION
## Problem

A single `DatabaseToolset` backs every SQL subtype (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite, ClickHouse), but its constructor **hardcoded the PostgreSQL icon** for all of them. Because the toolset icon is stamped onto every tool-call result (`Tool.invoke` sets `result.icon_url = self.icon_url`) and inherited by each tool at registration, **MySQL / SQL Server tool calls showed the Postgres logo** in the UI.

Reported in FRO-190: a SQL Server integration showed the Postgres icon.

## Fix

Resolve the icon from the **detected subtype** instead of hardcoding one:

- Added a `DatabaseSubtype → icon_url` map, with URLs **copied from the frontend data-source catalog** (`datasource-catalog.json`) so the tool-call icon matches the catalog card on the Data Sources page (SQL Server → `microsoft-icon.svg`, MySQL → `mysql-icon.svg`, MariaDB → `mariadb-icon.svg`, SQLite/ClickHouse → their simpleicons URLs).
- New `_apply_icon_url()` sets **both** the toolset icon and each tool's icon (the tool's icon is what actually gets stamped onto results). It runs at construction (explicit `subtype`) and again in `prerequisites_callable` after auto-detection — the latter also covers toolsets initialized lazily from cache, where the executor has already registered the tools.
- Replaced the hardcoded Postgres URL with a generic default used only for the unknown/undetected case (matches the catalog's generic `database/sql` entry).

## Tests

- Added `TestSubtypeIcons` (9 cases) in `tests/test_database_toolset.py`, including a direct regression for FRO-190 (`test_sql_server_does_not_get_postgres_icon`) and an auto-detect-without-connection case.
- All 99 database toolset tests pass.
- Verified every icon URL returns HTTP 200.

## Scope

Scoped to the database toolset only. The same latent pattern (hardcoded runtime `icon_url` on a multi-variant toolset) may exist in other subtyped toolsets (e.g. Prometheus); those are intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuWVUKE165iVX6zerFprUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuWVUKE165iVX6zerFprUg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database toolsets now show the correct icon based on the detected database subtype (with subtype-specific icon selection).
  * Unknown or undetected subtypes now consistently use a single fallback icon.
  * Icons are correctly refreshed after subtype detection, including during lazy initialization paths, ensuring each tool reflects the resolved icon.  
* **Tests**
  * Added coverage to validate subtype-to-icon mapping, fallback behavior, and icon updates during prerequisite checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->