### PR TITLE
Recover tool calls emitted as XML text (ROB-558)

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -40,6 +40,7 @@ from holmes.common.env_vars import (
 from holmes.core.azure_token import get_azure_ad_token
 from holmes.core.llm_usage import extract_usage_from_response
 from holmes.core.supabase_dal import SupabaseDal
+from holmes.core.tool_call_recovery import recover_tool_calls_from_text
 from holmes.utils.env import environ_get_safe_int, replace_env_vars_values
 from holmes.utils.file_utils import load_yaml_file
 
@@ -303,6 +304,48 @@ def _count_anthropic_image_tokens(message: dict) -> int:
         else:
             image_tokens += 1600  # conservative fallback
     return image_tokens
+
+
+def _offered_tool_names(tools: Optional[List[Dict[str, Any]]]) -> set:
+    """Names of the function tools offered to the model in this call."""
+    names = set()
+    for tool in tools or []:
+        fn = (tool or {}).get("function") if isinstance(tool, dict) else None
+        name = (fn or {}).get("name") if isinstance(fn, dict) else None
+        if name:
+            names.add(name)
+    return names
+
+
+def _recover_text_tool_calls(
+    result: ModelResponse, tools: Optional[List[Dict[str, Any]]]
+) -> None:
+    """Recover a tool call the model emitted as XML text instead of a structured
+    ``tool_calls`` field (ROB-558), mutating ``result`` in place.
+
+    Only fires when the message has no structured ``tool_calls`` and its content
+    holds tool-call XML for a tool that was actually offered — so a normal answer
+    that merely mentions ``<invoke>`` is never disturbed. See
+    ``tool_call_recovery`` for the parsing details.
+    """
+    offered = _offered_tool_names(tools)
+    if not offered:
+        return
+    try:
+        choices = result.choices or []
+    except AttributeError:
+        return
+    for choice in choices:
+        message = getattr(choice, "message", None)
+        if message is None or getattr(message, "tool_calls", None):
+            continue
+        content = getattr(message, "content", None)
+        if not isinstance(content, str):
+            continue
+        cleaned, recovered = recover_tool_calls_from_text(content, offered)
+        if recovered:
+            message.content = cleaned
+            message.tool_calls = recovered
 
 
 class LLM:
@@ -770,6 +813,7 @@ class DefaultLLM(LLM):
         )
 
         if isinstance(result, ModelResponse):
+            _recover_text_tool_calls(result, tools)
             return result
         elif isinstance(result, CustomStreamWrapper):
             return result

