### PR TITLE
Guard periodic toolset-refresh sync with dal.enabled

### DIFF
--- a/server.py
+++ b/server.py
@@ -315,7 +315,10 @@ def _toolset_status_refresh_loop():
                         logging.info(
                             f"Toolset '{toolset_name}' status changed: {old_status} -> {new_status}"
                         )
-                    holmes_sync_toolsets_status(dal, config)
+                    # Nothing to sync without a Robusta platform connection
+                    # (mirrors the same guard in sync_before_server_start).
+                    if dal.enabled:
+                        holmes_sync_toolsets_status(dal, config)
                 else:
                     logging.debug(
                         "Periodic toolset status refresh: no changes detected"


### PR DESCRIPTION
## Problem

The periodic toolset-status refresh loop in `server.py` calls `holmes_sync_toolsets_status(dal, config)` unconditionally whenever a toolset's status changes, even when `dal.enabled` is `False` (no Robusta SaaS platform / Supabase connection configured). That function's first check unconditionally requires `config.cluster_name` and raises if unset — which fires on every status transition (e.g. a transient healthcheck blip like `datadog/general: failed -> enabled`) for any self-hosted deployment that doesn't set `CLUSTER_NAME`.

The loop's generic `except Exception: logging.error(...)` catches this, and the surrounding retry-backoff logic then logs `"Failed MCP server(s) detected, retrying in N seconds"` on the next iteration — a misleading message, since nothing MCP-related actually failed.

## Fix

`sync_before_server_start()` already guards its call to the same function:
```python
if not dal.enabled:
    logging.info("Skipping holmes status and toolsets synchronization - not connected to Robusta platform")
    return
```

This PR mirrors that guard in `_toolset_status_refresh_loop()`'s inner `refresh_loop()`. Everything downstream of the `cluster_name` check (`SupabaseDal.sync_toolsets` and every other DAL method it touches) already has its own `if not self.enabled: return` guard, so this is a pure no-op safety fix — no behavior change for deployments that do use the Robusta platform, and no test regressions expected since the guarded call simply doesn't execute when `dal.enabled` is already `False`.

Fixes #2314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toolset status refresh handling by preventing status synchronization when the data layer is disabled.
  * Helps avoid unnecessary or invalid background updates during periodic status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->