### PR TITLE
fix(tools): apply approval_required_tools to YAML-defined toolsets

### DIFF
--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -293,6 +293,9 @@ class Tool(ABC, BaseModel):
         description="The URL of the icon for the tool, if None will get toolset icon",
     )
     transformers: Optional[List[Transformer]] = None
+    # Back-reference to the owning toolset. Read by _check_approval_config() to
+    # resolve `approval_required_tools`; set by Toolset.link_tools_to_toolset().
+    toolset: Optional[Any] = Field(default=None, exclude=True, repr=False)
 
     # Private attribute to store initialized transformer instances for performance
     _transformer_instances: Optional[List["BaseTransformer"]] = PrivateAttr(
@@ -921,6 +924,17 @@ class Toolset(BaseModel):
         values["tools"] = tools
 
         return values
+
+    @model_validator(mode="after")
+    def link_tools_to_toolset(self):
+        # Tools resolve `approval_required_tools` through this back-reference.
+        # Toolsets built in Python wire it up themselves (Tool(toolset=self)),
+        # but YAML/config-loaded toolsets construct their tools from dicts, so
+        # without this their approval patterns would never be applied.
+        for tool in self.tools or []:
+            if getattr(tool, "toolset", None) is None:
+                tool.toolset = self
+        return self
 
     def get_environment_variables(self) -> List[str]:
         env_vars = set()

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -926,7 +926,7 @@ class Toolset(BaseModel):
         return values
 
     @model_validator(mode="after")
-    def link_tools_to_toolset(self):
+    def link_tools_to_toolset(self) -> "Toolset":
         # Tools resolve `approval_required_tools` through this back-reference.
         # Toolsets built in Python wire it up themselves (Tool(toolset=self)),
         # but YAML/config-loaded toolsets construct their tools from dicts, so

--- a/tests/test_approval_required_tools.py
+++ b/tests/test_approval_required_tools.py
@@ -16,6 +16,7 @@ from holmes.core.tools import (
     Toolset,
     ToolsetTag,
     ToolsetYamlFromConfig,
+    YAMLToolset,
 )
 from holmes.core.models import StructuredToolResult, StructuredToolResultStatus
 
@@ -110,3 +111,30 @@ def test_deprecated_restricted_tools_is_ignored_with_warning(caplog):
     assert not hasattr(ts, "restricted_tools")
     assert ts.approval_required_tools == [APPROVAL_TOOL]
     assert any("restricted_tools" in r.message for r in caplog.records)
+
+
+def test_yaml_toolset_tools_are_gated_by_approval_required_tools():
+    """A YAML-defined toolset must gate its own tools without manual wiring."""
+    toolset = YAMLToolset(
+        name="custom_demo",
+        description="Custom toolset",
+        approval_required_tools=["sensitive_action"],
+        tools=[
+            {
+                "name": "sensitive_action",
+                "description": "Sensitive action",
+                "command": "echo hello",
+            },
+            {
+                "name": "safe_action",
+                "description": "Safe action",
+                "command": "echo hello",
+            },
+        ],
+    )
+
+    gated = _tool(toolset, "sensitive_action").invoke({}, _context("sensitive_action"))
+    assert gated.status == StructuredToolResultStatus.APPROVAL_REQUIRED
+
+    ungated = _tool(toolset, "safe_action").invoke({}, _context("safe_action"))
+    assert ungated.status != StructuredToolResultStatus.APPROVAL_REQUIRED

--- a/tests/test_approval_required_tools.py
+++ b/tests/test_approval_required_tools.py
@@ -137,4 +137,4 @@ def test_yaml_toolset_tools_are_gated_by_approval_required_tools():
     assert gated.status == StructuredToolResultStatus.APPROVAL_REQUIRED
 
     ungated = _tool(toolset, "safe_action").invoke({}, _context("safe_action"))
-    assert ungated.status != StructuredToolResultStatus.APPROVAL_REQUIRED
+    assert ungated.status == StructuredToolResultStatus.SUCCESS


### PR DESCRIPTION
Closes #2312

`Tool._check_approval_config()` resolves `approval_required_tools` through a `tool.toolset` back-reference. Toolsets built in Python set it themselves (`Tool(toolset=self)`), but YAML/config-loaded toolsets construct their tools from dicts, so the back-reference stayed `None` and the patterns were silently ignored — the tool ran without ever prompting for approval.

`Toolset` now sets the back-reference on its own tools in an after-validator, leaving an explicitly-provided `toolset` untouched. Regression test added to `tests/test_approval_required_tools.py`; it fails on master and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approval requirements now apply correctly to tools defined through YAML or configuration files.
  * Tools requiring approval are blocked until approval is granted, while unrestricted tools continue to run normally.

* **Tests**
  * Added coverage to verify approval enforcement for YAML-defined toolsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->