### PR TITLE
ROB-714 - Restore HTTP proxy support for the Supabase DAL connection

### DIFF
--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -9,6 +9,8 @@ import threading
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 from uuid import uuid4
 
 import httpx
@@ -247,7 +249,13 @@ class SupabaseDal:
         # verify/http2 go on the transport (httpx ignores them on the client once a
         # custom transport is supplied); timeout/follow_redirects stay on the client
         # (supabase ignores postgrest_client_timeout once an httpx_client is given).
-        transport = SupabaseRetryTransport(http2=False, verify=verify)
+        # httpx skips env proxies when given a custom transport; resolve it here
+        # so proxied clusters still reach Supabase.
+        parsed = urlparse(self.url)
+        proxy = None
+        if parsed.hostname and not proxy_bypass(parsed.hostname):
+            proxy = getproxies().get(parsed.scheme)
+        transport = SupabaseRetryTransport(http2=False, verify=verify, proxy=proxy)
         httpx_client = httpx.Client(
             transport=transport,
             timeout=SUPABASE_TIMEOUT_SECONDS,

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -253,8 +253,10 @@ class SupabaseDal:
         # so proxied clusters still reach Supabase.
         parsed = urlparse(self.url)
         proxy = None
-        if parsed.hostname and not proxy_bypass(parsed.hostname):
-            proxy = getproxies().get(parsed.scheme)
+        if parsed.hostname:
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+            if not proxy_bypass(f"{parsed.hostname}:{port}"):
+                proxy = getproxies().get(parsed.scheme)
         transport = SupabaseRetryTransport(http2=False, verify=verify, proxy=proxy)
         httpx_client = httpx.Client(
             transport=transport,

--- a/tests/core/test_supabase_dal_transport.py
+++ b/tests/core/test_supabase_dal_transport.py
@@ -185,7 +185,18 @@ def test_dal_skips_proxy_when_supabase_host_in_no_proxy(monkeypatch):
     assert cap["transport_kwargs"]["proxy"] is None
 
 
+def test_dal_skips_proxy_when_no_proxy_entry_has_port(monkeypatch):
+    # no_proxy entries may include a port; the default HTTPS port must match.
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("https_proxy", "http://proxy.corp:8080")
+    monkeypatch.setenv("no_proxy", "example.supabase.co:443")
+    _, cap = _build_dal(monkeypatch)
+    assert cap["transport_kwargs"]["proxy"] is None
+
+
 def test_dal_no_proxy_when_env_unset(monkeypatch):
     _clear_proxy_env(monkeypatch)
+    # Ignore any OS-level proxy config so the assertion is host-independent.
+    monkeypatch.setattr("holmes.core.supabase_dal.getproxies", lambda: {})
     _, cap = _build_dal(monkeypatch)
     assert cap["transport_kwargs"]["proxy"] is None

--- a/tests/core/test_supabase_dal_transport.py
+++ b/tests/core/test_supabase_dal_transport.py
@@ -157,3 +157,35 @@ def test_dal_always_disables_http2_regardless_of_ca(monkeypatch, ca_env):
     # http2 must stay disabled no matter the CA configuration.
     _, cap = _build_dal(monkeypatch, ca_env=ca_env)
     assert cap["transport_kwargs"]["http2"] is False
+
+
+_PROXY_ENV = ("https_proxy", "http_proxy", "all_proxy", "no_proxy")
+
+
+def _clear_proxy_env(monkeypatch):
+    for name in _PROXY_ENV:
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(name.upper(), raising=False)
+
+
+def test_dal_routes_supabase_through_https_proxy_from_env(monkeypatch):
+    # Regression (ROB-4017): a custom transport makes httpx ignore env proxies, so
+    # we must resolve and pass the proxy ourselves or proxied clusters break.
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("https_proxy", "http://proxy.corp:8080")
+    _, cap = _build_dal(monkeypatch)
+    assert cap["transport_kwargs"]["proxy"] == "http://proxy.corp:8080"
+
+
+def test_dal_skips_proxy_when_supabase_host_in_no_proxy(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("https_proxy", "http://proxy.corp:8080")
+    monkeypatch.setenv("no_proxy", "example.supabase.co")
+    _, cap = _build_dal(monkeypatch)
+    assert cap["transport_kwargs"]["proxy"] is None
+
+
+def test_dal_no_proxy_when_env_unset(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    _, cap = _build_dal(monkeypatch)
+    assert cap["transport_kwargs"]["proxy"] is None


### PR DESCRIPTION
## Problem

Users upgrading from 0.33.0 to 0.34.0+ whose clusters reach the internet only through a corporate proxy (`http_proxy`/`https_proxy`/`no_proxy` set) fail at startup with a DNS error during Supabase sign-in:

```
httpx.ConnectError: [Errno -2] Name or service not known
SupabaseDnsException: Error connecting to https://<project>.supabase.co
```

## Root cause

PR #2200 (ROB-4017, first shipped in 0.34.0) wired `SupabaseDal` onto a custom `SupabaseRetryTransport`. In httpx, environment proxies are only applied when **no** custom transport is supplied:

```python
# httpx/_client.py
allow_env_proxies = trust_env and transport is None
```

Once a custom transport is passed, `http_proxy`/`https_proxy`/`no_proxy` are silently ignored, so the client connects **directly** to `*.supabase.co`. In proxy-only clusters that host isn't resolvable/reachable directly, so sign-in fails. Pre-0.34.0 used the default transport, so the proxy was honored — hence the regression on upgrade.

## Fix

Resolve the proxy ourselves (honoring `no_proxy` via `proxy_bypass`) and pass it to the transport, which accepts a `proxy=` argument. This restores pre-0.34.0 behavior while keeping the HTTP/1.1 + `RemoteProtocolError` retry + CA-bundle hardening from #2200.

## Tests

Added three regression tests to `tests/core/test_supabase_dal_transport.py`:

- proxy from env is passed to the transport
- host in `no_proxy` → no proxy
- no proxy env → no proxy

All transport tests pass (13 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHNjeNaRrzd25fwK3qFm2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHNjeNaRrzd25fwK3qFm2F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Supabase connectivity to correctly apply HTTP/HTTPS proxy environment settings when using a custom retry transport.
  * Ensures `no_proxy` bypass rules are respected for the Supabase host, including cases where the bypass includes a port.

* **Tests**
  * Added regression tests validating proxy selection and bypass behavior across `https_proxy`/`no_proxy` combinations and when proxy environment variables are unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->