### PR TITLE
ROB-808 docs: add Bitbucket instructions for loading custom skills

### DIFF
--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -173,7 +173,7 @@ Same pattern as GitHub — only the credentials and clone URL differ. Bitbucket 
       --from-literal=token='<repository-access-token>'
     ```
 
-    For a public repo, omit the Secret and drop the `x-token-auth:${GIT_TOKEN}@` segment from the clone URL below.
+    For a public repo, omit the Secret, remove the `GIT_TOKEN` `env` block from the init container below, and drop the `x-token-auth:${GIT_TOKEN}@` segment from the clone URL.
 
     **2. Add the init container, volume, and skill path to your Helm values:**
 
@@ -239,7 +239,7 @@ Same pattern as GitHub — only the credentials and clone URL differ. Bitbucket 
       --from-literal=token='<repository-access-token>'
     ```
 
-    For a public repo, omit the Secret and drop the `x-token-auth:${GIT_TOKEN}@` segment from the clone URL below.
+    For a public repo, omit the Secret, remove the `GIT_TOKEN` `env` block from the init container below, and drop the `x-token-auth:${GIT_TOKEN}@` segment from the clone URL.
 
     **2. Add the init container, volume, and skill path to your `generated_values.yaml`:**
 
@@ -298,7 +298,15 @@ Same pattern as GitHub — only the credentials and clone URL differ. Bitbucket 
 
 === "Holmes CLI"
 