--- a/holmes/core/tool_call_recovery.py
+++ b/holmes/core/tool_call_recovery.py
@@ -1,0 +1,204 @@
+"""Recover tool calls that a model emitted as literal XML text.
+
+Some models (Claude in particular) sometimes "narrate" a tool call in the
+Anthropic tool-use XML dialect they were trained on::
+
+    <function_calls>
+    <invoke name="update_ai_triage_metadata">
+    <parameter name="team">payments</parameter>
+    <parameter name="root_cause_analysis"># RCA ...</parameter>
+    </invoke>
+    </function_calls>
+
+instead of returning it as a structured ``tool_calls`` field. This happens on
+routes where native (structured) function calling is not used end-to-end — e.g.
+LiteLLM's prompt-based tool-calling fallback for models it doesn't recognise as
+function-calling-capable. LiteLLM is supposed to parse that XML back into
+``tool_calls`` itself, but its parser (``ET.fromstring``) is strict XML and
+breaks whenever a parameter value contains markdown / unescaped ``<``, ``>``,
+``&`` or code fences, so the raw XML leaks into ``message.content`` and no tool
+call is made.
+
+When that happens Holmes treats the XML as the final answer: the intended tool
+(e.g. relay's ``update_ai_triage_metadata``) never runs, and the raw tags show
+up in the user-facing output (ROB-558).
+
+This module recovers such calls with a lenient, regex-based parser (never
+``ET.fromstring``) so a markdown-laden parameter value can't defeat it, and only
+when the recovered tool name was actually offered to the model — so ordinary
+prose that merely mentions ``<invoke>`` is never misread as a tool call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
+
+# The whole call container and each invoke block. `name="..."` is the modern
+# Anthropic dialect; the older LiteLLM/Anthropic template used a nested
+# `<tool_name>...</tool_name>` instead — both are handled.
+_INVOKE_OPEN_RE = re.compile(
+    r"<invoke\b[^>]*?\bname\s*=\s*[\"']([^\"']+)[\"'][^>]*>",
+    re.IGNORECASE,
+)
+_INVOKE_BARE_OPEN_RE = re.compile(r"<invoke\b[^>]*>", re.IGNORECASE)
+_INVOKE_CLOSE_RE = re.compile(r"</invoke>", re.IGNORECASE)
+_TOOL_NAME_TAG_RE = re.compile(
+    r"<tool_name>\s*(.+?)\s*</tool_name>", re.IGNORECASE | re.DOTALL
+)
+# A single `<parameter name="key">` opening marker. We deliberately do NOT try
+# to match its closing tag: the model closes it inconsistently (`</parameter>`,
+# `</key>`, or not at all), so each value is delimited by the NEXT marker /
+# block boundary and trailing close tags are stripped afterwards.
+_PARAM_OPEN_RE = re.compile(
+    r"<parameter\b[^>]*?\bname\s*=\s*[\"']([^\"']+)[\"'][^>]*>",
+    re.IGNORECASE,
+)
+# Trailing close tag left on a parameter value once it's been sliced out.
+_TRAILING_CLOSE_RE = re.compile(
+    r"\s*</(?:parameter|parameters|invoke|function_calls|[A-Za-z0-9_.\-]+)>\s*$",
+    re.IGNORECASE,
+)
+_FUNCTION_CALLS_OPEN_RE = re.compile(r"<function_calls>", re.IGNORECASE)
+
+
+def _looks_like_tool_call_xml(content: str) -> bool:
+    """Cheap pre-check so we never run the parser on ordinary answers."""
+    return "<invoke" in content.lower()
+
+
+def _maybe_json(value: str) -> Any:
+    """Mirror LiteLLM's parse_xml_params: decode a value as JSON when it looks
+    like a JSON scalar/array/object, otherwise keep the raw (stripped) string."""
+    stripped = value.strip()
+    if stripped and stripped[0] in "[{" or stripped in ("true", "false", "null"):
+        try:
+            return json.loads(stripped)
+        except (ValueError, TypeError):
+            return value
+    return value
+
+
+def _parse_parameters(block: str) -> Dict[str, Any]:
+    """Extract `<parameter name="k">v</parameter>`-style params from an invoke
+    block. Each value runs from its opening marker to the next marker (or the
+    end of the block); the trailing close tag, however the model wrote it, is
+    stripped."""
+    markers = list(_PARAM_OPEN_RE.finditer(block))
+    params: Dict[str, Any] = {}
+    for idx, match in enumerate(markers):
+        key = match.group(1)
+        start = match.end()
+        end = markers[idx + 1].start() if idx + 1 < len(markers) else len(block)
+        raw = block[start:end]
+        raw = _TRAILING_CLOSE_RE.sub("", raw)
+        params[key] = _maybe_json(raw)
+    return params
+
+
+def _recover_invocations(
+    content: str, offered_tool_names: Set[str]
+) -> List[Tuple[str, Dict[str, Any], int, int]]:
+    """Return (tool_name, params, span_start, span_end) for each invoke block
+    whose tool name was actually offered to the model."""
+    recovered: List[Tuple[str, Dict[str, Any], int, int]] = []
+    pos = 0
+    lowered_len = len(content)
+    while pos < lowered_len:
+        named = _INVOKE_OPEN_RE.search(content, pos)
+        bare = _INVOKE_BARE_OPEN_RE.search(content, pos)
+        if named is None and bare is None:
+            break
+        # Use whichever `<invoke ...>` comes first.
+        open_match = min(
+            (m for m in (named, bare) if m is not None), key=lambda m: m.start()
+        )
+        body_start = open_match.end()
+        close_match = _INVOKE_CLOSE_RE.search(content, body_start)
+        body_end = close_match.start() if close_match else len(content)
+        span_end = close_match.end() if close_match else len(content)
+        block = content[body_start:body_end]
+
+        tool_name: Optional[str] = None
+        if open_match is named:
+            tool_name = open_match.group(1)
+        else:
+            name_tag = _TOOL_NAME_TAG_RE.search(block)
+            if name_tag:
+                tool_name = name_tag.group(1).strip()
+
+        if tool_name and tool_name in offered_tool_names:
+            params = _parse_parameters(block)
+            span_start = open_match.start()
+            # Absorb a leading `<function_calls>` wrapper into the removed span
+            # so it doesn't linger in the cleaned content.
+            wrapper = _FUNCTION_CALLS_OPEN_RE.search(
+                content, max(0, span_start - 40), span_start
+            )
+            if wrapper is not None and content[wrapper.end() : span_start].strip() == "":
+                span_start = wrapper.start()
+            recovered.append((tool_name, params, span_start, span_end))
+
+        pos = span_end if span_end > pos else pos + 1
+    return recovered
+
+
+def _strip_spans(content: str, spans: List[Tuple[int, int]]) -> str:
+    """Remove the recovered XML spans and tidy up leftover `<function_calls>`
+    scaffolding and whitespace."""
+    kept = []
+    cursor = 0
+    for start, end in sorted(spans):
+        kept.append(content[cursor:start])
+        cursor = max(cursor, end)
+    kept.append(content[cursor:])
+    cleaned = "".join(kept)
+    # Drop now-empty container tags left behind.
+    cleaned = re.sub(
+        r"</?function_calls>", "", cleaned, flags=re.IGNORECASE
+    )
+    return cleaned.strip()
+
+
+def recover_tool_calls_from_text(
+    content: Optional[str], offered_tool_names: Set[str]
+) -> Tuple[Optional[str], List[ChatCompletionMessageToolCall]]:
+    """Recover tool calls a model wrote as XML text instead of structured
+    ``tool_calls``.
+
+    Returns ``(cleaned_content, tool_calls)``. When nothing is recovered the
+    original ``content`` is returned unchanged and the list is empty.
+    """
+    if not content or not offered_tool_names or not _looks_like_tool_call_xml(content):
+        return content, []
+
+    invocations = _recover_invocations(content, offered_tool_names)
+    if not invocations:
+        return content, []
+
+    tool_calls: List[ChatCompletionMessageToolCall] = []
+    spans: List[Tuple[int, int]] = []
+    for tool_name, params, span_start, span_end in invocations:
+        tool_calls.append(
+            ChatCompletionMessageToolCall(
+                id=f"call_recovered_{uuid.uuid4().hex[:24]}",
+                type="function",
+                function=Function(name=tool_name, arguments=json.dumps(params)),
+            )
+        )
+        spans.append((span_start, span_end))
+
+    cleaned = _strip_spans(content, spans)
+    logging.warning(
+        "Recovered %d tool call(s) emitted as XML text in the model response "
+        "(tools: %s). The model narrated the call instead of returning a "
+        "structured tool_calls field; recovering it so the tool runs.",
+        len(tool_calls),
+        ", ".join(tc.function.name for tc in tool_calls),
+    )
+    return (cleaned or None), tool_calls

--- a/tests/core/test_tool_call_recovery.py
+++ b/tests/core/test_tool_call_recovery.py
@@ -1,0 +1,209 @@
+"""Tests for recovering tool calls a model emitted as XML text (ROB-558)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+from holmes.core.llm import DefaultLLM
+from holmes.core.tool_call_recovery import recover_tool_calls_from_text
+
+TRIAGE = "update_ai_triage_metadata"
+OFFERED = {TRIAGE}
+
+# The modern Anthropic tool-use dialect a confused model narrates as text.
+MODERN_XML = (
+    "<function_calls>\n"
+    f'<invoke name="{TRIAGE}">\n'
+    '<parameter name="team">payments</parameter>\n'
+    '<parameter name="team_reason">Owns the checkout service.</parameter>\n'
+    '<parameter name="root_cause_analysis"># RCA\n'
+    "The pod OOMed because `limit < usage`.</parameter>\n"
+    "</invoke>\n"
+    "</function_calls>"
+)
+
+
+class TestRecoverToolCallsFromText:
+    def test_recovers_modern_anthropic_xml(self):
+        cleaned, calls = recover_tool_calls_from_text(MODERN_XML, OFFERED)
+        assert len(calls) == 1
+        assert calls[0].function.name == TRIAGE
+        args = json.loads(calls[0].function.arguments)
+        assert args["team"] == "payments"
+        assert args["team_reason"] == "Owns the checkout service."
+        assert args["root_cause_analysis"].startswith("# RCA")
+        assert "limit < usage" in args["root_cause_analysis"]
+        # The XML is stripped from the visible answer.
+        assert cleaned in (None, "")
+
+    def test_recovers_with_mismatched_closing_tags(self):
+        """The real ROB-558 payload: values closed with `</key>` (or the next
+        `<parameter>` opens before the previous one closes), not `</parameter>`.
+        A strict XML parser breaks on this; the lenient one must not."""
+        content = (
+            f'<invoke name="{TRIAGE}">'
+            '<parameter name="urgency_reason">High blast radius'
+            "</urgency_reason> "
+            '<parameter name="team">platform</parameter>'
+            "</invoke>"
+        )
+        cleaned, calls = recover_tool_calls_from_text(content, OFFERED)
+        assert len(calls) == 1
+        args = json.loads(calls[0].function.arguments)
+        assert args["urgency_reason"] == "High blast radius"
+        assert args["team"] == "platform"
+        assert cleaned in (None, "")
+
+    def test_value_with_xml_and_ampersand_that_breaks_strict_parsers(self):
+        content = (
+            f'<invoke name="{TRIAGE}">'
+            '<parameter name="root_cause_analysis">Config had `a < b && c > d` '
+            "and a `<div>` tag in the log.</parameter>"
+            "</invoke>"
+        )
+        _, calls = recover_tool_calls_from_text(content, OFFERED)
+        assert len(calls) == 1
+        args = json.loads(calls[0].function.arguments)
+        assert "a < b && c > d" in args["root_cause_analysis"]
+        assert "<div>" in args["root_cause_analysis"]
+
+    def test_preserves_leading_prose(self):
+        content = "Recording the triage decision now.\n" + MODERN_XML
+        cleaned, calls = recover_tool_calls_from_text(content, OFFERED)
+        assert len(calls) == 1
+        assert cleaned == "Recording the triage decision now."
+
+    def test_no_recovery_when_tool_not_offered(self):
+        cleaned, calls = recover_tool_calls_from_text(MODERN_XML, {"some_other_tool"})
+        assert calls == []
+        assert cleaned == MODERN_XML
+
+    def test_no_recovery_for_plain_answer(self):
+        content = "The pod is CrashLooping because of an OOM kill."
+        cleaned, calls = recover_tool_calls_from_text(content, OFFERED)
+        assert calls == []
+        assert cleaned == content
+
+    def test_no_recovery_without_offered_tools(self):
+        cleaned, calls = recover_tool_calls_from_text(MODERN_XML, set())
+        assert calls == []
+        assert cleaned == MODERN_XML
+
+    def test_none_content(self):
+        cleaned, calls = recover_tool_calls_from_text(None, OFFERED)
+        assert calls == []
+        assert cleaned is None
+
+    def test_recovers_multiple_invocations(self):
+        content = (
+            f'<invoke name="{TRIAGE}"><parameter name="team">a</parameter></invoke>'
+            f'<invoke name="{TRIAGE}"><parameter name="team">b</parameter></invoke>'
+        )
+        _, calls = recover_tool_calls_from_text(content, OFFERED)
+        assert [json.loads(c.function.arguments)["team"] for c in calls] == ["a", "b"]
+
+    def test_old_tool_name_tag_dialect(self):
+        content = (
+            "<function_calls><invoke>"
+            f"<tool_name>{TRIAGE}</tool_name>"
+            '<parameter name="team">infra</parameter>'
+            "</invoke></function_calls>"
+        )
+        _, calls = recover_tool_calls_from_text(content, OFFERED)
+        assert len(calls) == 1
+        assert calls[0].function.name == TRIAGE
+        assert json.loads(calls[0].function.arguments)["team"] == "infra"
+
+    def test_recovered_call_has_function_type_and_id(self):
+        _, calls = recover_tool_calls_from_text(MODERN_XML, OFFERED)
+        assert calls[0].type == "function"
+        assert calls[0].id
+
+
+def _make_llm(model: str = "bedrock/anthropic.claude") -> DefaultLLM:
+    llm = DefaultLLM.__new__(DefaultLLM)
+    llm.model = model
+    llm.api_key = None
+    llm.api_base = None
+    llm.api_version = None
+    llm.args = {}
+    llm.tracer = None
+    llm.name = None
+    llm.is_robusta_model = False
+    llm.max_context_size = 200000
+    return llm
+
+
+def _response(content, tool_calls=None) -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-test",
+        choices=[
+            Choices(
+                index=0,
+                message=Message(
+                    role="assistant", content=content, tool_calls=tool_calls
+                ),
+                finish_reason="stop",
+            )
+        ],
+        model="test-model",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+TOOLS = [{"type": "function", "function": {"name": TRIAGE, "description": "d"}}]
+
+
+class TestCompletionRecoveryIntegration:
+    def test_completion_recovers_xml_tool_call(self):
+        llm = _make_llm()
+        with patch("holmes.core.llm.litellm.completion") as mock:
+            mock.return_value = _response(MODERN_XML)
+            result = llm.completion(
+                messages=[{"role": "user", "content": "go"}],
+                tools=TOOLS,
+                tool_choice="auto",
+            )
+        msg = result.choices[0].message
+        assert msg.tool_calls, "XML tool call should have been recovered"
+        assert msg.tool_calls[0].function.name == TRIAGE
+        assert not (msg.content or "").strip()
+
+    def test_completion_leaves_structured_tool_calls_untouched(self):
+        llm = _make_llm()
+        structured = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": TRIAGE, "arguments": '{"team": "x"}'},
+            }
+        ]
+        with patch("holmes.core.llm.litellm.completion") as mock:
+            mock.return_value = _response("done", tool_calls=structured)
+            result = llm.completion(
+                messages=[{"role": "user", "content": "go"}],
+                tools=TOOLS,
+                tool_choice="auto",
+            )
+        msg = result.choices[0].message
+        assert len(msg.tool_calls) == 1
+        assert msg.content == "done"
+
+    def test_completion_leaves_plain_answer_untouched(self):
+        llm = _make_llm()
+        with patch("holmes.core.llm.litellm.completion") as mock:
+            mock.return_value = _response("Just a normal answer.")
+            result = llm.completion(
+                messages=[{"role": "user", "content": "go"}],
+                tools=TOOLS,
+                tool_choice="auto",
+            )
+        msg = result.choices[0].message
+        assert not msg.tool_calls
+        assert msg.content == "Just a normal answer."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes ROB-558 by recovering tool calls that models (particularly Claude) emit as literal XML text instead of structured `tool_calls` fields. This happens when LiteLLM's prompt-based tool-calling fallback is used for models it doesn't recognize as function-calling-capable. LiteLLM's strict XML parser breaks on unescaped markdown/code in parameter values, causing the raw XML to leak into message content and preventing tool execution.

