### PR TITLE
Fix tool result spills for long Gemini call IDs

### DIFF
--- a/holmes/core/tools_utils/filesystem_result_storage.py
+++ b/holmes/core/tools_utils/filesystem_result_storage.py
@@ -22,6 +22,21 @@ from holmes.common.env_vars import (
 )
 
 
+THOUGHT_SIGNATURE_SEPARATOR = "__thought__"
+MAX_FILENAME_BYTES = 200
+
+
+def _safe_filename(
+    tool_name: str, tool_call_id: str, extension: str, suffix: str = ""
+) -> str:
+    safe_name = re.sub(r"[^\w\-]", "_", tool_name)
+    call_id = tool_call_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0]
+    safe_id = re.sub(r"[^\w\-]", "_", call_id)
+    stem = f"{safe_name}_{safe_id}{suffix}"
+    stem_bytes = stem.encode("utf-8")[: MAX_FILENAME_BYTES - len(extension)]
+    return stem_bytes.decode("utf-8", errors="ignore") + extension
+
+
 @contextmanager
 def tool_result_storage() -> Generator[Path, None, None]:
     """Context manager that creates a temp directory for tool results and cleans up after."""
@@ -53,10 +68,10 @@ def save_large_result(
     Returns the file path, or None if storage failed.
     """
     try:
-        safe_name = re.sub(r"[^\w\-]", "_", tool_name)
-        safe_id = re.sub(r"[^\w\-]", "_", tool_call_id)
         extension = ".json" if is_json else ".txt"
-        file_path = tool_results_dir / f"{safe_name}_{safe_id}{extension}"
+        file_path = tool_results_dir / _safe_filename(
+            tool_name, tool_call_id, extension
+        )
         file_path.write_text(content, encoding="utf-8")
         logging.info(f"Saved large tool result to filesystem: {file_path}")
         return str(file_path)
@@ -85,8 +100,6 @@ def save_images(
     Returns a list of saved file paths.
     """
     saved: List[str] = []
-    safe_name = re.sub(r"[^\w\-]", "_", tool_name)
-    safe_id = re.sub(r"[^\w\-]", "_", tool_call_id)
     for i, img in enumerate(images):
         try:
             mime_type = img.get("mimeType", "image/png")
@@ -97,7 +110,9 @@ def save_images(
                     f"(supported: {', '.join(MIME_TO_EXT.keys())})"
                 )
                 continue
-            file_path = tool_results_dir / f"{safe_name}_{safe_id}_img{i}{ext}"
+            file_path = tool_results_dir / _safe_filename(
+                tool_name, tool_call_id, ext, suffix=f"_img{i}"
+            )
             image_bytes = base64.b64decode(img["data"])
             file_path.write_bytes(image_bytes)
             saved.append(str(file_path))

--- a/holmes/core/tools_utils/filesystem_result_storage.py
+++ b/holmes/core/tools_utils/filesystem_result_storage.py
@@ -32,9 +32,18 @@ def _safe_filename(
     safe_name = re.sub(r"[^\w\-]", "_", tool_name)
     call_id = tool_call_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0]
     safe_id = re.sub(r"[^\w\-]", "_", call_id)
-    stem = f"{safe_name}_{safe_id}{suffix}"
-    stem_bytes = stem.encode("utf-8")[: MAX_FILENAME_BYTES - len(extension)]
-    return stem_bytes.decode("utf-8", errors="ignore") + extension
+    base_stem = f"{safe_name}_{safe_id}"
+
+    # Reserve space for the suffix and extension, then truncate only the base
+    # stem so the suffix (e.g. "_img0") is always preserved in full. Truncating
+    # the stem including the suffix could cut the suffix off, giving multiple
+    # images the exact same filename and silently overwriting each other.
+    suffix_bytes = suffix.encode("utf-8")
+    extension_bytes = extension.encode("utf-8")
+    max_base_bytes = MAX_FILENAME_BYTES - len(suffix_bytes) - len(extension_bytes)
+    base_bytes = base_stem.encode("utf-8")[:max_base_bytes]
+
+    return base_bytes.decode("utf-8", errors="ignore") + suffix + extension
 
 
 @contextmanager

--- a/tests/core/tools_utils/test_filesystem_result_storage.py
+++ b/tests/core/tools_utils/test_filesystem_result_storage.py
@@ -69,6 +69,16 @@ class TestSaveImages:
         assert len(paths) == 1
         assert "img1" in paths[0]
 
+    def test_save_with_litellm_thought_signature(self, tmp_path):
+        """Long thought signatures embedded by LiteLLM do not exceed NAME_MAX."""
+        images = [{"data": base64.b64encode(b"data").decode(), "mimeType": "image/png"}]
+        call_id = "call_123__thought__" + "A" * 3000
+
+        paths = save_images(tmp_path, "tool", call_id, images)
+
+        assert len(paths) == 1
+        assert __import__("pathlib").Path(paths[0]).read_bytes() == b"data"
+
 
 class TestSaveLargeResult:
     def test_save_text_result(self, tmp_path):
@@ -85,3 +95,12 @@ class TestSaveLargeResult:
         )
         assert path is not None
         assert path.endswith(".json")
+
+    def test_save_with_litellm_thought_signature(self, tmp_path):
+        """Long thought signatures embedded by LiteLLM do not exceed NAME_MAX."""
+        call_id = "call_123__thought__" + "A" * 3000
+
+        path = save_large_result(tmp_path, "tool", call_id, "result")
+
+        assert path is not None
+        assert __import__("pathlib").Path(path).read_text() == "result"

--- a/tests/core/tools_utils/test_filesystem_result_storage.py
+++ b/tests/core/tools_utils/test_filesystem_result_storage.py
@@ -79,6 +79,24 @@ class TestSaveImages:
         assert len(paths) == 1
         assert __import__("pathlib").Path(paths[0]).read_bytes() == b"data"
 
+    def test_long_call_id_preserves_image_suffixes(self, tmp_path):
+        """Long call IDs must not truncate the _imgN suffix into a filename collision."""
+        images = [
+            {"data": base64.b64encode(b"data1").decode(), "mimeType": "image/png"},
+            {"data": base64.b64encode(b"data2").decode(), "mimeType": "image/png"},
+        ]
+        call_id = "call_" + "A" * 3000
+
+        paths = save_images(tmp_path, "tool", call_id, images)
+
+        assert len(paths) == 2
+        assert paths[0] != paths[1]
+        assert paths[0].endswith("_img0.png")
+        assert paths[1].endswith("_img1.png")
+        assert __import__("pathlib").Path(paths[0]).read_bytes() == b"data1"
+        assert __import__("pathlib").Path(paths[1]).read_bytes() == b"data2"
+        assert len(__import__("pathlib").Path(paths[0]).name.encode("utf-8")) <= 200
+
 
 class TestSaveLargeResult:
     def test_save_text_result(self, tmp_path):


### PR DESCRIPTION
LiteLLM embeds Gemini thought signatures in tool call IDs, which can make HolmesGPT's spill filenames exceed filesystem limits and silently drop oversized tool results. Strip that signature from filenames and cap remaining UTF-8 names for both text and image storage.

Regression tests cover long signed call IDs for both paths. The focused storage suite passes (10 tests); Ruff's only finding is the same pre-existing unused `pytest` import present on `master`.

Closes #2252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saved images from overwriting one another when tool call identifiers are long.
  * Ensured saved tool results and images retain their distinguishing filename suffixes.
  * Kept generated filenames safe and within the 200-byte limit, including for long identifiers and thought signatures.
  * Preserved expected image and result contents when filenames require sanitization or shortening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->