### PR TITLE
ROB-531: add sonnet-5 to weekly eval benchmark models

### DIFF
--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -16,7 +16,7 @@ on:
         description: 'Comma-separated list of models to test'
         required: false
         # NOTE: Keep in sync with DEFAULT_BENCHMARK_MODELS env var
-        default: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex,opus-4.8,gpt-5.5'
+        default: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex,opus-4.8,gpt-5.5,sonnet-5'
       test_markers:
         description: 'Custom pytest markers (ONLY use if not using benchmark_type). Cannot be combined with benchmark_type.'
         required: false
@@ -38,7 +38,7 @@ on:
 env:
   # Default models for benchmarks - single source of truth
   # NOTE: Keep workflow_dispatch default in sync with this for UI display
-  DEFAULT_BENCHMARK_MODELS: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex,opus-4.8,gpt-5.5'
+  DEFAULT_BENCHMARK_MODELS: 'opus-4.7,opus-4.6,sonnet-4.6,haiku-4.5,gpt-5.4,gemini-3.1-pro-preview,qwen-next-80B-instruct,qwen-next-80B-thinking,deepseek-r1-reasoner,deepseek-v3.2-chat,gpt-5.3-codex,opus-4.8,gpt-5.5,sonnet-5'
 
 jobs:
   run-benchmarks:


### PR DESCRIPTION
## What

Adds `sonnet-5` to the weekly eval benchmark, appended to both `DEFAULT_BENCHMARK_MODELS` and the `workflow_dispatch` models default (kept in sync per the in-file NOTE comments).

## ⚠️ Required before this takes effect

The `sonnet-5` alias must also be added to the **`MODEL_LIST_YAML` repository secret** (Settings → Secrets and variables → Actions). Without it, CI logs `Couldn't find model: sonnet-5` and records the run as **0% with no cost row** — a silent config failure, not a quality result.

This benchmark runs models via **Bedrock** (eu-south-2), so the entry mirrors the existing **`opus-4.8`** block (same model generation / API surface) — **not** a first-party `api_key` entry:

```yaml
sonnet-5:
  aws_access_key_id: "<same as other entries>"
  aws_region_name: eu-south-2
  aws_secret_access_key: "<same as other entries>"
  model: bedrock/eu.anthropic.claude-sonnet-5
  temperature: 1
  thinking:
    type: adaptive
    display: summarized
```

Notes:
- Copy the **`opus-4.8`** entry, not `sonnet-4.6`: Sonnet 5 rejects `thinking: {type: enabled, budget_tokens: N}` with a 400 — adaptive is the only on-mode.
- The `MODEL_LIST_YAML` secret is one blob holding the whole model list; edit it by pasting the complete document with this block added (GitHub replaces the entire secret — pasting only the new block wipes the others).
- Verify `eu.anthropic.claude-sonnet-5` is available as a Bedrock inference profile in **eu-south-2** before relying on it (Bedrock rollout is region-specific). Suggest a manual `workflow_dispatch` run with just `sonnet-5` first, to confirm a real cost row comes back.

_(Supersedes the secret snippet in the initial commit message, which assumed the first-party Anthropic API; this benchmark uses Bedrock.)_

## Context (ROB-531)

Local benchmarking (first-party API) found Sonnet 5 quality-indistinguishable from Opus 4.7 and Haiku 4.5 on a pure-diagnostic K8s subset (30/30 each at n=3). Adding it to CI gives an ongoing n=5 signal against the full model field. Note CI runs via **Bedrock**, so CI cost will differ from the first-party local figures (Bedrock is partner-priced and has no automatic prompt caching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)