### PR TITLE
feat(toolsets): code_execution toolset ("code mode") to cut tool-call token cost

### DIFF
--- a/docs/design/2026-07-28_holmes-code-mode.md
+++ b/docs/design/2026-07-28_holmes-code-mode.md
@@ -1,0 +1,431 @@
+| Authors | Naomi |
+| --- | --- |
+| Review Date | 28 / Jul / 2026 |
+| Participants | AI/Holmes team, Backend (relay), Frontend |
+
+Ticket: [ROB-723](https://linear.app/robusta/issue/ROB-723) — "Using Code mode
+instead of scripts may save our token cost for tool calls." Project: *Minimize
+Token Cost for us (and users)*.
+
+Related reading:
+- `2026-06-10_remote-tool-execution.md` (relay) — the `expose_remotely` /
+  `is_core` markers, the **pre-approved-only, no-approval-round-trip** trust
+  model, and the 1MB inline result cap. Code mode reuses all three.
+- `2025-10-23_holmes-event-driven-architecture.md` (relay) — the SSE event
+  contract (`start_tool_calling` / `tool_calling_result`) that carries tool
+  calls to the UI, and relay's role as a transparent pipe.
+
+# Introduction
+
+## Overview
+
+Holmes investigates by running an **agentic tool-calling loop**: the LLM emits
+one or more tool calls, Holmes executes them, appends each result to the
+conversation, and re-sends the whole growing history on the next step. Complex
+investigations run 10–55 tool calls across many steps, and because every step
+re-sends all prior tool results, input tokens grow super-linearly with
+iteration count.
+
+**Code mode** ([Anthropic](https://www.anthropic.com/engineering/code-execution-with-mcp),
+[Cloudflare](https://blog.cloudflare.com/code-mode/)) replaces "many small tool
+calls, one per LLM step" with "the LLM writes **one Python script** that composes
+many tool calls, runs it in a sandbox, and only the **filtered final result**
+returns to the model's context." Tool outputs the model never needs are
+filtered *inside the script* and never enter the context window at all.
+
+Solution: a new **`code_execution` toolset** in Holmes whose single tool takes a
+Python snippet, runs it in a subprocess pre-loaded with a **generated `holmes`
+client module** that exposes the current request's tools as callable Python
+functions. Each function dispatches back into the existing `ToolExecutor`, so
+tools behave identically whether called directly or from a script. Sub-calls
+still emit their own SSE events, so the UI shows the same per-tool cards it does
+today; the wrapping script does not become an opaque black box.
+
+Stakeholders: AI/Holmes team (the runtime + prompting), backend/relay (SSE
+passthrough — no code changes expected), frontend (one new event field to
+surface script + sub-calls).
+
+## Glossary
+
+- **Code mode** — the execution path where the LLM writes Python composing tool
+  calls, instead of emitting one function call per LLM step.
+- **`code_execution` toolset / `run_python_code` tool** — the new toolset and
+  its single tool (this design). Modeled on `BashExecutorToolset`
+  (`holmes/plugins/toolsets/bash/bash_toolset.py:399`).
+- **client module (`holmes`)** — an auto-generated Python module, injected into
+  the script's namespace, whose functions mirror the request's tools
+  (`holmes.kubernetes.get_pods(...)`, `holmes.prometheus.query(...)`). Each is a
+  thin wrapper that calls `ToolExecutor.get_tool_by_name(name).invoke(...)`.
+- **sub-call** — a tool invoked from inside a running script (as opposed to a
+  top-level tool call the LLM emits directly).
+- **the two token sinks** — (1) *tool-definition overhead*: all tool schemas
+  loaded into context up-front; (2) *intermediate-result bloat*: every tool
+  result re-sent through context on each subsequent step. Sink (2) is the one
+  that matters for Holmes (see Background).
+- **spill-to-disk** — the existing size guard
+  (`holmes/core/tools_utils/tool_context_window_limiter.py:30`) that saves an
+  oversized tool result to a file and hands the model a `cat … | jq` pointer
+  instead of the payload.
+
+## Background
+
+- **Where the money is (30-day prod, customer-facing).** ~$23k/mo total Holmes
+  spend; **82.6% overall prompt-cache hit** (89–94% on the expensive buckets).
+  Cost is ~99% *input* tokens (completion averages 4–11k against prompt averages
+  of 142k → 2.9M). Spend rises with iteration count in lockstep with
+  `avg_tool_calls` (4-6 iters → 10 calls, 7-10 → 19, 11-20 → 30, 21-50 → 55).
+  Requests with **≥6 iterations = $15.3k/mo (66.5% of spend)** — the exact
+  multi-tool-chaining regime code mode targets.
+- **Sink (1) is already neutralized by prompt caching.** The static prefix
+  (system prompt + all tool schemas) is identical every step and is the most
+  cacheable content, so at 82.6% cache hit the "don't load all tool defs
+  up-front" half of the Anthropic/Cloudflare 98% headline buys us almost nothing
+  in dollars. **The win must come from sink (2): fewer results entering context,
+  and fewer iterations.** This re-prioritizes the design: result-filtering and
+  call-consolidation first; progressive tool-def disclosure is a Future Goal, not
+  v1.
+- **Holmes already has a proto-code-mode.** The `bash` toolset
+  (`bash_toolset.py:94`) runs shell (kubectl/jq/grep) with prefix allow/deny
+  validation, and `spill_oversized_tool_result` already keeps oversized payloads
+  out of context behind a file pointer. So v1 is capturing the *residual* between
+  "compose CLI tools in bash" and "compose **all** toolsets (Prometheus, Grafana,
+  Datadog, k8s, …) in one typed script" — not a greenfield 98%. **Estimated
+  saving: ~15–25% of total spend (~$3–6k/mo)**, pending the trace study; the
+  wide band is because the result-vs-definition token split is not measurable
+  from prod telemetry alone.
+- **Not everything is addressable.** The single largest uncached-cost bucket is
+  short `user_chat` (1–3 iters, cold cache) — code mode does nothing for it.
+  `health_check` synthetic traffic is a separate config problem. v1 scopes to
+  multi-iteration, tool-heavy real traffic.
+
+## Goals
+
+User stories:
+
+1. Holmes investigates "which of the 200 pods in namespace X restarted in the
+   last hour, and why?" by writing one script that lists pods, filters to
+   restarted ones in Python, fetches logs only for those, and returns a 5-line
+   summary — instead of 20 LLM steps each re-sending the full pod list.
+2. A script that pulls a 10,000-series Prometheus range and returns only the top
+   3 offenders keeps the other 9,997 series out of the model's context entirely.
+3. The user watching the Ask-Holmes UI still sees each sub-call as its own tool
+   card (name, status, expandable output) plus the script that drove them — code
+   mode is not an opaque box.
+4. A simple single-tool ask ("is the cluster healthy?") is **not** made slower or
+   costlier — the model keeps using direct tool calls for trivial work.
+
+Technical requirements:
+
+- A new `code_execution` toolset with one tool `run_python_code`, off by default
+  behind a feature flag, modeled on `BashExecutorToolset`.
+- Tools callable from a script go through the **same** `ToolExecutor` path,
+  validation, transformers, and result-size guard as direct calls — no bypass.
+- **Read-only / pre-approved trust model**, identical to remote-tool-execution:
+  a running synchronous script cannot pause for interactive approval, so
+  approval-gated tools are **denied on the spot inside a script**; only
+  pre-approved / read-only tools are callable. `is_core` toolsets
+  (`robusta_platform_mcp`, `core_investigation`/`TodoWrite`, `skills`) are never
+  exposed in the client module.
+- Every sub-call emits its own `start_tool_calling` / `tool_calling_result` SSE
+  event (with a `parent_tool_call_id`) so relay forwards them unchanged and the
+  UI renders them — see Observability.
+- Script stdout over the per-tool cap goes through `spill_oversized_tool_result`
+  (same 15% / 25k-token guard), so a runaway script can't flood context.
+- `LLMResult` already exposes `num_llm_calls`, `total_tokens`,
+  `max_prompt_tokens_per_call`, etc. (`llm_usage.py:81`); code mode must move
+  these *down* for multi-step tasks and this is asserted in tests.
+- Works on any model/provider — it is an ordinary tool call, no special API.
+
+## Out of Scope
+
+- **Interactive approval inside a script.** No approval round-trip (matches
+  remote-tool-execution). Approval-gated tools are denied at call time inside a
+  script; the model must fall back to a direct tool call to trigger the normal
+  approval flow.
+- **A real language-level sandbox** (RestrictedPython / gVisor / container
+  isolation) in v1. v1 reuses the bash trust model — subprocess + `ulimit`
+  memory cap + read-only tools. Hardening is a Future Goal and an explicit
+  security decision (see Assumptions).
+- **Progressive disclosure of tool definitions** (filesystem tree of stubs,
+  `search_tools`) — deprioritized because caching already neutralizes sink (1).
+- **Writing/mutating tools from a script** — read-only tools only.
+- **Persisted "skills"** (saving successful scripts as reusable functions across
+  sessions).
+
+## Future Goals
+
+- Language-level sandboxing to allow a broader tool set and untrusted code.
+- Progressive tool-def disclosure if tool count ever grows enough to matter
+  despite caching.
+- Auto-routing: a cheap classifier that pre-selects code mode vs direct calls
+  per request, instead of leaving it to the model + prompt.
+- Persisted skills (reusable scripts) and cross-call state files.
+- Extending code mode across clusters by composing the remote tools from
+  `2026-06-10_remote-tool-execution.md` inside a script.
+
+## Assumptions & Constraints
+
+- **Security posture.** Holmes runs in-cluster with live credentials and RBAC.
+  Executing LLM-generated Python is a materially larger attack surface than
+  prefix-validated bash. v1's mitigation is **not** interpreter sandboxing; it is
+  that (a) only read-only / pre-approved tools are reachable, (b) the same
+  allow/deny validation still runs on any `bash` sub-call, (c) a `ulimit` memory
+  cap and wall-clock timeout bound the subprocess, and (d) the feature is
+  off-by-default behind a flag. This is the identical stance the team already
+  accepted for remote tool execution, and it is called out here as a conscious
+  decision, not an oversight.
+- **Relay is a transparent SSE pipe.** `ClientsManager.send_stream_message`
+  yields Holmes's SSE bytes verbatim; relay identifies tool calls solely by
+  `tool_call_id` (`SSE/holmes_tools_helper.py:upsert_tool_call`). So sub-calls
+  are observable **iff Holmes emits them as normal SSE events** — no relay change
+  needed as long as we reuse the existing event types.
+- The frontend renders a **flat `HolmesTool[]`** via two independent consumers
+  (legacy `onChunk` in `holmes-chat-history.store.ts:1333` and the realtime
+  `EventProjector._processEvent` in `event-projector.ts:228`). A new event field
+  must be handled in **both**, or it is silently dropped in one path.
+- Per-tool result cap = `min(15% ctx, 25k tokens)`
+  (`TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_*`); compaction fires at 95% (rarely — 0.5%
+  of requests). Code mode does not change these; it feeds through them.
+
+# Design
+
+## Current Design
+
+- **The loop** — `holmes/core/tool_calling_llm.py`. `ToolCallingLLM.call_stream`
+  (`:1035`) runs `while i < max_steps` (`:1105`): assemble messages → check/apply
+  compaction (`:1115`) → `self.llm.completion(..., tools=tools)` (`:1167`) →
+  append assistant turn → if `tool_calls` present, execute them in a
+  `ThreadPoolExecutor(max_workers=16)` (`:1320`), append each
+  `tool_call_result.to_llm_message()` (`:1415`), loop; else return the answer.
+  Tool execution funnels through `_invoke_llm_tool_call` (`:870`) →
+  `_directly_invoke_tool_call` (`:747`) → `tool.invoke(params, context)`
+  (`:789`).
+- **Tools** — `holmes/core/tools.py`. `Tool` (`:284`) with `parameters:
+  Dict[str, ToolParameter]` and abstract `_invoke(...) -> StructuredToolResult`
+  (`:516`). `Toolset` (`:719`). `StructuredToolResult` (`:96`) with
+  `stringify_data(compact=True)` (`:111`). Approval via `requires_approval`
+  (`:423`) returning `APPROVAL_REQUIRED`. `expose_remotely` / `is_core` markers
+  exist from remote-tool-execution.
+- **Tool → LLM schema** — `holmes/core/openai_formatting.py`.
+  `format_tool_to_open_ai_standard` (`:153`), `type_to_open_ai_schema` (`:71`).
+- **Dispatch registry** — `holmes/core/tools_utils/tool_executor.py`.
+  `get_all_tools_openai_format` (`:178`), `get_tool_by_name` (`:100`),
+  `clone_with_extra_tools` (`:153`, per-request tool injection).
+- **Result size guard** — `tool_context_window_limiter.py:spill_oversized_tool_result`
+  (`:30`); the file-pointer fallback is gated on `_has_bash_for_file_access`
+  (`:246`).
+- **The bash executor** — `bash_toolset.py`: `RunBashCommand` (`:94`),
+  validation via `validate_command`, `requires_approval` → `APPROVAL_REQUIRED`
+  for unknown prefixes; `BashExecutorToolset` (`:399`). Low level:
+  `common/bash.py:execute_bash_command` (`:17`) = `subprocess(shell=True)` +
+  `get_ulimit_prefix()` memory cap. **No interpreter sandbox.**
+- **Prompting** — `holmes/plugins/prompts/generic_ask.jinja2` (main system
+  prompt), `_toolsets_instructions.jinja2` (injects each toolset's
+  `llm_instructions`). Built by `holmes/core/prompt.py:build_system_prompt`
+  (`:177`).
+- **Streaming contract** — Holmes emits SSE `start_tool_calling` (name + id) then
+  `tool_calling_result` (result + status). Relay's `SSEEventType`
+  (`relay/pkg/holmes/common/data_types.py:7`) and `upsert_tool_call`
+  (`SSE/holmes_tools_helper.py:102`) merge the pair into one `HolmesToolCall`
+  keyed by `tool_call_id`. Frontend consumes via `enums.ts`, projects into
+  `HolmesTool[]` (`holmes-types.d.ts:189`), renders per-tool in
+  `HolmesToolsCollapseBlock.vue`.
+
+Pros: the loop, dispatch, size-guard, validation, and streaming are all
+battle-tested. Cons: tools compose only one-per-step through the model, so
+intermediate results flow through context repeatedly.
+
+## Proposed Design
+
+### 1. The `run_python_code` tool
+
+New toolset `holmes/plugins/toolsets/code_execution/`, registered in
+`holmes/plugins/toolsets/__init__.py:load_python_toolsets`. One `Tool`:
+
+- **Parameters**: `code: str` (the Python snippet), optional `timeout: int`
+  (default 60s).
+- **`_invoke(params, context)`**:
+  1. Materialize the **client module** (§2) for `context`'s `ToolExecutor` and
+     the request's enabled, non-`is_core`, pre-approved/read-only tools.
+  2. Write the snippet + a bootstrap that imports the client module to a temp
+     file (per-request `tmp` dir; `xdist_group` in tests).
+  3. Run it via `execute_bash_command("python3 <file>", timeout)` — reusing the
+     bash executor's `get_ulimit_prefix()` memory cap and timeout handling
+     (`common/bash.py`).
+  4. Capture stdout/stderr → `StructuredToolResult` (SUCCESS / ERROR / NO_DATA,
+     `return_code`, `invocation`, `elapsed_seconds`), same shape as
+     `bash_result_to_structured`.
+  5. Pass the result through `spill_oversized_tool_result` so oversized stdout
+     becomes a file pointer, not a context flood.
+- **`BashExecutorConfig`-style config**: `enabled=False` by default,
+  `is_core=False`, `expose_remotely=False` (a script fanning out to remote tools
+  is a Future Goal), plus a `llm_instructions` jinja2 template teaching the model
+  *when* to use it (multi-step / large-result tasks) and *when not to* (trivial
+  asks) — surfaced via `_toolsets_instructions.jinja2`.
+
+The agentic loop (`call_stream`) needs **no change**: `run_python_code` is an
+ordinary tool call. Parallel execution, the result-feedback path, and
+compaction all apply unchanged.
+
+### 2. The generated `holmes` client module
+
+Generated per request from the `ToolExecutor`'s eligible tools:
+
+```
+holmes/
+  kubernetes.py     get_pods(namespace: str, ...) -> dict
+  prometheus.py     query(promql: str, ...) -> dict
+  logs.py           fetch(pod: str, ...) -> dict
+  ...
+```
+
+- One Python function per `Tool`, grouped into a module per toolset. Signature is
+  derived from `parameters: Dict[str, ToolParameter]` by **inverting** the
+  `type_to_open_ai_schema` mapping (`openai_formatting.py:71`) into Python type
+  hints; docstring = the tool's `description`.
+- Each function body is a thin wrapper:
+  `return _dispatch("<tool_name>", locals())` → calls
+  `ToolExecutor.get_tool_by_name(name).invoke(params, context)` and returns the
+  parsed `StructuredToolResult.data` (raising a Python exception on ERROR so the
+  script can `try/except`).
+- **Eligibility filter** (applied when building the module):
+  - exclude `is_core` toolsets (`robusta_platform_mcp`, `core_investigation`,
+    `skills`);
+  - exclude tools whose `requires_approval(...)` is not statically
+    pre-approved/read-only — a call to one inside a script returns an ERROR
+    "approval-gated tool; call it directly instead," never a silent pause.
+- Dispatch runs in the **same process** as the loop (the script subprocess calls
+  back via a thin RPC/stdin-stdout bridge to the parent, or — simpler v1 — the
+  parent process runs the tools and the subprocess only runs the user's Python
+  with the client stubbed to IPC). The exact bridge is an implementation
+  decision captured in Open Questions; both keep validation server-side.
+
+### 3. Observability — sub-calls are first-class
+
+To keep the UI honest (user story 3), each sub-call emits the **existing** SSE
+events with one new field:
+
+- `start_tool_calling` / `tool_calling_result` gain an optional
+  `parent_tool_call_id` pointing at the `run_python_code` call's id.
+- Relay needs **no change** — it forwards bytes and keys tool calls by id
+  (`upsert_tool_call`), so the sub-call events flow through as ordinary tool
+  cards.
+- Frontend: add `parent_tool_call_id` handling in **both** consumers
+  (`holmes-chat-history.store.ts:1333` and `event-projector.ts:228`) and a
+  `subTools?: HolmesTool[]` field on `HolmesTool` (`holmes-types.d.ts:189`);
+  render sub-calls nested inside the parent row in `HolmesToolsCollapseBlock.vue`
+  (which already supports nested `HolmesTools`). The script itself renders in the
+  parent row's "Request" tab. Unknown/unhandled → the realtime projector's
+  `default` warns (`event-projector.ts:431`); we handle it explicitly so nothing
+  is dropped.
+
+### Data flow
+
+```
+LLM step k                Holmes                          UI (via relay pipe)
+  │                         │                               │
+  ├─ tool_call ───────────▶ run_python_code(code)           │
+  │                         │  build holmes client module   ├─ card: "run_python_code"
+  │                         │  spawn python subprocess ──┐   │
+  │                         │                            │   │
+  │                         │   script calls:            │   │
+  │                         │     holmes.k8s.get_pods() ─┼──▶ emit start/result   ├─ nested card (sub-call)
+  │                         │       → ToolExecutor.invoke │   │   (parent_tool_call_id)
+  │                         │     filter in Python        │   │
+  │                         │     holmes.logs.fetch(x3) ──┼──▶ emit start/result   ├─ nested cards
+  │                         │     print(summary)          │   │
+  │                         │                            ◀┘   │
+  │                         │  stdout → spill guard          │
+  ◀─ tool result (summary) ─┤  (only the 5-line summary      │
+  │   enters context           enters context, not the       │
+  │                            9,997 discarded series)        │
+  ▼
+LLM step k+1  (history grew by ~summary, not by all raw tool output)
+```
+
+The token win is structural: the raw `get_pods` list and the two unused log
+bodies **never enter the model's context** — only `print(summary)` does, once.
+
+### Feature flag & rollout
+
+- Off by default. Enable per-account/per-request via the existing config path
+  (`toolsets.code_execution.enabled: true`) and, for the hosted product, an
+  `AccountSettings` flag read the same way remote-tool-execution reads its flag.
+- Rollout: (1) internal accounts + evals; (2) opt-in beta on a few high-iteration
+  accounts (the ROB-723 project's target segment); (3) default-on for
+  tool-heavy request types if evals show correctness parity and a token win.
+
+# Token-cost impact
+
+- Addressable segment (≥6 iterations, tool-heavy real traffic): ~$15.3k/mo,
+  already ~82% cache-discounted.
+- Expected reduction on that segment: **20–40%**, from (i) fewer LLM iterations
+  (compose N calls in one script) and (ii) large results filtered before they
+  ever enter context.
+- **Net estimate: ~15–25% of total Holmes spend (~$3–6k/mo, ~$40–70k/yr)** — not
+  the 98% headline, because caching already banked sink (1) and bash+spill
+  already bank part of sink (2).
+- Instrumentation: `LLMResult`/`RequestStats` already record every needed field;
+  the eval harness records per-variant `total_tokens` / `num_llm_calls` /
+  `tool_call_count`, and `HolmesUsageEvents` gives the prod before/after.
+
+# Testing plan (summary)
+
+Full plan tracked separately; the layers:
+
+1. **Unit** (`tests/plugins/toolsets/code_execution/`) — real trivial
+   subprocesses (à la `test_bash_command_execution.py`), the
+   result→`StructuredToolResult` converter, and spill reuse (both
+   `_has_bash_for_file_access` branches).
+2. **Integration** (`tests/test_tool_calling_llm.py`) — script the mocked
+   `llm.completion` to emit a `run_python_code` call; assert `num_llm_calls` /
+   `total_tokens` are lower than the equivalent N-direct-call script;
+   re-entrancy under the 16-worker pool; sub-call error propagation.
+3. **LLM evals** — new `test_ask_holmes` fixture with
+   `toolsets_matrix: [classic, codemode]`, shared `expected_output` (correctness
+   parity), `max_tokens` on the codemode variant, plus a cross-variant assertion
+   `codemode.total_tokens < classic.total_tokens`. Runs in `eval-regression.yaml`
+   behind an `evals-*` label.
+4. **Observability** — unit tests in both FE consumers
+   (`event-projector.test.ts` + a new legacy `onChunk` test) asserting
+   `parent_tool_call_id` nests sub-calls and keeps intermediate output visible;
+   relay `test_holmes_chat_streaming.py` / `test_sse_events.py` for the new field.
+5. **Local-stack manual** — `harness/bind.py up` + `verify --ui`; drive a
+   code-mode investigation and confirm sub-call cards render.
+
+Edge / failure modes explicitly covered: syntax error → self-correcting ERROR;
+runtime exception; timeout / infinite loop; memory blow-up (ulimit); huge stdout
+→ spill; approval-gated sub-call denied (not bypassed); bash validation still
+enforced inside a script; partial sub-call failure; secret-leakage attempt;
+no-bash fallback; xdist temp-file isolation; cross-model codegen; routing
+regression on trivial asks.
+
+# Alternatives considered
+
+- **Do nothing / lean on bash.** The bash toolset already composes CLI tools, but
+  it can't reach Holmes's Python toolsets (Prometheus, Grafana, Datadog, …) and
+  the model must serialize/parse JSON by hand. Code mode gives a typed API over
+  *all* toolsets. Rejected as insufficient for the addressable segment.
+- **Progressive tool-def disclosure only** (the other half of the Anthropic
+  design). Rejected for v1: caching already makes sink (1) nearly free in
+  dollars, so it would add complexity for little saving.
+- **Real sandbox (RestrictedPython / container) in v1.** Safer, but a large lift
+  and it blocks shipping a measurable token win. Deferred to Future Goals; v1
+  adopts the already-accepted read-only/pre-approved trust model.
+- **New dedicated SSE event type for nested calls.** Rejected in favor of reusing
+  `start_tool_calling` / `tool_calling_result` + a `parent_tool_call_id` field,
+  so relay stays a pure pipe and the FE change is additive.
+
+# Open Questions
+
+1. **Execution bridge**: run tools in the parent process with the subprocess
+   calling back over IPC (keeps validation & credentials out of the subprocess —
+   preferred), vs. running tools in the subprocess directly (simpler, but the
+   subprocess then holds credentials). Leaning IPC.
+2. **Which tools are "statically pre-approved/read-only"** enough to expose in
+   the client module — reuse the remote-tool-execution `expose_remotely` set as
+   the v1 allowlist, or define a separate code-mode allowlist?
+3. **Routing**: prompt-only (model chooses) for v1, or a cheap pre-classifier?
+   Prompt-only is simplest; measure regression on trivial asks first.
+4. **Sub-call cost attribution** in `HolmesUsageEvents` — do sub-calls count
+   toward `tool_call_count`? (Yes, for honest before/after comparison.)

--- a/docs/design/2026-07-28_holmes-code-mode.md
+++ b/docs/design/2026-07-28_holmes-code-mode.md
@@ -271,7 +271,7 @@ compaction all apply unchanged.
 
 Generated per request from the `ToolExecutor`'s eligible tools:
 
-```
+```text
 holmes/
   kubernetes.py     get_pods(namespace: str, ...) -> dict
   prometheus.py     query(promql: str, ...) -> dict
@@ -321,7 +321,7 @@ events with one new field:
 
 ### Data flow
 
-```
+```text
 LLM step k                Holmes                          UI (via relay pipe)
   │                         │                               │
   ├─ tool_call ───────────▶ run_python_code(code)           │

--- a/docs/design/2026-07-28_holmes-code-mode.md
+++ b/docs/design/2026-07-28_holmes-code-mode.md
@@ -459,14 +459,55 @@ regression on trivial asks.
 
 # Open Questions
 
-1. **Execution bridge**: run tools in the parent process with the subprocess
-   calling back over IPC (keeps validation & credentials out of the subprocess —
-   preferred), vs. running tools in the subprocess directly (simpler, but the
-   subprocess then holds credentials). Leaning IPC.
-2. **Which tools are "statically pre-approved/read-only"** enough to expose in
-   the client module — reuse the remote-tool-execution `expose_remotely` set as
-   the v1 allowlist, or define a separate code-mode allowlist?
-3. **Routing**: prompt-only (model chooses) for v1, or a cheap pre-classifier?
-   Prompt-only is simplest; measure regression on trivial asks first.
-4. **Sub-call cost attribution** in `HolmesUsageEvents` — do sub-calls count
-   toward `tool_call_count`? (Yes, for honest before/after comparison.)
+## Resolved during implementation
+
+1. **Execution bridge** — *Resolved: IPC.* Tools run in the **parent**; the
+   subprocess calls back over a newline-delimited-JSON AF_UNIX socket. Keeps
+   validation and credentials out of the subprocess. (See `bridge.py`,
+   `runner.py`.)
+2. **Which tools are exposed** — *Resolved for v1.* Eligibility = exclude
+   `is_core` toolsets, `bash`/`kubectl_run`, and any `approval_required_tools`
+   (`client_generator._is_eligible`). Enforced parent-side in `dispatch`, not
+   just via the generated client. **Still worth confirming with the team**
+   whether this should be pinned to the exact remote-tool-execution
+   `expose_remotely` set — the two are defined independently and could drift.
+
+## Still open
+
+3. **Routing** — v1 is prompt-only (the model chooses when to use code mode). In
+   the first live A/B the model often kept using efficient server-side tools
+   (`kubernetes_jq_query`, log `filter`) and did not reach for code mode, so a
+   cheap pre-classifier — or stronger prompting — may be needed to actually
+   trigger it where it helps. Measure regression on trivial asks first.
+4. **Sub-call cost attribution** in `HolmesUsageEvents` — should sub-calls count
+   toward `tool_call_count` (proposed: yes, for honest before/after)? Not yet
+   wired.
+5. **Sandbox before default-on** — v1 has no language/OS sandbox, so the
+   documented residual risk (arbitrary outbound network + on-disk secret reads,
+   amplified under prompt injection — see Security model) stands. Decision:
+   gate default-on behind real isolation (RestrictedPython / gVisor / container
+   / egress-deny), or ship config-enabled only for trusted operators?
+6. **Demonstrating the token win in a *live* eval** — Holmes filters
+   server-side almost everywhere, so a live ask_holmes A/B can't cleanly show a
+   token drop (the two committed A/B evals only assert correctness parity). The
+   win is proven deterministically in
+   `tests/plugins/toolsets/code_execution/test_code_mode_token_reduction.py`
+   (result filtering 250k→136 tokens; call consolidation 8→1 result). Open
+   whether we also want a live eval backed by a data source with **no**
+   server-side filter, or accept the unit-level proof + a prod A/B.
+7. **When to flip default-on** — needs a real-traffic A/B; the ~15–25%
+   total-spend estimate is unvalidated in production.
+8. **Live sub-call streaming to the UI** — sub-calls are recorded (name / status
+   / timing) and summarized in the result today, but not streamed as nested
+   tool cards. That needs a `parent_tool_call_id` field + a loop-level streaming
+   hook + frontend work (separate PR).
+9. **Serial sub-calls** — the bridge is single-connection / single-threaded, so
+   sub-calls inside one script run serially. Fine for v1; open whether parallel
+   fan-out inside a script justifies a multi-connection bridge.
+10. **Prompt-overhead crossover** — enabling the toolset injects its API
+    reference into the system prompt; on small tasks that overhead isn't repaid
+    (observed in the CI eval, where the codemode variant cost slightly *more*).
+    Open where the crossover is and whether the reference should be trimmed or
+    lazily disclosed.
+11. **Documentation page** — `docs/data-sources/builtin-toolsets/code-execution.md`
+    is still a follow-up.

--- a/docs/design/2026-07-28_holmes-code-mode.md
+++ b/docs/design/2026-07-28_holmes-code-mode.md
@@ -355,6 +355,47 @@ bodies **never enter the model's context** — only `print(summary)` does, once.
   accounts (the ROB-723 project's target segment); (3) default-on for
   tool-heavy request types if evals show correctness parity and a token win.
 
+# Security model
+
+The script is arbitrary, LLM-generated Python. The model is therefore
+**capability-limiting, not code-sandboxing**: assume the script can run any
+Python, and constrain what it can *reach*.
+
+**The trust boundary is the parent-side allow-list, not the generated client.**
+The subprocess is handed the bridge socket path (`HOLMES_CODE_SOCKET`), so a
+script can bypass the generated `holmes.*` stubs and send raw
+`{"tool": ..., "params": ...}` requests over the socket by hand. Every request
+is therefore re-checked in the parent's `dispatch` before any tool is looked up
+or invoked:
+
+- **Allow-list enforced server-side.** A requested tool name not in
+  `eligible_tool_names(...)` is rejected outright — `is_core` toolsets,
+  `bash`/`kubectl_run`, and any `approval_required_tools` are excluded, so a
+  script cannot reach a mutation/approval surface even by forging the request.
+- **Approval cannot be scripted around.** An `APPROVAL_REQUIRED` result at
+  dispatch is converted to an error; there is no auto-approve path.
+- **Credentials never enter the subprocess.** Tools execute in the parent; the
+  subprocess env is a minimal allow-list (`PATH`/`LANG`/`HOLMES_CODE_*`), never
+  the parent's `os.environ` (LLM/provider keys, DB creds, etc.).
+- **Per-tool validation is unchanged.** Dispatched calls go through the real
+  `tool.invoke()`, so each tool's own guards still apply.
+- **Resource bounds.** `ulimit` memory cap + wall-clock timeout kill runaway
+  scripts; oversized stdout flows through `spill_oversized_tool_result`.
+
+**Residual risk (accepted for v1, off by default).** There is **no
+language-level or OS sandbox** — subprocess + `ulimit` only. So a script can
+still (a) make **arbitrary outbound network calls** and (b) **read on-disk files
+the process can access** (env secrets are stripped, but files such as
+`/var/run/secrets/kubernetes.io/serviceaccount/token` are not). Combined with a
+successful **prompt injection** (Holmes ingests untrusted logs/alerts/objects),
+the blast radius is "anything the pod's process can reach and exfiltrate". This
+is the primary reason the feature is off by default; real isolation
+(RestrictedPython / gVisor / container sandbox / egress deny) is a Future Goal
+(see Out of Scope). These boundaries are covered by
+`tests/plugins/toolsets/code_execution/test_code_execution_security.py`,
+including a script that forges raw socket requests to excluded tools and the
+documented (currently-permitted) local-file read.
+
 # Token-cost impact
 
 - Addressable segment (≥6 iterations, tool-heavy real traffic): ~$15.3k/mo,

--- a/docs/design/2026-07-28_holmes-code-mode.md
+++ b/docs/design/2026-07-28_holmes-code-mode.md
@@ -8,9 +8,10 @@ instead of scripts may save our token cost for tool calls." Project: *Minimize
 Token Cost for us (and users)*.
 
 Related reading:
+
 - `2026-06-10_remote-tool-execution.md` (relay) — the `expose_remotely` /
-  `is_core` markers, the **pre-approved-only, no-approval-round-trip** trust
-  model, and the 1MB inline result cap. Code mode reuses all three.
+  `is_core` markers and the **pre-approved-only, no-approval-round-trip** trust
+  model. Code mode reuses the same posture.
 - `2025-10-23_holmes-event-driven-architecture.md` (relay) — the SSE event
   contract (`start_tool_calling` / `tool_calling_result`) that carries tool
   calls to the UI, and relay's role as a transparent pipe.
@@ -19,495 +20,531 @@ Related reading:
 
 ## Overview
 
-Holmes investigates by running an **agentic tool-calling loop**: the LLM emits
-one or more tool calls, Holmes executes them, appends each result to the
-conversation, and re-sends the whole growing history on the next step. Complex
-investigations run 10–55 tool calls across many steps, and because every step
-re-sends all prior tool results, input tokens grow super-linearly with
-iteration count.
+Holmes investigates by running an **agentic tool-calling loop**: the LLM emits a
+tool call, Holmes runs it, appends the result to the conversation, and re-sends
+the whole growing history on the next step. Complex investigations run tens of
+tool calls across many steps, and because every step re-sends all prior tool
+results, input tokens grow super-linearly with the number of steps.
 
 **Code mode** ([Anthropic](https://www.anthropic.com/engineering/code-execution-with-mcp),
 [Cloudflare](https://blog.cloudflare.com/code-mode/)) replaces "many small tool
 calls, one per LLM step" with "the LLM writes **one Python script** that composes
-many tool calls, runs it in a sandbox, and only the **filtered final result**
-returns to the model's context." Tool outputs the model never needs are
-filtered *inside the script* and never enter the context window at all.
+many tool calls, runs it, and returns only the **filtered result** to the
+model." Tool output the model never needs is filtered *inside the script* and
+never enters the context window.
 
-Solution: a new **`code_execution` toolset** in Holmes whose single tool takes a
-Python snippet, runs it in a subprocess pre-loaded with a **generated `holmes`
-client module** that exposes the current request's tools as callable Python
-functions. Each function dispatches back into the existing `ToolExecutor`, so
-tools behave identically whether called directly or from a script. Sub-calls
-still emit their own SSE events, so the UI shows the same per-tool cards it does
-today; the wrapping script does not become an opaque black box.
+This design adds a `code_execution` toolset whose single tool, `run_python_code`,
+runs an LLM-written Python script in a subprocess. The script is given a
+generated `holmes` client — one Python function per tool the request already has
+— and each call is relayed back to the parent Holmes process, which runs the
+real tool through the existing `ToolExecutor`. So tools behave identically
+whether called directly or from a script, credentials stay in the parent, and
+the agentic loop is unchanged: `run_python_code` is just another tool call. The
+feature is off by default.
 
-Stakeholders: AI/Holmes team (the runtime + prompting), backend/relay (SSE
-passthrough — no code changes expected), frontend (one new event field to
-surface script + sub-calls).
+Stakeholders: AI/Holmes team (runtime + prompting), backend/relay (SSE
+passthrough — no relay change), frontend (nested sub-call rendering, a later
+increment).
 
 ## Glossary
 
 - **Code mode** — the execution path where the LLM writes Python composing tool
   calls, instead of emitting one function call per LLM step.
-- **`code_execution` toolset / `run_python_code` tool** — the new toolset and
-  its single tool (this design). Modeled on `BashExecutorToolset`
-  (`holmes/plugins/toolsets/bash/bash_toolset.py:399`).
-- **client module (`holmes`)** — an auto-generated Python module, injected into
-  the script's namespace, whose functions mirror the request's tools
-  (`holmes.kubernetes.get_pods(...)`, `holmes.prometheus.query(...)`). Each is a
-  thin wrapper that calls `ToolExecutor.get_tool_by_name(name).invoke(...)`.
-- **sub-call** — a tool invoked from inside a running script (as opposed to a
-  top-level tool call the LLM emits directly).
+- **`code_execution` toolset / `run_python_code` tool** — the new toolset and its
+  single tool (this design), modeled on the existing `bash` toolset.
+- **client (`holmes`)** — an auto-generated object injected into the script's
+  namespace, exposing one function per eligible tool (`holmes.kubectl_get(...)`,
+  `holmes.list_events(...)`). Each function relays the call to the parent.
+- **bridge** — the parent-side server that receives a script's tool-call requests
+  over a unix-domain socket, checks them against the allow-list, dispatches into
+  `ToolExecutor`, and streams the result back.
+- **sub-call** — a tool invoked from inside a running script (versus a top-level
+  tool call the LLM emits directly).
 - **the two token sinks** — (1) *tool-definition overhead*: all tool schemas
   loaded into context up-front; (2) *intermediate-result bloat*: every tool
   result re-sent through context on each subsequent step. Sink (2) is the one
   that matters for Holmes (see Background).
-- **spill-to-disk** — the existing size guard
-  (`holmes/core/tools_utils/tool_context_window_limiter.py:30`) that saves an
-  oversized tool result to a file and hands the model a `cat … | jq` pointer
-  instead of the payload.
+- **spill-to-disk** — the existing size guard that saves an oversized tool
+  result to a file and hands the model a `cat … | jq` pointer instead of the
+  payload.
+- **`is_core`** — a toolset marker (from remote-tool-execution) for internal
+  agent-loop machinery (`robusta_platform_mcp`, `core_investigation`/`TodoWrite`,
+  `skills`); such toolsets are never exposed to remote callers or to code mode.
 
 ## Background
 
-- **Where the money is (30-day prod, customer-facing).** ~$23k/mo total Holmes
-  spend; **82.6% overall prompt-cache hit** (89–94% on the expensive buckets).
-  Cost is ~99% *input* tokens (completion averages 4–11k against prompt averages
-  of 142k → 2.9M). Spend rises with iteration count in lockstep with
-  `avg_tool_calls` (4-6 iters → 10 calls, 7-10 → 19, 11-20 → 30, 21-50 → 55).
-  Requests with **≥6 iterations = $15.3k/mo (66.5% of spend)** — the exact
-  multi-tool-chaining regime code mode targets.
+- **Where the money is (30-day prod).** ~$23k/mo total Holmes spend; **82.6%
+  overall prompt-cache hit** (89–94% on the expensive buckets). Cost is ~99%
+  *input* tokens. Spend rises with step count in lockstep with tool-call count
+  (4–6 iters → ~10 calls, 7–10 → ~19, 11–20 → ~30, 21–50 → ~55). Requests with
+  **≥6 iterations are ~$15.3k/mo (66.5% of spend)** — the multi-tool-chaining
+  regime code mode targets.
 - **Sink (1) is already neutralized by prompt caching.** The static prefix
   (system prompt + all tool schemas) is identical every step and is the most
   cacheable content, so at 82.6% cache hit the "don't load all tool defs
-  up-front" half of the Anthropic/Cloudflare 98% headline buys us almost nothing
-  in dollars. **The win must come from sink (2): fewer results entering context,
-  and fewer iterations.** This re-prioritizes the design: result-filtering and
-  call-consolidation first; progressive tool-def disclosure is a Future Goal, not
-  v1.
-- **Holmes already has a proto-code-mode.** The `bash` toolset
-  (`bash_toolset.py:94`) runs shell (kubectl/jq/grep) with prefix allow/deny
-  validation, and `spill_oversized_tool_result` already keeps oversized payloads
-  out of context behind a file pointer. So v1 is capturing the *residual* between
-  "compose CLI tools in bash" and "compose **all** toolsets (Prometheus, Grafana,
-  Datadog, k8s, …) in one typed script" — not a greenfield 98%. **Estimated
-  saving: ~15–25% of total spend (~$3–6k/mo)**, pending the trace study; the
-  wide band is because the result-vs-definition token split is not measurable
-  from prod telemetry alone.
-- **Not everything is addressable.** The single largest uncached-cost bucket is
-  short `user_chat` (1–3 iters, cold cache) — code mode does nothing for it.
-  `health_check` synthetic traffic is a separate config problem. v1 scopes to
-  multi-iteration, tool-heavy real traffic.
+  up-front" half of the headline 98% figure buys almost nothing in dollars. The
+  win has to come from **sink (2): fewer results entering context, and fewer
+  steps.** So this design prioritizes result-filtering and call-consolidation;
+  progressive tool-def disclosure is out of scope.
+- **Holmes already has a proto-code-mode: the `bash` toolset.** It runs shell
+  (`kubectl`/`jq`/`grep`) with prefix allow/deny validation, and `spill-to-disk`
+  already keeps oversized payloads out of context. Code mode captures the
+  *residual* between "compose CLI tools in bash" and "compose **all** toolsets
+  (Prometheus, Grafana, Datadog, k8s, …) in one typed Python script." Because
+  bash is the closest existing analog, this doc compares the two directly under
+  [Code mode vs. bash mode](#code-mode-vs-bash-mode).
+- **Not everything is addressable.** The largest uncached-cost bucket is short
+  `user_chat` (1–3 iters, cold cache) — code mode does nothing for it. v1 scopes
+  to multi-iteration, tool-heavy traffic.
 
 ## Goals
 
 User stories:
 
-1. Holmes investigates "which of the 200 pods in namespace X restarted in the
-   last hour, and why?" by writing one script that lists pods, filters to
-   restarted ones in Python, fetches logs only for those, and returns a 5-line
-   summary — instead of 20 LLM steps each re-sending the full pod list.
+1. Holmes answers "which of the 200 pods in namespace X restarted in the last
+   hour, and why?" by writing one script that lists pods, filters to the
+   restarted ones in Python, fetches logs only for those, and returns a short
+   summary — instead of many LLM steps each re-sending the full pod list.
 2. A script that pulls a 10,000-series Prometheus range and returns only the top
-   3 offenders keeps the other 9,997 series out of the model's context entirely.
+   3 offenders keeps the other 9,997 series out of the model's context.
 3. The user watching the Ask-Holmes UI still sees each sub-call as its own tool
-   card (name, status, expandable output) plus the script that drove them — code
-   mode is not an opaque box.
-4. A simple single-tool ask ("is the cluster healthy?") is **not** made slower or
-   costlier — the model keeps using direct tool calls for trivial work.
+   card, plus the script that drove them — code mode is not an opaque box.
+4. A trivial single-tool ask ("is the cluster healthy?") is **not** made slower
+   or costlier — the model keeps using direct tool calls for simple work.
 
 Technical requirements:
 
-- A new `code_execution` toolset with one tool `run_python_code`, off by default
-  behind a feature flag, modeled on `BashExecutorToolset`.
-- Tools callable from a script go through the **same** `ToolExecutor` path,
-  validation, transformers, and result-size guard as direct calls — no bypass.
-- **Read-only / pre-approved trust model**, identical to remote-tool-execution:
-  a running synchronous script cannot pause for interactive approval, so
-  approval-gated tools are **denied on the spot inside a script**; only
-  pre-approved / read-only tools are callable. `is_core` toolsets
-  (`robusta_platform_mcp`, `core_investigation`/`TodoWrite`, `skills`) are never
-  exposed in the client module.
-- Every sub-call emits its own `start_tool_calling` / `tool_calling_result` SSE
-  event (with a `parent_tool_call_id`) so relay forwards them unchanged and the
-  UI renders them — see Observability.
-- Script stdout over the per-tool cap goes through `spill_oversized_tool_result`
-  (same 15% / 25k-token guard), so a runaway script can't flood context.
-- `LLMResult` already exposes `num_llm_calls`, `total_tokens`,
-  `max_prompt_tokens_per_call`, etc. (`llm_usage.py:81`); code mode must move
-  these *down* for multi-step tasks and this is asserted in tests.
+- One new toolset `code_execution` with one tool `run_python_code`, off by
+  default behind a feature flag.
+- A script's tool calls go through the **same** `ToolExecutor`, validation,
+  transformers, and result-size guard as direct calls — no bypass.
+- **Read-only / pre-approved surface only.** A synchronous script cannot pause
+  for interactive approval, so approval-gated tools are denied inside a script;
+  only read-only / pre-approved tools are callable. `is_core` toolsets are never
+  exposed.
+- **Credentials never enter the untrusted subprocess.**
+- Script stdout over the per-tool cap flows through `spill-to-disk`, so a runaway
+  script can't flood context.
 - Works on any model/provider — it is an ordinary tool call, no special API.
 
 ## Out of Scope
 
-- **Interactive approval inside a script.** No approval round-trip (matches
-  remote-tool-execution). Approval-gated tools are denied at call time inside a
-  script; the model must fall back to a direct tool call to trigger the normal
-  approval flow.
-- **A real language-level sandbox** (RestrictedPython / gVisor / container
-  isolation) in v1. v1 reuses the bash trust model — subprocess + `ulimit`
-  memory cap + read-only tools. Hardening is a Future Goal and an explicit
-  security decision (see Assumptions).
-- **Progressive disclosure of tool definitions** (filesystem tree of stubs,
-  `search_tools`) — deprioritized because caching already neutralizes sink (1).
+- **Interactive approval inside a script.** No approval round-trip; approval-gated
+  tools are denied at call time, and the model falls back to a direct tool call
+  to trigger the normal approval flow.
+- **A language-level or OS sandbox** in v1 (RestrictedPython / gVisor / container
+  isolation). v1's isolation is subprocess + `ulimit` + the tool allow-list; real
+  sandboxing is a Future Goal and the gating decision for broad rollout (see
+  [Security model](#security-model)).
+- **Progressive disclosure of tool definitions** — deprioritized because caching
+  already neutralizes sink (1).
 - **Writing/mutating tools from a script** — read-only tools only.
-- **Persisted "skills"** (saving successful scripts as reusable functions across
-  sessions).
+- **Persisted "skills"** (saving successful scripts as reusable functions).
 
 ## Future Goals
 
-- Language-level sandboxing to allow a broader tool set and untrusted code.
-- Progressive tool-def disclosure if tool count ever grows enough to matter
-  despite caching.
-- Auto-routing: a cheap classifier that pre-selects code mode vs direct calls
+- Language-level / OS sandboxing, to allow a broader tool set and to make the
+  feature safe under untrusted input.
+- Auto-routing: a cheap classifier that pre-selects code mode vs. direct calls
   per request, instead of leaving it to the model + prompt.
-- Persisted skills (reusable scripts) and cross-call state files.
+- Live per-sub-call streaming to the UI (nested tool cards) — see Observability.
 - Extending code mode across clusters by composing the remote tools from
   `2026-06-10_remote-tool-execution.md` inside a script.
 
 ## Assumptions & Constraints
 
-- **Security posture.** Holmes runs in-cluster with live credentials and RBAC.
-  Executing LLM-generated Python is a materially larger attack surface than
-  prefix-validated bash. v1's mitigation is **not** interpreter sandboxing; it is
-  that (a) only read-only / pre-approved tools are reachable, (b) the same
-  allow/deny validation still runs on any `bash` sub-call, (c) a `ulimit` memory
-  cap and wall-clock timeout bound the subprocess, and (d) the feature is
-  off-by-default behind a flag. This is the identical stance the team already
-  accepted for remote tool execution, and it is called out here as a conscious
-  decision, not an oversight.
-- **Relay is a transparent SSE pipe.** `ClientsManager.send_stream_message`
-  yields Holmes's SSE bytes verbatim; relay identifies tool calls solely by
-  `tool_call_id` (`SSE/holmes_tools_helper.py:upsert_tool_call`). So sub-calls
-  are observable **iff Holmes emits them as normal SSE events** — no relay change
-  needed as long as we reuse the existing event types.
-- The frontend renders a **flat `HolmesTool[]`** via two independent consumers
-  (legacy `onChunk` in `holmes-chat-history.store.ts:1333` and the realtime
-  `EventProjector._processEvent` in `event-projector.ts:228`). A new event field
-  must be handled in **both**, or it is silently dropped in one path.
-- Per-tool result cap = `min(15% ctx, 25k tokens)`
-  (`TOOL_MAX_ALLOCATED_CONTEXT_WINDOW_*`); compaction fires at 95% (rarely — 0.5%
-  of requests). Code mode does not change these; it feeds through them.
+- Holmes runs in-cluster with live credentials and RBAC. Executing
+  LLM-generated Python is a materially larger surface than prefix-validated bash;
+  the design constrains what a script can *reach*, not what Python it can run
+  (see [Security model](#security-model)).
+- **Relay is a transparent SSE pipe** — it forwards Holmes's SSE bytes verbatim
+  and keys tool calls by `tool_call_id`. So sub-calls become observable purely by
+  Holmes emitting them as normal SSE events; no relay change is needed.
+- The per-tool result cap is `min(15% of context, 25k tokens)`; compaction fires
+  at 95% (rare). Code mode does not change these; its output feeds through them.
 
 # Design
 
 ## Current Design
 
-- **The loop** — `holmes/core/tool_calling_llm.py`. `ToolCallingLLM.call_stream`
-  (`:1035`) runs `while i < max_steps` (`:1105`): assemble messages → check/apply
-  compaction (`:1115`) → `self.llm.completion(..., tools=tools)` (`:1167`) →
-  append assistant turn → if `tool_calls` present, execute them in a
-  `ThreadPoolExecutor(max_workers=16)` (`:1320`), append each
-  `tool_call_result.to_llm_message()` (`:1415`), loop; else return the answer.
-  Tool execution funnels through `_invoke_llm_tool_call` (`:870`) →
-  `_directly_invoke_tool_call` (`:747`) → `tool.invoke(params, context)`
-  (`:789`).
-- **Tools** — `holmes/core/tools.py`. `Tool` (`:284`) with `parameters:
-  Dict[str, ToolParameter]` and abstract `_invoke(...) -> StructuredToolResult`
-  (`:516`). `Toolset` (`:719`). `StructuredToolResult` (`:96`) with
-  `stringify_data(compact=True)` (`:111`). Approval via `requires_approval`
-  (`:423`) returning `APPROVAL_REQUIRED`. `expose_remotely` / `is_core` markers
-  exist from remote-tool-execution.
-- **Tool → LLM schema** — `holmes/core/openai_formatting.py`.
-  `format_tool_to_open_ai_standard` (`:153`), `type_to_open_ai_schema` (`:71`).
-- **Dispatch registry** — `holmes/core/tools_utils/tool_executor.py`.
-  `get_all_tools_openai_format` (`:178`), `get_tool_by_name` (`:100`),
-  `clone_with_extra_tools` (`:153`, per-request tool injection).
-- **Result size guard** — `tool_context_window_limiter.py:spill_oversized_tool_result`
-  (`:30`); the file-pointer fallback is gated on `_has_bash_for_file_access`
-  (`:246`).
-- **The bash executor** — `bash_toolset.py`: `RunBashCommand` (`:94`),
-  validation via `validate_command`, `requires_approval` → `APPROVAL_REQUIRED`
-  for unknown prefixes; `BashExecutorToolset` (`:399`). Low level:
-  `common/bash.py:execute_bash_command` (`:17`) = `subprocess(shell=True)` +
-  `get_ulimit_prefix()` memory cap. **No interpreter sandbox.**
-- **Prompting** — `holmes/plugins/prompts/generic_ask.jinja2` (main system
-  prompt), `_toolsets_instructions.jinja2` (injects each toolset's
-  `llm_instructions`). Built by `holmes/core/prompt.py:build_system_prompt`
-  (`:177`).
-- **Streaming contract** — Holmes emits SSE `start_tool_calling` (name + id) then
-  `tool_calling_result` (result + status). Relay's `SSEEventType`
-  (`relay/pkg/holmes/common/data_types.py:7`) and `upsert_tool_call`
-  (`SSE/holmes_tools_helper.py:102`) merge the pair into one `HolmesToolCall`
-  keyed by `tool_call_id`. Frontend consumes via `enums.ts`, projects into
-  `HolmesTool[]` (`holmes-types.d.ts:189`), renders per-tool in
-  `HolmesToolsCollapseBlock.vue`.
+Holmes's agentic loop assembles the conversation, calls the LLM with the full
+tool-schema set, executes any returned tool calls in a bounded thread pool,
+appends each result back into the conversation, and repeats until the model
+answers. Every tool result therefore lives in the context and is re-sent on
+every later step.
 
-Pros: the loop, dispatch, size-guard, validation, and streaming are all
-battle-tested. Cons: tools compose only one-per-step through the model, so
-intermediate results flow through context repeatedly.
+Two existing pieces matter for this design:
+
+- **The `bash` toolset** runs a shell command in a subprocess with a `ulimit`
+  memory cap and a wall-clock timeout, validating the command against a prefix
+  allow/deny list and returning `APPROVAL_REQUIRED` for anything not
+  pre-approved. It is Holmes's existing "compose tools in code" path, limited to
+  CLI tools.
+- **The result-size guard (`spill-to-disk`)** intercepts any oversized tool
+  result and replaces it with a file pointer so it can't flood the context.
+
+Both are reused unchanged by code mode. The gap they leave: tools compose only
+one-per-step through the model (or, for bash, only CLI tools), so intermediate
+results flow through the context repeatedly.
 
 ## Proposed Design
 
-### 1. The `run_python_code` tool
+### The `run_python_code` tool
 
-New toolset `holmes/plugins/toolsets/code_execution/`, registered in
-`holmes/plugins/toolsets/__init__.py:load_python_toolsets`. One `Tool`:
+A new toolset `code_execution` with a single tool:
 
-- **Parameters**: `code: str` (the Python snippet), optional `timeout: int`
-  (default 60s).
-- **`_invoke(params, context)`**:
-  1. Materialize the **client module** (§2) for `context`'s `ToolExecutor` and
-     the request's enabled, non-`is_core`, pre-approved/read-only tools.
-  2. Write the snippet + a bootstrap that imports the client module to a temp
-     file (per-request `tmp` dir; `xdist_group` in tests).
-  3. Run it via `execute_bash_command("python3 <file>", timeout)` — reusing the
-     bash executor's `get_ulimit_prefix()` memory cap and timeout handling
-     (`common/bash.py`).
-  4. Capture stdout/stderr → `StructuredToolResult` (SUCCESS / ERROR / NO_DATA,
-     `return_code`, `invocation`, `elapsed_seconds`), same shape as
-     `bash_result_to_structured`.
-  5. Pass the result through `spill_oversized_tool_result` so oversized stdout
-     becomes a file pointer, not a context flood.
-- **`BashExecutorConfig`-style config**: `enabled=False` by default,
-  `is_core=False`, `expose_remotely=False` (a script fanning out to remote tools
-  is a Future Goal), plus a `llm_instructions` jinja2 template teaching the model
-  *when* to use it (multi-step / large-result tasks) and *when not to* (trivial
-  asks) — surfaced via `_toolsets_instructions.jinja2`.
+- **Parameters:** `code` (the Python script) and optional `timeout` (default 60s,
+  clamped to ≤300s).
+- **Behavior:** the tool generates the `holmes` client for the request's eligible
+  tools, writes the script plus a small bootstrap to a temp file, runs it as a
+  `python3` subprocess (reusing bash's `ulimit` memory cap and timeout), captures
+  stdout/stderr into a `StructuredToolResult`, and passes that result through
+  `spill-to-disk`. The result also carries a short footer listing each sub-call
+  (name / status / timing) for traceability.
+- **Config:** `enabled=False` by default; `is_core=False`; not exposed remotely.
+  Its `llm_instructions` teach the model *when* to use code mode (multi-step /
+  large-result tasks) and *when not to* (trivial asks).
 
-The agentic loop (`call_stream`) needs **no change**: `run_python_code` is an
-ordinary tool call. Parallel execution, the result-feedback path, and
-compaction all apply unchanged.
+The agentic loop needs **no change** — `run_python_code` is an ordinary tool
+call, so parallel execution, the result-feedback path, and compaction all apply
+unchanged.
 
-### 2. The generated `holmes` client module
+### The generated `holmes` client
 
-Generated per request from the `ToolExecutor`'s eligible tools:
+For each request, Holmes generates a `holmes` object with one function per
+**eligible** tool. A function's signature is derived from the tool's parameter
+schema and its docstring from the tool's description; the body relays the call to
+the parent and returns the tool's data (raising a catchable `holmes.HolmesToolError`
+on a tool error, so a script can `try/except`).
 
-```text
-holmes/
-  kubernetes.py     get_pods(namespace: str, ...) -> dict
-  prometheus.py     query(promql: str, ...) -> dict
-  logs.py           fetch(pod: str, ...) -> dict
-  ...
-```
+**Eligibility** (the allow-list) excludes:
 
-- One Python function per `Tool`, grouped into a module per toolset. Signature is
-  derived from `parameters: Dict[str, ToolParameter]` by **inverting** the
-  `type_to_open_ai_schema` mapping (`openai_formatting.py:71`) into Python type
-  hints; docstring = the tool's `description`.
-- Each function body is a thin wrapper:
-  `return _dispatch("<tool_name>", locals())` → calls
-  `ToolExecutor.get_tool_by_name(name).invoke(params, context)` and returns the
-  parsed `StructuredToolResult.data` (raising a Python exception on ERROR so the
-  script can `try/except`).
-- **Eligibility filter** (applied when building the module):
-  - exclude `is_core` toolsets (`robusta_platform_mcp`, `core_investigation`,
-    `skills`);
-  - exclude tools whose `requires_approval(...)` is not statically
-    pre-approved/read-only — a call to one inside a script returns an ERROR
-    "approval-gated tool; call it directly instead," never a silent pause.
-- Dispatch runs in the **same process** as the loop (the script subprocess calls
-  back via a thin RPC/stdin-stdout bridge to the parent, or — simpler v1 — the
-  parent process runs the tools and the subprocess only runs the user's Python
-  with the client stubbed to IPC). The exact bridge is an implementation
-  decision captured in Open Questions; both keep validation server-side.
+- `is_core` toolsets (agent-loop machinery);
+- the `bash` and `kubectl_run` toolsets (mutation / shell surfaces) and the
+  `code_execution` toolset itself (no recursion);
+- any tool matching its toolset's `approval_required_tools` patterns.
 
-### 3. Observability — sub-calls are first-class
+The remaining read-only / pre-approved tools are the only functions the client
+exposes.
 
-To keep the UI honest (user story 3), each sub-call emits the **existing** SSE
-events with one new field:
+### Execution and isolation
 
-- `start_tool_calling` / `tool_calling_result` gain an optional
-  `parent_tool_call_id` pointing at the `run_python_code` call's id.
-- Relay needs **no change** — it forwards bytes and keys tool calls by id
-  (`upsert_tool_call`), so the sub-call events flow through as ordinary tool
-  cards.
-- Frontend: add `parent_tool_call_id` handling in **both** consumers
-  (`holmes-chat-history.store.ts:1333` and `event-projector.ts:228`) and a
-  `subTools?: HolmesTool[]` field on `HolmesTool` (`holmes-types.d.ts:189`);
-  render sub-calls nested inside the parent row in `HolmesToolsCollapseBlock.vue`
-  (which already supports nested `HolmesTools`). The script itself renders in the
-  parent row's "Request" tab. Unknown/unhandled → the realtime projector's
-  `default` warns (`event-projector.ts:431`); we handle it explicitly so nothing
-  is dropped.
+The untrusted script runs in a **subprocess**; the real tools run in the
+**parent** Holmes process. They communicate over a **unix-domain socket**: the
+script's `holmes.*` call sends `{tool, params}` to the parent; the parent's
+**bridge** validates and dispatches it and streams the result back. Two
+properties fall out of this split:
+
+- **Credentials stay in the parent.** The subprocess is started with a minimal
+  environment allow-list (`PATH`, locale, and the bridge's socket/script paths) —
+  never the parent's `os.environ`, so LLM/provider keys and other secrets are not
+  visible to the script.
+- **The allow-list is enforced parent-side.** The subprocess is given the socket
+  path, so a script can bypass the generated client and hand-craft raw socket
+  requests. The parent therefore re-checks every request's tool name against the
+  eligibility allow-list *before* looking up or invoking anything, and converts
+  an `APPROVAL_REQUIRED` outcome into an error. The generated client is a
+  convenience; the socket boundary is the security boundary.
+
+### Observability — sub-calls stay visible
+
+Code mode must not turn N tool calls into one opaque box (user story 3). The
+design keeps sub-calls first-class by reusing the **existing** SSE events with
+one added optional field, `parent_tool_call_id`, pointing at the enclosing
+`run_python_code` call. Because relay only forwards bytes and keys tool calls by
+id, sub-call events flow through unchanged, and the frontend nests them under the
+parent card (the script renders in the parent's "Request" tab). This needs no
+relay change and an additive frontend change in both stream consumers.
+
+*v1 status:* the tool records each sub-call and returns them as a summary footer
+in the result; the live nested-card streaming (the `parent_tool_call_id` field +
+frontend nesting) is the remaining increment and ships as a separate frontend
+PR.
 
 ### Data flow
 
 ```text
-LLM step k                Holmes                          UI (via relay pipe)
-  │                         │                               │
-  ├─ tool_call ───────────▶ run_python_code(code)           │
-  │                         │  build holmes client module   ├─ card: "run_python_code"
-  │                         │  spawn python subprocess ──┐   │
-  │                         │                            │   │
-  │                         │   script calls:            │   │
-  │                         │     holmes.k8s.get_pods() ─┼──▶ emit start/result   ├─ nested card (sub-call)
-  │                         │       → ToolExecutor.invoke │   │   (parent_tool_call_id)
-  │                         │     filter in Python        │   │
-  │                         │     holmes.logs.fetch(x3) ──┼──▶ emit start/result   ├─ nested cards
-  │                         │     print(summary)          │   │
-  │                         │                            ◀┘   │
-  │                         │  stdout → spill guard          │
-  ◀─ tool result (summary) ─┤  (only the 5-line summary      │
-  │   enters context           enters context, not the       │
-  │                            9,997 discarded series)        │
+LLM step k                Holmes parent                     UI (via relay pipe)
+  │                         │                                 │
+  ├─ tool_call ───────────▶ run_python_code(code)             ├─ card: "run_python_code"
+  │                         │  generate holmes client         │
+  │                         │  spawn python subprocess ──┐     │
+  │                         │                            │     │
+  │                         │  script (subprocess):      │     │
+  │                         │    holmes.list_pods() ──────▶ bridge: validate + dispatch
+  │                         │       (result → subprocess)│     ├─ nested card (sub-call)
+  │                         │    filter in Python        │     │
+  │                         │    holmes.logs(x3) ─────────▶ bridge: validate + dispatch
+  │                         │    print(summary)          │     ├─ nested cards
+  │                         │                            ◀┘     │
+  │                         │  stdout → spill guard            │
+  ◀─ tool result (summary) ─┤  (only the summary enters        │
+  │                            context, not the raw data)      │
   ▼
 LLM step k+1  (history grew by ~summary, not by all raw tool output)
 ```
 
-The token win is structural: the raw `get_pods` list and the two unused log
-bodies **never enter the model's context** — only `print(summary)` does, once.
+The token win is structural: the raw tool outputs the script discards **never
+enter the model's context** — only what it `print`s does, once.
 
-### Feature flag & rollout
+## Code mode vs. bash mode
 
-- Off by default. Enable per-account/per-request via the existing config path
-  (`toolsets.code_execution.enabled: true`) and, for the hosted product, an
-  `AccountSettings` flag read the same way remote-tool-execution reads its flag.
-- Rollout: (1) internal accounts + evals; (2) opt-in beta on a few high-iteration
-  accounts (the ROB-723 project's target segment); (3) default-on for
-  tool-heavy request types if evals show correctness parity and a token win.
+Bash is the existing "compose tools in code" path, so it is the right baseline.
+The two share their runtime primitives (subprocess, `ulimit`, timeout,
+spill-to-disk) but differ in reach and in where the safety boundary sits.
 
-# Security model
+| Dimension | Bash mode (`bash` toolset) | Code mode (`code_execution`) |
+|---|---|---|
+| **What executes** | One shell command line (`shell=True`) | An arbitrary Python script |
+| **Reach / composition** | CLI tools only (`kubectl`, `jq`, `grep`, …); model hand-writes/parses text | All Holmes toolsets (Prometheus, Grafana, k8s, …) as typed `holmes.*` functions in one script |
+| **Whitelisting** | Prefix allow/deny list on the **command** itself | No allow-list on the **code** (arbitrary Python by design); the allow-list is on **which Holmes tools** the script may call, enforced parent-side at the bridge |
+| **Approval** | Per-command: an unknown/mutating prefix returns `APPROVAL_REQUIRED` → interactive approval | Approval-gated tools are **denied** at dispatch inside a script (no round-trip); the model must call them directly |
+| **Memory** | `ulimit -v` cap on the shell subprocess | Same `ulimit -v` cap on the `python3` subprocess |
+| **CPU / time** | Wall-clock timeout on the command | Wall-clock timeout on the script (default 60s, ≤300s) |
+| **Credentials / env** | Command inherits the Holmes process environment (kubeconfig, keys) | Subprocess gets a **minimal env allow-list** — no `os.environ`; tools (and their creds) run in the parent, reached only via the socket |
+| **Security boundary** | Command-prefix validation; single process | Parent-side tool allow-list + per-tool validation at the socket bridge; untrusted code isolated to the subprocess |
+| **Injection patterns** | Shell injection bounded by prefix validation (metachar/quoting risk within allowed commands; secrets-read commands denied) | No shell. Tool-name/param **injection over the bridge** is bounded by the parent allow-list + each tool's own validation. **Residual (v1):** the Python itself can make arbitrary outbound network calls and read on-disk files — no OS sandbox (see Security model) |
+| **Result-size guard** | `spill-to-disk` on stdout | Same guard on stdout — *and* the script can pre-filter so less reaches stdout at all |
+| **Sandbox** | None (subprocess + `ulimit`) | None in v1 (subprocess + `ulimit`); OS/language sandbox is a Future Goal |
+| **Token behavior** | Intermediate data can stay in the shell pipe, but only across CLI tools | Intermediate data from **any** toolset stays in the subprocess; only `print()` output re-enters context |
 
-The script is arbitrary, LLM-generated Python. The model is therefore
-**capability-limiting, not code-sandboxing**: assume the script can run any
-Python, and constrain what it can *reach*.
+Net: code mode is a strict superset of bash's composition ability across all
+toolsets, with the same resource bounds, and it moves the safety boundary from
+"validate the command string" to "validate which tools the code may call, in the
+parent." Its new risk relative to bash is that the executed language is
+unconstrained (network + filesystem), which is what the Security model addresses.
 
-**The trust boundary is the parent-side allow-list, not the generated client.**
-The subprocess is handed the bridge socket path (`HOLMES_CODE_SOCKET`), so a
-script can bypass the generated `holmes.*` stubs and send raw
-`{"tool": ..., "params": ...}` requests over the socket by hand. Every request
-is therefore re-checked in the parent's `dispatch` before any tool is looked up
-or invoked:
+## Error states / failure scenarios
 
-- **Allow-list enforced server-side.** A requested tool name not in
-  `eligible_tool_names(...)` is rejected outright — `is_core` toolsets,
-  `bash`/`kubectl_run`, and any `approval_required_tools` are excluded, so a
-  script cannot reach a mutation/approval surface even by forging the request.
-- **Approval cannot be scripted around.** An `APPROVAL_REQUIRED` result at
-  dispatch is converted to an error; there is no auto-approve path.
-- **Credentials never enter the subprocess.** Tools execute in the parent; the
-  subprocess env is a minimal allow-list (`PATH`/`LANG`/`HOLMES_CODE_*`), never
-  the parent's `os.environ` (LLM/provider keys, DB creds, etc.).
-- **Per-tool validation is unchanged.** Dispatched calls go through the real
-  `tool.invoke()`, so each tool's own guards still apply.
-- **Resource bounds.** `ulimit` memory cap + wall-clock timeout kill runaway
-  scripts; oversized stdout flows through `spill_oversized_tool_result`.
+- **Syntax error / runtime exception** → `ERROR` result with the traceback and a
+  non-zero return code; the model reads it and self-corrects.
+- **Timeout / infinite loop** → the subprocess is killed at the wall-clock
+  deadline; `ERROR` result.
+- **Memory blow-up** → the `ulimit` cap kills the subprocess; `ERROR` result.
+- **Huge stdout** → `spill-to-disk` replaces it with a file pointer.
+- **Sub-call to a non-eligible / approval-gated / unknown tool** → the bridge
+  returns an error to the script (raised as `holmes.HolmesToolError`); the tool
+  never runs.
+- **Sub-tool returns an error** → surfaced as a catchable `holmes.HolmesToolError`.
+- **Executor not wired** → the tool returns a clear configuration error rather
+  than crashing the loop.
 
-**Residual risk (accepted for v1, off by default).** There is **no
-language-level or OS sandbox** — subprocess + `ulimit` only. So a script can
-still (a) make **arbitrary outbound network calls** and (b) **read on-disk files
-the process can access** (env secrets are stripped, but files such as
-`/var/run/secrets/kubernetes.io/serviceaccount/token` are not). Combined with a
-successful **prompt injection** (Holmes ingests untrusted logs/alerts/objects),
-the blast radius is "anything the pod's process can reach and exfiltrate". This
-is the primary reason the feature is off by default; real isolation
-(RestrictedPython / gVisor / container sandbox / egress deny) is a Future Goal
-(see Out of Scope). These boundaries are covered by
+## Scale / limitations
+
+- **Concurrency.** The agentic loop already runs top-level tool calls in a
+  bounded thread pool; each `run_python_code` call is one such call and spawns one
+  subprocess. Memory must be sized so `pool_size × ulimit` fits the pod's limit.
+- **Serial sub-calls.** The bridge is single-connection / single-threaded, so
+  sub-calls *within* one script run serially. Fine for v1; parallel fan-out
+  inside a script would need a multi-connection bridge (Open Questions).
+- **Prompt overhead when unused.** Enabling the toolset adds its API reference to
+  the system prompt; on small tasks that overhead is not repaid (Open Questions).
+
+## Security model
+
+The script is arbitrary, LLM-generated Python, and Holmes ingests untrusted data
+(logs, alerts, k8s object contents), so the realistic threat is **prompt
+injection → code execution**. The model is therefore **capability-limiting, not
+code-sandboxing**: assume the script can run any Python, and constrain what it
+can reach.
+
+**Enforced boundary (v1).**
+
+- **Parent-side tool allow-list.** Every bridge request is checked against the
+  eligibility set *before* dispatch, so a script cannot reach `is_core`, `bash` /
+  `kubectl_run`, or approval-gated tools — even by forging raw socket requests
+  that bypass the generated client.
+- **Approval is not scriptable.** An `APPROVAL_REQUIRED` result at dispatch
+  becomes an error; there is no auto-approve path.
+- **Credentials isolated.** Tools run in the parent; the subprocess env is a
+  minimal allow-list, never the parent's secrets.
+- **Per-tool validation unchanged**, and **resource bounds** (`ulimit` + timeout)
+  apply to the subprocess.
+
+**Residual risk (accepted for v1, off by default).** There is **no language/OS
+sandbox** — subprocess + `ulimit` only. A script can therefore still (a) make
+**arbitrary outbound network calls** and (b) **read on-disk files** the process
+can access (env secrets are stripped, but files such as the mounted
+ServiceAccount token are not). Under prompt injection the blast radius is
+"anything the pod's process can reach and exfiltrate", and note that reading the
+SA token from disk would let a script bypass the read-only tool allow-list by
+calling the API server directly. **The allow-list bounds the tools, not the
+runtime.**
+
+**Path to production.** The IPC split is deliberately sandbox-friendly: the
+untrusted subprocess needs *only* the socket, so it can be jailed hard without
+losing function. The recommended posture:
+
+- *Self-hosted, single-tenant (operator owns the data):* ship enabled-by-config
+  with least-privilege read-only RBAC (no secret reads), an egress `NetworkPolicy`
+  that denies all but the LLM/relay endpoint, and no SA-token mount in the exec
+  path.
+- *Multi-tenant / untrusted input:* real isolation is a **prerequisite** — run the
+  subprocess in an egress-denied, credential-free sandbox (gVisor or a microVM;
+  read-only rootfs, non-root, dropped caps, seccomp). This is the gating decision
+  for default-on (Open Questions).
+
+These boundaries are covered by
 `tests/plugins/toolsets/code_execution/test_code_execution_security.py`,
-including a script that forges raw socket requests to excluded tools and the
-documented (currently-permitted) local-file read.
+including a script that forges raw socket requests to excluded tools (denied) and
+the documented, currently-permitted local-file read.
 
-# Token-cost impact
+## Observability
 
-- Addressable segment (≥6 iterations, tool-heavy real traffic): ~$15.3k/mo,
-  already ~82% cache-discounted.
-- Expected reduction on that segment: **20–40%**, from (i) fewer LLM iterations
-  (compose N calls in one script) and (ii) large results filtered before they
-  ever enter context.
-- **Net estimate: ~15–25% of total Holmes spend (~$3–6k/mo, ~$40–70k/yr)** — not
-  the 98% headline, because caching already banked sink (1) and bash+spill
-  already bank part of sink (2).
-- Instrumentation: `LLMResult`/`RequestStats` already record every needed field;
-  the eval harness records per-variant `total_tokens` / `num_llm_calls` /
-  `tool_call_count`, and `HolmesUsageEvents` gives the prod before/after.
+- **Sub-call visibility** as described above — recorded + summarized in v1, live
+  nested cards as the follow-up.
+- **Operational:** every executed script and its sub-call list should be logged
+  for audit/forensics; `LLMResult`/`RequestStats` already record `num_llm_calls`,
+  `total_tokens`, and tool-call counts, and `HolmesUsageEvents` gives the prod
+  before/after for a rollout A/B.
 
-# Testing plan (summary)
+## Infrastructure
 
-Full plan tracked separately; the layers:
+- No new infra. `run_python_code` needs `python3` in the Holmes image (already
+  present) and is verified by the toolset's prerequisite check.
+- Off by default; enabled per-account/per-request via the existing config path
+  and (for the hosted product) an `AccountSettings` flag read the same way
+  remote-tool-execution reads its flag.
+- Rollout: (1) internal accounts + evals; (2) opt-in beta on high-iteration
+  accounts under the self-hosted hardening above; (3) default-on for tool-heavy
+  request types once evals show correctness parity, a prod A/B shows the win, and
+  — for any untrusted-input exposure — the runtime sandbox is in place.
 
-1. **Unit** (`tests/plugins/toolsets/code_execution/`) — real trivial
-   subprocesses (à la `test_bash_command_execution.py`), the
-   result→`StructuredToolResult` converter, and spill reuse (both
-   `_has_bash_for_file_access` branches).
-2. **Integration** (`tests/test_tool_calling_llm.py`) — script the mocked
-   `llm.completion` to emit a `run_python_code` call; assert `num_llm_calls` /
-   `total_tokens` are lower than the equivalent N-direct-call script;
-   re-entrancy under the 16-worker pool; sub-call error propagation.
-3. **LLM evals** — new `test_ask_holmes` fixture with
-   `toolsets_matrix: [classic, codemode]`, shared `expected_output` (correctness
-   parity), `max_tokens` on the codemode variant, plus a cross-variant assertion
-   `codemode.total_tokens < classic.total_tokens`. Runs in `eval-regression.yaml`
-   behind an `evals-*` label.
-4. **Observability** — unit tests in both FE consumers
-   (`event-projector.test.ts` + a new legacy `onChunk` test) asserting
-   `parent_tool_call_id` nests sub-calls and keeps intermediate output visible;
-   relay `test_holmes_chat_streaming.py` / `test_sse_events.py` for the new field.
-5. **Local-stack manual** — `harness/bind.py up` + `verify --ui`; drive a
-   code-mode investigation and confirm sub-call cards render.
+## Token-cost impact
 
-Edge / failure modes explicitly covered: syntax error → self-correcting ERROR;
-runtime exception; timeout / infinite loop; memory blow-up (ulimit); huge stdout
-→ spill; approval-gated sub-call denied (not bypassed); bash validation still
-enforced inside a script; partial sub-call failure; secret-leakage attempt;
-no-bash fallback; xdist temp-file isolation; cross-model codegen; routing
-regression on trivial asks.
-
-# Alternatives considered
-
-- **Do nothing / lean on bash.** The bash toolset already composes CLI tools, but
-  it can't reach Holmes's Python toolsets (Prometheus, Grafana, Datadog, …) and
-  the model must serialize/parse JSON by hand. Code mode gives a typed API over
-  *all* toolsets. Rejected as insufficient for the addressable segment.
-- **Progressive tool-def disclosure only** (the other half of the Anthropic
-  design). Rejected for v1: caching already makes sink (1) nearly free in
-  dollars, so it would add complexity for little saving.
-- **Real sandbox (RestrictedPython / container) in v1.** Safer, but a large lift
-  and it blocks shipping a measurable token win. Deferred to Future Goals; v1
-  adopts the already-accepted read-only/pre-approved trust model.
-- **New dedicated SSE event type for nested calls.** Rejected in favor of reusing
-  `start_tool_calling` / `tool_calling_result` + a `parent_tool_call_id` field,
-  so relay stays a pure pipe and the FE change is additive.
+- Addressable segment (≥6 iterations, tool-heavy): ~$15.3k/mo, already ~82%
+  cache-discounted.
+- **Net estimate: ~15–25% of total Holmes spend (~$3–6k/mo)** — deliberately not
+  the headline 98%, because caching already banked sink (1) and bash+spill
+  already bank part of sink (2). The band is wide because the
+  result-vs-definition token split isn't measurable from prod telemetry alone;
+  the rollout A/B closes it.
+- The *mechanism* is proven deterministically (not model-dependent): measuring
+  the context-token cost of a tool result with the product's own tokenizer, a
+  filtered script returns **250,029 → 136 tokens** on a large payload and
+  collapses **8 sub-call results into 1** (30,952 → 275 tokens). See
+  Implementation & Verification.
 
 # Open Questions
 
-## Resolved during implementation
+1. **Sandbox before default-on.** Ship config-enabled for trusted operators with
+   the RBAC/egress hardening, or block default-on on a real runtime sandbox
+   (gVisor / microVM)? This is the main go-to-prod decision.
+2. **Routing.** v1 is prompt-only. Because Holmes's server-side filters
+   (`kubernetes_jq_query`, log `filter`) already handle many tasks, the model
+   often won't reach for code mode; a cheap pre-classifier or stronger prompting
+   may be needed to realize the savings. Measure regression on trivial asks
+   first.
+3. **Eligibility source of truth.** Should the code-mode allow-list be pinned to
+   the exact remote-tool-execution `expose_remotely` set (they are defined
+   independently today and could drift)?
+4. **Sub-call cost attribution.** Should sub-calls count toward `tool_call_count`
+   in `HolmesUsageEvents` (proposed: yes, for an honest before/after)?
+5. **Parallel sub-calls.** Is intra-script parallel fan-out worth a
+   multi-connection bridge, or is serial fine indefinitely?
+6. **Prompt-overhead crossover.** Where is the task size at which the toolset's
+   API-reference overhead is repaid, and should the reference be trimmed or
+   lazily disclosed for small requests?
+7. **Live A/B demonstration.** Do we want a live eval backed by a data source
+   with no server-side filter (to show the win end-to-end), or is the
+   deterministic proof + a prod A/B sufficient?
 
-1. **Execution bridge** — *Resolved: IPC.* Tools run in the **parent**; the
-   subprocess calls back over a newline-delimited-JSON AF_UNIX socket. Keeps
-   validation and credentials out of the subprocess. (See `bridge.py`,
-   `runner.py`.)
-2. **Which tools are exposed** — *Resolved for v1.* Eligibility = exclude
-   `is_core` toolsets, `bash`/`kubectl_run`, and any `approval_required_tools`
-   (`client_generator._is_eligible`). Enforced parent-side in `dispatch`, not
-   just via the generated client. **Still worth confirming with the team**
-   whether this should be pinned to the exact remote-tool-execution
-   `expose_remotely` set — the two are defined independently and could drift.
+# Implementation & Verification
 
-## Still open
+Implemented in HolmesGPT: the `code_execution` toolset (tool, generated client,
+socket bridge, subprocess runner, config), a generic `set_tool_executor` wiring
+hook on the agentic loop, and a request-scoped executor handle on the tool
+context. Off by default. Verified by:
 
-3. **Routing** — v1 is prompt-only (the model chooses when to use code mode). In
-   the first live A/B the model often kept using efficient server-side tools
-   (`kubernetes_jq_query`, log `filter`) and did not reach for code mode, so a
-   cheap pre-classifier — or stronger prompting — may be needed to actually
-   trigger it where it helps. Measure regression on trivial asks first.
-4. **Sub-call cost attribution** in `HolmesUsageEvents` — should sub-calls count
-   toward `tool_call_count` (proposed: yes, for honest before/after)? Not yet
-   wired.
-5. **Sandbox before default-on** — v1 has no language/OS sandbox, so the
-   documented residual risk (arbitrary outbound network + on-disk secret reads,
-   amplified under prompt injection — see Security model) stands. Decision:
-   gate default-on behind real isolation (RestrictedPython / gVisor / container
-   / egress-deny), or ship config-enabled only for trusted operators?
-6. **Demonstrating the token win in a *live* eval** — Holmes filters
-   server-side almost everywhere, so a live ask_holmes A/B can't cleanly show a
-   token drop (the two committed A/B evals only assert correctness parity). The
-   win is proven deterministically in
-   `tests/plugins/toolsets/code_execution/test_code_mode_token_reduction.py`
-   (result filtering 250k→136 tokens; call consolidation 8→1 result). Open
-   whether we also want a live eval backed by a data source with **no**
-   server-side filter, or accept the unit-level proof + a prod A/B.
-7. **When to flip default-on** — needs a real-traffic A/B; the ~15–25%
-   total-spend estimate is unvalidated in production.
-8. **Live sub-call streaming to the UI** — sub-calls are recorded (name / status
-   / timing) and summarized in the result today, but not streamed as nested
-   tool cards. That needs a `parent_tool_call_id` field + a loop-level streaming
-   hook + frontend work (separate PR).
-9. **Serial sub-calls** — the bridge is single-connection / single-threaded, so
-   sub-calls inside one script run serially. Fine for v1; open whether parallel
-   fan-out inside a script justifies a multi-connection bridge.
-10. **Prompt-overhead crossover** — enabling the toolset injects its API
-    reference into the system prompt; on small tasks that overhead isn't repaid
-    (observed in the CI eval, where the codemode variant cost slightly *more*).
-    Open where the crossover is and whether the reference should be trimmed or
-    lazily disclosed.
-11. **Documentation page** — `docs/data-sources/builtin-toolsets/code-execution.md`
-    is still a follow-up.
+- **Deterministic token-reduction proof** (`test_code_mode_token_reduction.py`) —
+  measures the context-token cost of a tool result classic vs. code mode with the
+  product's own formatter + `litellm` tokenizer. Result filtering 250,029 → 136
+  tokens (99.95%); call consolidation (8 results → 1) 30,952 → 275 (99.11%);
+  correctness asserted. No LLM, no cluster.
+- **Unit / integration** (`test_code_execution.py`, `_wiring.py`, `_security.py`)
+  — 24 tests over the real subprocess: eligibility exclusions, the token-saving
+  property, executor wiring, and failure modes (syntax/runtime error, timeout,
+  unavailable tool, erroring sub-tool, approval denied-not-paused, unwired
+  executor, timeout clamping, env-secret isolation), plus the security-boundary
+  tests (raw-socket bypass of the client denied for excluded/approval-gated/
+  unknown names; documented local-file-read gap). No regressions in the existing
+  loop/executor tests.
+- **LLM evals** — two ask_holmes A/B fixtures (`toolsets_matrix`: classic vs.
+  codemode) asserting **correctness parity**; 4/4 passing in CI on opus-4.6.
+  These do not claim the token win (Holmes filters server-side, so the model
+  didn't switch to code mode on small fixtures) — the deterministic test above is
+  the token-win proof.
+
+# Detailed Implementation & Context
+
+Files as of this doc's writing; re-verify line numbers before editing.
+
+## The loop and existing primitives (reused)
+
+- **Loop:** `holmes/core/tool_calling_llm.py` — `ToolCallingLLM.call_stream` runs
+  `while i < max_steps`: assemble → compaction check → `llm.completion(tools=…)` →
+  execute tool calls in `ThreadPoolExecutor(max_workers=16)` → append each
+  `to_llm_message()` → repeat. Tool execution funnels through
+  `_directly_invoke_tool_call` → `tool.invoke(params, context)`.
+- **Tools:** `holmes/core/tools.py` — `Tool` (abstract `_invoke → StructuredToolResult`),
+  `Toolset`, `StructuredToolResult.stringify_data`, `requires_approval →
+  APPROVAL_REQUIRED`, and the `is_core` marker.
+- **Dispatch registry:** `holmes/core/tools_utils/tool_executor.py` —
+  `get_tool_by_name`, `ensure_toolset_initialized`.
+- **Result guard:** `holmes/core/tools_utils/tool_context_window_limiter.py:spill_oversized_tool_result`.
+- **Bash primitives:** `holmes/plugins/toolsets/bash/common/bash.py` —
+  `execute_bash_command`, `get_ulimit_prefix()`.
+- **Token measurement:** `holmes/core/tools_utils/token_counting.py:count_tool_response_tokens`
+  → `holmes/core/models.py:format_tool_result_data` + `LLM.count_tokens`.
+
+## New: `holmes/plugins/toolsets/code_execution/`
+
+- **`code_execution_toolset.py`** — `RunPythonCode(Tool)` + `CodeExecutionToolset(Toolset)`.
+  `_invoke` resolves the request's `ToolExecutor` from a request-scoped handle on
+  `ToolInvokeContext` (falling back to the wired toolset handle), builds the
+  eligible-tool spec, launches the runner subprocess (stdout → temp file to avoid
+  a pipe deadlock), and serves the bridge until the process exits or the deadline
+  passes. `_make_dispatch(context, executor, allowed)` is the **security boundary**:
+  it rejects any `tool_name not in allowed`, converts `APPROVAL_REQUIRED` to an
+  error, and otherwise invokes the real tool with a request-scoped sub-context.
+  `_build_subprocess_env(...)` builds the minimal env allow-list (`_ENV_PASSTHROUGH`
+  = PATH/LANG/LC_*/TZ + `HOLMES_CODE_*`), never `os.environ`. `_resolve_timeout`
+  clamps to `[1, max_timeout_seconds]`, default `default_timeout_seconds`.
+  `_is_core=True`, `enabled=False`.
+- **`client_generator.py`** — `EXCLUDED_TOOLSET_NAMES = {"bash", "kubectl_run",
+  "code_execution"}`; `_is_eligible(tool, toolset)` (excludes `is_core`, the
+  excluded names, and `approval_required_tools` matches); `eligible_tools`,
+  `eligible_tool_names`, `build_tools_spec`, `build_api_reference`, `_sanitize_attr`.
+- **`bridge.py`** — `ToolCallBridge` (context manager binding an AF_UNIX socket;
+  `serve_until_exit(process, deadline)` is single-connection with recv/accept
+  timeouts) and `SubToolCall` records. `_handle_line` parses `{tool, params}` and
+  calls the injected `dispatch`.
+- **`runner.py`** — stdlib-only subprocess bootstrap. `_Bridge` (newline-delimited
+  JSON over the socket), `_build_holmes_namespace` (turns the tools spec into
+  `holmes.<attr>()` functions + `holmes.HolmesToolError`), and `main()` returning
+  exit codes (0 ok, 1 exception, 2 SyntaxError, 3 HolmesToolError). Reads
+  `HOLMES_CODE_SOCKET` / `HOLMES_CODE_USER_FILE` / `HOLMES_CODE_TOOLS` from env.
+- **`code_execution_config.py`** — `CodeExecutionConfig(ToolsetConfig)` with
+  `default_timeout_seconds=60`, `max_timeout_seconds=300`.
+
+## Wiring (minimal, generic)
+
+- `holmes/core/tool_calling_llm.py` — a `_wire_toolset_executors()` hook called
+  from `__init__` invokes `set_tool_executor(self.tool_executor)` on any toolset
+  that exposes it (guarded for non-list `toolsets`); and the `ToolInvokeContext`
+  built in `_directly_invoke_tool_call` now carries `tool_executor` so dispatch is
+  request-scoped.
+- `holmes/core/tools.py` — `ToolInvokeContext.tool_executor: Optional[Any] =
+  Field(default=None, exclude=True)` (excluded from serialization).
+- `holmes/plugins/toolsets/__init__.py` — `CodeExecutionToolset()` appended in
+  `load_python_toolsets` after `BashExecutorToolset()`.
+
+## Tests
+
+`tests/plugins/toolsets/code_execution/` — `test_code_execution.py`,
+`test_code_execution_wiring.py`, `test_code_execution_security.py`,
+`test_code_mode_token_reduction.py`; all run the real subprocess bridge, grouped
+under `xdist_group("code_execution")`. Eval fixtures:
+`tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/` and
+`286_code_mode_large_configmap_filter/` (each a classic-vs-codemode
+`toolsets_matrix`).

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -807,6 +807,7 @@ class ToolCallingLLM:
                 tool_call_id=tool_call_id,
                 session_approved_prefixes=session_approved_prefixes or [],
                 request_context=request_context,
+                tool_executor=self.tool_executor,
             )
             tool_response = tool.invoke(tool_params, context=invoke_context)
 

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -213,6 +213,28 @@ class ToolCallingLLM:
         self.tracer = tracer
         self.llm = llm
         self.tool_results_dir = tool_results_dir
+        self._wire_toolset_executors()
+
+    def _wire_toolset_executors(self) -> None:
+        """Give toolsets that opt in (via a ``set_tool_executor`` method) a
+        back-reference to the ToolExecutor so they can dispatch sibling tool
+        calls — used by the code_execution ("code mode") toolset. Generic hook:
+        no code-mode-specific coupling here.
+        """
+        toolsets = getattr(self.tool_executor, "toolsets", None)
+        if not isinstance(toolsets, (list, tuple)):
+            return  # e.g. a mocked tool_executor in tests
+        for toolset in toolsets:
+            setter = getattr(toolset, "set_tool_executor", None)
+            if callable(setter):
+                try:
+                    setter(self.tool_executor)
+                except Exception:
+                    logging.warning(
+                        "failed wiring tool_executor into toolset %s",
+                        getattr(toolset, "name", "?"),
+                        exc_info=True,
+                    )
 
     def with_executor(self, tool_executor: ToolExecutor) -> "ToolCallingLLM":
         """Return a shallow copy with a different ToolExecutor.

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -265,6 +265,10 @@ class ToolInvokeContext(BaseModel):
         str
     ] = []  # Bash prefixes approved during this session
     request_context: Optional[Dict[str, Any]] = None
+    # Request-scoped ToolExecutor, set by the agentic loop. Lets a tool dispatch
+    # sibling tool calls (used by the code_execution toolset) without reading
+    # shared, mutable toolset state. Typed Any to avoid a circular import.
+    tool_executor: Optional[Any] = None
 
     def model_dump(self, **kwargs):
         """Override to exclude sensitive context from serialization"""

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -268,7 +268,8 @@ class ToolInvokeContext(BaseModel):
     # Request-scoped ToolExecutor, set by the agentic loop. Lets a tool dispatch
     # sibling tool calls (used by the code_execution toolset) without reading
     # shared, mutable toolset state. Typed Any to avoid a circular import.
-    tool_executor: Optional[Any] = None
+    # exclude=True so executor/toolset/config state never appears in model_dump().
+    tool_executor: Optional[Any] = Field(default=None, exclude=True)
 
     def model_dump(self, **kwargs):
         """Override to exclude sensitive context from serialization"""

--- a/holmes/plugins/toolsets/__init__.py
+++ b/holmes/plugins/toolsets/__init__.py
@@ -22,6 +22,9 @@ from holmes.core.tools import (
 from holmes.plugins.toolsets.atlas_mongodb.mongodb_atlas import MongoDBAtlasToolset
 from holmes.plugins.toolsets.azure_sql.azure_sql_toolset import AzureSQLToolset
 from holmes.plugins.toolsets.bash.bash_toolset import BashExecutorToolset
+from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
+    CodeExecutionToolset,
+)
 from holmes.plugins.toolsets.confluence.confluence import ConfluenceToolset
 from holmes.plugins.toolsets.connectivity_check import ConnectivityCheckToolset
 from holmes.plugins.toolsets.coralogix.toolset_coralogix import CoralogixToolset
@@ -121,6 +124,7 @@ def load_python_toolsets(
         multi_instance(CoralogixToolset),
         RabbitMQToolset(),
         BashExecutorToolset(),
+        CodeExecutionToolset(),
         KubectlRunToolset(),
         multi_instance(ConfluenceToolset),
         multi_instance(MongoDBAtlasToolset),

--- a/holmes/plugins/toolsets/code_execution/__init__.py
+++ b/holmes/plugins/toolsets/code_execution/__init__.py
@@ -1,0 +1,5 @@
+from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
+    CodeExecutionToolset,
+)
+
+__all__ = ["CodeExecutionToolset"]

--- a/holmes/plugins/toolsets/code_execution/bridge.py
+++ b/holmes/plugins/toolsets/code_execution/bridge.py
@@ -1,0 +1,144 @@
+"""Parent-side tool-call bridge for code mode.
+
+While the LLM-authored script runs in a subprocess, this bridge listens on a
+unix-domain socket and services each ``holmes.<tool>(...)`` request by invoking
+the real tool through the ToolExecutor (in the parent, where credentials live)
+and streaming the result back. It is single-connection and single-threaded: a
+script's tool calls are sequential, so no concurrency is needed within one run.
+
+The subprocess writes its stdout/stderr to a file (not a pipe), so there is no
+pipe-buffer deadlock; the bridge only ever blocks on the socket, always with a
+timeout, and gives up when the subprocess exits or the wall-clock deadline
+passes.
+"""
+
+import json
+import logging
+import os
+import socket
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List
+
+logger = logging.getLogger(__name__)
+
+# {"status": "ok"|"error", "data": <str|None>, "error": <str|None>}
+DispatchFn = Callable[[str, dict], dict]
+
+_ACCEPT_TIMEOUT = 0.2
+_RECV_TIMEOUT = 0.2
+
+
+@dataclass
+class SubToolCall:
+    """A record of one tool call made from inside a code-mode script."""
+
+    tool_name: str
+    params: dict
+    status: str
+    error: str = ""
+    output_chars: int = 0
+    elapsed_seconds: float = 0.0
+
+
+@dataclass
+class ToolCallBridge:
+    dispatch: DispatchFn
+    socket_path: str
+    records: List[SubToolCall] = field(default_factory=list)
+    _server: socket.socket = field(default=None, init=False, repr=False)
+
+    def __enter__(self) -> "ToolCallBridge":
+        if os.path.exists(self.socket_path):
+            os.unlink(self.socket_path)
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(self.socket_path)
+        self._server.listen(1)
+        self._server.settimeout(_ACCEPT_TIMEOUT)
+        return self
+
+    def __exit__(self, *exc) -> None:
+        try:
+            if self._server is not None:
+                self._server.close()
+        finally:
+            if os.path.exists(self.socket_path):
+                try:
+                    os.unlink(self.socket_path)
+                except OSError:
+                    pass
+
+    def _handle_line(self, line: bytes) -> dict:
+        try:
+            req = json.loads(line.decode())
+        except Exception:
+            return {"status": "error", "error": "malformed tool-call request"}
+        tool_name = req.get("tool")
+        params = req.get("params") or {}
+        if not isinstance(tool_name, str) or not isinstance(params, dict):
+            return {"status": "error", "error": "invalid tool-call request"}
+        started = time.monotonic()
+        try:
+            resp = self.dispatch(tool_name, params)
+        except Exception as exc:  # dispatch must not crash the bridge
+            logger.warning("code-mode dispatch of %s raised", tool_name, exc_info=True)
+            resp = {"status": "error", "error": f"tool dispatch failed: {exc}"}
+        self.records.append(
+            SubToolCall(
+                tool_name=tool_name,
+                params=params,
+                status=resp.get("status", "error"),
+                error=resp.get("error") or "",
+                output_chars=len(resp.get("data") or ""),
+                elapsed_seconds=round(time.monotonic() - started, 3),
+            )
+        )
+        return resp
+
+    def serve_until_exit(self, process, deadline: float) -> None:
+        """Service requests until the subprocess exits or ``deadline`` passes."""
+        conn = None
+        buf = b""
+        try:
+            while True:
+                if conn is None:
+                    if process.poll() is not None:
+                        return
+                    if time.monotonic() > deadline:
+                        return
+                    try:
+                        conn, _ = self._server.accept()
+                        conn.settimeout(_RECV_TIMEOUT)
+                        buf = b""
+                    except socket.timeout:
+                        continue
+                    continue
+
+                try:
+                    chunk = conn.recv(65536)
+                except socket.timeout:
+                    if process.poll() is not None or time.monotonic() > deadline:
+                        return
+                    continue
+                if not chunk:
+                    conn.close()
+                    conn = None
+                    if process.poll() is not None:
+                        return
+                    continue
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    if not line.strip():
+                        continue
+                    resp = self._handle_line(line)
+                    try:
+                        conn.sendall((json.dumps(resp) + "\n").encode())
+                    except OSError:
+                        return
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except OSError:
+                    pass

--- a/holmes/plugins/toolsets/code_execution/client_generator.py
+++ b/holmes/plugins/toolsets/code_execution/client_generator.py
@@ -1,0 +1,109 @@
+"""Build the ``holmes`` code-mode client surface from a ToolExecutor.
+
+Two products, both derived from the same eligibility filter:
+
+- ``build_tools_spec`` — the ``[{"attr", "name"}]`` list handed to the
+  subprocess runner so it can expose one function per allowed tool.
+- ``build_api_reference`` — human/LLM-readable documentation of the available
+  ``holmes.<attr>(...)`` functions, injected into the system prompt via the
+  toolset's ``llm_instructions``.
+
+Eligibility (v1, deliberately conservative — see the design doc
+``relay/docs/design/2026-07-28_holmes-code-mode.md``): read-only tools only.
+A tool is excluded when its toolset is internal agent-machinery (``is_core``),
+is an approval/mutation surface (bash, kubectl_run), the code_execution toolset
+itself (no recursion), or the tool matches an ``approval_required_tools``
+pattern. A synchronous script cannot pause for interactive approval, so
+approval-gated tools are never exposed here; the model must call those directly.
+"""
+
+import fnmatch
+import keyword
+import re
+from typing import TYPE_CHECKING, List, Tuple
+
+from holmes.core.tools import Tool
+
+if TYPE_CHECKING:
+    from holmes.core.tools_utils.tool_executor import ToolExecutor
+
+# Toolsets that expose approval-gated or mutating surfaces, or the code-mode
+# toolset itself. Excluded from the code-mode client regardless of config.
+EXCLUDED_TOOLSET_NAMES = frozenset({"bash", "kubectl_run", "code_execution"})
+
+
+def _sanitize_attr(name: str, taken: set) -> str:
+    """Turn a tool name into a valid, unique Python attribute name."""
+    attr = re.sub(r"\W", "_", name)
+    if not attr or attr[0].isdigit():
+        attr = f"t_{attr}"
+    if keyword.iskeyword(attr):
+        attr = f"{attr}_"
+    base = attr
+    i = 2
+    while attr in taken:
+        attr = f"{base}_{i}"
+        i += 1
+    taken.add(attr)
+    return attr
+
+
+def _is_eligible(tool: Tool, toolset) -> bool:
+    if toolset is None:
+        return False
+    if getattr(toolset, "is_core", False):
+        return False
+    if toolset.name in EXCLUDED_TOOLSET_NAMES:
+        return False
+    real_name = getattr(tool, "mcp_tool_name", "") or tool.name
+    for pattern in getattr(toolset, "approval_required_tools", []) or []:
+        if fnmatch.fnmatch(real_name, pattern):
+            return False
+    return True
+
+
+def eligible_tools(executor: "ToolExecutor") -> List[Tuple[str, Tool]]:
+    """Return ``[(attr, tool)]`` for every tool exposable in code mode."""
+    result: List[Tuple[str, Tool]] = []
+    taken: set = set()
+    for name, tool in sorted(executor.tools_by_name.items()):
+        toolset = executor._tool_to_toolset.get(name)
+        if not _is_eligible(tool, toolset):
+            continue
+        result.append((_sanitize_attr(name, taken), tool))
+    return result
+
+
+def eligible_tool_names(executor: "ToolExecutor") -> set:
+    """The set of real tool names dispatchable from code mode (defense in depth)."""
+    return {tool.name for _, tool in eligible_tools(executor)}
+
+
+def build_tools_spec(executor: "ToolExecutor") -> List[dict]:
+    return [{"attr": attr, "name": tool.name} for attr, tool in eligible_tools(executor)]
+
+
+def _one_line(text: str, limit: int = 200) -> str:
+    text = " ".join((text or "").split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _signature(tool: Tool) -> str:
+    required = [p for p, spec in tool.parameters.items() if spec.required]
+    optional = [p for p, spec in tool.parameters.items() if not spec.required]
+    parts = list(required) + [f"{p}=None" for p in optional]
+    return ", ".join(parts)
+
+
+def build_api_reference(executor: "ToolExecutor") -> str:
+    """Markdown listing of the available ``holmes.<attr>(...)`` functions."""
+    tools = eligible_tools(executor)
+    if not tools:
+        return (
+            "No read-only tools are currently available for code mode. "
+            "Use direct tool calls instead."
+        )
+    lines = ["Available functions on the `holmes` object:"]
+    for attr, tool in tools:
+        lines.append(f"- `holmes.{attr}({_signature(tool)})` — {_one_line(tool.description)}")
+    return "\n".join(lines)

--- a/holmes/plugins/toolsets/code_execution/code_execution_config.py
+++ b/holmes/plugins/toolsets/code_execution/code_execution_config.py
@@ -1,9 +1,7 @@
-from pydantic import BaseModel, ConfigDict
+from holmes.utils.pydantic_utils import ToolsetConfig
 
 
-class CodeExecutionConfig(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
+class CodeExecutionConfig(ToolsetConfig):
     # Default wall-clock timeout for a script, in seconds. The LLM may pass a
     # smaller/larger value per call; it is clamped to max_timeout_seconds.
     default_timeout_seconds: int = 60

--- a/holmes/plugins/toolsets/code_execution/code_execution_config.py
+++ b/holmes/plugins/toolsets/code_execution/code_execution_config.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class CodeExecutionConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    # Default wall-clock timeout for a script, in seconds. The LLM may pass a
+    # smaller/larger value per call; it is clamped to max_timeout_seconds.
+    default_timeout_seconds: int = 60
+    max_timeout_seconds: int = 300

--- a/holmes/plugins/toolsets/code_execution/code_execution_toolset.py
+++ b/holmes/plugins/toolsets/code_execution/code_execution_toolset.py
@@ -1,0 +1,367 @@
+"""Code mode: let the LLM write one Python script that composes many tool
+calls and filters results in code, so only what it ``print()``s enters the
+model's context.
+
+Design: ``relay/docs/design/2026-07-28_holmes-code-mode.md``.
+
+The script runs in a subprocess with a generated ``holmes`` object whose
+functions relay back to this process (over a unix socket) and dispatch into the
+real ToolExecutor. Credentials never leave the parent. Only read-only tools are
+exposed (see ``client_generator``); approval-gated tools must be called
+directly.
+"""
+
+import itertools
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Any, ClassVar, Dict, List, Optional, Type
+
+from pydantic import PrivateAttr
+
+from holmes.core.tools import (
+    CallablePrerequisite,
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    Tool,
+    ToolInvokeContext,
+    ToolParameter,
+    Toolset,
+    ToolsetTag,
+)
+from holmes.plugins.toolsets.code_execution.bridge import SubToolCall, ToolCallBridge
+from holmes.plugins.toolsets.code_execution.client_generator import (
+    build_api_reference,
+    build_tools_spec,
+    eligible_tool_names,
+)
+from holmes.plugins.toolsets.code_execution.code_execution_config import (
+    CodeExecutionConfig,
+)
+from holmes.utils.memory_limit import check_oom_and_append_hint, get_ulimit_prefix
+
+logger = logging.getLogger(__name__)
+
+_RUNNER_PATH = os.path.join(os.path.dirname(__file__), "runner.py")
+
+_TOOL_DESCRIPTION = (
+    "Run a Python 3 script that gathers and FILTERS data by calling Holmes "
+    "tools through the injected `holmes` object, returning only what you "
+    "print(). Prefer this over many separate tool calls for multi-step "
+    "investigations (e.g. list resources, filter in Python, then fetch details "
+    "only for the ones that matter) — it keeps large intermediate results out "
+    "of the conversation. Call tools as `holmes.<function>(param=value, ...)`; "
+    "each returns the tool output as a string (use json.loads if you need "
+    "structured data). A failed tool call raises holmes.HolmesToolError. Only "
+    "read-only tools are available here; approval-gated tools such as bash or "
+    "kubectl must be called directly, not from a script. The list of available "
+    "functions is provided in this toolset's instructions."
+)
+
+
+def _summarize_subcalls(records: List[SubToolCall]) -> str:
+    if not records:
+        return ""
+    lines = [f"[holmes] code mode executed {len(records)} tool call(s):"]
+    for rec in records:
+        marker = "ok" if rec.status == "ok" else f"error: {rec.error}"
+        lines.append(
+            f"  - {rec.tool_name} ({rec.elapsed_seconds}s, "
+            f"{rec.output_chars} chars) [{marker}]"
+        )
+    return "\n".join(lines)
+
+
+class RunPythonCode(Tool):
+    toolset: "CodeExecutionToolset"
+
+    def __init__(self, toolset: "CodeExecutionToolset"):
+        super().__init__(
+            name="run_python_code",
+            description=_TOOL_DESCRIPTION,
+            parameters={
+                "code": ToolParameter(
+                    description=(
+                        "The Python 3 script to run. Access tools via the "
+                        "`holmes` object, e.g. "
+                        "`data = json.loads(holmes.some_tool(arg='x')); "
+                        "print(len(data))`. print() only the final, filtered "
+                        "result."
+                    ),
+                    type="string",
+                    required=True,
+                ),
+                "timeout": ToolParameter(
+                    description="Optional wall-clock timeout in seconds (default 60).",
+                    type="integer",
+                    required=False,
+                ),
+            },
+            toolset=toolset,  # type: ignore[call-arg]
+        )
+
+    def _resolve_timeout(self, params: dict) -> int:
+        config = self.toolset.config or CodeExecutionConfig()
+        timeout = params.get("timeout") or config.default_timeout_seconds
+        try:
+            timeout = int(timeout)
+        except (TypeError, ValueError):
+            timeout = config.default_timeout_seconds
+        return max(1, min(timeout, config.max_timeout_seconds))
+
+    def _make_dispatch(self, context: ToolInvokeContext, allowed: set):
+        executor = self.toolset._tool_executor
+        counter = itertools.count()
+
+        def dispatch(tool_name: str, tool_params: dict) -> dict:
+            if tool_name not in allowed:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"tool '{tool_name}' is not available in code mode "
+                        "(only read-only tools are; call approval-gated tools directly)"
+                    ),
+                }
+            init_error = executor.ensure_toolset_initialized(tool_name)
+            if isinstance(init_error, str):
+                return {"status": "error", "error": init_error}
+            tool = executor.get_tool_by_name(tool_name)
+            if tool is None:
+                return {"status": "error", "error": f"unknown tool '{tool_name}'"}
+
+            sub_context = ToolInvokeContext(
+                tool_number=context.tool_number,
+                user_approved=False,
+                llm=context.llm,
+                max_token_count=context.max_token_count,
+                tool_name=tool_name,
+                tool_call_id=f"{context.tool_call_id}:code:{next(counter)}",
+                session_approved_prefixes=context.session_approved_prefixes,
+                request_context=context.request_context,
+            )
+            result = tool.invoke(tool_params, sub_context)
+            if result.status == StructuredToolResultStatus.APPROVAL_REQUIRED:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"tool '{tool_name}' requires approval and cannot run from "
+                        "code mode; call it directly instead"
+                    ),
+                }
+            data, _ = result.stringify_data(compact=True)
+            status = (
+                "ok"
+                if result.status
+                in (
+                    StructuredToolResultStatus.SUCCESS,
+                    StructuredToolResultStatus.NO_DATA,
+                )
+                else "error"
+            )
+            return {"status": status, "data": data, "error": result.error}
+
+        return dispatch
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        code = params.get("code")
+        if not code or not isinstance(code, str):
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error="The 'code' parameter is required and must be a string.",
+                params=params,
+            )
+
+        executor = self.toolset._tool_executor
+        if executor is None:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=(
+                    "Code mode is unavailable: the tool executor was not wired "
+                    "into the code_execution toolset."
+                ),
+                params=params,
+            )
+
+        timeout = self._resolve_timeout(params)
+        allowed = eligible_tool_names(executor)
+        tools_spec = build_tools_spec(executor)
+        records: List[SubToolCall] = []
+
+        work_dir = tempfile.mkdtemp(prefix="holmes_code_")
+        socket_path = os.path.join(work_dir, "bridge.sock")
+        user_file = os.path.join(work_dir, "user_code.py")
+        tools_file = os.path.join(work_dir, "tools.json")
+        stdout_path = os.path.join(work_dir, "stdout.txt")
+
+        try:
+            with open(user_file, "w") as fh:
+                fh.write(code)
+            with open(tools_file, "w") as fh:
+                json.dump(tools_spec, fh)
+
+            env = {
+                **os.environ,
+                "HOLMES_CODE_SOCKET": socket_path,
+                "HOLMES_CODE_USER_FILE": user_file,
+                "HOLMES_CODE_TOOLS": tools_file,
+            }
+            cmd = get_ulimit_prefix() + f"python3 {shlex.quote(_RUNNER_PATH)}"
+
+            timed_out = False
+            with ToolCallBridge(
+                dispatch=self._make_dispatch(context, allowed),
+                socket_path=socket_path,
+            ) as bridge, open(stdout_path, "wb") as out:
+                process = subprocess.Popen(
+                    cmd,
+                    shell=True,
+                    executable="/bin/bash",
+                    stdout=out,
+                    stderr=subprocess.STDOUT,
+                    env=env,
+                    cwd=work_dir,
+                )
+                deadline = time.monotonic() + timeout
+                bridge.serve_until_exit(process, deadline)
+                if process.poll() is None:
+                    timed_out = True
+                    process.kill()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        logger.warning("code-mode subprocess did not die after kill")
+                return_code = process.returncode
+                records = bridge.records
+
+            with open(stdout_path, "r", errors="replace") as fh:
+                stdout = fh.read().strip()
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+        return self._build_result(
+            params, code, stdout, return_code, timed_out, timeout, records
+        )
+
+    def _build_result(
+        self,
+        params: dict,
+        code: str,
+        stdout: str,
+        return_code: Optional[int],
+        timed_out: bool,
+        timeout: int,
+        records: List[SubToolCall],
+    ) -> StructuredToolResult:
+        invocation = code if len(code) <= 400 else code[:399] + "…"
+        summary = _summarize_subcalls(records)
+        body = f"{summary}\n\n{stdout}".strip() if summary else stdout
+
+        if timed_out:
+            return StructuredToolResult(
+                status=StructuredToolResultStatus.ERROR,
+                error=f"Code execution timed out after {timeout} seconds.",
+                data=body or None,
+                params=params,
+                invocation=invocation,
+            )
+
+        stdout = check_oom_and_append_hint(stdout, return_code)
+        body = f"{summary}\n\n{stdout}".strip() if summary else stdout
+
+        if return_code == 0:
+            status = (
+                StructuredToolResultStatus.SUCCESS
+                if body
+                else StructuredToolResultStatus.NO_DATA
+            )
+            return StructuredToolResult(
+                status=status,
+                data=body or None,
+                params=params,
+                invocation=invocation,
+                return_code=return_code,
+            )
+
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.ERROR,
+            error=(
+                f"The script exited with code {return_code}. See output for the "
+                "traceback; fix the script and try again."
+            ),
+            data=body or None,
+            params=params,
+            invocation=invocation,
+            return_code=return_code,
+        )
+
+    def get_parameterized_one_liner(self, params: Dict[str, Any]) -> str:
+        code = params.get("code", "")
+        first_line = code.strip().splitlines()[0] if code.strip() else ""
+        return first_line[:200] + ("…" if len(first_line) > 200 else "")
+
+
+class CodeExecutionToolset(Toolset):
+    config_classes: ClassVar[list[Type[CodeExecutionConfig]]] = [CodeExecutionConfig]
+    config: Optional[CodeExecutionConfig] = None
+    _tool_executor: Any = PrivateAttr(default=None)
+
+    def __init__(self):
+        super().__init__(
+            name="code_execution",
+            enabled=False,  # opt-in; off by default (feature flagged)
+            description=(
+                "Code mode: run a Python script that composes read-only Holmes "
+                "tools and filters results in code, cutting token cost on "
+                "multi-step investigations."
+            ),
+            docs_url="https://holmesgpt.dev/data-sources/builtin-toolsets/code-execution/",
+            icon_url="https://raw.githubusercontent.com/Templarian/MaterialDesign/master/svg/language-python.svg",
+            prerequisites=[CallablePrerequisite(callable=self.prerequisites_callable)],
+            tools=[RunPythonCode(self)],
+            tags=[ToolsetTag.CORE],
+        )
+        # Never expose the code-mode toolset itself remotely or recursively.
+        self._is_core = True
+
+    def prerequisites_callable(self, config: dict[str, Any]) -> tuple[bool, str]:
+        self.config = CodeExecutionConfig(**(config or {}))
+        if shutil.which("python3") is None:
+            return False, "python3 is not available on PATH"
+        return True, ""
+
+    def set_tool_executor(self, tool_executor) -> None:
+        """Generic hook (called by ToolCallingLLM) giving code mode a
+        back-reference to the ToolExecutor so it can dispatch sibling tools,
+        and refreshing the API reference shown to the model."""
+        self._tool_executor = tool_executor
+        try:
+            self.llm_instructions = self._render_instructions()
+        except Exception:
+            logger.warning("failed to render code_execution instructions", exc_info=True)
+
+    def _render_instructions(self) -> str:
+        api = (
+            build_api_reference(self._tool_executor)
+            if self._tool_executor is not None
+            else ""
+        )
+        return (
+            "## Code mode (`run_python_code`)\n"
+            "For multi-step data gathering, prefer writing ONE Python script that "
+            "calls tools through the `holmes` object and filters results in code, "
+            "so only what you `print()` returns to the conversation. This avoids "
+            "flooding the context with raw tool output across many turns.\n\n"
+            "Rules:\n"
+            "- Call tools as `holmes.<function>(param=value, ...)`; each returns the "
+            "tool's output as a string. Use `json.loads(...)` for structured data.\n"
+            "- A failed tool call raises `holmes.HolmesToolError` (catch it if useful).\n"
+            "- `print()` only the final, filtered result — never raw dumps.\n"
+            "- Only the read-only functions listed below are available. Approval-gated "
+            "tools (e.g. bash, kubectl) are NOT callable here; use direct tool calls for those.\n\n"
+            f"{api}"
+        )

--- a/holmes/plugins/toolsets/code_execution/code_execution_toolset.py
+++ b/holmes/plugins/toolsets/code_execution/code_execution_toolset.py
@@ -64,6 +64,35 @@ _TOOL_DESCRIPTION = (
 )
 
 
+# Only these parent env vars are forwarded to the untrusted subprocess.
+_ENV_PASSTHROUGH = ("PATH", "LANG", "LC_ALL", "LC_CTYPE", "TZ")
+_FALLBACK_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
+def _build_subprocess_env(socket_path: str, user_file: str, tools_file: str) -> dict:
+    """Build a minimal environment for the untrusted subprocess.
+
+    Deliberately does NOT inherit the parent's ``os.environ``: credentials
+    exposed to Holmes as environment variables (LLM/provider keys, DB
+    passwords, other toolsets' secrets) must never be readable by the
+    LLM-authored script. Only PATH/locale and the bridge handoff vars are
+    passed through.
+    """
+    env = {
+        "HOLMES_CODE_SOCKET": socket_path,
+        "HOLMES_CODE_USER_FILE": user_file,
+        "HOLMES_CODE_TOOLS": tools_file,
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONUNBUFFERED": "1",
+    }
+    for key in _ENV_PASSTHROUGH:
+        val = os.environ.get(key)
+        if val is not None:
+            env[key] = val
+    env.setdefault("PATH", _FALLBACK_PATH)
+    return env
+
+
 def _summarize_subcalls(records: List[SubToolCall]) -> str:
     if not records:
         return ""
@@ -114,8 +143,7 @@ class RunPythonCode(Tool):
             timeout = config.default_timeout_seconds
         return max(1, min(timeout, config.max_timeout_seconds))
 
-    def _make_dispatch(self, context: ToolInvokeContext, allowed: set):
-        executor = self.toolset._tool_executor
+    def _make_dispatch(self, context: ToolInvokeContext, executor, allowed: set):
         counter = itertools.count()
 
         def dispatch(tool_name: str, tool_params: dict) -> dict:
@@ -176,7 +204,10 @@ class RunPythonCode(Tool):
                 params=params,
             )
 
-        executor = self.toolset._tool_executor
+        # Prefer the request-scoped executor from the invoke context (set by the
+        # agentic loop) over the toolset's wired reference, so concurrent
+        # requests never share/overwrite each other's executor.
+        executor = getattr(context, "tool_executor", None) or self.toolset._tool_executor
         if executor is None:
             return StructuredToolResult(
                 status=StructuredToolResultStatus.ERROR,
@@ -204,17 +235,12 @@ class RunPythonCode(Tool):
             with open(tools_file, "w") as fh:
                 json.dump(tools_spec, fh)
 
-            env = {
-                **os.environ,
-                "HOLMES_CODE_SOCKET": socket_path,
-                "HOLMES_CODE_USER_FILE": user_file,
-                "HOLMES_CODE_TOOLS": tools_file,
-            }
+            env = _build_subprocess_env(socket_path, user_file, tools_file)
             cmd = get_ulimit_prefix() + f"python3 {shlex.quote(_RUNNER_PATH)}"
 
             timed_out = False
             with ToolCallBridge(
-                dispatch=self._make_dispatch(context, allowed),
+                dispatch=self._make_dispatch(context, executor, allowed),
                 socket_path=socket_path,
             ) as bridge, open(stdout_path, "wb") as out:
                 process = subprocess.Popen(
@@ -300,7 +326,7 @@ class RunPythonCode(Tool):
         )
 
     def get_parameterized_one_liner(self, params: Dict[str, Any]) -> str:
-        code = params.get("code", "")
+        code = params.get("code") or ""  # tolerate {"code": null}
         first_line = code.strip().splitlines()[0] if code.strip() else ""
         return first_line[:200] + ("…" if len(first_line) > 200 else "")
 

--- a/holmes/plugins/toolsets/code_execution/runner.py
+++ b/holmes/plugins/toolsets/code_execution/runner.py
@@ -1,0 +1,124 @@
+"""Subprocess bootstrap for the code_execution toolset ("code mode").
+
+This file is executed by a fresh ``python3`` process (NOT inside the Holmes
+process). It uses ONLY the standard library so it runs anywhere ``python3``
+exists. It:
+
+  1. builds a ``holmes`` namespace whose attributes are functions, one per
+     tool that the parent Holmes process made available;
+  2. runs the LLM-authored user script with ``holmes`` in scope;
+  3. relays every ``holmes.<tool>(...)`` call to the parent over a unix-domain
+     socket and returns the tool output to the script.
+
+Credentials and the real ToolExecutor live in the PARENT process only; this
+subprocess can do nothing but ask the parent to run an allow-listed tool.
+
+Environment (set by the parent):
+  HOLMES_CODE_SOCKET     path to the parent's AF_UNIX socket
+  HOLMES_CODE_USER_FILE  path to the file containing the user's Python script
+  HOLMES_CODE_TOOLS      path to a JSON file: [{"attr": ..., "name": ...}, ...]
+"""
+
+import json
+import os
+import socket
+import sys
+import traceback
+import types
+
+
+class HolmesToolError(Exception):
+    """Raised inside a code-mode script when a tool call fails."""
+
+
+class _Bridge:
+    """Newline-delimited JSON request/response over a persistent unix socket."""
+
+    def __init__(self, path: str):
+        self._path = path
+        self._conn = None
+        self._buf = b""
+
+    def _connect(self):
+        if self._conn is None:
+            conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            conn.connect(self._path)
+            self._conn = conn
+        return self._conn
+
+    def _read_line(self) -> bytes:
+        while b"\n" not in self._buf:
+            chunk = self._conn.recv(65536)
+            if not chunk:
+                break
+            self._buf += chunk
+        if b"\n" in self._buf:
+            line, self._buf = self._buf.split(b"\n", 1)
+            return line
+        line, self._buf = self._buf, b""
+        return line
+
+    def call(self, tool_name: str, params: dict):
+        conn = self._connect()
+        conn.sendall((json.dumps({"tool": tool_name, "params": params}) + "\n").encode())
+        line = self._read_line()
+        if not line:
+            raise HolmesToolError(f"no response from Holmes for tool '{tool_name}'")
+        resp = json.loads(line.decode())
+        if resp.get("status") == "error":
+            raise HolmesToolError(resp.get("error") or f"tool '{tool_name}' failed")
+        return resp.get("data")
+
+
+def _build_holmes_namespace(bridge: _Bridge, tools: list) -> types.SimpleNamespace:
+    ns = types.SimpleNamespace()
+    ns.HolmesToolError = HolmesToolError
+
+    def _make(real_name: str):
+        def _fn(**params):
+            return bridge.call(real_name, params)
+
+        return _fn
+
+    for spec in tools:
+        setattr(ns, spec["attr"], _make(spec["name"]))
+    return ns
+
+
+def main() -> int:
+    socket_path = os.environ["HOLMES_CODE_SOCKET"]
+    user_file = os.environ["HOLMES_CODE_USER_FILE"]
+    tools_file = os.environ["HOLMES_CODE_TOOLS"]
+
+    with open(tools_file) as fh:
+        tools = json.load(fh)
+    with open(user_file) as fh:
+        source = fh.read()
+
+    bridge = _Bridge(socket_path)
+    holmes = _build_holmes_namespace(bridge, tools)
+
+    user_globals = {
+        "__name__": "__main__",
+        "holmes": holmes,
+        "HolmesToolError": HolmesToolError,
+    }
+
+    try:
+        code = compile(source, "<holmes-code>", "exec")
+    except SyntaxError:
+        traceback.print_exc()
+        return 2
+    try:
+        exec(code, user_globals)  # noqa: S102 - executing LLM-authored code is the point
+    except HolmesToolError as exc:
+        print(f"\n[holmes] tool call failed: {exc}", file=sys.stderr)
+        return 3
+    except Exception:
+        traceback.print_exc()
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/test_case.yaml
@@ -1,0 +1,80 @@
+user_prompt:
+- "Find every namespace whose name starts with 'app-285' and tell me how many ConfigMaps are in each one. Give me the exact count per namespace and the total across all of them."
+
+# Same counting task as eval 227, but run as an A/B matrix over the toolset
+# config (see toolsets_matrix below): one variant with the ordinary read-only
+# kubernetes toolset ([toolsets]) and one that also enables the code_execution
+# "code mode" toolset ([codemode]). The expected answer is identical for both,
+# so this asserts CORRECTNESS PARITY — enabling code mode must not regress the
+# answer. The per-variant token / LLM-call counts recorded by the harness are
+# what quantify the token win; correctness is the pass/fail gate here.
+expected_output:
+  - The answer must state that app-285-alpha has exactly 23 ConfigMaps
+  - The answer must state that app-285-bravo has exactly 47 ConfigMaps
+  - The answer must state that app-285-charlie has exactly 71 ConfigMaps
+  - The answer must state that the total across all namespaces is exactly 141 ConfigMaps
+
+tags:
+  - kubernetes
+  - counting
+  - numerical
+  - benchmark
+
+toolsets_matrix:
+  - toolsets.yaml
+  - toolsets_codemode.yaml
+
+include_tool_calls: true
+
+before_test: |
+  set -e
+  echo "Creating 3 namespaces for the code-mode ConfigMap counting test"
+  for NS in alpha bravo charlie; do
+    kubectl create namespace "app-285-$NS" --dry-run=client -o yaml | kubectl apply -f -
+  done
+
+  create_configmaps() {
+    local NS=$1
+    local COUNT=$2
+    echo "Creating $COUNT ConfigMaps in $NS with random names..."
+    for i in $(seq 1 "$COUNT"); do
+      NAME="cm-$(cat /proc/sys/kernel/random/uuid | cut -c1-12)"
+      kubectl create configmap "$NAME" --from-literal=data="value-$RANDOM" -n "$NS" &
+    done
+    wait
+    echo "Created $COUNT ConfigMaps in $NS"
+  }
+
+  # Each namespace also has an auto-created kube-root-ca.crt ConfigMap, so the
+  # observable count is (created + 1): 22->23, 46->47, 70->71. Total = 141.
+  create_configmaps app-285-alpha 22
+  create_configmaps app-285-bravo 46
+  create_configmaps app-285-charlie 70
+
+  echo "Verifying counts..."
+  FAIL=false
+  for PAIR in "app-285-alpha:23" "app-285-bravo:47" "app-285-charlie:71"; do
+    NS="${PAIR%%:*}"
+    EXPECTED="${PAIR##*:}"
+    ACTUAL=$(kubectl get configmaps -n "$NS" --no-headers | wc -l)
+    echo "$NS: $ACTUAL ConfigMaps (expected $EXPECTED)"
+    if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+      echo "ERROR: Count mismatch in $NS"
+      FAIL=true
+    fi
+  done
+
+  if [ "$FAIL" = true ]; then
+    exit 1
+  fi
+
+  echo "Test setup complete!"
+
+after_test: |
+  for NS in alpha bravo charlie; do
+    kubectl delete namespace "app-285-$NS" --ignore-not-found
+  done
+
+# Routine counting investigation — nothing reusable to teach the environment, so
+# a well-behaved agent must not propose a skill. Mirrors eval 227.
+memories_generated: false

--- a/tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/toolsets.yaml
@@ -1,0 +1,5 @@
+# Classic variant ([toolsets]): only the ordinary read-only kubernetes toolset.
+# The model counts ConfigMaps by emitting individual tool calls per LLM step.
+toolsets:
+  kubernetes/core:
+    enabled: true

--- a/tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/toolsets_codemode.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/285_code_mode_count_configmaps/toolsets_codemode.yaml
@@ -1,0 +1,9 @@
+# Code-mode variant ([codemode]): same read-only kubernetes toolset PLUS the
+# code_execution toolset. The model can write a single Python script that lists
+# and counts ConfigMaps across namespaces, so intermediate results are filtered
+# in code and never re-enter the model's context on each step.
+toolsets:
+  kubernetes/core:
+    enabled: true
+  code_execution:
+    enabled: true

--- a/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/generate_configs.py
+++ b/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/generate_configs.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Generate a large platform-config YAML file with 130 service configurations.
+
+One service (payment-gateway) contains a unique needle connection string
+that the LLM must discover by querying the ConfigMap with advanced jq operations.
+"""
+
+import random
+import sys
+
+
+SEED = 212
+NEEDLE_SERVICE = "payment-gateway"
+NEEDLE_CONNECTION_STRING = "postgresql://admin@db-pmt-7k3m9x.internal.svc:5432/transactions_v2"
+
+SERVICE_NAMES = [
+    "auth-provider", "billing-engine", "cart-service", "checkout-api",
+    "content-delivery", "coupon-manager", "customer-profile", "data-pipeline",
+    "delivery-tracker", "discount-engine", "email-dispatcher", "event-bus",
+    "feature-flags", "feedback-collector", "file-storage", "fraud-detector",
+    "geo-locator", "graph-resolver", "health-monitor", "identity-broker",
+    "image-processor", "import-service", "index-builder", "insight-engine",
+    "integration-hub", "inventory-manager", "invoice-generator", "job-scheduler",
+    "kafka-bridge", "key-manager", "label-service", "lead-tracker",
+    "license-manager", "link-shortener", "load-balancer", "log-aggregator",
+    "loyalty-program", "mail-queue", "marketplace-api", "media-encoder",
+    "membership-service", "message-broker", "metrics-collector", "migration-runner",
+    "ml-inference", "notification-hub", "oauth-gateway", "onboarding-flow",
+    "order-processor", "org-manager", "outbox-relay", "package-registry",
+    NEEDLE_SERVICE, "pdf-generator", "permission-service", "pipeline-orchestrator",
+    "platform-gateway", "plugin-loader", "policy-engine", "preference-store",
+    "price-calculator", "product-catalog", "promo-engine", "provisioner",
+    "pubsub-adapter", "query-optimizer", "queue-manager", "quota-service",
+    "rate-limiter", "recommendation-engine", "refund-processor", "registry-sync",
+    "reminder-service", "render-engine", "report-builder", "request-router",
+    "resource-allocator", "retry-handler", "review-moderator", "risk-analyzer",
+    "role-manager", "rule-engine", "sandbox-controller", "scheduler-api",
+    "schema-registry", "search-indexer", "secret-rotator", "session-manager",
+    "settlement-service", "shard-manager", "shipping-calculator", "sla-monitor",
+    "snapshot-service", "social-connector", "sse-gateway", "status-page",
+    "storage-gateway", "stream-processor", "subscription-manager", "support-ticket",
+    "sync-coordinator", "tag-service", "task-runner", "tax-calculator",
+    "telemetry-agent", "template-engine", "tenant-manager", "test-harness",
+    "theme-service", "throttle-controller", "timeline-service", "token-issuer",
+    "transaction-log", "transform-pipeline", "translation-service", "trial-manager",
+    "upload-handler", "usage-tracker", "user-directory", "validation-service",
+    "vault-proxy", "vendor-api", "version-control", "video-transcoder",
+    "virtual-network", "visitor-tracker", "webhook-relay", "workflow-engine",
+    "workspace-manager", "zipkin-collector",
+]
+
+TEAMS = [
+    "platform", "payments", "identity", "growth", "infrastructure",
+    "data", "commerce", "security", "observability", "devex",
+    "mobile", "frontend", "backend", "ml-ops", "sre",
+]
+
+DB_ENGINES = ["postgresql", "mysql", "mongodb", "redis", "cassandra"]
+DB_PREFIXES = ["db", "rds", "store", "persist", "data"]
+CACHE_BACKENDS = ["redis", "memcached", "hazelcast"]
+LOG_LEVELS = ["info", "debug", "warn", "error"]
+PROTOCOLS = ["http", "grpc", "graphql", "websocket"]
+REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"]
+ENVIRONMENTS = ["production", "staging", "canary"]
+
+
+def random_hex(rng, length=6):
+    return "".join(rng.choice("0123456789abcdef") for _ in range(length))
+
+
+def random_version(rng):
+    return f"{rng.randint(1, 12)}.{rng.randint(0, 30)}.{rng.randint(0, 99)}"
+
+
+def random_connection_string(rng, service_name):
+    engine = rng.choice(DB_ENGINES)
+    prefix = rng.choice(DB_PREFIXES)
+    host_id = random_hex(rng)
+    port_map = {
+        "postgresql": 5432,
+        "mysql": 3306,
+        "mongodb": 27017,
+        "redis": 6379,
+        "cassandra": 9042,
+    }
+    port = port_map[engine]
+    db_name = f"{service_name.replace('-', '_')}_{rng.choice(['main', 'primary', 'prod', 'data', 'store'])}"
+    user = rng.choice(["app", "svc", "admin", "readwrite", "service"])
+    return f"{engine}://{user}@{prefix}-{host_id}.internal.svc:{port}/{db_name}"
+
+
+def generate_service_config(rng, name, connection_string=None):
+    team = rng.choice(TEAMS)
+    version = random_version(rng)
+    protocol = rng.choice(PROTOCOLS)
+    region = rng.choice(REGIONS)
+    env = rng.choice(ENVIRONMENTS)
+
+    if connection_string is None:
+        connection_string = random_connection_string(rng, name)
+
+    cpu_req = rng.choice(["100m", "250m", "500m", "1000m"])
+    cpu_limit = rng.choice(["500m", "1000m", "2000m", "4000m"])
+    mem_req = rng.choice(["128Mi", "256Mi", "512Mi", "1Gi"])
+    mem_limit = rng.choice(["256Mi", "512Mi", "1Gi", "2Gi"])
+    replicas_min = rng.randint(1, 4)
+    replicas_max = rng.randint(replicas_min + 1, replicas_min + 8)
+    port = rng.randint(3000, 9999)
+    cache_backend = rng.choice(CACHE_BACKENDS)
+    cache_host = f"cache-{random_hex(rng)}.internal.svc"
+    cache_port = rng.choice([6379, 11211])
+    log_level = rng.choice(LOG_LEVELS)
+    timeout_ms = rng.choice([1000, 2000, 3000, 5000, 10000])
+    retry_count = rng.randint(1, 5)
+    circuit_breaker_threshold = rng.randint(3, 10)
+    circuit_breaker_timeout = rng.randint(10, 60)
+    health_path = rng.choice(["/healthz", "/health", "/ready", "/status", "/_health"])
+    metrics_path = rng.choice(["/metrics", "/prometheus", "/_metrics"])
+    num_deps = rng.randint(1, 5)
+    deps = rng.sample([s for s in SERVICE_NAMES if s != name], num_deps)
+    env_vars = {
+        "NODE_ENV": env,
+        "LOG_FORMAT": rng.choice(["json", "text", "structured"]),
+        "TRACE_SAMPLING_RATE": str(round(rng.uniform(0.01, 1.0), 2)),
+        "MAX_CONNECTIONS": str(rng.randint(10, 200)),
+        "WORKER_THREADS": str(rng.randint(1, 16)),
+        "GRACEFUL_SHUTDOWN_TIMEOUT": f"{rng.randint(5, 30)}s",
+        "REQUEST_BODY_LIMIT": f"{rng.choice([1, 5, 10, 50])}mb",
+    }
+
+    lines = []
+    lines.append(f"  {name}:")
+    lines.append(f"    name: {name}")
+    lines.append(f"    version: \"{version}\"")
+    lines.append(f"    team: {team}")
+    lines.append(f"    deployment:")
+    lines.append(f"      region: {region}")
+    lines.append(f"      environment: {env}")
+    lines.append(f"      strategy: {rng.choice(['rolling', 'blue-green', 'canary'])}")
+    lines.append(f"      max_surge: {rng.choice(['25%', '50%', '1', '2'])}")
+    lines.append(f"      max_unavailable: {rng.choice(['0', '1', '25%'])}")
+    lines.append(f"    resources:")
+    lines.append(f"      requests:")
+    lines.append(f"        cpu: \"{cpu_req}\"")
+    lines.append(f"        memory: \"{mem_req}\"")
+    lines.append(f"      limits:")
+    lines.append(f"        cpu: \"{cpu_limit}\"")
+    lines.append(f"        memory: \"{mem_limit}\"")
+    lines.append(f"    networking:")
+    lines.append(f"      protocol: {protocol}")
+    lines.append(f"      port: {port}")
+    lines.append(f"      health_check: {health_path}")
+    lines.append(f"      metrics_endpoint: {metrics_path}")
+    lines.append(f"      timeout_ms: {timeout_ms}")
+    lines.append(f"    database:")
+    lines.append(f"      connection_string: \"{connection_string}\"")
+    lines.append(f"      pool_size: {rng.randint(5, 50)}")
+    lines.append(f"      max_idle: {rng.randint(2, 20)}")
+    lines.append(f"      connection_timeout_ms: {rng.randint(1000, 10000)}")
+    lines.append(f"      read_replicas: {rng.randint(0, 3)}")
+    lines.append(f"    cache:")
+    lines.append(f"      backend: {cache_backend}")
+    lines.append(f"      host: \"{cache_host}\"")
+    lines.append(f"      port: {cache_port}")
+    lines.append(f"      ttl_seconds: {rng.choice([60, 300, 600, 1800, 3600])}")
+    lines.append(f"      max_memory: \"{rng.choice(['64mb', '128mb', '256mb', '512mb'])}\"")
+    lines.append(f"    logging:")
+    lines.append(f"      level: {log_level}")
+    lines.append(f"      output: {rng.choice(['stdout', 'file', 'both'])}")
+    lines.append(f"      retention_days: {rng.choice([7, 14, 30, 90])}")
+    lines.append(f"      structured: {rng.choice(['true', 'false'])}")
+    lines.append(f"    monitoring:")
+    lines.append(f"      alerts_enabled: {rng.choice(['true', 'false'])}")
+    lines.append(f"      slo_target: \"{round(rng.uniform(99.0, 99.99), 2)}%\"")
+    lines.append(f"      error_budget_burn_rate: {round(rng.uniform(1.0, 10.0), 1)}")
+    lines.append(f"      pager_severity: {rng.choice(['P1', 'P2', 'P3', 'P4'])}")
+    lines.append(f"    resilience:")
+    lines.append(f"      retry_count: {retry_count}")
+    lines.append(f"      retry_backoff_ms: {rng.choice([100, 200, 500, 1000])}")
+    lines.append(f"      circuit_breaker_threshold: {circuit_breaker_threshold}")
+    lines.append(f"      circuit_breaker_timeout_s: {circuit_breaker_timeout}")
+    lines.append(f"      bulkhead_max_concurrent: {rng.randint(10, 100)}")
+    lines.append(f"    autoscaling:")
+    lines.append(f"      min_replicas: {replicas_min}")
+    lines.append(f"      max_replicas: {replicas_max}")
+    lines.append(f"      cpu_target_percent: {rng.choice([50, 60, 70, 80])}")
+    lines.append(f"      memory_target_percent: {rng.choice([60, 70, 80, 85])}")
+    lines.append(f"      scale_down_stabilization_s: {rng.choice([60, 120, 300])}")
+    lines.append(f"    environment:")
+    for k, v in env_vars.items():
+        lines.append(f"      {k}: \"{v}\"")
+    lines.append(f"    dependencies:")
+    for dep in deps:
+        lines.append(f"      - {dep}")
+
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <output_file>", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = sys.argv[1]
+    rng = random.Random(SEED)
+
+    sections = []
+    sections.append("services:")
+
+    for name in SERVICE_NAMES:
+        if name == NEEDLE_SERVICE:
+            section = generate_service_config(rng, name, connection_string=NEEDLE_CONNECTION_STRING)
+        else:
+            section = generate_service_config(rng, name)
+        sections.append(section)
+
+    content = "\n".join(sections) + "\n"
+
+    with open(output_path, "w") as f:
+        f.write(content)
+
+    size_bytes = len(content.encode("utf-8"))
+    size_tokens_approx = size_bytes // 4
+
+    if NEEDLE_CONNECTION_STRING not in content:
+        print("ERROR: Needle connection string not found in generated content", file=sys.stderr)
+        sys.exit(1)
+
+    if "7k3m9x" not in content:
+        print("ERROR: Needle identifier 7k3m9x not found in generated content", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Generated {len(SERVICE_NAMES)} service configs")
+    print(f"File size: {size_bytes:,} bytes (~{size_tokens_approx:,} tokens)")
+    print(f"Needle present: {NEEDLE_CONNECTION_STRING}")
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/test_case.yaml
@@ -1,0 +1,61 @@
+user_prompt: "In namespace app-286 there is a ConfigMap called platform-config whose data key 'platform-config.yaml' describes ~130 services. Each service has a database.connection_string. Exactly one service uses a database host whose id is '7k3m9x'. Which service is it, and what is its exact, full database connection_string?"
+
+# A/B matrix (see toolsets_matrix): the [toolsets] variant uses only the
+# read-only kubernetes toolset; the [codemode] variant also enables the
+# code_execution toolset. This exercises the SECOND token sink — intermediate
+# result bloat. Answering requires scanning a large (~40k-token) ConfigMap for
+# one needle; in code mode the script can fetch the blob, filter it in Python,
+# and print only the matching line, so the bulk never enters the model context.
+# The expected answer is identical for both variants, so the pass/fail gate is
+# correctness parity; the per-variant token counts recorded by the harness are
+# what show the result-filtering win.
+expected_output:
+  - "Must identify the service as payment-gateway"
+  - "Must report the exact database connection string: postgresql://admin@db-pmt-7k3m9x.internal.svc:5432/transactions_v2"
+  - "Must include the unique identifier 7k3m9x in the connection string"
+
+tags:
+  - kubernetes
+  - question-answer
+  - context_window
+  - benchmark
+
+toolsets_matrix:
+  - toolsets.yaml
+  - toolsets_codemode.yaml
+
+include_tool_calls: true
+
+before_test: |
+  set -e
+  kubectl create namespace app-286 --dry-run=client -o yaml | kubectl apply -f -
+
+  python3 generate_configs.py /tmp/holmesgpt-test-286-platform-config.yaml
+
+  kubectl delete configmap platform-config -n app-286 --ignore-not-found
+  kubectl create configmap platform-config \
+    --from-file=platform-config.yaml=/tmp/holmesgpt-test-286-platform-config.yaml \
+    -n app-286
+
+  # Verify the needle is present (retry loop for eventual consistency).
+  VERIFIED=false
+  for i in $(seq 1 30); do
+    if kubectl get configmap platform-config -n app-286 -o jsonpath='{.data.platform-config\.yaml}' 2>/dev/null | grep -q '7k3m9x'; then
+      echo "Needle verified on attempt $i"
+      VERIFIED=true
+      break
+    fi
+    sleep 1
+  done
+
+  if [ "$VERIFIED" = false ]; then
+    echo "Needle value 7k3m9x not found in ConfigMap after 30 attempts"
+    exit 1
+  fi
+
+  rm -f /tmp/holmesgpt-test-286-platform-config.yaml
+  echo "Setup complete"
+
+after_test: |
+  kubectl delete namespace app-286 --ignore-not-found
+  rm -f /tmp/holmesgpt-test-286-platform-config.yaml

--- a/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/toolsets.yaml
@@ -1,0 +1,5 @@
+# Classic variant ([toolsets]): only the read-only kubernetes toolset. Fetching
+# the large ConfigMap brings its whole body into the model's context.
+toolsets:
+  kubernetes/core:
+    enabled: true

--- a/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/toolsets_codemode.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/286_code_mode_large_configmap_filter/toolsets_codemode.yaml
@@ -1,0 +1,9 @@
+# Code-mode variant ([codemode]): the read-only kubernetes toolset PLUS the
+# code_execution toolset. The model can fetch the ConfigMap inside a Python
+# script, filter for the needle, and print only the matching connection string,
+# so the ~40k-token body never enters the model's context.
+toolsets:
+  kubernetes/core:
+    enabled: true
+  code_execution:
+    enabled: true

--- a/tests/llm/fixtures/test_ask_holmes/287_code_mode_used_for_counting/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/287_code_mode_used_for_counting/test_case.yaml
@@ -1,0 +1,77 @@
+user_prompt:
+- "Use the code execution tool (run_python_code) to write a SINGLE Python script that lists the ConfigMaps in every namespace whose name starts with 'app-287', counts them per namespace, and returns the exact count per namespace and the total. Do the gathering and counting inside one script via the holmes.* client — do not call the kubernetes tools directly one-by-one."
+
+# Unlike evals 285/286 (which only assert correctness parity), this eval verifies
+# that CODE MODE IS ACTUALLY USED end-to-end: the prompt directs the model to use
+# run_python_code, `bash` is disabled so it cannot shell-script around it, and
+# include_tool_calls lets the evaluator confirm the run_python_code tool was
+# invoked. It also checks the answer is correct, so a passing run means: the model
+# chose code mode, the script dispatched the real kubernetes tools through the
+# bridge, and the aggregated result came back right.
+include_tool_calls: true
+
+expected_output:
+  - "Must call the run_python_code tool (code mode) to gather and count the ConfigMaps"
+  - "The answer must state that app-287-alpha has exactly 19 ConfigMaps"
+  - "The answer must state that app-287-bravo has exactly 43 ConfigMaps"
+  - "The answer must state that app-287-charlie has exactly 61 ConfigMaps"
+  - "The answer must state that the total across all namespaces is exactly 123 ConfigMaps"
+
+tags:
+  - kubernetes
+  - counting
+  - numerical
+  - benchmark
+
+before_test: |
+  set -e
+  echo "Creating 3 namespaces for the code-mode usage test"
+  for NS in alpha bravo charlie; do
+    kubectl create namespace "app-287-$NS" --dry-run=client -o yaml | kubectl apply -f -
+  done
+
+  create_configmaps() {
+    local NS=$1
+    local COUNT=$2
+    echo "Creating $COUNT ConfigMaps in $NS with random names..."
+    for i in $(seq 1 "$COUNT"); do
+      NAME="cm-$(cat /proc/sys/kernel/random/uuid | cut -c1-12)"
+      kubectl create configmap "$NAME" --from-literal=data="value-$RANDOM" -n "$NS" &
+    done
+    wait
+    echo "Created $COUNT ConfigMaps in $NS"
+  }
+
+  # Each namespace also has an auto-created kube-root-ca.crt ConfigMap, so the
+  # observable count is (created + 1): 18->19, 42->43, 60->61. Total = 123.
+  create_configmaps app-287-alpha 18
+  create_configmaps app-287-bravo 42
+  create_configmaps app-287-charlie 60
+
+  echo "Verifying counts..."
+  FAIL=false
+  for PAIR in "app-287-alpha:19" "app-287-bravo:43" "app-287-charlie:61"; do
+    NS="${PAIR%%:*}"
+    EXPECTED="${PAIR##*:}"
+    ACTUAL=$(kubectl get configmaps -n "$NS" --no-headers | wc -l)
+    echo "$NS: $ACTUAL ConfigMaps (expected $EXPECTED)"
+    if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+      echo "ERROR: Count mismatch in $NS"
+      FAIL=true
+    fi
+  done
+
+  if [ "$FAIL" = true ]; then
+    exit 1
+  fi
+
+  echo "Test setup complete!"
+
+after_test: |
+  for NS in alpha bravo charlie; do
+    kubectl delete namespace "app-287-$NS" --ignore-not-found
+  done
+
+# Routine counting investigation — nothing reusable to teach; a well-behaved
+# agent must not propose a skill. Mirrors evals 227/285.
+memories_generated: false

--- a/tests/llm/fixtures/test_ask_holmes/287_code_mode_used_for_counting/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/287_code_mode_used_for_counting/toolsets.yaml
@@ -1,0 +1,11 @@
+# Enable the read-only kubernetes toolset + code_execution, and DISABLE bash so
+# the model cannot compose the whole thing in a shell one-liner and bypass code
+# mode. (The eval framework merges default_toolsets.yaml; entries here override
+# it, so `bash: enabled: false` genuinely turns bash off for this test.)
+toolsets:
+  kubernetes/core:
+    enabled: true
+  code_execution:
+    enabled: true
+  bash:
+    enabled: false

--- a/tests/plugins/toolsets/code_execution/test_code_execution.py
+++ b/tests/plugins/toolsets/code_execution/test_code_execution.py
@@ -1,0 +1,314 @@
+"""Unit + integration tests for the code_execution toolset ("code mode").
+
+These run the REAL subprocess bridge (no mocking of the runner) against a set of
+in-memory test tools, mirroring the pattern in test_bash_command_execution.py.
+"""
+
+from typing import List
+
+import pytest
+
+from holmes.core.tools import (
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    Tool,
+    ToolInvokeContext,
+    Toolset,
+    ToolsetStatusEnum,
+    ToolsetTag,
+)
+from holmes.core.tools_utils.tool_executor import ToolExecutor
+from holmes.plugins.toolsets.code_execution.client_generator import (
+    build_api_reference,
+    eligible_tool_names,
+)
+from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
+    CodeExecutionToolset,
+)
+from tests.conftest import create_mock_tool_invoke_context
+
+# All subprocess tests are stateful (temp dirs / sockets) but independent; group
+# them so xdist keeps them on one worker and they don't fight for CPU.
+pytestmark = pytest.mark.xdist_group("code_execution")
+
+
+# ── test tools ──────────────────────────────────────────────────────────────
+
+
+class EchoTool(Tool):
+    name: str = "echo_tool"
+    description: str = "Echo back the given text."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS, data=params.get("text", "")
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "echo"
+
+
+class ListNumbersTool(Tool):
+    name: str = "list_numbers"
+    description: str = "Return the list of integers 0..n-1 as JSON."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        n = int(params.get("n", 10))
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS, data=list(range(n))
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "list_numbers"
+
+
+class ErroringTool(Tool):
+    name: str = "always_errors"
+    description: str = "Always returns an error."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.ERROR, error="boom", data=None
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "always_errors"
+
+
+class NeedsApprovalTool(Tool):
+    name: str = "needs_approval_dynamic"
+    description: str = "Returns APPROVAL_REQUIRED at invoke time."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.APPROVAL_REQUIRED, error="approve me"
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "needs_approval_dynamic"
+
+
+class SecretTool(Tool):
+    name: str = "secret_core_tool"
+    description: str = "Should never be exposed to code mode."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(status=StructuredToolResultStatus.SUCCESS, data="x")
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "secret"
+
+
+def _toolset(name, tools, *, is_core=False, approval_patterns=None) -> Toolset:
+    ts = Toolset(
+        name=name,
+        description=f"{name} toolset",
+        tools=tools,
+        tags=[ToolsetTag.CORE],
+        enabled=True,
+        approval_required_tools=approval_patterns or [],
+    )
+    ts.status = ToolsetStatusEnum.ENABLED
+    if is_core:
+        ts._is_core = True
+    return ts
+
+
+@pytest.fixture
+def wired_toolset():
+    """A CodeExecutionToolset wired to a ToolExecutor with a mix of toolsets."""
+    code_ts = CodeExecutionToolset()
+    code_ts.prerequisites_callable({})
+    code_ts.status = ToolsetStatusEnum.ENABLED
+
+    data_ts = _toolset(
+        "readonly_data",
+        [ListNumbersTool(), EchoTool(), ErroringTool(), NeedsApprovalTool()],
+    )
+    core_ts = _toolset("core_stuff", [SecretTool()], is_core=True)
+    bash_ts = _toolset("bash", [EchoTool.model_construct(name="bash")])
+    approval_ts = _toolset(
+        "approval_ts",
+        [EchoTool.model_construct(name="gated_tool")],
+        approval_patterns=["*"],
+    )
+
+    executor = ToolExecutor(toolsets=[code_ts, data_ts, core_ts, bash_ts, approval_ts])
+    code_ts.set_tool_executor(executor)
+    return code_ts
+
+
+def _run(code_ts: CodeExecutionToolset, code: str, timeout: int = 30):
+    tool = code_ts.tools[0]
+    ctx = create_mock_tool_invoke_context(tool_name="run_python_code")
+    return tool.invoke({"code": code, "timeout": timeout}, ctx)
+
+
+# ── eligibility ───────────────────────────────────────────────────────────────
+
+
+def test_eligibility_excludes_core_bash_and_approval(wired_toolset):
+    names = eligible_tool_names(wired_toolset._tool_executor)
+    assert "list_numbers" in names
+    assert "echo_tool" in names
+    assert "always_errors" in names
+    assert "needs_approval_dynamic" in names  # eligible statically; guarded at dispatch
+    # excluded surfaces:
+    assert "secret_core_tool" not in names  # is_core
+    assert "bash" not in names  # excluded toolset name
+    assert "gated_tool" not in names  # approval_required_tools pattern
+    assert "run_python_code" not in names  # no recursion
+
+
+def test_api_reference_lists_functions(wired_toolset):
+    ref = build_api_reference(wired_toolset._tool_executor)
+    assert "holmes.list_numbers" in ref
+    assert "holmes.echo_tool" in ref
+    assert "secret_core_tool" not in ref
+
+
+def test_llm_instructions_populated_after_wiring(wired_toolset):
+    assert wired_toolset.llm_instructions
+    assert "Code mode" in wired_toolset.llm_instructions
+    assert "holmes.list_numbers" in wired_toolset.llm_instructions
+
+
+# ── happy path + the core token-saving property ───────────────────────────────
+
+
+def test_prints_only_filtered_result(wired_toolset):
+    code = (
+        "import json\n"
+        "nums = json.loads(holmes.list_numbers(n=1000))\n"
+        "evens = [x for x in nums if x % 2 == 0]\n"
+        "print('num_evens', len(evens))\n"
+    )
+    result = _run(wired_toolset, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "num_evens 500" in result.data
+    # The 1000-element raw list never appears in the returned data — only the
+    # filtered summary does. This is the whole point of code mode.
+    assert "999" not in result.data
+
+
+def test_multiple_subcalls_collapse_into_one_result(wired_toolset):
+    """N tool calls inside a script produce ONE tool result (call consolidation)."""
+    code = (
+        "a = holmes.echo_tool(text='one')\n"
+        "b = holmes.echo_tool(text='two')\n"
+        "c = holmes.echo_tool(text='three')\n"
+        "print(a, b, c)\n"
+    )
+    result = _run(wired_toolset, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "one two three" in result.data
+    assert "executed 3 tool call(s)" in result.data
+
+
+def test_no_tool_calls_just_compute(wired_toolset):
+    result = _run(wired_toolset, "print(2 + 2)")
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "4" in result.data
+
+
+def test_no_output_is_no_data(wired_toolset):
+    result = _run(wired_toolset, "x = 1 + 1")
+    assert result.status == StructuredToolResultStatus.NO_DATA
+
+
+# ── failure modes ─────────────────────────────────────────────────────────────
+
+
+def test_syntax_error_returns_actionable_error(wired_toolset):
+    result = _run(wired_toolset, "print('unterminated")
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert result.return_code == 2
+    assert "SyntaxError" in (result.data or "")
+
+
+def test_runtime_exception_returns_traceback(wired_toolset):
+    result = _run(wired_toolset, "raise ValueError('kaboom')")
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert result.return_code == 1
+    assert "kaboom" in (result.data or "")
+
+
+def test_calling_unavailable_tool_is_attribute_error(wired_toolset):
+    # bash is not exposed, so holmes.bash doesn't exist in the namespace.
+    result = _run(wired_toolset, "holmes.bash(command='ls')")
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "AttributeError" in (result.data or "")
+
+
+def test_subtool_error_raises_catchable_holmes_error(wired_toolset):
+    code = (
+        "try:\n"
+        "    holmes.always_errors()\n"
+        "    print('NO ERROR')\n"
+        "except holmes.HolmesToolError as e:\n"
+        "    print('caught:', e)\n"
+    )
+    result = _run(wired_toolset, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "caught:" in result.data
+    assert "boom" in result.data
+
+
+def test_approval_gated_subtool_is_denied_not_paused(wired_toolset):
+    """An APPROVAL_REQUIRED result at dispatch becomes an error, never a pause."""
+    code = (
+        "try:\n"
+        "    holmes.needs_approval_dynamic()\n"
+        "    print('NO ERROR')\n"
+        "except holmes.HolmesToolError as e:\n"
+        "    print('denied:', e)\n"
+    )
+    result = _run(wired_toolset, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "denied:" in result.data
+    assert "requires approval" in result.data
+
+
+def test_timeout_kills_runaway_script(wired_toolset):
+    result = _run(wired_toolset, "while True:\n    pass\n", timeout=1)
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "timed out" in (result.error or "")
+
+
+def test_missing_code_param(wired_toolset):
+    tool = wired_toolset.tools[0]
+    ctx = create_mock_tool_invoke_context(tool_name="run_python_code")
+    result = tool.invoke({}, ctx)
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "code" in (result.error or "")
+
+
+def test_unwired_executor_errors_gracefully():
+    code_ts = CodeExecutionToolset()
+    code_ts.prerequisites_callable({})
+    tool = code_ts.tools[0]
+    ctx = create_mock_tool_invoke_context(tool_name="run_python_code")
+    result = tool.invoke({"code": "print(1)"}, ctx)
+    assert result.status == StructuredToolResultStatus.ERROR
+    assert "executor" in (result.error or "").lower()
+
+
+# ── config / clamping ─────────────────────────────────────────────────────────
+
+
+def test_timeout_is_clamped_to_max(wired_toolset):
+    tool = wired_toolset.tools[0]
+    assert tool._resolve_timeout({"timeout": 99999}) == 300  # max_timeout_seconds
+    assert tool._resolve_timeout({"timeout": -5}) == 1  # negative floored to 1
+    assert tool._resolve_timeout({"timeout": 0}) == 60  # 0 is falsy -> default
+    assert tool._resolve_timeout({}) == 60  # default
+    assert tool._resolve_timeout({"timeout": "not-an-int"}) == 60
+
+
+def test_records_track_subcalls(wired_toolset):
+    """The bridge records each sub-call (basis for later live SSE streaming)."""
+    code = "holmes.echo_tool(text='hi'); holmes.always_errors()"
+    result = _run(wired_toolset, code)
+    # summary footer reflects both calls and their statuses
+    assert "echo_tool" in result.data
+    assert "always_errors" in result.data

--- a/tests/plugins/toolsets/code_execution/test_code_execution.py
+++ b/tests/plugins/toolsets/code_execution/test_code_execution.py
@@ -305,6 +305,24 @@ def test_timeout_is_clamped_to_max(wired_toolset):
     assert tool._resolve_timeout({"timeout": "not-an-int"}) == 60
 
 
+def test_subprocess_env_excludes_parent_secrets(wired_toolset, monkeypatch):
+    """The untrusted script must NOT see the parent's env (credential leak)."""
+    monkeypatch.setenv("SUPER_SECRET_API_KEY", "leak-me-if-you-can")
+    code = "import os; print('SUPER_SECRET_API_KEY' in os.environ)"
+    result = _run(wired_toolset, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "False" in result.data
+    assert "leak-me-if-you-can" not in (result.data or "")
+
+
+def test_null_code_one_liner_does_not_crash(wired_toolset):
+    """get_parameterized_one_liner runs outside the invoke try/except, so it
+    must tolerate {"code": null} without raising."""
+    tool = wired_toolset.tools[0]
+    assert tool.get_parameterized_one_liner({"code": None}) == ""
+    assert tool.get_parameterized_one_liner({}) == ""
+
+
 def test_records_track_subcalls(wired_toolset):
     """The bridge records each sub-call (basis for later live SSE streaming)."""
     code = "holmes.echo_tool(text='hi'); holmes.always_errors()"

--- a/tests/plugins/toolsets/code_execution/test_code_execution_security.py
+++ b/tests/plugins/toolsets/code_execution/test_code_execution_security.py
@@ -1,0 +1,201 @@
+"""Security boundary tests for code mode.
+
+The generated ``holmes.*`` client only exposes eligible tools, but a script is
+arbitrary Python and is handed the bridge socket path in ``HOLMES_CODE_SOCKET``.
+So the real trust boundary is NOT the client stubs — it is the parent-side
+allow-list check in ``dispatch`` (``code_execution_toolset._make_dispatch``).
+These tests exercise that boundary directly, including a script that bypasses
+the client and talks to the socket by hand.
+"""
+
+import pytest
+
+from holmes.core.tools import (
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    Tool,
+    ToolInvokeContext,
+    Toolset,
+    ToolsetStatusEnum,
+    ToolsetTag,
+)
+from holmes.core.tools_utils.tool_executor import ToolExecutor
+from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
+    CodeExecutionToolset,
+)
+from tests.conftest import create_mock_tool_invoke_context
+
+pytestmark = pytest.mark.xdist_group("code_execution")
+
+# If an excluded tool were ever dispatched, its result would contain this
+# sentinel. Asserting the sentinel never appears proves the tool never ran.
+_SENTINEL = "SECRET-DATA-LEAK-b3a1f7"
+
+
+class EchoTool(Tool):
+    name: str = "echo_tool"
+    description: str = "Echo text back."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS, data=params.get("text", "")
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "echo"
+
+
+class SecretCoreTool(Tool):
+    """Present in the executor but NOT eligible (its toolset is is_core).
+    If dispatch ever ran it, the sentinel would leak into the output."""
+
+    name: str = "secret_core_tool"
+    description: str = "Must never be reachable from code mode."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS, data=_SENTINEL
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "secret"
+
+
+class GatedTool(Tool):
+    name: str = "gated_tool"
+    description: str = "Approval-gated; must be denied inside a script."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.APPROVAL_REQUIRED, error="approve me"
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "gated"
+
+
+def _toolset(name, tools, *, is_core=False, approval_patterns=None) -> Toolset:
+    ts = Toolset(
+        name=name,
+        description=f"{name} toolset",
+        tools=tools,
+        tags=[ToolsetTag.CORE],
+        enabled=True,
+        approval_required_tools=approval_patterns or [],
+    )
+    ts.status = ToolsetStatusEnum.ENABLED
+    if is_core:
+        ts._is_core = True
+    return ts
+
+
+@pytest.fixture
+def wired():
+    code_ts = CodeExecutionToolset()
+    code_ts.prerequisites_callable({})
+    code_ts.status = ToolsetStatusEnum.ENABLED
+
+    data_ts = _toolset("readonly_data", [EchoTool()])
+    core_ts = _toolset("core_stuff", [SecretCoreTool()], is_core=True)
+    bash_ts = _toolset("bash", [EchoTool.model_construct(name="bash")])
+    approval_ts = _toolset(
+        "approval_ts", [GatedTool()], approval_patterns=["*"]
+    )
+
+    executor = ToolExecutor(
+        toolsets=[code_ts, data_ts, core_ts, bash_ts, approval_ts]
+    )
+    code_ts.set_tool_executor(executor)
+    return code_ts, executor
+
+
+def _run(code_ts, code):
+    ctx = create_mock_tool_invoke_context(tool_name="run_python_code")
+    return code_ts.tools[0].invoke({"code": code, "timeout": 30}, ctx)
+
+
+# ── the boundary itself: dispatch denies non-eligible names ───────────────────
+
+
+@pytest.mark.parametrize(
+    "name", ["secret_core_tool", "bash", "gated_tool", "does_not_exist"]
+)
+def test_bridge_denies_every_non_eligible_name(wired, name):
+    """For each excluded/unknown name, a raw bridge request is denied WITHOUT
+    the tool running — exercised through the real socket boundary (the client
+    stubs are bypassed)."""
+    code_ts, _ = wired
+    code = (
+        "import os, socket, json\n"
+        "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        "s.connect(os.environ['HOLMES_CODE_SOCKET'])\n"
+        f"s.sendall((json.dumps({{'tool': {name!r}, 'params': {{}}}}) + chr(10)).encode())\n"
+        "print(s.recv(65536).decode())\n"
+    )
+    result = _run(code_ts, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "not available" in (result.data or "")
+    assert _SENTINEL not in (result.data or "")  # the tool never ran
+
+
+def test_bridge_allows_eligible_name(wired):
+    """Positive control: an eligible tool IS reachable over the same boundary."""
+    code_ts, _ = wired
+    result = _run(code_ts, "print(holmes.echo_tool(text='hi'))")
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "hi" in (result.data or "")
+
+
+# ── the realistic attack: a script bypasses the client via the raw socket ─────
+
+
+def test_raw_socket_bypass_of_client_is_denied(wired):
+    """A script is arbitrary Python and is given HOLMES_CODE_SOCKET. Even talking
+    to the bridge by hand (bypassing the generated holmes.* client), it cannot
+    reach an excluded tool — the parent allow-list denies it."""
+    code_ts, _ = wired
+    code = (
+        "import os, socket, json\n"
+        "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        "s.connect(os.environ['HOLMES_CODE_SOCKET'])\n"
+        "s.sendall((json.dumps({'tool': 'secret_core_tool', 'params': {}}) + chr(10)).encode())\n"
+        "print('BRIDGE_REPLY:', s.recv(65536).decode())\n"
+    )
+    result = _run(code_ts, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS  # script itself ran
+    # ...but the excluded tool was denied and its data never came back:
+    assert _SENTINEL not in (result.data or "")
+    assert "not available" in (result.data or "")
+
+
+def test_raw_socket_bypass_cannot_reach_bash(wired):
+    """Same bypass, targeting bash (a mutation/approval surface) — denied."""
+    code_ts, _ = wired
+    code = (
+        "import os, socket, json\n"
+        "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        "s.connect(os.environ['HOLMES_CODE_SOCKET'])\n"
+        "s.sendall((json.dumps({'tool': 'bash', 'params': {'command': 'id'}}) + chr(10)).encode())\n"
+        "print(s.recv(65536).decode())\n"
+    )
+    result = _run(code_ts, code)
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "not available" in (result.data or "")
+
+
+# ── documented residual risk: no filesystem isolation ─────────────────────────
+
+
+def test_subprocess_can_still_read_local_files_documented_gap(wired, tmp_path):
+    """v1 has NO filesystem sandbox. This test documents that known, accepted
+    limitation (see the design doc Security section): env secrets are stripped,
+    but on-disk files the process can read are still reachable. If a future
+    change adds fs isolation, this test should be updated to assert denial."""
+    code_ts, _ = wired
+    secret_file = tmp_path / "on_disk_secret.txt"
+    secret_file.write_text("sa-token-xyz")
+    code = f"print(open({str(secret_file)!r}).read())\n"
+    result = _run(code_ts, code)
+    # Documents current behavior: the file IS readable (no fs sandbox in v1).
+    assert result.status == StructuredToolResultStatus.SUCCESS
+    assert "sa-token-xyz" in (result.data or "")

--- a/tests/plugins/toolsets/code_execution/test_code_execution_wiring.py
+++ b/tests/plugins/toolsets/code_execution/test_code_execution_wiring.py
@@ -1,0 +1,68 @@
+"""ToolCallingLLM must wire the ToolExecutor into code mode so it can dispatch
+sibling tools. This is the integration seam between the agentic loop and the
+code_execution toolset."""
+
+from holmes.core.tool_calling_llm import ToolCallingLLM
+from holmes.core.tools import ToolsetStatusEnum, ToolsetTag, Toolset
+from holmes.core.tools_utils.tool_executor import ToolExecutor
+from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
+    CodeExecutionToolset,
+)
+from tests.conftest import MockLLM
+from tests.mocks.toolset_mocks import DummyTool
+
+
+def _enabled(ts: Toolset) -> Toolset:
+    ts.status = ToolsetStatusEnum.ENABLED
+    return ts
+
+
+def test_tool_calling_llm_wires_executor_into_code_mode():
+    code_ts = CodeExecutionToolset()
+    code_ts.prerequisites_callable({})
+    _enabled(code_ts)
+
+    data_ts = _enabled(
+        Toolset(
+            name="data",
+            description="data",
+            tools=[DummyTool()],
+            tags=[ToolsetTag.CORE],
+            enabled=True,
+        )
+    )
+
+    executor = ToolExecutor(toolsets=[code_ts, data_ts])
+    assert code_ts._tool_executor is None  # not wired yet
+
+    ToolCallingLLM(
+        tool_executor=executor,
+        max_steps=1,
+        llm=MockLLM(),
+        tool_results_dir=None,
+    )
+
+    # The loop's __init__ wired it, and the API reference now reflects siblings.
+    assert code_ts._tool_executor is executor
+    assert "dummy_tool" in (code_ts.llm_instructions or "")
+
+
+def test_wiring_hook_is_generic_and_ignores_plain_toolsets():
+    """Toolsets without set_tool_executor are simply skipped (no crash)."""
+    plain = _enabled(
+        Toolset(
+            name="plain",
+            description="plain",
+            tools=[DummyTool()],
+            tags=[ToolsetTag.CORE],
+            enabled=True,
+        )
+    )
+    executor = ToolExecutor(toolsets=[plain])
+    # Should not raise.
+    ToolCallingLLM(
+        tool_executor=executor,
+        max_steps=1,
+        llm=MockLLM(),
+        tool_results_dir=None,
+    )

--- a/tests/plugins/toolsets/code_execution/test_code_execution_wiring.py
+++ b/tests/plugins/toolsets/code_execution/test_code_execution_wiring.py
@@ -3,7 +3,7 @@ sibling tools. This is the integration seam between the agentic loop and the
 code_execution toolset."""
 
 from holmes.core.tool_calling_llm import ToolCallingLLM
-from holmes.core.tools import ToolsetStatusEnum, ToolsetTag, Toolset
+from holmes.core.tools import ToolInvokeContext, ToolsetStatusEnum, ToolsetTag, Toolset
 from holmes.core.tools_utils.tool_executor import ToolExecutor
 from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
     CodeExecutionToolset,
@@ -66,3 +66,17 @@ def test_wiring_hook_is_generic_and_ignores_plain_toolsets():
         llm=MockLLM(),
         tool_results_dir=None,
     )
+
+
+def test_tool_executor_excluded_from_context_model_dump():
+    """The request-scoped executor must not leak into serialized context."""
+    executor = ToolExecutor(toolsets=[])
+    ctx = ToolInvokeContext(
+        llm=MockLLM(),
+        max_token_count=1000,
+        tool_call_id="x",
+        tool_name="t",
+        tool_executor=executor,
+    )
+    assert ctx.tool_executor is executor  # available at runtime
+    assert "tool_executor" not in ctx.model_dump()  # but never serialized

--- a/tests/plugins/toolsets/code_execution/test_code_mode_token_reduction.py
+++ b/tests/plugins/toolsets/code_execution/test_code_mode_token_reduction.py
@@ -1,0 +1,234 @@
+"""Deterministic proof that code mode reduces the number of tokens a tool's
+output contributes to the LLM context.
+
+This does NOT depend on an LLM choosing to use code mode, on a Kubernetes
+cluster, or on any network call. It measures the exact quantity that drives
+Holmes's input-token cost: how many tokens the ``{"role": "tool", ...}`` message
+adds to the conversation, using the SAME formatter (``format_tool_result_data``)
+and the SAME tokenizer (``litellm.token_counter``) the product uses to size and
+spill tool results.
+
+For an identical underlying dataset and question we compare two paths:
+
+* **classic** — the tool is invoked directly, so its full result is appended to
+  the context (and re-sent on every subsequent agentic step).
+* **code mode** — a script calls the same tool(s) inside the subprocess, filters
+  in Python, and ``print``s only the answer; only that summary is appended.
+
+Two token sinks are covered:
+
+1. *result filtering* — one tool returns a large payload; only a summary returns.
+2. *call consolidation* — N sub-calls collapse into a single tool result.
+"""
+
+import json
+from typing import List
+
+import litellm
+import pytest
+
+from holmes.core.models import format_tool_result_data
+from holmes.core.tools import (
+    StructuredToolResult,
+    StructuredToolResultStatus,
+    Tool,
+    ToolInvokeContext,
+    Toolset,
+    ToolsetStatusEnum,
+    ToolsetTag,
+)
+from holmes.core.tools_utils.tool_executor import ToolExecutor
+from holmes.plugins.toolsets.code_execution.code_execution_toolset import (
+    CodeExecutionToolset,
+)
+from tests.conftest import create_mock_tool_invoke_context
+
+pytestmark = pytest.mark.xdist_group("code_execution")
+
+# Real tokenizer, evaluated offline (tiktoken); no API call.
+_TOKENIZER_MODEL = "gpt-4o"
+
+# Deterministic dataset knobs (no RNG so the proof is reproducible).
+_NUM_EVENTS = 6000
+_ERROR_EVERY = 37  # every Nth event is an ERROR
+_SERVICES = ["checkout", "payment", "inventory", "search", "profile"]
+
+
+def _expected_error_count() -> int:
+    return sum(1 for i in range(_NUM_EVENTS) if i % _ERROR_EVERY == 0)
+
+
+def _make_event(i: int) -> dict:
+    return {
+        "id": i,
+        "service": _SERVICES[i % len(_SERVICES)],
+        "level": "ERROR" if i % _ERROR_EVERY == 0 else "INFO",
+        "region": "us-east-1" if i % 2 == 0 else "eu-west-1",
+        "latency_ms": 20 + (i % 400),
+        "message": f"request {i} processed by worker-{i % 16} on shard-{i % 8}",
+    }
+
+
+class ListEventsTool(Tool):
+    """Returns a large list of event records (no server-side filtering) — the
+    kind of raw payload that floods context when returned directly."""
+
+    name: str = "list_events"
+    description: str = "Return the full event log as a JSON list."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        n = int(params.get("n", _NUM_EVENTS))
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS,
+            data=[_make_event(i) for i in range(n)],
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "list_events"
+
+
+class ShardReportTool(Tool):
+    """Returns a moderate per-shard report; used to show call consolidation."""
+
+    name: str = "shard_report"
+    description: str = "Return a report for a single shard."
+
+    def _invoke(self, params: dict, context: ToolInvokeContext) -> StructuredToolResult:
+        shard = int(params.get("shard", 0))
+        rows = [
+            {
+                "shard": shard,
+                "key": f"metric_{shard}_{j}",
+                "value": (shard * 1000 + j) % 997,
+                "note": f"sample row {j} for shard {shard} with some padding text",
+            }
+            for j in range(120)
+        ]
+        return StructuredToolResult(
+            status=StructuredToolResultStatus.SUCCESS, data=rows
+        )
+
+    def get_parameterized_one_liner(self, params) -> str:
+        return "shard_report"
+
+
+def _wired(tools: List[Tool]) -> CodeExecutionToolset:
+    code_ts = CodeExecutionToolset()
+    code_ts.prerequisites_callable({})
+    code_ts.status = ToolsetStatusEnum.ENABLED
+
+    data_ts = Toolset(
+        name="events_data",
+        description="events data toolset",
+        tools=tools,
+        tags=[ToolsetTag.CORE],
+        enabled=True,
+    )
+    data_ts.status = ToolsetStatusEnum.ENABLED
+
+    executor = ToolExecutor(toolsets=[code_ts, data_ts])
+    code_ts.set_tool_executor(executor)
+    return code_ts
+
+
+def _context_tokens(result: StructuredToolResult) -> int:
+    """Tokens the tool result contributes to the LLM context — exactly how
+    Holmes measures it (format_tool_result_data + litellm.token_counter)."""
+    content = format_tool_result_data(
+        tool_result=result, tool_call_id="call_x", tool_name="t"
+    )
+    return litellm.token_counter(
+        model=_TOKENIZER_MODEL, messages=[{"role": "tool", "content": content}]
+    )
+
+
+def _run_code(code_ts: CodeExecutionToolset, code: str) -> StructuredToolResult:
+    tool = code_ts.tools[0]
+    ctx = create_mock_tool_invoke_context(tool_name="run_python_code")
+    return tool.invoke({"code": code, "timeout": 30}, ctx)
+
+
+def test_result_filtering_cuts_context_tokens(capsys):
+    """A tool returns 6000 events; the question is 'how many are ERROR?'.
+
+    Classic: the whole 6000-event list enters context.
+    Code mode: only 'error_count <N>' enters context.
+    """
+    code_ts = _wired([ListEventsTool()])
+    expected = _expected_error_count()
+
+    # classic: direct tool call → full payload in context
+    raw = ListEventsTool()._invoke(
+        {"n": _NUM_EVENTS}, create_mock_tool_invoke_context(tool_name="list_events")
+    )
+    classic_tokens = _context_tokens(raw)
+
+    # code mode: filter in Python, print only the answer
+    codemode = _run_code(
+        code_ts,
+        "import json\n"
+        "events = json.loads(holmes.list_events(n=%d))\n"
+        "n = sum(1 for e in events if e['level'] == 'ERROR')\n"
+        "print('error_count', n)\n" % _NUM_EVENTS,
+    )
+    codemode_tokens = _context_tokens(codemode)
+
+    # correctness: code mode computed the right answer from the same data
+    assert codemode.status == StructuredToolResultStatus.SUCCESS
+    assert f"error_count {expected}" in codemode.data
+
+    reduction = 100 * (1 - codemode_tokens / classic_tokens)
+    with capsys.disabled():
+        print(
+            f"\n[result filtering] classic={classic_tokens:,} tokens  "
+            f"code_mode={codemode_tokens:,} tokens  "
+            f"reduction={reduction:.2f}%  (answer: {expected} errors)"
+        )
+
+    # The raw payload is thousands of tokens; the summary is a handful.
+    assert classic_tokens > 10_000
+    assert codemode_tokens < classic_tokens * 0.02  # >=98% reduction
+    # And the raw records genuinely never entered context in code mode.
+    assert "latency_ms" not in (codemode.data or "")
+
+
+def test_call_consolidation_cuts_context_tokens(capsys):
+    """8 sub-calls inside one script produce ONE tool result, versus 8 separate
+    tool results in the classic path."""
+    code_ts = _wired([ShardReportTool()])
+    n_shards = 8
+
+    # classic: 8 separate tool results, each appended to context
+    classic_total = 0
+    for shard in range(n_shards):
+        r = ShardReportTool()._invoke(
+            {"shard": shard},
+            create_mock_tool_invoke_context(tool_name="shard_report"),
+        )
+        classic_total += _context_tokens(r)
+
+    # code mode: one script fans out to all shards, prints only the aggregate
+    codemode = _run_code(
+        code_ts,
+        "import json\n"
+        "total = 0\n"
+        "for s in range(%d):\n"
+        "    rows = json.loads(holmes.shard_report(shard=s))\n"
+        "    total += sum(r['value'] for r in rows)\n"
+        "print('sum_of_values', total)\n" % n_shards,
+    )
+    codemode_tokens = _context_tokens(codemode)
+
+    assert codemode.status == StructuredToolResultStatus.SUCCESS
+    assert "sum_of_values" in codemode.data
+    assert f"executed {n_shards} tool call(s)" in codemode.data
+
+    reduction = 100 * (1 - codemode_tokens / classic_total)
+    with capsys.disabled():
+        print(
+            f"\n[call consolidation] classic({n_shards} results)={classic_total:,} "
+            f"tokens  code_mode(1 result)={codemode_tokens:,} tokens  "
+            f"reduction={reduction:.2f}%"
+        )
+
+    assert codemode_tokens < classic_total * 0.1  # >=90% reduction


### PR DESCRIPTION
## Summary

Adds an **opt-in `code_execution` toolset** implementing "code mode": instead of the LLM emitting one tool call per agentic step (re-sending all prior results each turn), it writes **one Python script** that composes many read-only Holmes tools and **filters results in code**, so only what it `print()`s enters the model's context. This targets the biggest token sink in production — intermediate-result bloat on multi-step investigations (≥6-iteration requests are ~66% of spend).

Design doc: `docs/design/2026-07-28_holmes-code-mode.md` (included in this PR — design and implementation reviewed together). Ticket: [ROB-723](https://linear.app/robusta/issue/ROB-723).

## How it works

- `run_python_code(code, timeout?)` runs the script in a **subprocess**. A generated `holmes` object exposes one function per eligible tool; each call is relayed over a **unix-domain socket** back to the parent, which dispatches into the real `ToolExecutor`. **Credentials never leave the parent process** — the subprocess can only ask the parent to run an allow-listed tool.
- **Read-only surface only.** `is_core` toolsets, `bash`/`kubectl_run`, and any `approval_required_tools` are excluded from the generated client. Because a synchronous script can't pause for interactive approval, an `APPROVAL_REQUIRED` result at dispatch is **denied** (the model is told to call that tool directly) — mirroring the trust model in the remote-tool-execution design.
- Reuses the existing `ulimit` memory cap; oversized stdout flows through the loop's existing `spill_oversized_tool_result` guard. **Off by default** (feature-flagged via `enabled=False`).
- `ToolCallingLLM` gains a small **generic** `set_tool_executor` wiring hook (no code-mode-specific coupling).

## Testing

**Deterministic token-reduction proof** (`test_code_mode_token_reduction.py`) — measures the exact context-token cost of a tool's output, classic vs code mode, for identical data, using the **same formatter (`format_tool_result_data`) and tokenizer (`litellm.token_counter`, gpt-4o) the product uses to size/spill results**. No LLM, no cluster, no RNG:

| Sink | Classic (tokens in context) | Code mode | Reduction |
|---|---|---|---|
| Result filtering (6000-event log → "how many ERROR?") | 250,029 | 136 | **99.95%** |
| Call consolidation (8 sub-calls → 1 result) | 30,952 | 275 | **99.11%** |

(Correctness asserted too — code mode computes the right answer from the same data.)

**Unit / integration** — 21 tests (real subprocess, no mocking of the runner): eligibility (`is_core`/bash/approval-gated/self excluded), the token-saving property, and failure modes (syntax error, runtime exception, timeout, unavailable tool, erroring sub-tool, approval-gated sub-tool denied-not-paused, unwired executor, timeout clamping). No regressions in `test_tool_calling_llm.py` / `test_tool_executor.py` (47 passing).

**LLM evals** — two ask_holmes A/B evals (`toolsets_matrix`: `[default]` vs `[codemode]`), **4/4 passing in CI** on opus-4.6 ([run 30478931611](https://github.com/HolmesGPT/holmesgpt/actions/runs/30478931611)). These assert **correctness parity** (code mode doesn't regress the answer) — they are deliberately *not* the token-win proof: Holmes's server-side filters (`kubernetes_jq_query`, log `filter`) already keep k8s data out of context, and the live A/B run confirmed the model kept using those rather than code mode, so the small fixtures show no token delta. The deterministic test above is where the token win is proven. Run on demand in `eval-regression.yaml`.

## Toolset checklist

- [x] Unit tests (+ deterministic token-reduction proof)
- [x] `config_classes` defined (`CodeExecutionConfig`)
- [x] Prerequisite check (verifies `python3` availability)
- [x] ask_holmes **evals** — A/B `toolsets_matrix`, 4/4 passing in CI (correctness parity)
- [ ] **Documentation** page — follow-up (`docs/data-sources/builtin-toolsets/code-execution.md`)

## Notes / follow-ups

- **Observability**: sub-calls are recorded (name/status/timing) and summarized in the result today. Live per-sub-call SSE streaming to the UI is a follow-up requiring a loop-level streaming hook + a `parent_tool_call_id` field (see the design doc; frontend PR to follow).
- This is a first, conservative v1 (read-only, subprocess + `ulimit`, no language-level sandbox). Hardening the sandbox is a documented Future Goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMU8v729xhwopf4QcrJcPU)_