### PR TITLE
feat: add Telegram and data platform integrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,20 +77,20 @@ RUN curl -fsSLO "${MSODBCSQL_DOWNLOAD}/msodbcsql18_${MSODBCSQL_VERSION}_${TARGET
 # kube-lineage / ArgoCD / Helm: CVE-patched static binaries (see scripts/build_go_binaries.sh).
 COPY bin/go-cve-rebuild/${TARGETARCH}/kube-lineage.gz /tmp/kube-lineage.gz
 COPY bin/go-cve-rebuild/${TARGETARCH}/kube-lineage.gz.sha256 /tmp/kube-lineage.gz.sha256
-RUN cd /tmp && sha256sum -c kube-lineage.gz.sha256 \
+RUN cd /tmp && sed -i 's/\r$//' kube-lineage.gz.sha256 && sha256sum -c kube-lineage.gz.sha256 \
     && gunzip /tmp/kube-lineage.gz && mv /tmp/kube-lineage /kube-lineage && chmod +x /kube-lineage \
     && rm -f /tmp/kube-lineage.gz.sha256
 RUN /kube-lineage --version
 
 COPY bin/go-cve-rebuild/${TARGETARCH}/argocd.gz /tmp/argocd.gz
 COPY bin/go-cve-rebuild/${TARGETARCH}/argocd.gz.sha256 /tmp/argocd.gz.sha256
-RUN cd /tmp && sha256sum -c argocd.gz.sha256 \
+RUN cd /tmp && sed -i 's/\r$//' argocd.gz.sha256 && sha256sum -c argocd.gz.sha256 \
     && gunzip /tmp/argocd.gz && mv /tmp/argocd /argocd && chmod +x /argocd \
     && rm -f /tmp/argocd.gz.sha256
 
 COPY bin/go-cve-rebuild/${TARGETARCH}/helm.gz /tmp/helm.gz
 COPY bin/go-cve-rebuild/${TARGETARCH}/helm.gz.sha256 /tmp/helm.gz.sha256