## Key Changes

- **New module `holmes/core/tool_call_recovery.py`**: Implements lenient regex-based parsing to recover tool calls from XML text
  - Handles both modern Anthropic dialect (`name="..."` attribute) and older `<tool_name>` tag syntax
  - Tolerates malformed XML (mismatched closing tags, unescaped `<`, `>`, `&` in values)
  - Only recovers calls for tools actually offered to the model (prevents false positives on prose mentioning `<invoke>`)
  - Strips recovered XML from message content and returns cleaned text

- **Integration in `holmes/core/llm.py`**: 
  - Added `_offered_tool_names()` helper to extract tool names from the tools parameter
  - Added `_recover_text_tool_calls()` function that mutates the LLM response to recover XML tool calls
  - Integrated recovery into `DefaultLLM.completion()` after receiving the response from LiteLLM
  - Only attempts recovery when message has no structured `tool_calls` and content contains tool-call XML

- **Comprehensive test suite `tests/core/test_tool_call_recovery.py`**:
  - Tests modern Anthropic XML format with proper closing tags
  - Tests real ROB-558 payload with mismatched closing tags
  - Tests values containing unescaped XML characters and markdown
  - Tests preservation of leading prose
  - Tests that recovery only happens for offered tools
  - Tests multiple invocations and older `<tool_name>` dialect
  - Integration tests verifying end-to-end recovery in `DefaultLLM.completion()`

## Implementation Details

- Uses regex-based parsing instead of strict XML parsing to handle malformed input
- Recovers tool name from either `name="..."` attribute or nested `<tool_name>` tag
- Extracts parameters by finding opening `<parameter name="...">` markers and slicing to the next marker
- Strips trailing close tags (which may be `</parameter>`, `</key>`, or other variants)
- Attempts JSON parsing of parameter values (matching LiteLLM's behavior) but falls back to raw strings
- Generates unique IDs for recovered tool calls using UUID
- Logs a warning when recovery occurs to aid debugging
- Cleans up leftover XML scaffolding from the message content

https://claude.ai/code/session_019TBGvpjmk6npFcvivReBp1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-streaming responses where tool calls are returned as XML-formatted text.
  * Recognizes supported modern and legacy tool-call formats and converts them into usable tool calls.
  * Preserves normal response text while removing successfully recovered tool-call markup.
  * Avoids altering responses that already contain structured tool calls or unmatched content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->