### PR TITLE
docs: add MiniMax model configuration examples

### DIFF
--- a/docs/ai-providers/index.md
+++ b/docs/ai-providers/index.md
@@ -16,6 +16,7 @@ HolmesGPT supports multiple AI providers, giving you flexibility in choosing the
 -   [:material-earth:{ .lg .middle } **OpenRouter**](openrouter.md)
 -   [:material-robot:{ .lg .middle } **Robusta AI**](robusta-ai.md)
 -   [:material-layers-triple:{ .lg .middle } **Using Multiple Providers**](using-multiple-providers.md)
+-   [:material-dots-horizontal:{ .lg .middle } **Other LiteLLM Providers**](other.md)
 
 </div>
 

--- a/docs/ai-providers/other.md
+++ b/docs/ai-providers/other.md
@@ -2,6 +2,34 @@
 
 HolmesGPT supports all AI providers available through [LiteLLM](https://litellm.vercel.app/docs/providers){:target="_blank"}, including 100+ different LLM providers. This guide shows how to configure any LiteLLM-supported provider using DeepSeek via Novita as an example.
 
+## Example: MiniMax M3 and M2.7
+
+MiniMax provides OpenAI-compatible endpoints in both global and China regions. Configure either
+endpoint by selecting the matching base URL and setting `MINIMAX_API_KEY`.
+
+```yaml
+modelList:
+  minimax-m3:
+    model: openai/MiniMax-M3
+    api_key: "{{ env.MINIMAX_API_KEY }}"
+    api_base: "https://api.minimax.io/v1"
+    custom_args:
+      max_context_size: 1000000
+  minimax-m27:
+    model: openai/MiniMax-M2.7
+    api_key: "{{ env.MINIMAX_API_KEY }}"
+    api_base: "https://api.minimax.io/v1"
+    custom_args:
+      max_context_size: 204800
+```
+
+For users in China, replace `https://api.minimax.io/v1` with
+`https://api.minimaxi.com/v1`. MiniMax M3 accepts text, image, and video input with adaptive
+or disabled thinking; M2.7 is text-only with thinking enabled.
+
+See the [global MiniMax API documentation](https://platform.minimax.io/docs/api-reference/api-overview){:target="_blank"}
+or [China MiniMax API documentation](https://platform.minimaxi.com/docs/api-reference/api-overview){:target="_blank"}.
+
 ## Example: DeepSeek 3.1 Terminus via Novita
 
 Let's walk through setting up DeepSeek 3.1 Terminus using the Novita AI provider.

--- a/docs/ai-providers/other.md
+++ b/docs/ai-providers/other.md
@@ -24,8 +24,15 @@ modelList:
 ```
 
 For users in China, replace `https://api.minimax.io/v1` with
-`https://api.minimaxi.com/v1`. MiniMax M3 accepts text, image, and video input with adaptive
-or disabled thinking; M2.7 is text-only with thinking enabled.
+`https://api.minimaxi.com/v1`. The corresponding Anthropic-compatible endpoints are
+`https://api.minimax.io/anthropic` (global) and `https://api.minimaxi.com/anthropic` (China).
+
+Model capabilities and pricing in USD per million tokens are:
+
+| Model | Context window | Input | Output | Cache read | Cache write | Input types | Thinking mode |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| MiniMax M3 | 1,000,000 | $0.60 | $2.40 | $0.12 | — | Text, image, video | Adaptive or disabled |
+| MiniMax M2.7 | 204,800 | $0.30 | $1.20 | $0.06 | $0.375 | Text | Always on |
 
 See the [global MiniMax API documentation](https://platform.minimax.io/docs/api-reference/api-overview){:target="_blank"}
 or [China MiniMax API documentation](https://platform.minimaxi.com/docs/api-reference/api-overview){:target="_blank"}.


### PR DESCRIPTION
Reason: Document MiniMax M3 and M2.7 configuration for HolmesGPT's LiteLLM model list.

This adds ready-to-use `modelList` entries for both models, including their context windows and the global OpenAI-compatible endpoint. It also documents the China endpoint, model input and thinking capabilities, and links to both official API references.

Checks:
- `uvx --from mkdocs-material mkdocs build --strict`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Other LiteLLM Providers” entry to the AI providers documentation.
  * Added configuration guidance and examples for MiniMax M3 and M2.7, including regional endpoints, API keys, model settings, supported input types, and thinking modes.
  * Documented Anthropic-compatible endpoints and linked to MiniMax’s global and China API documentation.
  * Included a comparison of MiniMax model capabilities and pricing-related configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->