-RUN cd /tmp && sha256sum -c helm.gz.sha256 \
+RUN cd /tmp && sed -i 's/\r$//' helm.gz.sha256 && sha256sum -c helm.gz.sha256 \
     && gunzip /tmp/helm.gz && mv /tmp/helm /helm && chmod +x /helm \
     && rm -f /tmp/helm.gz.sha256
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ HolmesGPT integrates with popular observability and cloud platforms. The followi
 | [<img src="images/integration_logos/aws_logo.png" alt="AWS" width="20" style="vertical-align: middle;"> **AWS**](https://holmesgpt.dev/data-sources/builtin-toolsets/aws/) | RDS events, instances, slow query logs, and more (MCP) |
 | [<img src="images/integration_logos/azure.png" alt="Azure" width="20" style="vertical-align: middle;"> **Azure**](https://holmesgpt.dev/data-sources/builtin-toolsets/azure-mcp/) | Azure resources and diagnostics (MCP) |
 | [<img src="images/integration_logos/azure.png" alt="Azure SQL" width="20" style="vertical-align: middle;"> **Azure SQL**](https://holmesgpt.dev/data-sources/builtin-toolsets/azure-sql/) | Database health, performance, connections, and slow queries |
+| [**Apache Airflow**](https://holmesgpt.dev/data-sources/builtin-toolsets/airflow/) | DAG runs, task instances, and bounded task logs |
+| [**Apache Flink**](https://holmesgpt.dev/data-sources/builtin-toolsets/flink/) | Job status, exceptions, and checkpoint diagnostics |
 | [<img src="images/integration_logos/confluence_logo.png" alt="Confluence" width="20" style="vertical-align: middle;"> **Confluence**](https://holmesgpt.dev/data-sources/builtin-toolsets/confluence/) | Private runbooks and documentation |
 | [<img src="images/integration_logos/confluence_logo.png" alt="Confluence MCP" width="20" style="vertical-align: middle;"> **Confluence (MCP)**](https://holmesgpt.dev/data-sources/builtin-toolsets/confluence-mcp/) | Private runbooks and documentation (MCP) |
 | [<img src="images/integration_logos/coralogix-icon.png" alt="Coralogix" width="20" style="vertical-align: middle;"> **Coralogix**](https://holmesgpt.dev/data-sources/builtin-toolsets/coralogix-logs/) | Retrieve logs for any resource |
@@ -80,6 +82,7 @@ HolmesGPT integrates with popular observability and cloud platforms. The followi
 | **Splunk** | Log search and analysis (MCP) |
 | [<img src="images/integration_logos/postgres-icon.png" alt="SQL Databases" width="20" style="vertical-align: middle;"> **SQL Databases**](https://holmesgpt.dev/data-sources/builtin-toolsets/database-postgresql/) | PostgreSQL, MySQL, ClickHouse, MariaDB, SQL Server, SQLite |
 | [<img src="images/integration_logos/tempo_logo.png" alt="Tempo" width="20" style="vertical-align: middle;"> **Tempo**](https://holmesgpt.dev/data-sources/builtin-toolsets/grafanatempo/) | Fetch trace info, debug issues like high latency in application |
+| [**Trino**](https://holmesgpt.dev/data-sources/builtin-toolsets/trino/) | Bounded read-only SQL and coordinator diagnostics |
 | [<img src="images/integration_logos/victorialogs-icon.png" alt="VictoriaLogs" width="20" style="vertical-align: middle;"> **VictoriaLogs**](https://holmesgpt.dev/data-sources/builtin-toolsets/victorialogs/) | Query logs from VictoriaLogs using LogsQL |
 | **VictoriaMetrics** | Query metrics from a Prometheus-compatible TSDB (`vmsingle` / `vmcluster`) |
 | [<img src="images/integration_logos/zabbix-icon.png" alt="Zabbix" width="20" style="vertical-align: middle;"> **Zabbix**](https://holmesgpt.dev/data-sources/builtin-toolsets/zabbix/) | Monitor hosts, problems, events, triggers, and historical metrics |
@@ -94,6 +97,7 @@ HolmesGPT can fetch alerts/tickets to investigate from external systems, then wr
 |-------------------------|-----------|-------|
 | Slack                   | ✅        | [Demo.](https://www.loom.com/share/afcd81444b1a4adfaa0bbe01c37a4847) Available via [Robusta](https://home.robusta.dev/) |
 | Microsoft Teams         | ✅        | Available via [Robusta](https://home.robusta.dev/) |
+| Telegram                | ✅        | Built-in long-polling adapter for the HolmesGPT HTTP server |
 | Prometheus/AlertManager | ✅        | Robusta or HolmesGPT CLI |
 | PagerDuty               | ✅        | HolmesGPT CLI only |
 | OpsGenie                | ✅        | HolmesGPT CLI only |

--- a/docs/data-sources/builtin-toolsets/.nav.yml
+++ b/docs/data-sources/builtin-toolsets/.nav.yml
@@ -1,6 +1,8 @@
 nav:
   - index.md
   - AKS Node Health: aks-node-health.md
+  - Apache Airflow: airflow.md
+  - Apache Flink: flink.md
   - ArgoCD: argocd.md
   - AWS (MCP): aws.md
   - Azure (MCP): azure-mcp.md
@@ -24,6 +26,7 @@ nav:
   - Grafana Dashboards: grafanadashboards.md
   - Loki: grafanaloki.md
   - Tempo: grafanatempo.md
+  - Trino: trino.md
   - Helm: helm.md
   - Inspektor Gadget: inspektor-gadget.md
   - Internet: internet.md

--- a/docs/data-sources/builtin-toolsets/airflow.md
+++ b/docs/data-sources/builtin-toolsets/airflow.md
@@ -1,0 +1,48 @@
+# Apache Airflow
+
+Connect HolmesGPT to the Airflow Stable REST API.
+
+## Prerequisites
+
+- A reachable Airflow API server
+- Read access to DAGs, DAG runs, task instances, and task logs
+
+## Configuration
+
+Airflow 3 uses API v2:
+
+```yaml-toolset-config
+toolsets:
+  airflow:
+    enabled: true
+    config:
+      api_url: https://airflow.example.com
+      api_version: v2
+      bearer_token: "{{ env.AIRFLOW_TOKEN }}"
+      max_items: 100
+      max_log_characters: 20000
+```
+
+For Airflow 2, set `api_version: v1`. Basic authentication is available through
+`username` and `password`.
+
+## Multiple Instances
+
+```multi-instance
+toolset: airflow
+name: Apache Airflow
+config: |
+  api_url: https://airflow.example.com
+  api_version: v2
+  bearer_token: "{{ env.AIRFLOW_TOKEN }}"
+```
+
+## Common Use Cases
+
+```text
+Find the failed tasks in the latest orders DAG run
+```
+
+```text
+Read the failed task attempt log and identify the root cause
+```

--- a/docs/data-sources/builtin-toolsets/flink.md
+++ b/docs/data-sources/builtin-toolsets/flink.md
@@ -1,0 +1,40 @@
+# Apache Flink
+
+Connect HolmesGPT to the Flink JobManager monitoring REST API.
+
+## Prerequisites
+
+- A reachable Flink JobManager REST endpoint
+
+## Configuration
+
+```yaml-toolset-config
+toolsets:
+  flink:
+    enabled: true
+    config:
+      api_url: http://flink-jobmanager.streaming.svc:8081
+      max_items: 100
+```
+
+For authenticated gateways, set `bearer_token`, basic-auth `username` and
+`password`, or templated `extra_headers`.
+
+## Multiple Instances
+
+```multi-instance
+toolset: flink
+name: Apache Flink
+config: |
+  api_url: http://flink-jobmanager.streaming.svc:8081
+```
+
+## Common Use Cases
+
+```text
+Why did the latest Flink job fail?
+```
+
+```text
+Check whether checkpoint duration or failed checkpoints explain the lag
+```

--- a/docs/data-sources/builtin-toolsets/index.md
+++ b/docs/data-sources/builtin-toolsets/index.md
@@ -48,6 +48,7 @@ HolmesGPT includes pre-built integrations for popular monitoring and observabili
 -   [:simple-mongodb:{ .lg .middle } **MongoDB**](mongodb.md)
 -   [:simple-mongodb:{ .lg .middle } **MongoDB Atlas**](mongodb-atlas.md)
 -   [:simple-mariadb:{ .lg .middle } **MariaDB (MCP)**](mariadb-mcp.md)
+-   [:material-database-search:{ .lg .middle } **Trino**](trino.md)
 
 </div>
 
@@ -115,6 +116,8 @@ HolmesGPT includes pre-built integrations for popular monitoring and observabili
 <div class="grid cards" markdown>
 
 -   [:material-pipe:{ .lg .middle } **Prefect (MCP)**](prefect-mcp.md)
+-   [:material-airplane:{ .lg .middle } **Apache Airflow**](airflow.md)
+-   [:material-water:{ .lg .middle } **Apache Flink**](flink.md)
 
 </div>
 

--- a/docs/data-sources/builtin-toolsets/trino.md
+++ b/docs/data-sources/builtin-toolsets/trino.md
@@ -1,0 +1,46 @@
+# Trino
+
+Connect HolmesGPT to a Trino coordinator for bounded, read-only SQL diagnostics.
+
+## Prerequisites
+
+- A reachable Trino coordinator
+- A Trino user with access to the catalogs and schemas Holmes should inspect
+
+## Configuration
+
+```yaml-toolset-config
+toolsets:
+  trino:
+    enabled: true
+    config:
+      api_url: https://trino.example.com
+      trino_user: holmes
+      catalog: system
+      schema: runtime
+      max_rows: 200
+      bearer_token: "{{ env.TRINO_TOKEN }}"
+```
+
+Use `username` and `password` instead of `bearer_token` when the endpoint uses
+HTTP basic authentication. `extra_headers` can supply proxy or gateway headers.
+
+## Multiple Instances
+
+```multi-instance
+toolset: trino
+name: Trino
+config: |
+  api_url: https://trino.example.com
+  trino_user: holmes
+```
+
+## Common Use Cases
+
+```text
+Show failed Trino queries from the last hour and summarize their error types
+```
+
+```text
+Explain the query plan for this SELECT without running it
+```

--- a/docs/installation/.nav.yml
+++ b/docs/installation/.nav.yml
@@ -3,6 +3,7 @@ nav:
     - Web UI (3rd party): ui-installation.md
     - Slack Bot (3rd party): slack-installation.md
     - Teams Bot (3rd party): teams-installation.md
+    - Telegram Bot: telegram-installation.md
     - Backstage (3rd party): backstage-integration.md
     - K9s: k9s-installation.md
     - HTTP Server (Docker): docker-compose-installation.md

--- a/docs/installation/telegram-installation.md
+++ b/docs/installation/telegram-installation.md
@@ -1,0 +1,25 @@
+# Telegram Bot
+
+The `holmes-telegram` process connects a Telegram bot to a running HolmesGPT
+HTTP server. It keeps per-chat conversation context in memory and forwards
+questions to `/api/chat`.
+
+## Setup
+
+1. Create a bot with [BotFather](https://t.me/BotFather) and copy its token.
+2. Start the HolmesGPT HTTP server.
+3. Run the Telegram adapter:
+
+```bash
+export TELEGRAM_BOT_TOKEN="<bot token>"
+export HOLMES_API_URL="http://localhost:8080"
+export TELEGRAM_ALLOWED_CHAT_IDS="123456789,-1001234567890"
+holmes-telegram
+```
+
+`TELEGRAM_ALLOWED_CHAT_IDS` is optional. When it is set, messages from other
+private chats and groups are rejected. Use `/reset` in Telegram to clear the
+in-memory conversation context for that chat.
+
+The adapter uses Telegram long polling, so it does not require a public webhook
+endpoint. Run only one polling adapter for a bot token.

--- a/docs/installation/telegram-installation.md
+++ b/docs/installation/telegram-installation.md
@@ -23,3 +23,35 @@ in-memory conversation context for that chat.
 
 The adapter uses Telegram long polling, so it does not require a public webhook
 endpoint. Run only one polling adapter for a bot token.
+
+## Kubernetes with Helm
+
+Configure Telegram in Helm values in the same way as other messaging
+integrations: keep the bot token in a Kubernetes Secret and reference it from
+the chart.
+
+```bash
+kubectl create secret generic holmes-telegram \
+  --from-literal=bot-token="<bot token>" \
+  --namespace holmes
+```
+
+```yaml
+telegram:
+  enabled: true
+  existingSecret:
+    name: holmes-telegram
+    key: bot-token
+  allowedChatIds:
+    - 123456789
+    - -1001234567890
+```
+
+The chart runs one Telegram polling replica independently of the Holmes API
+replica count. By default it connects to the in-cluster Holmes Service created
+by the same Helm release. Use `telegram.holmesApiUrl` only when the bot should
+connect to a different Holmes server.
+
+Optional settings include `pollTimeoutSeconds`, `requestTimeoutSeconds`,
+`historyMessages`, `additionalEnvVars`, `resources`, `nodeSelector`,
+`tolerations`, `affinity`, and `podAnnotations`.

--- a/docs/why-holmesgpt.md
+++ b/docs/why-holmesgpt.md
@@ -60,9 +60,9 @@ HolmesGPT ships with read-only integrations for every major observability vendor
 - **Traces**: Tempo, Datadog, NewRelic
 - **Dashboards**: Grafana
 - **Infrastructure**: Kubernetes, Docker, Helm, ArgoCD, Crossplane, OpenShift, Cilium, KubeVela
-- **CI/CD**: Jenkins
+- **CI/CD & orchestration**: Jenkins, Apache Airflow, Apache Flink
 - **Cloud**: AWS RDS, Azure SQL, Azure AKS, GCP
-- **Databases**: PostgreSQL, MySQL, ClickHouse, MariaDB, SQL Server, MongoDB Atlas
+- **Databases**: PostgreSQL, MySQL, ClickHouse, MariaDB, SQL Server, MongoDB Atlas, Trino
 - **ITSM**: ServiceNow
 - **Messaging**: Kafka, RabbitMQ
 - **Knowledge**: Confluence, Notion, Slab, Internet/web search

--- a/helm/holmes/templates/telegram-deployment.yaml
+++ b/helm/holmes/templates/telegram-deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.telegram.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-telegram
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: holmes-telegram
+    app.kubernetes.io/name: holmes-telegram
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "holmes.commonLabels" . | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: holmes-telegram
+      app.kubernetes.io/name: holmes-telegram
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: holmes-telegram
+        app.kubernetes.io/name: holmes-telegram
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "holmes.commonLabels" . | nindent 8 }}
+      annotations:
+        checksum/telegram-config: {{ .Values.telegram | toYaml | sha256sum }}
+        {{- with (include "holmes.commonAnnotations" .) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.telegram.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: telegram
+        image: "{{ .Values.registry }}/{{ .Values.image }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+          - python3
+          - -u
+          - -m
+          - holmes.plugins.telegram.bot
+        env:
+        - name: TELEGRAM_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "telegram.existingSecret.name is required when telegram.enabled=true" .Values.telegram.existingSecret.name }}
+              key: {{ .Values.telegram.existingSecret.key | default "bot-token" }}
+        - name: HOLMES_API_URL
+          value: {{ .Values.telegram.holmesApiUrl | default (printf "http://%s-holmes:80" .Release.Name) | quote }}
+        - name: TELEGRAM_ALLOWED_CHAT_IDS
+          value: {{ join "," .Values.telegram.allowedChatIds | quote }}
+        - name: TELEGRAM_POLL_TIMEOUT_SECONDS
+          value: {{ .Values.telegram.pollTimeoutSeconds | quote }}
+        - name: TELEGRAM_REQUEST_TIMEOUT_SECONDS
+          value: {{ .Values.telegram.requestTimeoutSeconds | quote }}
+        - name: TELEGRAM_HISTORY_MESSAGES
+          value: {{ .Values.telegram.historyMessages | quote }}
+        - name: LOG_LEVEL
+          value: {{ .Values.logLevel | quote }}
+        - name: ENABLE_JSON_LOGS_FORMAT
+          value: {{ .Values.global.enableJsonLogsFormat | default .Values.enableJsonLogsFormat | default false | quote }}
+        {{- with .Values.telegram.additionalEnvVars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.telegram.resources | nindent 10 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+      {{- with .Values.telegram.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.telegram.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.telegram.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -175,6 +175,34 @@ resources:
   limits:
     memory: 2048Mi
 
+# Optional Telegram chat adapter. It is deployed as a dedicated single-replica
+# workload so Holmes API autoscaling never starts competing Telegram pollers.
+telegram:
+  enabled: false
+  # Existing Secret containing the Telegram Bot API token.
+  existingSecret:
+    name: ""
+    key: bot-token
+  # Empty means every Telegram chat may use the bot. Prefer an explicit
+  # allowlist for production; group chat IDs are usually negative.
+  allowedChatIds: []
+  # Defaults to the Holmes Service created by this release.
+  holmesApiUrl: ""
+  pollTimeoutSeconds: 30
+  requestTimeoutSeconds: 120
+  historyMessages: 30
+  additionalEnvVars: []
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
 additionalVolumes: []
 additionalVolumeMounts: []
 
@@ -968,9 +996,3 @@ operator:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
-
-
-
-
-       

--- a/holmes/plugins/telegram/__init__.py
+++ b/holmes/plugins/telegram/__init__.py
@@ -1,0 +1,3 @@
+from holmes.plugins.telegram.bot import HolmesTelegramBot, TelegramBotConfig
+
+__all__ = ["HolmesTelegramBot", "TelegramBotConfig"]

--- a/holmes/plugins/telegram/bot.py
+++ b/holmes/plugins/telegram/bot.py
@@ -206,5 +206,16 @@ def run() -> None:
         bot_token=token,
         holmes_api_url=os.environ.get("HOLMES_API_URL", "http://localhost:8080"),
         allowed_chat_ids=allowed,
+        poll_timeout_seconds=int(
+            os.environ.get("TELEGRAM_POLL_TIMEOUT_SECONDS", "30")
+        ),
+        request_timeout_seconds=int(
+            os.environ.get("TELEGRAM_REQUEST_TIMEOUT_SECONDS", "120")
+        ),
+        history_messages=int(os.environ.get("TELEGRAM_HISTORY_MESSAGES", "30")),
     )
     HolmesTelegramBot(config).run()
+
+
+if __name__ == "__main__":
+    run()

--- a/holmes/plugins/telegram/bot.py
+++ b/holmes/plugins/telegram/bot.py
@@ -1,0 +1,210 @@
+import logging
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+from pydantic import BaseModel, Field
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_never,
+    wait_exponential,
+)
+
+TELEGRAM_MESSAGE_LIMIT = 4096
+logger = logging.getLogger(__name__)
+
+
+class TelegramBotConfig(BaseModel):
+    bot_token: str
+    holmes_api_url: str = "http://localhost:8080"
+    allowed_chat_ids: set[int] = Field(default_factory=set)
+    poll_timeout_seconds: int = Field(default=30, ge=1, le=50)
+    request_timeout_seconds: int = Field(default=120, ge=1, le=600)
+    history_messages: int = Field(default=30, ge=2, le=200)
+
+
+class TelegramAPI:
+    def __init__(self, config: TelegramBotConfig):
+        self.config = config
+        self.base_url = f"https://api.telegram.org/bot{config.bot_token}"
+
+    @retry(
+        retry=retry_if_exception_type(requests.exceptions.RequestException),
+        wait=wait_exponential(multiplier=1, min=1, max=30),
+        stop=stop_never,
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    def get_updates(self, offset: Optional[int]) -> List[Dict[str, Any]]:
+        response = requests.get(
+            f"{self.base_url}/getUpdates",
+            params={
+                "offset": offset,
+                "timeout": self.config.poll_timeout_seconds,
+                "allowed_updates": '["message"]',
+            },
+            timeout=self.config.poll_timeout_seconds + 10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not payload.get("ok"):
+            raise RuntimeError(f"Telegram getUpdates failed: {payload}")
+        return payload.get("result", [])
+
+    def send_message(self, chat_id: int, text: str) -> None:
+        for chunk in split_telegram_message(text):
+            response = requests.post(
+                f"{self.base_url}/sendMessage",
+                json={
+                    "chat_id": chat_id,
+                    "text": chunk,
+                    "disable_web_page_preview": True,
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not payload.get("ok"):
+                raise RuntimeError(f"Telegram sendMessage failed: {payload}")
+
+
+class HolmesAPI:
+    def __init__(self, config: TelegramBotConfig):
+        self.config = config
+
+    def ask(
+        self,
+        prompt: str,
+        *,
+        chat_id: int,
+        history: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        response = requests.post(
+            f"{self.config.holmes_api_url.rstrip('/')}/api/chat",
+            json={
+                "ask": prompt,
+                "conversation_history": history,
+                "stream": False,
+                "user_id": f"telegram:{chat_id}",
+                "conversation_id": f"telegram:{chat_id}",
+                "request_type": "telegram_chat",
+                "request_source": "telegram",
+            },
+            timeout=self.config.request_timeout_seconds,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload.get("analysis"), str):
+            raise RuntimeError(f"Holmes returned an invalid chat response: {payload}")
+        return payload
+
+
+class HolmesTelegramBot:
+    def __init__(
+        self,
+        config: TelegramBotConfig,
+        telegram: Optional[TelegramAPI] = None,
+        holmes: Optional[HolmesAPI] = None,
+    ):
+        self.config = config
+        self.telegram = telegram or TelegramAPI(config)
+        self.holmes = holmes or HolmesAPI(config)
+        self._histories: Dict[int, List[Dict[str, Any]]] = {}
+
+    def handle_update(self, update: Dict[str, Any]) -> None:
+        message = update.get("message") or {}
+        chat_id = (message.get("chat") or {}).get("id")
+        text = message.get("text")
+        if not isinstance(chat_id, int) or not isinstance(text, str):
+            return
+        if self.config.allowed_chat_ids and chat_id not in self.config.allowed_chat_ids:
+            self.telegram.send_message(
+                chat_id, "This chat is not allowed to use HolmesGPT."
+            )
+            return
+
+        prompt = text.strip()
+        if prompt in {"/start", "/help"}:
+            self.telegram.send_message(
+                chat_id,
+                "Send an infrastructure question. "
+                "Use /reset to clear this chat's context.",
+            )
+            return
+        if prompt == "/reset":
+            self._histories.pop(chat_id, None)
+            self.telegram.send_message(chat_id, "Conversation context cleared.")
+            return
+        if not prompt:
+            return
+
+        try:
+            response = self.holmes.ask(
+                prompt,
+                chat_id=chat_id,
+                history=self._histories.get(chat_id),
+            )
+            history = response.get("conversation_history")
+            if isinstance(history, list):
+                self._histories[chat_id] = trim_conversation_history(
+                    history, self.config.history_messages
+                )
+            self.telegram.send_message(chat_id, response["analysis"])
+        except requests.exceptions.RequestException as error:
+            logging.exception("Telegram request failed")
+            self.telegram.send_message(chat_id, f"HolmesGPT request failed: {error}")
+        except Exception as error:
+            logging.exception("Telegram update failed")
+            self.telegram.send_message(chat_id, f"HolmesGPT could not answer: {error}")
+
+    def run(self) -> None:
+        offset: Optional[int] = None
+        logging.info("HolmesGPT Telegram bot started")
+        while True:
+            updates = self.telegram.get_updates(offset)
+            for update in updates:
+                update_id = update.get("update_id")
+                if isinstance(update_id, int):
+                    offset = update_id + 1
+                self.handle_update(update)
+
+
+def split_telegram_message(text: str) -> Iterable[str]:
+    remaining = text or "(empty response)"
+    while len(remaining) > TELEGRAM_MESSAGE_LIMIT:
+        split_at = remaining.rfind("\n", 0, TELEGRAM_MESSAGE_LIMIT + 1)
+        if split_at <= 0:
+            split_at = TELEGRAM_MESSAGE_LIMIT
+        yield remaining[:split_at]
+        remaining = remaining[split_at:].lstrip("\n")
+    yield remaining
+
+
+def trim_conversation_history(
+    history: List[Dict[str, Any]], max_messages: int
+) -> List[Dict[str, Any]]:
+    if len(history) <= max_messages:
+        return history
+    first = history[0]
+    if first.get("role") == "system":
+        return [first, *history[-(max_messages - 1) :]]
+    return history[-max_messages:]
+
+
+def run() -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN is required")
+    allowed = {
+        int(value.strip())
+        for value in os.environ.get("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")
+        if value.strip()
+    }
+    config = TelegramBotConfig(
+        bot_token=token,
+        holmes_api_url=os.environ.get("HOLMES_API_URL", "http://localhost:8080"),
+        allowed_chat_ids=allowed,
+    )
+    HolmesTelegramBot(config).run()

--- a/holmes/plugins/toolsets/__init__.py
+++ b/holmes/plugins/toolsets/__init__.py
@@ -20,6 +20,7 @@ from holmes.core.tools import (
     YAMLToolset,
 )
 from holmes.plugins.toolsets.atlas_mongodb.mongodb_atlas import MongoDBAtlasToolset
+from holmes.plugins.toolsets.airflow.airflow import AirflowToolset
 from holmes.plugins.toolsets.azure_sql.azure_sql_toolset import AzureSQLToolset
 from holmes.plugins.toolsets.bash.bash_toolset import BashExecutorToolset
 from holmes.plugins.toolsets.confluence.confluence import ConfluenceToolset
@@ -41,6 +42,7 @@ from holmes.plugins.toolsets.elasticsearch.elasticsearch import (
     ElasticsearchClusterToolset,
     ElasticsearchDataToolset,
 )
+from holmes.plugins.toolsets.flink.flink import FlinkToolset
 from holmes.plugins.toolsets.elasticsearch.opensearch_query_assist import (
     OpenSearchQueryAssistToolset,
 )
@@ -68,6 +70,7 @@ from holmes.plugins.toolsets.skills.skills_fetcher import SkillsToolset
 from holmes.plugins.toolsets.servicenow_tables.servicenow_tables import (
     ServiceNowTablesToolset,
 )
+from holmes.plugins.toolsets.trino.trino import TrinoToolset
 from holmes.plugins.toolsets.victorialogs.victorialogs import VictoriaLogsToolset
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -127,6 +130,9 @@ def load_python_toolsets(
         SkillsToolset(dal=dal, additional_search_paths=additional_search_paths),
         multi_instance(AzureSQLToolset),
         multi_instance(ServiceNowTablesToolset),
+        multi_instance(AirflowToolset),
+        multi_instance(FlinkToolset),
+        multi_instance(TrinoToolset),
         multi_instance(VictoriaLogsToolset),
         DatabaseToolset(),
         multi_instance(ElasticsearchDataToolset),

--- a/holmes/plugins/toolsets/airflow/__init__.py
+++ b/holmes/plugins/toolsets/airflow/__init__.py
@@ -1,0 +1,3 @@
+from holmes.plugins.toolsets.airflow.airflow import AirflowToolset
+
+__all__ = ["AirflowToolset"]

--- a/holmes/plugins/toolsets/airflow/airflow.py
+++ b/holmes/plugins/toolsets/airflow/airflow.py
@@ -1,0 +1,256 @@
+import os
+from typing import Any, ClassVar, Dict, List, Tuple, Type, cast
+from urllib.parse import quote
+
+from pydantic import Field
+
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    ToolInvokeContext,
+    ToolParameter,
+)
+from holmes.plugins.toolsets.http_api_base import (
+    HTTPAPITool,
+    HTTPAPIToolset,
+    HTTPAPIToolsetConfig,
+)
+from holmes.plugins.toolsets.utils import toolset_name_for_one_liner
+
+
+class AirflowConfig(HTTPAPIToolsetConfig):
+    api_version: str = Field(
+        default="v2",
+        pattern=r"^v[12]$",
+        description="Airflow REST API version (v2 for Airflow 3, v1 for Airflow 2)",
+    )
+    max_items: int = Field(default=100, ge=1, le=1000)
+    max_log_characters: int = Field(default=20000, ge=1000, le=200000)
+
+
+class AirflowToolset(HTTPAPIToolset):
+    config_classes: ClassVar[List[Type[AirflowConfig]]] = [AirflowConfig]
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="airflow",
+            description=(
+                "Inspect Apache Airflow DAG runs, task instances, and task logs"
+            ),
+            docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/airflow/",
+            icon_url="https://airflow.apache.org/favicons/favicon-32x32.png",
+            prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
+            tools=[],
+        )
+        self.tools = [
+            AirflowListDags(self),
+            AirflowListDagRuns(self),
+            AirflowListTaskInstances(self),
+            AirflowGetTaskLog(self),
+        ]
+        self._load_llm_instructions_from_file(
+            os.path.dirname(__file__), "instructions.jinja2"
+        )
+
+    @property
+    def airflow_config(self) -> AirflowConfig:
+        return cast(AirflowConfig, self.config)
+
+    @property
+    def api_prefix(self) -> str:
+        return f"/api/{self.airflow_config.api_version}"
+
+    def prerequisites_callable(self, config: Dict[str, Any]) -> Tuple[bool, str]:
+        try:
+            self.config = AirflowConfig(**config)
+        except Exception as error:
+            return False, f"Failed to validate airflow configuration: {error}"
+        return self._health_check(
+            AirflowConfig, config, f"/api/{self.airflow_config.api_version}/version"
+        )
+
+
+class _AirflowTool(HTTPAPITool):
+    def _bounded(
+        self, result: StructuredToolResult, collection_key: str
+    ) -> StructuredToolResult:
+        if result.status != StructuredToolResultStatus.SUCCESS or not isinstance(
+            result.data, dict
+        ):
+            return result
+        values = result.data.get(collection_key)
+        if isinstance(values, list):
+            max_items = cast(AirflowToolset, self._toolset).airflow_config.max_items
+            result.data[collection_key] = values[:max_items]
+            result.data["holmes_truncated"] = len(values) > max_items
+        return result
+
+    def get_parameterized_one_liner(self, params: Dict) -> str:
+        return f"{toolset_name_for_one_liner(self._toolset.name)}: {self.name}"
+
+
+class AirflowListDags(_AirflowTool):
+    def __init__(self, toolset: AirflowToolset):
+        super().__init__(
+            toolset,
+            name="airflow_list_dags",
+            description=(
+                "List Airflow DAGs with bounded pagination and optional tag filtering."
+            ),
+            parameters={
+                "limit": ToolParameter(type="integer", required=False),
+                "offset": ToolParameter(type="integer", required=False),
+                "tags": ToolParameter(
+                    type="array",
+                    items=ToolParameter(type="string"),
+                    required=False,
+                    description="Optional DAG tags",
+                ),
+            },
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        max_items = cast(AirflowToolset, self._toolset).airflow_config.max_items
+        query = {
+            "limit": max(1, min(int(params.get("limit", max_items)), max_items)),
+            "offset": max(int(params.get("offset", 0)), 0),
+        }
+        if params.get("tags"):
+            query["tags"] = params["tags"]
+        endpoint = f"{cast(AirflowToolset, self._toolset).api_prefix}/dags"
+        return self._bounded(
+            self._get_json(endpoint, params, context, query_params=query), "dags"
+        )
+
+
+def _dag_parameter() -> Dict[str, ToolParameter]:
+    return {
+        "dag_id": ToolParameter(
+            type="string", required=True, description="Airflow DAG ID"
+        ),
+        "limit": ToolParameter(type="integer", required=False),
+        "offset": ToolParameter(type="integer", required=False),
+    }
+
+
+class AirflowListDagRuns(_AirflowTool):
+    def __init__(self, toolset: AirflowToolset):
+        super().__init__(
+            toolset,
+            name="airflow_list_dag_runs",
+            description="List recent runs for one Airflow DAG.",
+            parameters=_dag_parameter(),
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        dag_id = quote(str(params.get("dag_id", "")), safe="")
+        if not dag_id:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error="Missing required parameter 'dag_id'",
+                params=params,
+            )
+        max_items = cast(AirflowToolset, self._toolset).airflow_config.max_items
+        query = {
+            "limit": max(1, min(int(params.get("limit", max_items)), max_items)),
+            "offset": max(int(params.get("offset", 0)), 0),
+            "order_by": "-logical_date",
+        }
+        endpoint = (
+            f"{cast(AirflowToolset, self._toolset).api_prefix}/dags/{dag_id}/dagRuns"
+        )
+        return self._bounded(
+            self._get_json(endpoint, params, context, query_params=query), "dag_runs"
+        )
+
+
+class AirflowListTaskInstances(_AirflowTool):
+    def __init__(self, toolset: AirflowToolset):
+        parameters = _dag_parameter()
+        parameters["dag_run_id"] = ToolParameter(
+            type="string", required=True, description="Airflow DAG run ID"
+        )
+        super().__init__(
+            toolset,
+            name="airflow_list_task_instances",
+            description="List task instances and states for one Airflow DAG run.",
+            parameters=parameters,
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        dag_id = quote(str(params.get("dag_id", "")), safe="")
+        run_id = quote(str(params.get("dag_run_id", "")), safe="")
+        if not dag_id or not run_id:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error="Both 'dag_id' and 'dag_run_id' are required",
+                params=params,
+            )
+        max_items = cast(AirflowToolset, self._toolset).airflow_config.max_items
+        query = {
+            "limit": max(1, min(int(params.get("limit", max_items)), max_items)),
+            "offset": max(int(params.get("offset", 0)), 0),
+        }
+        endpoint = (
+            f"{cast(AirflowToolset, self._toolset).api_prefix}/dags/{dag_id}"
+            f"/dagRuns/{run_id}/taskInstances"
+        )
+        return self._bounded(
+            self._get_json(endpoint, params, context, query_params=query),
+            "task_instances",
+        )
+
+
+class AirflowGetTaskLog(_AirflowTool):
+    def __init__(self, toolset: AirflowToolset):
+        super().__init__(
+            toolset,
+            name="airflow_get_task_log",
+            description="Fetch a bounded log for one Airflow task attempt.",
+            parameters={
+                "dag_id": ToolParameter(type="string", required=True),
+                "dag_run_id": ToolParameter(type="string", required=True),
+                "task_id": ToolParameter(type="string", required=True),
+                "try_number": ToolParameter(type="integer", required=True),
+                "map_index": ToolParameter(type="integer", required=False),
+            },
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        required = ("dag_id", "dag_run_id", "task_id", "try_number")
+        if any(params.get(key) is None or params.get(key) == "" for key in required):
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=f"Required parameters: {', '.join(required)}",
+                params=params,
+            )
+        dag_id = quote(str(params["dag_id"]), safe="")
+        run_id = quote(str(params["dag_run_id"]), safe="")
+        task_id = quote(str(params["task_id"]), safe="")
+        endpoint = (
+            f"{cast(AirflowToolset, self._toolset).api_prefix}/dags/{dag_id}"
+            f"/dagRuns/{run_id}/taskInstances/{task_id}/logs/"
+            f"{int(params['try_number'])}"
+        )
+        result = self._get_json(
+            endpoint,
+            params,
+            context,
+            query_params={
+                "full_content": "false",
+                "map_index": int(params.get("map_index", -1)),
+            },
+        )
+        if result.status == StructuredToolResultStatus.SUCCESS:
+            max_chars = cast(
+                AirflowToolset, self._toolset
+            ).airflow_config.max_log_characters
+            text = result.get_stringified_data()
+            if len(text) > max_chars:
+                result.data = {
+                    "content": text[:max_chars],
+                    "holmes_truncated": True,
+                    "original_characters": len(text),
+                }
+        return result

--- a/holmes/plugins/toolsets/airflow/instructions.jinja2
+++ b/holmes/plugins/toolsets/airflow/instructions.jinja2
@@ -1,0 +1,3 @@
+Use Airflow to inspect DAG and task execution state. Start with DAG runs, then
+inspect task instances for the exact failed run. Fetch a task log only after
+identifying the failed task and try number.

--- a/holmes/plugins/toolsets/flink/__init__.py
+++ b/holmes/plugins/toolsets/flink/__init__.py
@@ -1,0 +1,3 @@
+from holmes.plugins.toolsets.flink.flink import FlinkToolset
+
+__all__ = ["FlinkToolset"]

--- a/holmes/plugins/toolsets/flink/flink.py
+++ b/holmes/plugins/toolsets/flink/flink.py
@@ -1,0 +1,178 @@
+import os
+from typing import Any, ClassVar, Dict, List, Tuple, Type, cast
+
+from pydantic import Field
+
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    ToolInvokeContext,
+    ToolParameter,
+)
+from holmes.plugins.toolsets.http_api_base import (
+    HTTPAPITool,
+    HTTPAPIToolset,
+    HTTPAPIToolsetConfig,
+)
+from holmes.plugins.toolsets.utils import toolset_name_for_one_liner
+
+
+class FlinkConfig(HTTPAPIToolsetConfig):
+    max_items: int = Field(default=100, ge=1, le=1000)
+
+
+class FlinkToolset(HTTPAPIToolset):
+    config_classes: ClassVar[List[Type[FlinkConfig]]] = [FlinkConfig]
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="flink",
+            description="Inspect Apache Flink jobs, failures, and checkpoints",
+            docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/flink/",
+            icon_url="https://flink.apache.org/img/logo/png/500/flink_squirrel_500.png",
+            prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
+            tools=[],
+        )
+        self.tools = [
+            FlinkListJobs(self),
+            FlinkGetJob(self),
+            FlinkGetExceptions(self),
+            FlinkGetCheckpoints(self),
+        ]
+        self._load_llm_instructions_from_file(
+            os.path.dirname(__file__), "instructions.jinja2"
+        )
+
+    @property
+    def flink_config(self) -> FlinkConfig:
+        return cast(FlinkConfig, self.config)
+
+    def prerequisites_callable(self, config: Dict[str, Any]) -> Tuple[bool, str]:
+        return self._health_check(FlinkConfig, config, "/overview")
+
+
+class _FlinkTool(HTTPAPITool):
+    def _bounded(
+        self, result: StructuredToolResult, collection_key: str
+    ) -> StructuredToolResult:
+        if result.status != StructuredToolResultStatus.SUCCESS or not isinstance(
+            result.data, dict
+        ):
+            return result
+        values = result.data.get(collection_key)
+        if isinstance(values, list):
+            max_items = cast(FlinkToolset, self._toolset).flink_config.max_items
+            result.data[collection_key] = values[:max_items]
+            result.data["holmes_truncated"] = len(values) > max_items
+        return result
+
+
+class FlinkListJobs(_FlinkTool):
+    def __init__(self, toolset: FlinkToolset):
+        super().__init__(
+            toolset,
+            name="flink_list_jobs",
+            description=(
+                "List running and recently completed Flink jobs with their states."
+            ),
+            parameters={},
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return self._bounded(self._get_json("/jobs/overview", params, context), "jobs")
+
+    def get_parameterized_one_liner(self, params: Dict) -> str:
+        return f"{toolset_name_for_one_liner(self._toolset.name)}: jobs"
+
+
+class _FlinkJobTool(_FlinkTool):
+    endpoint_suffix: ClassVar[str] = ""
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        job_id = str(params.get("job_id", "")).strip()
+        if not job_id:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error="Missing required parameter 'job_id'",
+                params=params,
+            )
+        return self._get_json(f"/jobs/{job_id}{self.endpoint_suffix}", params, context)
+
+    def get_parameterized_one_liner(self, params: Dict) -> str:
+        return (
+            f"{toolset_name_for_one_liner(self._toolset.name)}: "
+            f"{self.name} {params.get('job_id', '')}"
+        )
+
+
+def _job_id_parameter() -> Dict[str, ToolParameter]:
+    return {
+        "job_id": ToolParameter(
+            type="string", required=True, description="32-character Flink job ID"
+        )
+    }
+
+
+class FlinkGetJob(_FlinkJobTool):
+    def __init__(self, toolset: FlinkToolset):
+        super().__init__(
+            toolset,
+            name="flink_get_job",
+            description="Get execution details and vertices for a Flink job.",
+            parameters=_job_id_parameter(),
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return self._bounded(super()._invoke(params, context), "vertices")
+
+
+class FlinkGetExceptions(_FlinkJobTool):
+    endpoint_suffix: ClassVar[str] = "/exceptions"
+
+    def __init__(self, toolset: FlinkToolset):
+        super().__init__(
+            toolset,
+            name="flink_get_job_exceptions",
+            description="Get the most recent handled exceptions for a Flink job.",
+            parameters=_job_id_parameter(),
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        result = super()._invoke(params, context)
+        if result.status == StructuredToolResultStatus.SUCCESS and isinstance(
+            result.data, dict
+        ):
+            history = result.data.get("exceptionHistory")
+            if isinstance(history, dict) and isinstance(history.get("entries"), list):
+                max_items = cast(FlinkToolset, self._toolset).flink_config.max_items
+                entries = history["entries"]
+                history["entries"] = entries[:max_items]
+                history["holmes_truncated"] = len(entries) > max_items
+        return result
+
+
+class FlinkGetCheckpoints(_FlinkJobTool):
+    endpoint_suffix: ClassVar[str] = "/checkpoints"
+
+    def __init__(self, toolset: FlinkToolset):
+        super().__init__(
+            toolset,
+            name="flink_get_job_checkpoints",
+            description=(
+                "Get checkpoint counts, latest checkpoints, and checkpoint history."
+            ),
+            parameters=_job_id_parameter(),
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        result = super()._invoke(params, context)
+        if result.status == StructuredToolResultStatus.SUCCESS and isinstance(
+            result.data, dict
+        ):
+            history = result.data.get("history")
+            if isinstance(history, list):
+                max_items = cast(FlinkToolset, self._toolset).flink_config.max_items
+                result.data["history"] = history[:max_items]
+                result.data["holmes_truncated"] = len(history) > max_items
+        return result

--- a/holmes/plugins/toolsets/flink/instructions.jinja2
+++ b/holmes/plugins/toolsets/flink/instructions.jinja2
@@ -1,0 +1,2 @@
+Start with flink_list_jobs. For an unhealthy job, inspect its details, recent
+exceptions, and checkpoint statistics. Use the exact job ID returned by Flink.

--- a/holmes/plugins/toolsets/http_api_base.py
+++ b/holmes/plugins/toolsets/http_api_base.py
@@ -1,0 +1,170 @@
+import json
+from abc import ABC
+from typing import Any, Dict, Optional, Tuple, cast
+from urllib.parse import urljoin
+
+import requests
+from pydantic import Field, model_validator
+from requests.auth import HTTPBasicAuth
+
+from holmes.core.tools import (
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    Tool,
+    ToolInvokeContext,
+    Toolset,
+)
+from holmes.utils.header_rendering import render_header_templates
+from holmes.utils.pydantic_utils import ToolsetConfig
+
+
+class HTTPAPIToolsetConfig(ToolsetConfig):
+    api_url: str = Field(description="Base URL of the service API")
+    bearer_token: Optional[str] = Field(
+        default=None, description="Bearer token used for API authentication"
+    )
+    username: Optional[str] = Field(
+        default=None, description="Username used for HTTP basic authentication"
+    )
+    password: Optional[str] = Field(
+        default=None, description="Password used for HTTP basic authentication"
+    )
+    verify_ssl: bool = Field(default=True, description="Verify TLS certificates")
+    timeout_seconds: int = Field(
+        default=30, ge=1, le=300, description="HTTP request timeout in seconds"
+    )
+    extra_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Additional HTTP headers; values support Holmes header templates",
+    )
+
+    @model_validator(mode="after")
+    def validate_auth(self) -> "HTTPAPIToolsetConfig":
+        if self.bearer_token and (self.username or self.password):
+            raise ValueError(
+                "authentication must use either bearer token or basic auth, not both"
+            )
+        if self.username and not self.password:
+            raise ValueError("password is required when username is set")
+        if self.password and not self.username:
+            raise ValueError("username is required when password is set")
+        return self
+
+
+class HTTPAPIToolset(Toolset):
+    @property
+    def http_config(self) -> HTTPAPIToolsetConfig:
+        return cast(HTTPAPIToolsetConfig, self.config)
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[str] = None,
+        request_context: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> requests.Response:
+        url = urljoin(self.http_config.api_url.rstrip("/") + "/", endpoint.lstrip("/"))
+        request_headers = {"Accept": "application/json"}
+        if self.http_config.bearer_token:
+            request_headers["Authorization"] = f"Bearer {self.http_config.bearer_token}"
+        if self.http_config.extra_headers:
+            rendered_headers = render_header_templates(
+                extra_headers=self.http_config.extra_headers,
+                request_context=request_context,
+                source_name=self.name,
+            )
+            if rendered_headers:
+                request_headers.update(rendered_headers)
+        if headers:
+            request_headers.update(headers)
+
+        auth = None
+        if self.http_config.username and self.http_config.password:
+            auth = HTTPBasicAuth(
+                username=self.http_config.username,
+                password=self.http_config.password,
+            )
+
+        response = requests.request(
+            method,
+            url,
+            params=params,
+            data=data,
+            headers=request_headers,
+            auth=auth,
+            timeout=self.http_config.timeout_seconds,
+            verify=self.http_config.verify_ssl,
+        )
+        response.raise_for_status()
+        return response
+
+    def _health_check(
+        self,
+        config_class: type[HTTPAPIToolsetConfig],
+        config: Dict[str, Any],
+        endpoint: str,
+    ) -> Tuple[bool, str]:
+        try:
+            self.config = config_class(**config)
+            self._request("GET", endpoint)
+            return True, f"{self.name} API is accessible at {self.http_config.api_url}"
+        except Exception as error:
+            return False, f"Failed to connect to {self.name}: {error}"
+
+
+class HTTPAPITool(Tool, ABC):
+    def __init__(self, toolset: HTTPAPIToolset, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._toolset = toolset
+
+    def _get_json(
+        self,
+        endpoint: str,
+        params: Dict[str, Any],
+        context: ToolInvokeContext,
+        *,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> StructuredToolResult:
+        try:
+            response = self._toolset._request(
+                "GET",
+                endpoint,
+                params=query_params,
+                request_context=context.request_context,
+            )
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.SUCCESS,
+                data=response.json(),
+                params=params,
+                url=response.url,
+            )
+        except requests.exceptions.HTTPError as error:
+            status = (
+                error.response.status_code
+                if error.response is not None
+                else "unknown"
+            )
+            body = error.response.text if error.response is not None else ""
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    f"{self._toolset.name} request to {endpoint} failed "
+                    f"with HTTP {status}. "
+                    f"Query parameters: {json.dumps(query_params or {}, default=str)}. "
+                    f"Response body: {body}"
+                ),
+                params=params,
+            )
+        except requests.exceptions.RequestException as error:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    f"Failed to reach {self._toolset.name} endpoint "
+                    f"{endpoint}: {error}. "
+                    f"Query parameters: {json.dumps(query_params or {}, default=str)}"
+                ),
+                params=params,
+            )

--- a/holmes/plugins/toolsets/trino/__init__.py
+++ b/holmes/plugins/toolsets/trino/__init__.py
@@ -1,0 +1,3 @@
+from holmes.plugins.toolsets.trino.trino import TrinoToolset
+
+__all__ = ["TrinoToolset"]

--- a/holmes/plugins/toolsets/trino/instructions.jinja2
+++ b/holmes/plugins/toolsets/trino/instructions.jinja2
@@ -1,0 +1,3 @@
+Use Trino for read-only discovery and diagnosis. Prefer SHOW, DESCRIBE, EXPLAIN,
+and tightly filtered SELECT queries. Always include restrictive predicates and
+small LIMIT clauses when querying application data.

--- a/holmes/plugins/toolsets/trino/trino.py
+++ b/holmes/plugins/toolsets/trino/trino.py
@@ -1,0 +1,230 @@
+import os
+import re
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, cast
+
+import requests
+from pydantic import Field
+
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    ToolInvokeContext,
+    ToolParameter,
+)
+from holmes.plugins.toolsets.http_api_base import (
+    HTTPAPITool,
+    HTTPAPIToolset,
+    HTTPAPIToolsetConfig,
+)
+from holmes.plugins.toolsets.utils import toolset_name_for_one_liner
+
+
+class TrinoConfig(HTTPAPIToolsetConfig):
+    trino_user: str = Field(
+        default="holmes", description="Trino user sent in X-Trino-User"
+    )
+    catalog: Optional[str] = Field(default=None, description="Default Trino catalog")
+    schema_name: Optional[str] = Field(
+        default=None, alias="schema", description="Default Trino schema"
+    )
+    source: str = Field(default="holmesgpt", description="Trino client source")
+    max_rows: int = Field(default=200, ge=1, le=2000)
+    max_pages: int = Field(default=20, ge=1, le=100)
+
+
+class TrinoToolset(HTTPAPIToolset):
+    config_classes: ClassVar[List[Type[TrinoConfig]]] = [TrinoConfig]
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="trino",
+            description="Inspect Trino and execute bounded read-only SQL queries",
+            docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/trino/",
+            icon_url="https://trino.io/assets/trino-og.png",
+            prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
+            tools=[],
+        )
+        self.tools = [TrinoClusterInfo(self), TrinoQuery(self)]
+        self._load_llm_instructions_from_file(
+            os.path.dirname(__file__), "instructions.jinja2"
+        )
+
+    @property
+    def trino_config(self) -> TrinoConfig:
+        return cast(TrinoConfig, self.config)
+
+    def prerequisites_callable(self, config: Dict[str, Any]) -> Tuple[bool, str]:
+        return self._health_check(TrinoConfig, config, "/v1/info")
+
+    def _trino_headers(self) -> Dict[str, str]:
+        headers = {
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Trino-User": self.trino_config.trino_user,
+            "X-Trino-Source": self.trino_config.source,
+        }
+        if self.trino_config.catalog:
+            headers["X-Trino-Catalog"] = self.trino_config.catalog
+        if self.trino_config.schema_name:
+            headers["X-Trino-Schema"] = self.trino_config.schema_name
+        return headers
+
+
+class TrinoClusterInfo(HTTPAPITool):
+    def __init__(self, toolset: TrinoToolset):
+        super().__init__(
+            toolset,
+            name="trino_cluster_info",
+            description=(
+                "Return Trino coordinator version, environment, uptime, and node state."
+            ),
+            parameters={},
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return self._get_json("/v1/info", params, context)
+
+    def get_parameterized_one_liner(self, params: Dict) -> str:
+        return f"{toolset_name_for_one_liner(self._toolset.name)}: cluster info"
+
+
+class TrinoQuery(HTTPAPITool):
+    _READ_ONLY_PREFIX: ClassVar[re.Pattern[str]] = re.compile(
+        r"^\s*(SELECT|SHOW|DESCRIBE|DESC|EXPLAIN|VALUES|WITH)\b", re.IGNORECASE
+    )
+    _MUTATING_KEYWORD: ClassVar[re.Pattern[str]] = re.compile(
+        r"\b(ALTER|CALL|CREATE|DELETE|DROP|GRANT|INSERT|MERGE|RENAME|REVOKE|"
+        r"SET|TRUNCATE|UPDATE|USE)\b",
+        re.IGNORECASE,
+    )
+
+    def __init__(self, toolset: TrinoToolset):
+        super().__init__(
+            toolset,
+            name="trino_query",
+            description=(
+                "Execute one bounded read-only Trino SQL statement. Only SELECT, SHOW, "
+                "DESCRIBE, EXPLAIN, VALUES, and non-mutating WITH queries are allowed."
+            ),
+            parameters={
+                "query": ToolParameter(
+                    type="string", required=True, description="Read-only Trino SQL"
+                )
+            },
+        )
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        query = str(params.get("query", "")).strip()
+        if not query or not self._READ_ONLY_PREFIX.match(query):
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error="Trino query rejected: only read-only SQL is allowed.",
+                params=params,
+            )
+        without_trailing_semicolon = query[:-1] if query.endswith(";") else query
+        if ";" in without_trailing_semicolon or self._MUTATING_KEYWORD.search(query):
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    "Trino query rejected: multiple or mutating statements "
+                    "are not allowed."
+                ),
+                params=params,
+            )
+
+        rows: List[Any] = []
+        columns: List[Dict[str, Any]] = []
+        pages = 0
+        next_uri: Optional[str] = None
+        last_payload: Dict[str, Any] = {}
+        try:
+            response = self._toolset._request(
+                "POST",
+                "/v1/statement",
+                data=query,
+                request_context=context.request_context,
+                headers=cast(TrinoToolset, self._toolset)._trino_headers(),
+            )
+            while True:
+                pages += 1
+                last_payload = response.json()
+                if last_payload.get("error"):
+                    return StructuredToolResult(
+                        status=StructuredToolResultStatus.ERROR,
+                        error=(
+                            f"Trino query failed. Query: {query}. "
+                            f"Error: {last_payload['error']}"
+                        ),
+                        params=params,
+                        url=last_payload.get("infoUri"),
+                    )
+                if last_payload.get("columns"):
+                    columns = last_payload["columns"]
+                rows.extend(last_payload.get("data") or [])
+                next_uri = last_payload.get("nextUri")
+                if (
+                    not next_uri
+                    or pages >= cast(TrinoToolset, self._toolset).trino_config.max_pages
+                    or len(rows)
+                    >= cast(TrinoToolset, self._toolset).trino_config.max_rows
+                ):
+                    break
+                response = self._toolset._request(
+                    "GET", next_uri, request_context=context.request_context
+                )
+
+            truncated = bool(next_uri)
+            if truncated:
+                try:
+                    self._toolset._request(
+                        "DELETE", next_uri, request_context=context.request_context
+                    )
+                except requests.exceptions.RequestException:
+                    pass
+            max_rows = cast(TrinoToolset, self._toolset).trino_config.max_rows
+            data = {
+                "query_id": last_payload.get("id"),
+                "columns": columns,
+                "rows": rows[:max_rows],
+                "row_count": min(len(rows), max_rows),
+                "truncated": truncated or len(rows) > max_rows,
+                "stats": last_payload.get("stats"),
+            }
+            status = (
+                StructuredToolResultStatus.SUCCESS
+                if rows or columns
+                else StructuredToolResultStatus.NO_DATA
+            )
+            return StructuredToolResult(
+                status=status,
+                data=data,
+                params=params,
+                url=last_payload.get("infoUri"),
+            )
+        except requests.exceptions.HTTPError as error:
+            status = (
+                error.response.status_code
+                if error.response is not None
+                else "unknown"
+            )
+            body = error.response.text if error.response is not None else ""
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    f"Trino query failed with HTTP {status}. Query: {query}. "
+                    f"Response body: {body}"
+                ),
+                params=params,
+            )
+        except requests.exceptions.RequestException as error:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=f"Failed to reach Trino while executing query '{query}': {error}",
+                params=params,
+            )
+
+    def get_parameterized_one_liner(self, params: Dict) -> str:
+        return (
+            f"{toolset_name_for_one_liner(self._toolset.name)}: "
+            f"{params.get('query', '')}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ packages = [{ include = "holmes" }]
 
 [tool.poetry.scripts]
 holmes = "holmes.main:run"
+holmes-telegram = "holmes.plugins.telegram.bot:run"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"

--- a/tests/plugins/test_telegram_bot.py
+++ b/tests/plugins/test_telegram_bot.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock
+
+from holmes.plugins.telegram.bot import (
+    HolmesTelegramBot,
+    TelegramBotConfig,
+    split_telegram_message,
+    trim_conversation_history,
+)
+
+
+def test_forbidden_chat_is_rejected_without_calling_holmes():
+    telegram = MagicMock()
+    holmes = MagicMock()
+    bot = HolmesTelegramBot(
+        TelegramBotConfig(bot_token="token", allowed_chat_ids={42}),
+        telegram=telegram,
+        holmes=holmes,
+    )
+
+    bot.handle_update({"message": {"chat": {"id": 7}, "text": "What failed?"}})
+
+    telegram.send_message.assert_called_once_with(
+        7, "This chat is not allowed to use HolmesGPT."
+    )
+    holmes.ask.assert_not_called()
+
+
+def test_question_is_forwarded_and_conversation_history_is_reused():
+    telegram = MagicMock()
+    holmes = MagicMock()
+    holmes.ask.side_effect = [
+        {
+            "analysis": "The first answer",
+            "conversation_history": [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "The first answer"},
+            ],
+        },
+        {
+            "analysis": "The follow-up answer",
+            "conversation_history": [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "follow-up"},
+                {"role": "assistant", "content": "The follow-up answer"},
+            ],
+        },
+    ]
+    bot = HolmesTelegramBot(
+        TelegramBotConfig(bot_token="token"), telegram=telegram, holmes=holmes
+    )
+
+    bot.handle_update({"message": {"chat": {"id": 42}, "text": "first"}})
+    bot.handle_update({"message": {"chat": {"id": 42}, "text": "follow-up"}})
+
+    assert holmes.ask.call_args_list[0].kwargs["history"] is None
+    assert holmes.ask.call_args_list[1].kwargs["history"] == [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "The first answer"},
+    ]
+    assert telegram.send_message.call_args_list[-1].args == (
+        42,
+        "The follow-up answer",
+    )
+
+
+def test_reset_clears_conversation_history():
+    telegram = MagicMock()
+    holmes = MagicMock(
+        return_value={
+            "analysis": "answer",
+            "conversation_history": [{"role": "system", "content": "system"}],
+        }
+    )
+    holmes.ask.return_value = {
+        "analysis": "answer",
+        "conversation_history": [{"role": "system", "content": "system"}],
+    }
+    bot = HolmesTelegramBot(
+        TelegramBotConfig(bot_token="token"), telegram=telegram, holmes=holmes
+    )
+    bot.handle_update({"message": {"chat": {"id": 42}, "text": "question"}})
+
+    bot.handle_update({"message": {"chat": {"id": 42}, "text": "/reset"}})
+    bot.handle_update({"message": {"chat": {"id": 42}, "text": "new question"}})
+
+    assert holmes.ask.call_args_list[-1].kwargs["history"] is None
+    assert telegram.send_message.call_args_list[-2].args == (
+        42,
+        "Conversation context cleared.",
+    )
+
+
+def test_long_message_is_split_on_newline_within_telegram_limit():
+    text = ("a" * 3000) + "\n" + ("b" * 3000)
+
+    chunks = list(split_telegram_message(text))
+
+    assert chunks == ["a" * 3000, "b" * 3000]
+
+
+def test_trimmed_history_preserves_required_system_message():
+    history = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "new"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+
+    trimmed = trim_conversation_history(history, 3)
+
+    assert trimmed == [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "new"},
+        {"role": "assistant", "content": "new answer"},
+    ]

--- a/tests/plugins/test_telegram_bot.py
+++ b/tests/plugins/test_telegram_bot.py
@@ -1,8 +1,9 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from holmes.plugins.telegram.bot import (
     HolmesTelegramBot,
     TelegramBotConfig,
+    run,
     split_telegram_message,
     trim_conversation_history,
 )
@@ -116,3 +117,26 @@ def test_trimmed_history_preserves_required_system_message():
         {"role": "user", "content": "new"},
         {"role": "assistant", "content": "new answer"},
     ]
+
+
+def test_run_reads_deployment_configuration_from_environment(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "secret-token")
+    monkeypatch.setenv("HOLMES_API_URL", "http://holmes:80")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_CHAT_IDS", "42,-1007")
+    monkeypatch.setenv("TELEGRAM_POLL_TIMEOUT_SECONDS", "20")
+    monkeypatch.setenv("TELEGRAM_REQUEST_TIMEOUT_SECONDS", "180")
+    monkeypatch.setenv("TELEGRAM_HISTORY_MESSAGES", "40")
+
+    with patch("holmes.plugins.telegram.bot.HolmesTelegramBot") as bot_class:
+        run()
+
+    config = bot_class.call_args.args[0]
+    assert config == TelegramBotConfig(
+        bot_token="secret-token",
+        holmes_api_url="http://holmes:80",
+        allowed_chat_ids={42, -1007},
+        poll_timeout_seconds=20,
+        request_timeout_seconds=180,
+        history_messages=40,
+    )
+    bot_class.return_value.run.assert_called_once_with()

--- a/tests/plugins/toolsets/test_data_platform_toolsets.py
+++ b/tests/plugins/toolsets/test_data_platform_toolsets.py
@@ -1,0 +1,168 @@
+import pytest
+import responses
+
+from holmes.core.tools import StructuredToolResultStatus
+from holmes.plugins.toolsets.airflow.airflow import AirflowConfig, AirflowToolset
+from holmes.plugins.toolsets.flink.flink import FlinkConfig, FlinkToolset
+from holmes.plugins.toolsets.trino.trino import TrinoConfig, TrinoToolset
+from tests.conftest import create_mock_tool_invoke_context
+
+
+def _tool(toolset, name):
+    return next(tool for tool in toolset.tools if tool.name == name)
+
+
+class TestTrinoToolset:
+    def test_rejects_mutating_sql_without_network_request(self):
+        toolset = TrinoToolset()
+        toolset.config = TrinoConfig(api_url="http://trino:8080")
+
+        result = _tool(toolset, "trino_query").invoke(
+            {"query": "DROP TABLE production.orders"},
+            create_mock_tool_invoke_context(),
+        )
+
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "read-only" in result.error
+
+    @responses.activate
+    def test_returns_bounded_query_results_and_cancels_remaining_pages(self):
+        toolset = TrinoToolset()
+        toolset.config = TrinoConfig(
+            api_url="http://trino:8080", trino_user="sre", max_rows=2
+        )
+        responses.post(
+            "http://trino:8080/v1/statement",
+            json={
+                "id": "query-1",
+                "columns": [{"name": "state", "type": "varchar"}],
+                "data": [["RUNNING"], ["FAILED"]],
+                "nextUri": "http://trino:8080/v1/statement/query-1/2",
+                "infoUri": "http://trino:8080/ui/query.html?query-1",
+                "stats": {"state": "RUNNING"},
+            },
+        )
+        responses.delete("http://trino:8080/v1/statement/query-1/2", json={})
+
+        result = _tool(toolset, "trino_query").invoke(
+            {"query": "SELECT state FROM system.runtime.queries LIMIT 2"},
+            create_mock_tool_invoke_context(),
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert result.data["rows"] == [["RUNNING"], ["FAILED"]]
+        assert result.data["truncated"] is True
+        assert responses.calls[0].request.headers["X-Trino-User"] == "sre"
+        assert responses.calls[1].request.method == "DELETE"
+
+
+class TestFlinkToolset:
+    @responses.activate
+    def test_list_jobs_bounds_large_response(self):
+        toolset = FlinkToolset()
+        toolset.config = FlinkConfig(api_url="http://flink:8081", max_items=2)
+        responses.get(
+            "http://flink:8081/jobs/overview",
+            json={
+                "jobs": [
+                    {"jid": "1", "state": "RUNNING"},
+                    {"jid": "2", "state": "FAILED"},
+                    {"jid": "3", "state": "FINISHED"},
+                ]
+            },
+        )
+
+        result = _tool(toolset, "flink_list_jobs").invoke(
+            {}, create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert result.data["jobs"] == [
+            {"jid": "1", "state": "RUNNING"},
+            {"jid": "2", "state": "FAILED"},
+        ]
+        assert result.data["holmes_truncated"] is True
+
+    @responses.activate
+    def test_exception_error_includes_endpoint_and_response(self):
+        toolset = FlinkToolset()
+        toolset.config = FlinkConfig(api_url="http://flink:8081")
+        responses.get(
+            "http://flink:8081/jobs/deadbeef/exceptions",
+            status=404,
+            body="Unknown job",
+        )
+
+        result = _tool(toolset, "flink_get_job_exceptions").invoke(
+            {"job_id": "deadbeef"}, create_mock_tool_invoke_context()
+        )
+
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "/jobs/deadbeef/exceptions" in result.error
+        assert "Unknown job" in result.error
+
+    @responses.activate
+    def test_job_details_bound_vertices(self):
+        toolset = FlinkToolset()
+        toolset.config = FlinkConfig(api_url="http://flink:8081", max_items=1)
+        responses.get(
+            "http://flink:8081/jobs/deadbeef",
+            json={
+                "jid": "deadbeef",
+                "vertices": [{"id": "source"}, {"id": "sink"}],
+            },
+        )
+
+        result = _tool(toolset, "flink_get_job").invoke(
+            {"job_id": "deadbeef"}, create_mock_tool_invoke_context()
+        )
+
+        assert result.data["vertices"] == [{"id": "source"}]
+        assert result.data["holmes_truncated"] is True
+
+
+class TestAirflowToolset:
+    @responses.activate
+    def test_list_dag_runs_uses_bounded_pagination(self):
+        toolset = AirflowToolset()
+        toolset.config = AirflowConfig(
+            api_url="http://airflow:8080", api_version="v2", max_items=25
+        )
+        responses.get(
+            "http://airflow:8080/api/v2/dags/orders%2Fdaily/dagRuns",
+            json={"dag_runs": [{"dag_run_id": "scheduled__1", "state": "failed"}]},
+        )
+
+        result = _tool(toolset, "airflow_list_dag_runs").invoke(
+            {"dag_id": "orders/daily", "limit": 500},
+            create_mock_tool_invoke_context(),
+        )
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert result.data["dag_runs"] == [
+            {"dag_run_id": "scheduled__1", "state": "failed"}
+        ]
+        assert responses.calls[0].request.params["limit"] == "25"
+        assert responses.calls[0].request.params["order_by"] == "-logical_date"
+
+    @pytest.mark.parametrize(
+        ("config", "message"),
+        [
+            (
+                {
+                    "api_url": "http://airflow:8080",
+                    "bearer_token": "token",
+                    "username": "user",
+                    "password": "password",
+                },
+                "either bearer token or basic auth",
+            ),
+            (
+                {"api_url": "http://airflow:8080", "username": "user"},
+                "password is required",
+            ),
+        ],
+    )
+    def test_rejects_invalid_auth_config(self, config, message):
+        with pytest.raises(ValueError, match=message):
+            AirflowConfig(**config)

--- a/tests/test_telegram_helm.py
+++ b/tests/test_telegram_helm.py
@@ -1,0 +1,52 @@
+"""Regression checks for the Telegram Helm integration."""
+
+from pathlib import Path
+
+import yaml
+
+HELM_DIR = Path(__file__).resolve().parents[1] / "helm" / "holmes"
+TELEGRAM_TEMPLATE = HELM_DIR / "templates" / "telegram-deployment.yaml"
+
+
+def _telegram_values() -> dict:
+    with open(HELM_DIR / "values.yaml") as values_file:
+        return yaml.safe_load(values_file)["telegram"]
+
+
+def test_telegram_values_are_secure_and_opt_in():
+    values = _telegram_values()
+
+    assert values["enabled"] is False
+    assert values["existingSecret"] == {"name": "", "key": "bot-token"}
+    assert values["allowedChatIds"] == []
+    assert values["pollTimeoutSeconds"] == 30
+    assert values["requestTimeoutSeconds"] == 120
+    assert values["historyMessages"] == 30
+
+
+def test_telegram_deployment_has_one_poller_and_internal_holmes_url():
+    template = TELEGRAM_TEMPLATE.read_text()
+
+    assert "replicas: 1" in template
+    assert 'printf "http://%s-holmes:80" .Release.Name' in template
+    assert "holmes.plugins.telegram.bot" in template
+    assert "TELEGRAM_ALLOWED_CHAT_IDS" in template
+
+
+def test_telegram_token_comes_from_existing_secret():
+    template = TELEGRAM_TEMPLATE.read_text()
+
+    assert "telegram.existingSecret.name is required" in template
+    assert "secretKeyRef:" in template
+    assert "TELEGRAM_BOT_TOKEN" in template
+
+
+def test_telegram_pod_uses_restricted_security_defaults():
+    template = TELEGRAM_TEMPLATE.read_text()
+
+    assert "automountServiceAccountToken: false" in template
+    assert "readOnlyRootFilesystem: true" in template
+    assert "runAsUser: 10001" in template
+    assert "allowPrivilegeEscalation: false" in template
+    assert "drop:" in template
+    assert "- ALL" in template


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in diagnostics toolsets for Apache Airflow, Apache Flink, and Trino (bounded, read-only SQL where applicable).
  * Added a Telegram bot adapter with per-chat context, allowed-chat allowlisting, `/reset`, and safe long-message splitting.
  * Introduced the `holmes-telegram` console entry point and an opt-in Helm deployment for Telegram.
* **Documentation**
  * Added/updated setup and configuration docs plus navigation/README entries for Airflow, Flink, Trino, and Telegram.
* **Tests**
  * Added unit and Helm validation coverage for Telegram, and toolset behavior checks for auth, limits, and pagination.
* **Chores**
  * Improved checksum verification robustness in the container build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->