### PR TITLE
Fix log filter leaks in parallel test execution

### DIFF
--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -9,6 +9,7 @@ import unittest
 from io import StringIO
 from unittest.mock import Mock, patch
 
+import pytest
 from rich.console import Console
 
 from holmes.core.feedback import FeedbackMetadata
@@ -19,6 +20,7 @@ from holmes.interactive import (
     SlashCommandCompleter,
     SlashCommands,
     UserFeedback,
+    _LiveLogFilter,
     _make_live,
     _run_inline_menu,
     handle_feedback_command,
@@ -26,6 +28,27 @@ from holmes.interactive import (
 )
 from holmes.utils.stream import StreamEvents, StreamMessage
 from tests.mocks.toolset_mocks import SampleToolset
+
+
+@pytest.fixture(autouse=True)
+def _strip_leaked_live_log_filters():
+    """Guarantee no AgenticProgressRenderer log filter survives a test.
+
+    ``AgenticProgressRenderer.start()`` installs a ``_LiveLogFilter`` on every
+    root-logger handler; ``flush()``/``_stop_live()`` removes it again. Some
+    tests intentionally leave Live active (e.g. ``test_ai_message_keeps_live_active``)
+    and never flush, so the filter — which buffers and then *drops* every log
+    record it sees — stays attached to the root handlers, including pytest's own
+    ``LogCaptureHandler``. Under the parallel (xdist) suite that poisons log
+    capture for unrelated tests that happen to share the worker
+    (``test_otel_tracing``, ``test_mcp_toolset``), making them flaky. Strip any
+    leftover filters after each test so global logging state stays clean.
+    """
+    yield
+    for handler in logging.getLogger().handlers:
+        for log_filter in list(handler.filters):
+            if isinstance(log_filter, _LiveLogFilter):
+                handler.removeFilter(log_filter)
 
 
 class TestAgenticProgressRendererSummary(unittest.TestCase):


### PR DESCRIPTION
## Summary
Fixes flaky tests in parallel test execution (xdist) caused by `_LiveLogFilter` instances leaking from tests that intentionally keep `Live` active without flushing. These filters persist on root logger handlers and interfere with pytest's log capture, causing unrelated tests to fail intermittently.

## Changes
- Added `pytest` import to test dependencies
- Imported `_LiveLogFilter` from `holmes.interactive` module
- Added `_strip_leaked_live_log_filters()` autouse fixture that:
  - Runs after each test automatically
  - Iterates through all root logger handlers
  - Removes any lingering `_LiveLogFilter` instances
  - Ensures global logging state stays clean between tests

## Implementation Details
The fixture uses `autouse=True` to guarantee cleanup runs for every test without requiring explicit invocation. It targets the root logger's handlers directly since `AgenticProgressRenderer.start()` installs filters there. Tests like `test_ai_message_keeps_live_active` intentionally leave `Live` active without calling `flush()`, which leaves the filter attached. The filter buffers and drops log records, poisoning pytest's `LogCaptureHandler` on shared xdist workers and causing flakiness in unrelated tests like `test_otel_tracing` and `test_mcp_toolset`.

https://claude.ai/code/session_01KGkWSdPM9rx9LHgQ4sJdQV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by cleaning up temporary live logging filters after each test.
  * Prevented logging capture issues from carrying over between tests or parallel test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->