### PR TITLE
feat(operator): Add  imagePullSecrets  support for holmes-operator

### DIFF
--- a/helm/holmes/templates/operator-deployment.yaml
+++ b/helm/holmes/templates/operator-deployment.yaml
@@ -34,6 +34,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-operator
+      {{- if .Values.operator.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml .Values.operator.imagePullSecrets | nindent 6 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -942,6 +942,7 @@ operator:
   image: holmes-operator:0.0.0
   registry: robustadev
   imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
 
   # Holmes API connection
   holmesApiUrl: ""  # Defaults to "http://<release-name>-holmes:80"


### PR DESCRIPTION
## What changed
• Added a new  operator.imagePullSecrets  value (default  [] ) to  helm/holmes/values.yaml 
• Updated  helm/holmes/templates/operator-deployment.yaml  to render an  imagePullSecrets  block on the operator's pod spec when  operator.imagePullSecrets  is set, using the standard  {{- if }}  /  toYaml  guard pattern

## Why
The  holmes-operator  Deployment had no way to reference image pull secrets, so it couldn't pull its image from a private registry. The main Holmes deployment ( holmes.yaml ) and the chart's service accounts already support  imagePullSecrets  via this same pattern — this brings the operator deployment in line with that existing convention.

## Impact
• Backward compatible: defaults to  [] , so existing deployments render no  imagePullSecrets  block and behave exactly as before.
• Users deploying  holmes-operator  from a private registry can now set  operator.imagePullSecrets  in their values file (or via  --set ) to reference a pull secret, consistent with how it's already done for the main Holmes app.
• No code, RBAC, or API changes — Helm chart only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for Kubernetes image pull secrets when deploying the Holmes Operator.
  * Helm deployments now include configured image pull secrets in the generated Deployment manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->