### PR TITLE
ROB-651 Update request_source field docs with taxonomy cross-references

### DIFF
--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -230,7 +230,7 @@ class ChatRequestBaseModel(BaseModel):
         description=(
             "FE-supplied UI flow label, free-form. Examples: 'freeform', "
             "'followup_logs', 'manual_investigation', 'resource_chat'. "
-            "Taxonomy: relay relay/pkg/model/conversation_request_type.py."
+            "Taxonomy: relay repo, relay/pkg/model/conversation_request_type.py."
         ),
     )
     source_ref: Optional[str] = Field(

--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -230,10 +230,7 @@ class ChatRequestBaseModel(BaseModel):
         description=(
             "FE-supplied UI flow label, free-form. Examples: 'freeform', "
             "'followup_logs', 'manual_investigation', 'resource_chat'. "
-            "Canonical FE values: robusta-frontend "
-            "src/features/holmes/request-sources.ts; the full origin/"
-            "request_type/request_source taxonomy is documented in relay "
-            "relay/pkg/model/conversation_request_type.py."
+            "Taxonomy: relay relay/pkg/model/conversation_request_type.py."
         ),
     )
     source_ref: Optional[str] = Field(

--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -229,7 +229,11 @@ class ChatRequestBaseModel(BaseModel):
         default=None,
         description=(
             "FE-supplied UI flow label, free-form. Examples: 'freeform', "
-            "'followup_logs', 'alert_investigation', 'resource_chat'."
+            "'followup_logs', 'manual_investigation', 'resource_chat'. "
+            "Canonical FE values: robusta-frontend "
+            "src/features/holmes/request-sources.ts; the full origin/"
+            "request_type/request_source taxonomy is documented in relay "
+            "relay/pkg/model/conversation_request_type.py."
         ),
     )
     source_ref: Optional[str] = Field(

--- a/holmes/core/usage_recorder.py
+++ b/holmes/core/usage_recorder.py
@@ -249,7 +249,8 @@ class UsageRecorderState:
     # FE/runner-supplied finer UI flow label. Free-form text — adding new
     # values doesn't need a Holmes migration. Examples:
     #   'freeform'              — user typed a question in the FE
-    #   'alert_investigation'   — chat opened from an alert
+    #   'manual_investigation'  — user-triggered alert investigation run
+    #   'alert_investigation'   — follow-up chat on an investigated alert
     #   'followup_logs'         — user clicked a follow-up action button
     #   'resource_chat'         — chat opened from a Kubernetes resource
     #   'slack' / 'teams'       — auto-detected for messaging-platform

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -1075,10 +1075,8 @@ class TestStreamableHttp:
         assert build_remote_tools_meta(ts_a, ex) is None
 
     def test_collision_preserves_approval_gate_and_warns(
-        self, monkeypatch, caplog, suppress_migration_warnings
+        self, monkeypatch, suppress_migration_warnings
     ):
-        import logging
-
         from holmes.core.tools_utils.tool_executor import ToolExecutor
 
         gated = Tool(
@@ -1095,21 +1093,18 @@ class TestStreamableHttp:
         ts_a.approval_required_tools = ["run_kubectl_command"]
         ts_b.approval_required_tools = ["run_kubectl_command"]
 
-        # Attach directly to the emitting logger (propagation capture is flaky).
-        exec_logger = logging.getLogger("holmes.display.tool_executor")
-        exec_logger.addHandler(caplog.handler)
-        exec_logger.setLevel(logging.WARNING)
-        try:
+        # Spy on the emitting logger method directly — capturing dispatched log
+        # records (even with a handler attached to this exact logger) is flaky
+        # when other tests in the session reconfigure logging state.
+        with patch(
+            "holmes.core.tools_utils.tool_executor.display_logger.warning"
+        ) as warn:
             ex = ToolExecutor([ts_a, ts_b])
-        finally:
-            exec_logger.removeHandler(caplog.handler)
 
         # Collision → name namespaced, warning logged.
         assert "run_kubectl_command" not in ex.tools_by_name
-        assert any(
-            "Multiple tools named 'run_kubectl_command'" in r.getMessage()
-            for r in caplog.records
-        )
+        warned = [c.args[0] % tuple(c.args[1:]) for c in warn.call_args_list]
+        assert any("Multiple tools named 'run_kubectl_command'" in m for m in warned)
 
         # Approval still fires, matched on the real name.
         tool = ex.tools_by_name["remediation_a__run_kubectl_command"]

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -1,12 +1,15 @@
 """Tests for OpenTelemetry tracing implementation."""
+import contextvars
 import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from holmes.core.otel_tracing import OTelSpan
 from holmes.core.tracing import DummySpan, DummyTracer, SpanType, TracingFactory
 
 
@@ -216,16 +219,9 @@ class TestOTelSpan:
 
     def test_rob278_reproduce_bug_then_verify_fix(self, in_memory_exporter):
         """Reproduce the real ROB-278 detach error, then prove _safe_detach avoids it."""
-        import contextvars
-
-        from opentelemetry import context as otel_context
-        from opentelemetry import trace as _trace
-
-        from holmes.core.otel_tracing import OTelSpan
-
-        tracer = _trace.get_tracer("test")
+        tracer = trace.get_tracer("test")
         span_a = tracer.start_span("a")
-        token_a = otel_context.attach(_trace.set_span_in_context(span_a))
+        token_a = otel_context.attach(trace.set_span_in_context(span_a))
         try:
             # 1) Naive detach in a DIFFERENT context reproduces the OTel error.
             #    Spy on the module logger directly — caplog can't be trusted here

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -214,10 +214,9 @@ class TestOTelSpan:
         detach.assert_not_called()
         assert otel_span._token is None  # token cleared either way
 
-    def test_rob278_reproduce_bug_then_verify_fix(self, in_memory_exporter, caplog):
+    def test_rob278_reproduce_bug_then_verify_fix(self, in_memory_exporter):
         """Reproduce the real ROB-278 detach error, then prove _safe_detach avoids it."""
         import contextvars
-        import logging
 
         from opentelemetry import context as otel_context
         from opentelemetry import trace as _trace
@@ -229,23 +228,23 @@ class TestOTelSpan:
         token_a = otel_context.attach(_trace.set_span_in_context(span_a))
         try:
             # 1) Naive detach in a DIFFERENT context reproduces the OTel error.
+            #    Spy on the module logger directly — caplog can't be trusted here
+            #    because other tests in the session may reconfigure logging.
             def naive_detach():
                 otel_context.detach(token_a)
 
-            caplog.clear()
-            with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+            with patch.object(otel_context.logger, "exception") as log_exc:
                 contextvars.Context().run(naive_detach)
-            assert "Failed to detach context" in caplog.text
+            log_exc.assert_called_once_with("Failed to detach context")
 
             # 2) _safe_detach in that same cross-context situation stays silent:
             #    span_a is not current there, so it skips the detach.
             def safe_detach():
                 OTelSpan(span_a, tracer, token_a)._safe_detach()
 
-            caplog.clear()
-            with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+            with patch.object(otel_context.logger, "exception") as log_exc:
                 contextvars.Context().run(safe_detach)
-            assert "Failed to detach context" not in caplog.text
+            log_exc.assert_not_called()
         finally:
             # in-order detach in the original context — clean, no error
             otel_context.detach(token_a)


### PR DESCRIPTION
Docs-only change to the `request_source` field description on `HolmesChatAPIRequest` (`holmes/core/models.py`):

- Updates the free-form examples to current values (`manual_investigation` replaced `alert_investigation` for FE-driven initial investigation runs — see robusta-dev/robusta-frontend#3415).
- Cross-references the canonical FE constants module (robusta-frontend `src/features/holmes/request-sources.ts`) and the full `origin`/`request_type`/`request_source` taxonomy doc (relay `relay/pkg/model/conversation_request_type.py`, robusta-dev/relay#652).

No behavior change — the field remains an optional free-form string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCVndEvRQpwzvjW5eSoDUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCVndEvRQpwzvjW5eSoDUw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated request-source example guidance for chat requests and usage recording to better reflect supported label values, now including `manual_investigation` and `alert_investigation` alongside the existing option.

* **Tests**
  * Improved OpenTelemetry detach error assertions to validate expected logging behavior by checking the tracing context logger directly, rather than relying on log-capture scanning.
  * Updated tool collision warning coverage to confirm the correct warning text is emitted without using log-capture fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->