### PR TITLE
Set HOLMES_CONFIGPATH_DIR to /tmp/.holmes in the Helm deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,6 @@ FROM python:3.11-alpine
 ENV PYTHONUNBUFFERED=1
 ENV PATH="/venv/bin:$PATH"
 ENV PYTHONPATH=$PYTHONPATH:.:/app/holmes
-# /tmp is the only writable mount when readOnlyRootFilesystem is set
-ENV HOLMES_CONFIGPATH_DIR=/tmp/.holmes
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,8 @@ FROM python:3.11-alpine
 ENV PYTHONUNBUFFERED=1
 ENV PATH="/venv/bin:$PATH"
 ENV PYTHONPATH=$PYTHONPATH:.:/app/holmes
+# /tmp is the only writable mount when readOnlyRootFilesystem is set
+ENV HOLMES_CONFIGPATH_DIR=/tmp/.holmes
 
 WORKDIR /app
 

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -147,10 +147,18 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
         env:
-          # readOnlyRootFilesystem makes the default config path (~/.holmes)
-          # unwritable, so point it at the writable /tmp emptyDir.
+          {{- /* readOnlyRootFilesystem makes the default config path (~/.holmes)
+                 unwritable, so default it to the writable /tmp emptyDir. Skipped
+                 when the user sets it themselves, so we don't emit a duplicate
+                 env var and rely on the runtime's last-one-wins ordering. */}}
+          {{- $userEnvNames := list }}
+          {{- range concat (.Values.additionalEnvVars | default list) (.Values.additional_env_vars | default list) }}
+          {{- $userEnvNames = append $userEnvNames .name }}
+          {{- end }}
+          {{- if not (has "HOLMES_CONFIGPATH_DIR" $userEnvNames) }}
           - name: HOLMES_CONFIGPATH_DIR
             value: /tmp/.holmes
+          {{- end }}
           - name: LOG_LEVEL
             value: {{ .Values.logLevel }}
           - name: ENABLE_JSON_LOGS_FORMAT

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -147,6 +147,10 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
         env:
+          # readOnlyRootFilesystem makes the default config path (~/.holmes)
+          # unwritable, so point it at the writable /tmp emptyDir.
+          - name: HOLMES_CONFIGPATH_DIR
+            value: /tmp/.holmes
           - name: LOG_LEVEL
             value: {{ .Values.logLevel }}
           - name: ENABLE_JSON_LOGS_FORMAT

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -147,18 +147,9 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
         env:
-          {{- /* readOnlyRootFilesystem makes the default config path (~/.holmes)
-                 unwritable, so default it to the writable /tmp emptyDir. Skipped
-                 when the user sets it themselves, so we don't emit a duplicate
-                 env var and rely on the runtime's last-one-wins ordering. */}}
-          {{- $userEnvNames := list }}
-          {{- range concat (.Values.additionalEnvVars | default list) (.Values.additional_env_vars | default list) }}
-          {{- $userEnvNames = append $userEnvNames .name }}
-          {{- end }}
-          {{- if not (has "HOLMES_CONFIGPATH_DIR" $userEnvNames) }}
+          # ~/.holmes is unwritable under readOnlyRootFilesystem; /tmp is the emptyDir
           - name: HOLMES_CONFIGPATH_DIR
             value: /tmp/.holmes
-          {{- end }}
           - name: LOG_LEVEL
             value: {{ .Values.logLevel }}
           - name: ENABLE_JSON_LOGS_FORMAT


### PR DESCRIPTION
## Problem

The server pod runs with `readOnlyRootFilesystem: true` (`helm/holmes/templates/holmes.yaml`, always on). `HOLMES_CONFIGPATH_DIR` is unset, so `config_path_dir` falls back to `~/.holmes` = `/root/.holmes`, which cannot be created. The periodic toolset refresh thread crashed on every interval:

```
ERROR    Failed to refresh platform-mcp tools
  File "/app/holmes/core/toolset_manager.py", line 428, in refresh_toolset_status
    os.makedirs(os.path.dirname(self.toolset_status_location))
OSError: [Errno 30] Read-only file system: '/root/.holmes'
```

Because the exception fired before `refresh_platform_mcp_tools(executor)`, the dynamic remote-tool surface (new clusters joining, flipped account flags) never re-discovered — it required a pod restart to pick up.

## Fix

Set `HOLMES_CONFIGPATH_DIR=/tmp/.holmes` in the Holmes Deployment. `/tmp` is already mounted as a writable 256Mi emptyDir in the chart, specifically for this reason.

Scoped to the Kubernetes deployment rather than the image: an image-wide `ENV` would also apply to Docker Compose, which mounts user config at `/root/.holmes`, so `config.yaml` would stop being discovered there. Only the Kubernetes deployment sets `readOnlyRootFilesystem`, so every other runtime keeps the default `~/.holmes`.

The chart mounts nothing at `/root/.holmes` (config comes from env or `/etc/robusta/config`), so no existing config path is orphaned.

## Verification

Reproduced against a real read-only mount pointed at `config_path_dir`: before the change, `prepare_toolsets(PrerequisiteCacheMode.ENABLED)` raises the exact traceback above (`toolset_manager.py:684 → 481 → 428`, `Errno 30`); with the config path on a writable location it returns 43 toolsets and the status cache is written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with read-only container filesystems by always directing Holmes to use a writable temporary config directory (`/tmp/.holmes`).
  * Removes conditional env-var handling to ensure `HOLMES_CONFIGPATH_DIR` is consistently set, avoiding missing or conflicting configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->