-    Clone the repo to your machine and point `custom_skill_paths` at the clone in `~/.holmes/config.yaml`:
+    Clone the repo to your machine. For a private repo, authenticate with a Repository Access Token (`Repositories: Read` scope):
+
+    ```bash
+    git clone "https://x-token-auth:<repository-access-token>@bitbucket.org/<workspace>/<repo>.git"
+    ```
+
+    For a public repo, drop the `x-token-auth:<repository-access-token>@` segment.
+
+    Then point `custom_skill_paths` at the clone in `~/.holmes/config.yaml`:
 
     ```yaml
     custom_skill_paths:

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -157,6 +157,156 @@ Keep skills version-controlled in a Git repo so they can be reviewed, versioned,
 
     Run `git pull` in the clone whenever you want to pick up new or updated skills.
 
+### From a Bitbucket Repository
+
+Same pattern as GitHub — only the credentials and clone URL differ. Bitbucket uses a [Repository Access Token](https://support.atlassian.com/bitbucket-cloud/docs/repository-access-tokens/) with the `x-token-auth` username.
+
+=== "Holmes Helm Chart"
+
+    Have Holmes re-clone the repo on every pod restart. An init container pulls the repo into an `emptyDir` shared with the main Holmes container, and a `customSkillPaths` entry registers the directory.
+
+    **1. Create a Secret with a Bitbucket Repository Access Token.** Create the token under *Repository settings → Access tokens* with the `Repositories: Read` scope:
+
+    ```bash
+    kubectl create secret generic holmes-skills-git-credentials \
+      -n <holmes-namespace> \
+      --from-literal=token='<repository-access-token>'
+    ```
+
+    For a public repo, omit the Secret and drop the `x-token-auth:${GIT_TOKEN}@` segment from the clone URL below.
+
+    **2. Add the init container, volume, and skill path to your Helm values:**
+
+    ```yaml
+    additionalVolumes:
+      - name: skills-repo
+        emptyDir:
+          sizeLimit: 64Mi
+
+    additionalVolumeMounts:
+      - name: skills-repo
+        mountPath: /etc/holmes/skills-git
+        readOnly: true
+
+    initContainers:
+      - name: clone-skills
+        image: alpine/git:2.45.2
+        env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: holmes-skills-git-credentials
+                key: token
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+
+            rm -rf /skills-repo/* /skills-repo/.[!.]* /skills-repo/..?* 2>/dev/null || true
+
+            git clone --depth 1 --branch main \
+              "https://x-token-auth:${GIT_TOKEN}@bitbucket.org/<workspace>/<repo>.git" \
+              /skills-repo
+        volumeMounts:
+          - name: skills-repo
+            mountPath: /skills-repo
+
+    customSkillPaths:
+      - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
+    ```
+
+    Adjust:
+
+    - `--branch main` — branch you push skills to.
+    - `https://bitbucket.org/<workspace>/<repo>.git` — your repo URL.
+    - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
+
+    **3. Refresh after changes.** The clone runs only on pod startup. After pushing skill changes to the tracked branch, roll the Holmes Deployment:
+
+    ```bash
+    kubectl rollout restart deploy/<release>-holmes -n <holmes-namespace>
+    ```
+
+=== "Robusta Helm Chart"
+
+    Have Holmes re-clone the repo on every pod restart. An init container pulls the repo into an `emptyDir` shared with the main Holmes container, and a `customSkillPaths` entry registers the directory.
+
+    **1. Create a Secret with a Bitbucket Repository Access Token.** Create the token under *Repository settings → Access tokens* with the `Repositories: Read` scope:
+
+    ```bash
+    kubectl create secret generic holmes-skills-git-credentials \
+      -n <robusta-namespace> \
+      --from-literal=token='<repository-access-token>'
+    ```
+
+    For a public repo, omit the Secret and drop the `x-token-auth:${GIT_TOKEN}@` segment from the clone URL below.
+
+    **2. Add the init container, volume, and skill path to your `generated_values.yaml`:**
+
+    ```yaml
+    enableHolmesGPT: true
+
+    holmes:
+      additionalVolumes:
+        - name: skills-repo
+          emptyDir:
+            sizeLimit: 64Mi
+
+      additionalVolumeMounts:
+        - name: skills-repo
+          mountPath: /etc/holmes/skills-git
+          readOnly: true
+
+      initContainers:
+        - name: clone-skills
+          image: alpine/git:2.45.2
+          env:
+            - name: GIT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: holmes-skills-git-credentials
+                  key: token
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              rm -rf /skills-repo/* /skills-repo/.[!.]* /skills-repo/..?* 2>/dev/null || true
+
+              git clone --depth 1 --branch main \
+                "https://x-token-auth:${GIT_TOKEN}@bitbucket.org/<workspace>/<repo>.git" \
+                /skills-repo
+          volumeMounts:
+            - name: skills-repo
+              mountPath: /skills-repo
+
+      customSkillPaths:
+        - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
+    ```
+
+    Adjust:
+
+    - `--branch main` — branch you push skills to.
+    - `https://bitbucket.org/<workspace>/<repo>.git` — your repo URL.
+    - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
+
+    **3. Refresh after changes.** The clone runs only on pod startup. After pushing skill changes to the tracked branch, roll the Holmes Deployment:
+
+    ```bash
+    kubectl rollout restart deploy/robusta-holmes -n <robusta-namespace>
+    ```
+
+=== "Holmes CLI"
+
+    Clone the repo to your machine and point `custom_skill_paths` at the clone in `~/.holmes/config.yaml`:
+
+    ```yaml
+    custom_skill_paths:
+      - /path/to/your-skills-clone/
+    ```
+
+    Run `git pull` in the clone whenever you want to pick up new or updated skills.
+
 ### Inline in Helm Values
 
 Define skills directly in your Helm values. The chart creates a ConfigMap, mounts it, and registers the path — no extra wiring. Changes take effect on the next `helm upgrade`.


### PR DESCRIPTION
Adds a **From a Bitbucket Repository** section to the skills reference, mirroring the existing GitHub section with the Bitbucket-specific bits:

- Bitbucket Repository Access Token (`Repositories: Read` scope) instead of a GitHub PAT
- `x-token-auth:${GIT_TOKEN}@bitbucket.org/<workspace>/<repo>.git` clone URL
- Hidden-file-safe cleanup of the `emptyDir` before cloning

Covers all three deployment tabs (Holmes Helm Chart, Robusta Helm Chart, Holmes CLI). Verified end-to-end on a live cluster: skills repo on Bitbucket cloned by the init container and loaded by Holmes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for loading custom skills from Bitbucket repositories.
  * Documented repository access tokens, Helm and Robusta Helm configuration, secure repository cloning, path setup, deployment refresh commands, and Holmes CLI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->