### PR TITLE
vertex support

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -105,8 +105,7 @@ def _register_custom_pricing(litellm_name: str, pricing: Dict[str, float]) -> No
         )
     except Exception as e:
         logging.warning(
-            f"Failed to register custom pricing for '{litellm_name}': {e}"
-        )
+        logging.warning(f"Failed to register custom pricing for '{litellm_name}': {e}")
 
 
 def _pricing_dict_from_bundled(bundled: Dict[str, Any]) -> Optional[Dict[str, float]]:
@@ -483,6 +482,15 @@ class DefaultLLM(LLM):
             if not model_requirements["missing_keys"]:
                 model_requirements["keys_in_environment"] = True
 
+        elif provider == "vertex_ai" and (
+            (args.get("vertex_project") and args.get("vertex_location"))
+            or args.get("vertex_credentials")
+        ):
+            # Vertex project/location/credentials passed via model args aren't
+            # visible to litellm.validate_environment (it only checks the
+            # VERTEXAI_* env vars), so treat the args as satisfying it.
+            # If they're absent, fall through to the env-var check below.
+            return
         else:
             model_requirements = litellm.validate_environment(
                 model=model, api_key=api_key, api_base=api_base

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -104,7 +104,6 @@ def _register_custom_pricing(litellm_name: str, pricing: Dict[str, float]) -> No
             f"input={entry['input_cost_per_token']}, output={entry['output_cost_per_token']}"
         )
     except Exception as e:
-        logging.warning(
         logging.warning(f"Failed to register custom pricing for '{litellm_name}': {e}")
 
 


### PR DESCRIPTION
solves 
Exception: model vertex_ai/claude-fable-5 requires the following environment variables: ['VERTEXAI_PROJECT', 'VERTEXAI_LOCATION']
can use vertex llms from model list now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vertex AI configuration handling when project, location, and credentials are provided directly, reducing unnecessary validation failures.
  * Simplified the warning shown if custom model pricing registration fails, while keeping the same failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->