### PR TITLE
fix: filter Azure-incompatible MCP tool schemas (fixes #2297)

### DIFF
--- a/holmes/core/openai_formatting.py
+++ b/holmes/core/openai_formatting.py
@@ -68,6 +68,68 @@ def _is_tool_strict_compatible(tool_parameters: dict) -> bool:
     return True
 
 
+def _is_azure_compatible(tool_parameters: dict) -> bool:
+    """Check if a tool's parameters are compatible with Azure OpenAI strict schema.
+
+    Azure OpenAI requires that 'required' only includes keys present in 'properties'.
+    Tools with dynamic object arguments (additionalProperties with a schema) may have
+    'required' keys that don't match 'properties', causing Azure to reject the schema.
+
+    Returns True if compatible, False if the tool should be filtered out for Azure.
+    """
+    for param_name, param_attributes in tool_parameters.items():
+        if not hasattr(param_attributes, 'type'):
+            continue
+        param_type = param_attributes.type if isinstance(param_attributes.type, str) else str(param_attributes.type)
+        if param_type != 'object':
+            continue
+
+        # If it has explicit properties, it's fine
+        if hasattr(param_attributes, 'properties') and param_attributes.properties:
+            continue
+
+        # If it has additionalProperties with a schema (dynamic keys), it's Azure-incompatible
+        if hasattr(param_attributes, 'additional_properties'):
+            ap = param_attributes.additional_properties
+            if ap is not None and ap is not False:
+                return False
+
+        # If it's a generic object with no properties and required=True, it's problematic
+        if hasattr(param_attributes, 'required') and param_attributes.required:
+            if not hasattr(param_attributes, 'properties') or not param_attributes.properties:
+                return False
+
+    return True
+
+
+def filter_azure_incompatible_tools(tools: list) -> list:
+    """Filter out tools that have Azure-incompatible schemas.
+
+    Azure OpenAI requires 'required' to only include keys in 'properties'.
+    Tools with dynamic object arguments violate this and cause the entire
+    tool catalog to be rejected.
+
+    Returns a filtered list of tools that are Azure-compatible.
+    """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    compatible = []
+    for tool in tools:
+        if hasattr(tool, 'parameters') and tool.parameters:
+            if _is_azure_compatible(tool.parameters):
+                compatible.append(tool)
+            else:
+                tool_name = getattr(tool, 'name', 'unknown')
+                logger.warning(
+                    f"Tool '{tool_name}' filtered out: Azure-incompatible schema "
+                    f"(dynamic object arguments with additionalProperties)"
+                )
+        else:
+            compatible.append(tool)
+    return compatible
+
+
 def type_to_open_ai_schema(param_attributes: Any, strict_mode: bool) -> dict[str, Any]:
     # Handle union types (anyOf with multiple non-null branches) first.
     if hasattr(param_attributes, "any_of") and param_attributes.any_of:

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -935,11 +935,15 @@ class RemoteMCPToolset(Toolset):
             tools_result = asyncio.run(self._get_server_tools_with_context(request_context))
         else:
             tools_result = asyncio.run(self._get_server_tools())
+        # Filter out tools with Azure-incompatible schemas (Issue #2297)
+        from holmes.core.openai_formatting import filter_azure_incompatible_tools
+        compatible_tools = filter_azure_incompatible_tools(tools_result.tools)
+
         return [
             RemoteMCPTool.create(
                 tool, self, is_remote=tool.name.startswith(REMOTE_TOOL_NAME_PREFIX)
             )
-            for tool in tools_result.tools
+            for tool in compatible_tools
         ]
 
     def _render_headers(

--- a/tests/test_azure_schema_compat.py
+++ b/tests/test_azure_schema_compat.py
@@ -1,0 +1,121 @@
+"""Tests for Azure OpenAI schema compatibility (Issue #2297).
+
+Azure OpenAI requires 'required' to only include keys present in 'properties'.
+Tools with dynamic object arguments (additionalProperties with schema) violate
+this and cause the entire tool catalog to be rejected.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from holmes.core.openai_formatting import (
+    _is_azure_compatible,
+    filter_azure_incompatible_tools,
+)
+
+
+def _make_param(type_str="string", required=True, properties=None, additional_properties=None):
+    """Create a mock ToolParameter."""
+    param = MagicMock()
+    param.type = type_str
+    param.required = required
+    param.properties = properties
+    param.additional_properties = additional_properties
+    return param
+
+
+class TestAzureCompatibility:
+    def test_simple_string_params_are_compatible(self):
+        params = {
+            "query": _make_param("string"),
+            "limit": _make_param("integer", required=False),
+        }
+        assert _is_azure_compatible(params) is True
+
+    def test_object_with_explicit_properties_is_compatible(self):
+        props = {
+            "name": _make_param("string"),
+            "value": _make_param("string"),
+        }
+        params = {
+            "config": _make_param("object", properties=props),
+        }
+        assert _is_azure_compatible(params) is True
+
+    def test_object_with_additional_properties_is_incompatible(self):
+        params = {
+            "args": _make_param("object", additional_properties={"type": "string"}),
+        }
+        assert _is_azure_compatible(params) is False
+
+    def test_object_with_additional_properties_true_is_incompatible(self):
+        params = {
+            "args": _make_param("object", additional_properties=True),
+        }
+        assert _is_azure_compatible(params) is False
+
+    def test_object_with_additional_properties_false_is_compatible(self):
+        params = {
+            "config": _make_param("object", additional_properties=False, properties={"key": _make_param()}),
+        }
+        assert _is_azure_compatible(params) is True
+
+    def test_required_object_without_properties_is_incompatible(self):
+        params = {
+            "data": _make_param("object", required=True, properties=None),
+        }
+        assert _is_azure_compatible(params) is False
+
+    def test_optional_object_without_properties_is_compatible(self):
+        params = {
+            "data": _make_param("object", required=False, properties=None),
+        }
+        assert _is_azure_compatible(params) is True
+
+    def test_mixed_params_with_one_incompatible(self):
+        props = {"name": _make_param("string")}
+        params = {
+            "tool": _make_param("string"),
+            "args": _make_param("object", additional_properties={"type": "string"}),
+            "detail": _make_param("string"),
+        }
+        assert _is_azure_compatible(params) is False
+
+
+class TestFilterAzureIncompatibleTools:
+    def test_filters_out_incompatible_tools(self):
+        tool1 = MagicMock()
+        tool1.name = "good_tool"
+        tool1.parameters = {"query": _make_param("string")}
+
+        tool2 = MagicMock()
+        tool2.name = "bad_tool"
+        tool2.parameters = {"args": _make_param("object", additional_properties=True)}
+
+        tool3 = MagicMock()
+        tool3.name = "another_good_tool"
+        tool3.parameters = {"name": _make_param("string")}
+
+        result = filter_azure_incompatible_tools([tool1, tool2, tool3])
+        assert len(result) == 2
+        assert result[0].name == "good_tool"
+        assert result[1].name == "another_good_tool"
+
+    def test_keeps_all_compatible_tools(self):
+        tools = []
+        for i in range(5):
+            tool = MagicMock()
+            tool.name = f"tool_{i}"
+            tool.parameters = {"query": _make_param("string")}
+            tools.append(tool)
+
+        result = filter_azure_incompatible_tools(tools)
+        assert len(result) == 5
+
+    def test_handles_tools_without_parameters(self):
+        tool = MagicMock()
+        tool.name = "no_params"
+        tool.parameters = None
+
+        result = filter_azure_incompatible_tools([tool])
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

Azure OpenAI requires `required` to only include keys present in `properties`. MCP servers with dynamic object arguments generate schemas that violate this, causing the entire tool catalog to be rejected.

## Solution

Filter out Azure-incompatible tools before sending to the LLM:

1. **Detection**: `_is_azure_compatible()` checks for dynamic object arguments
2. **Filtering**: `filter_azure_incompatible_tools()` removes incompatible tools with warning
3. **Integration**: Applied in `_load_remote_tools()`

## Files Changed

- `holmes/core/openai_formatting.py` — Add detection + filtering functions
- `holmes/plugins/toolsets/mcp/toolset_mcp.py` — Apply filter
- `tests/test_azure_schema_compat.py` — 11 unit tests

## Test

```bash
python3 -m pytest tests/test_azure_schema_compat.py -v
```

Closes #2297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure OpenAI compatibility by automatically filtering out tool definitions with unsupported parameter schemas when loading tools from remote MCP servers.
  * Compatible tools remain available in their original order, while unsupported tools are excluded and logged when their names are available.
* **Tests**
  * Added coverage for Azure schema-compatibility rules, filtering behavior, and tools without parameter definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->