### PR TITLE
feat(helm): support deploymentAnnotations for GitHub MCP server

### DIFF
--- a/helm/holmes/templates/mcp-servers/github/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/github/deployment.yaml
@@ -41,9 +41,14 @@ metadata:
     app.kubernetes.io/component: mcp-server
     app.kubernetes.io/part-of: holmes
     {{- include "holmes.commonLabels" . | nindent 4 }}
-  {{- with (include "holmes.commonAnnotations" .) }}
+  {{- if or (include "holmes.commonAnnotations" .) .Values.mcpAddons.github.deploymentAnnotations }}
   annotations:
+    {{- with (include "holmes.commonAnnotations" .) }}
     {{- . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.mcpAddons.github.deploymentAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   replicas: 1

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -500,6 +500,11 @@ mcpAddons:
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
     imagePullPolicy: IfNotPresent
 
+    # Optional annotations added to the GitHub MCP server Deployment metadata.
+    # Useful for integrations such as stakater/Reloader to roll pods when
+    # referenced Secrets change.
+    deploymentAnnotations: {}
+
     # Authentication - choose ONE of the two methods below
     auth:
       # Option 1: Personal Access Token (PAT)


### PR DESCRIPTION
Fixes #1995

Adds support for custom annotations on the GitHub MCP server Deployment metadata via the new `mcpAddons.github.deploymentAnnotations` value. This allows integrations such as stakater/Reloader to roll pods when referenced Secrets are updated by ESO.

Changes:
- Updated `helm/holmes/templates/mcp-servers/github/deployment.yaml` to merge the new per-addon annotations with existing common annotations.
- Added `deploymentAnnotations: {}` to `helm/holmes/values.yaml` under `mcpAddons.github` with a usage comment.

No-op when `deploymentAnnotations` is unset. Existing deployments are unaffected.

Verified:
- `helm lint helm/holmes` passes.
- `helm template holmes helm/holmes -f /tmp/holmes-test-values.yaml --show-only templates/mcp-servers/github/deployment.yaml` renders the custom annotation correctly.
- Rendering with `deploymentAnnotations` empty omits the Deployment metadata annotations block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom annotations on GitHub MCP server deployments while preserving common annotations.
  * Added bearer-token authentication for the Kubernetes Remediation MCP addon, with generated or existing Secret support.
  * Added configurable policies for diagnostic probe targets, including external access and internal DNS suffixes.
  * Added GitHub App multi-organization token routing with optional image configuration.
* **Updates**
  * Updated the Kubernetes Remediation MCP addon image.
  * Removed the MariaDB MCP addon configuration.
  * Updated the GitLab MCP server version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->