### PR TITLE
Clarify namespace requirements for Holmes service account setup

### DIFF
--- a/docs/installation/namespace-scoped-access.md
+++ b/docs/installation/namespace-scoped-access.md
@@ -19,14 +19,23 @@ createServiceAccount: false
 customServiceAccountName: holmes
 ```
 
-Create the service account, `Role`, and `RoleBinding` (`holmes-namespace-scoped.yaml`). Replace `monitoring` with the namespace you want Holmes to investigate, and `holmes` with the namespace Holmes is installed in:
+Create the service account, `Role`, and `RoleBinding` (`holmes-namespace-scoped.yaml`).
+
+!!! warning "The service account must live in the namespace where Holmes is deployed"
+    Create the `ServiceAccount` in the **same namespace where the Holmes agent runs** (the release namespace, e.g. the namespace you pass to `helm install ... -n <namespace>`). If it is created in a different namespace, Holmes' pod won't be able to use it and the setup will not work. The `RoleBinding` in the target namespace then references this service account by its name **and** its namespace.
+
+In the manifest below, replace:
+
+- `monitoring` — the namespace you want Holmes to investigate
+- `holmes-agent-namespace` — the namespace where the Holmes agent is deployed (both places it appears)
 
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: holmes
-  namespace: holmes
+  # Must match the namespace where the Holmes agent is deployed
+  namespace: holmes-agent-namespace
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -83,7 +92,8 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: holmes
-    namespace: holmes
+    # Must match the namespace where the Holmes agent is deployed
+    namespace: holmes-agent-namespace
 ```
 
 Apply it, then upgrade Holmes with the values above:
@@ -92,7 +102,7 @@ Apply it, then upgrade Holmes with the values above:
 kubectl apply -f holmes-namespace-scoped.yaml
 ```
 
-To grant access to more than one namespace, create an additional `Role` + `RoleBinding` in each namespace, all bound to the same `holmes` service account.
+To grant access to more than one namespace, create an additional `Role` + `RoleBinding` in each namespace, all bound to the same `holmes` service account (still referencing it in its own `holmes-agent-namespace`).
 
 ## Verify the Configuration
 
@@ -102,6 +112,7 @@ kubectl get role holmes-namespace-scoped -n monitoring
 kubectl get rolebinding holmes-namespace-scoped -n monitoring
 
 # Check what the service account can and cannot do
-kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:holmes:holmes
-kubectl auth can-i list nodes --as=system:serviceaccount:holmes:holmes  # expected: no
+# Format: system:serviceaccount:<holmes-agent-namespace>:<serviceaccount-name>
+kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:holmes-agent-namespace:holmes
+kubectl auth can-i list nodes --as=system:serviceaccount:holmes-agent-namespace:holmes  # expected: no
 ```

--- a/docs/installation/namespace-scoped-access.md
+++ b/docs/installation/namespace-scoped-access.md
@@ -112,6 +112,7 @@ kubectl get role holmes-namespace-scoped -n monitoring
 kubectl get rolebinding holmes-namespace-scoped -n monitoring
 
 # Check what the service account can and cannot do
+# Replace <HOLMES_NAMESPACE> with the namespace where Holmes is deployed before running these commands.
 # Format: system:serviceaccount:<HOLMES_NAMESPACE>:<serviceaccount-name>
 kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:<HOLMES_NAMESPACE>:holmes
 kubectl auth can-i list nodes --as=system:serviceaccount:<HOLMES_NAMESPACE>:holmes  # expected: no

