### PR TITLE
fix(operator): install the holmes package into the operator image

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -12,13 +12,14 @@ ARG WHEEL_MIN_VERSION=0.46.2
 ARG SETUPTOOLS_MIN_VERSION=80.0.0
 
 COPY pyproject.toml poetry.lock* ./
+COPY holmes/ ./holmes/
 # Upgrade build tooling first so poetry and the package installs it runs use the
 # CVE-patched pip/setuptools/wheel.
 RUN pip install --no-cache-dir -U \
         "pip>=${PIP_MIN_VERSION}" "setuptools>=${SETUPTOOLS_MIN_VERSION}" "wheel>=${WHEEL_MIN_VERSION}" && \
     pip install --no-cache-dir poetry && \
     poetry config virtualenvs.create false && \
-    poetry install --no-interaction --no-ansi --no-root
+    poetry install --no-interaction --no-ansi
 
 COPY holmes_operator/ ./holmes_operator/
 

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -12,6 +12,7 @@ ARG WHEEL_MIN_VERSION=0.46.2
 ARG SETUPTOOLS_MIN_VERSION=80.0.0
 
 COPY pyproject.toml poetry.lock* ./
+COPY README.md ./
 COPY holmes/ ./holmes/
 # Upgrade build tooling first so poetry and the package installs it runs use the
 # CVE-patched pip/setuptools/wheel.


### PR DESCRIPTION
Fixes #2326

The operator entrypoint (`holmes_operator/operator.py`) imports shared helpers from the main `holmes` package:

- `holmes.common.env_vars.ENABLE_JSON_LOGS_FORMAT`
- `holmes.utils.log.build_json_formatter`

`Dockerfile.operator` installed dependencies with `poetry install --no-root` and then copied only `holmes_operator/`, so the `holmes` package was never present in the image. Starting `robustadev/holmes-operator:0.37.0` therefore fails with:

```text
ModuleNotFoundError: No module named 'holmes'
```

Changes:
- Copy `holmes/` into the operator build context before `poetry install`.
- Remove `--no-root` so `poetry install` also installs the `holmes` root package.
- Keep the existing `holmes_operator/` copy step after installation.

This keeps the operator image self-contained while reusing the existing JSON-logging/env-var helpers instead of inlining them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container build setup by including `README.md` in the image and installing the application package as part of the dependency installation.
  * Updated dependency tooling configuration to provide a more consistent, non-interactive runtime environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->