--- a/docs/installation/namespace-scoped-access.md
+++ b/docs/installation/namespace-scoped-access.md
@@ -27,7 +27,7 @@ Create the service account, `Role`, and `RoleBinding` (`holmes-namespace-scoped.
 In the manifest below, replace:
 
 - `monitoring` — the namespace you want Holmes to investigate
-- `holmes-agent-namespace` — the namespace where the Holmes agent is deployed (both places it appears)
+- `<HOLMES_NAMESPACE>` — the namespace where the Holmes agent is deployed (both places it appears)
 
 ```yaml
 apiVersion: v1
@@ -35,7 +35,7 @@ kind: ServiceAccount
 metadata:
   name: holmes
   # Must match the namespace where the Holmes agent is deployed
-  namespace: holmes-agent-namespace
+  namespace: <HOLMES_NAMESPACE>
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,7 +93,7 @@ subjects:
   - kind: ServiceAccount
     name: holmes
     # Must match the namespace where the Holmes agent is deployed
-    namespace: holmes-agent-namespace
+    namespace: <HOLMES_NAMESPACE>
 ```
 
 Apply it, then upgrade Holmes with the values above:
@@ -102,7 +102,7 @@ Apply it, then upgrade Holmes with the values above:
 kubectl apply -f holmes-namespace-scoped.yaml
 ```
 
-To grant access to more than one namespace, create an additional `Role` + `RoleBinding` in each namespace, all bound to the same `holmes` service account (still referencing it in its own `holmes-agent-namespace`).
+To grant access to more than one namespace, create an additional `Role` + `RoleBinding` in each namespace, all bound to the same `holmes` service account (still referencing it in its own `<HOLMES_NAMESPACE>`).
 
 ## Verify the Configuration
 
@@ -112,7 +112,7 @@ kubectl get role holmes-namespace-scoped -n monitoring
 kubectl get rolebinding holmes-namespace-scoped -n monitoring
 
 # Check what the service account can and cannot do
-# Format: system:serviceaccount:<holmes-agent-namespace>:<serviceaccount-name>
-kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:holmes-agent-namespace:holmes
-kubectl auth can-i list nodes --as=system:serviceaccount:holmes-agent-namespace:holmes  # expected: no
+# Format: system:serviceaccount:<HOLMES_NAMESPACE>:<serviceaccount-name>
+kubectl auth can-i list pods -n monitoring --as=system:serviceaccount:<HOLMES_NAMESPACE>:holmes
+kubectl auth can-i list nodes --as=system:serviceaccount:<HOLMES_NAMESPACE>:holmes  # expected: no
 ```


### PR DESCRIPTION
## Summary

Improves the documentation for namespace-scoped access configuration to clarify critical requirements about where the Holmes service account must be created and how to properly reference it across namespaces.

## Key Changes

- **Added warning box** highlighting that the `ServiceAccount` must be created in the same namespace where the Holmes agent is deployed, not in the target monitoring namespace
- **Introduced placeholder variable** `<HOLMES_NAMESPACE>` to make it explicit where users need to substitute their actual Holmes deployment namespace
- **Updated all references** to use the placeholder consistently in:
  - ServiceAccount namespace field
  - RoleBinding subject namespace field
  - kubectl auth verification commands
- **Clarified multi-namespace setup** by noting that additional RoleBindings still reference the service account in its original `<HOLMES_NAMESPACE>`
- **Improved verification commands** with format documentation showing the correct `system:serviceaccount:<HOLMES_NAMESPACE>:<serviceaccount-name>` syntax

## Implementation Details

The changes maintain the existing YAML structure while making the configuration requirements more explicit through:
- Inline comments in the manifest explaining namespace requirements
- Clear variable substitution instructions before the code block
- Updated example commands that show the proper namespace reference format

This prevents a common misconfiguration where users create the service account in the target monitoring namespace instead of the Holmes deployment namespace, which would cause the setup to fail silently.

https://claude.ai/code/session_01VNJfoLLKpLdt4MG67R6BL1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the namespace-scoped access installation guide to replace hardcoded namespace assumptions with a configurable `<HOLMES_NAMESPACE>` placeholder.
  * Added an explicit warning that the required ServiceAccount must be created in the same namespace where the agent runs.
  * Clarified that the RoleBinding must reference the ServiceAccount by both name and namespace.
  * Refined the example manifests and verification instructions for multi-namespace setups using the impersonation format `system:serviceaccount:<HOLMES_NAMESPACE>:holmes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->