### PR TITLE
ROB-835 Prune the custom-skills mirror when the last skill is deleted

### DIFF
--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -1028,38 +1028,65 @@ class SupabaseDal:
                 f"An error occurred during toolset synchronization: {e}", exc_info=True
             )
 
-    def sync_skills(self, skills: list[dict], cluster_name: str) -> None:
+    def sync_skills(
+        self, skills: list[dict], cluster_name: str, prune: bool
+    ) -> None:
         """Mirror this cluster's filesystem + builtin skills into HolmesCustomSkills.
 
         The filesystem stays the source of truth -- Holmes keeps executing these from disk.
         These rows exist only so the UI can display them, so this is a plain upsert plus a
-        prune of names that no longer exist for this (account, cluster), exactly like
-        sync_toolsets. Best-effort: a failure here must never break startup.
+        prune of names that no longer exist for this (account, cluster). Best-effort: a
+        failure here must never break startup.
 
-        Note this intentionally does NOT delete when `skills` is empty: an empty list means
-        "no skills loaded", which we cannot distinguish from a load failure, and wiping the
-        UI's view on a transient error would be worse than showing slightly stale rows.
+        `prune` is required rather than defaulted because it gates a DELETE, so the caller
+        has to state whether the loaded set is authoritative. Pass the loader's
+        FilesystemSkills.sources_ok: True only when every skill source was readable.
+
+        The four cases:
+          prune=True,  skills non-empty -> upsert, then delete every other name
+          prune=True,  skills empty     -> delete every row for this cluster (the user really
+                                           did delete their last skill)
+          prune=False, skills non-empty -> upsert only; a partially-readable load must not
+                                           prune the part that failed to load
+          prune=False, skills empty     -> no-op; nothing was read, so nothing is known
         """
         if not self.enabled:
             logging.info("Robusta store not initialized. Skipping sync holmes skills.")
             return
 
-        if not skills:
-            logging.debug("No skills were provided for synchronization.")
+        if not skills and not prune:
+            logging.debug(
+                "No skills loaded and sources were not fully readable; skipping sync."
+            )
             return
 
         provided_skill_names = [skill["skill_name"] for skill in skills]
 
         try:
-            self.client.table(HOLMES_CUSTOM_SKILLS_TABLE).upsert(
-                skills, on_conflict="account_id, cluster_id, skill_name"
-            ).execute()
+            if skills:
+                self.client.table(HOLMES_CUSTOM_SKILLS_TABLE).upsert(
+                    skills, on_conflict="account_id, cluster_id, skill_name"
+                ).execute()
 
-            self.client.table(HOLMES_CUSTOM_SKILLS_TABLE).delete().eq(
-                "account_id", self.account_id
-            ).eq("cluster_id", cluster_name).not_.in_(
-                "skill_name", provided_skill_names
-            ).execute()
+            if not prune:
+                logging.info(
+                    f"Upserted {len(skills)} custom skills; skipped pruning because at "
+                    "least one skill source could not be read."
+                )
+                return
+
+            stale = (
+                self.client.table(HOLMES_CUSTOM_SKILLS_TABLE)
+                .delete()
+                .eq("account_id", self.account_id)
+                .eq("cluster_id", cluster_name)
+            )
+            # Only add the not-in filter when there is something to exclude. An empty list
+            # renders as `skill_name=not.in.()`, which PostgREST does not reliably accept --
+            # and semantically the empty case wants an unfiltered delete anyway.
+            if provided_skill_names:
+                stale = stale.not_.in_("skill_name", provided_skill_names)
+            stale.execute()
 
             logging.info(f"Synchronized {len(skills)} custom skills successfully.")
         except Exception as e:

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -1014,38 +1014,65 @@ class SupabaseDal:
                 f"An error occurred during toolset synchronization: {e}", exc_info=True
             )
 
-    def sync_skills(self, skills: list[dict], cluster_name: str) -> None:
+    def sync_skills(
+        self, skills: list[dict], cluster_name: str, prune: bool
+    ) -> None:
         """Mirror this cluster's filesystem + builtin skills into HolmesCustomSkills.
 
         The filesystem stays the source of truth -- Holmes keeps executing these from disk.
         These rows exist only so the UI can display them, so this is a plain upsert plus a
-        prune of names that no longer exist for this (account, cluster), exactly like
-        sync_toolsets. Best-effort: a failure here must never break startup.
+        prune of names that no longer exist for this (account, cluster). Best-effort: a
+        failure here must never break startup.
 
-        Note this intentionally does NOT delete when `skills` is empty: an empty list means
-        "no skills loaded", which we cannot distinguish from a load failure, and wiping the
-        UI's view on a transient error would be worse than showing slightly stale rows.
+        `prune` is required rather than defaulted because it gates a DELETE, so the caller
+        has to state whether the loaded set is authoritative. Pass the loader's
+        FilesystemSkills.sources_ok: True only when every skill source was readable.
+
+        The four cases:
+          prune=True,  skills non-empty -> upsert, then delete every other name
+          prune=True,  skills empty     -> delete every row for this cluster (the user really
+                                           did delete their last skill)
+          prune=False, skills non-empty -> upsert only; a partially-readable load must not
+                                           prune the part that failed to load
+          prune=False, skills empty     -> no-op; nothing was read, so nothing is known
         """
         if not self.enabled:
             logging.info("Robusta store not initialized. Skipping sync holmes skills.")
             return
 
-        if not skills:
-            logging.debug("No skills were provided for synchronization.")
+        if not skills and not prune:
+            logging.debug(
+                "No skills loaded and sources were not fully readable; skipping sync."
+            )
             return
 
         provided_skill_names = [skill["skill_name"] for skill in skills]
 
         try:
-            self.client.table(HOLMES_CUSTOM_SKILLS_TABLE).upsert(
-                skills, on_conflict="account_id, cluster_id, skill_name"
-            ).execute()
+            if skills:
+                self.client.table(HOLMES_CUSTOM_SKILLS_TABLE).upsert(
+                    skills, on_conflict="account_id, cluster_id, skill_name"
+                ).execute()
 
-            self.client.table(HOLMES_CUSTOM_SKILLS_TABLE).delete().eq(
-                "account_id", self.account_id
-            ).eq("cluster_id", cluster_name).not_.in_(
-                "skill_name", provided_skill_names
-            ).execute()
+            if not prune:
+                logging.info(
+                    f"Upserted {len(skills)} custom skills; skipped pruning because at "
+                    "least one skill source could not be read."
+                )
+                return
+
+            stale = (
+                self.client.table(HOLMES_CUSTOM_SKILLS_TABLE)
+                .delete()
+                .eq("account_id", self.account_id)
+                .eq("cluster_id", cluster_name)
+            )
+            # Only add the not-in filter when there is something to exclude. An empty list
+            # renders as `skill_name=not.in.()`, which PostgREST does not reliably accept --
+            # and semantically the empty case wants an unfiltered delete anyway.
+            if provided_skill_names:
+                stale = stale.not_.in_("skill_name", provided_skill_names)
+            stale.execute()
 
             logging.info(f"Synchronized {len(skills)} custom skills successfully.")
         except Exception as e:

--- a/holmes/plugins/skills/skill_loader.py
+++ b/holmes/plugins/skills/skill_loader.py
@@ -171,16 +171,71 @@ def parse_skill_file(path: Path, source: SkillSource = SkillSource.USER) -> Skil
     )
 
 
+class SkillLoadProblem(BaseModel):
+    """Something that went wrong while loading filesystem skills.
+
+    `skill_name` is what splits the two kinds apart, and the split matters:
+
+    * NAMED -- a specific SKILL.md exists but could not be parsed. We know exactly which
+      skill is broken, so the mirror can show it with status="error" and the user can find
+      it in the UI instead of wondering why their file has no effect.
+    * UNNAMED -- a directory is missing or unreadable, or a configured path is not a skill
+      source at all. We do not know what skills should have been there, so anything built
+      from this load is incomplete and must not be used to DELETE.
+
+    Only the unnamed kind blocks pruning: a parse failure is a known state we can represent,
+    not an unknown one. Without that distinction a single malformed SKILL.md would suppress
+    pruning for the whole cluster, so deleting an unrelated skill would leave its row behind.
+    """
+
+    error: str
+    # Set only when a specific skill is identifiable. The normalized directory name, which
+    # is exactly what parse_skill_file would have defaulted to had the frontmatter parsed.
+    skill_name: Optional[str] = None
+    source_path: Optional[str] = None
+    source: Optional[SkillSource] = None
+
+
 def scan_skill_directory(
-    directory: Path, source: SkillSource = SkillSource.USER, max_depth: int = 2
+    directory: Path,
+    source: SkillSource = SkillSource.USER,
+    max_depth: int = 2,
+    problems: Optional[List[SkillLoadProblem]] = None,
 ) -> List[Skill]:
-    """Scan a directory for SKILL.md files up to max_depth levels deep."""
+    """Scan a directory for SKILL.md files up to max_depth levels deep.
+
+    When `problems` is passed, everything that went wrong is appended to it, so a caller can
+    tell "this directory really holds no skills" from "this directory could not be read" --
+    a distinction an empty return value cannot express. See SkillLoadProblem.
+    """
     skills: List[Skill] = []
     directory = directory.resolve()
 
     if not directory.is_dir():
         logging.warning(f"Skill directory does not exist: {directory}")
+        if problems is not None:
+            problems.append(
+                SkillLoadProblem(error=f"skill directory does not exist: {directory}")
+            )
         return skills
+
+    def on_walk_error(error: OSError) -> None:
+        """os.walk swallows traversal errors unless this is passed.
+
+        Without it, a directory that exists but cannot be read into yields nothing and
+        records nothing -- and `is_dir()` above succeeds for such a directory, so the whole
+        scan looks like "readable and genuinely empty". For a caller that DELETES based on
+        what loaded that is the worst possible confusion: the mirror would prune rows for
+        skills that are still on disk and merely unreadable this cycle. Applies to nested
+        directories too, not just the root.
+        """
+        logging.warning(f"Failed to read skill directory {error.filename}: {error}")
+        if problems is not None:
+            problems.append(
+                SkillLoadProblem(
+                    error=f"failed to read skill directory {error.filename}: {error}"
+                )
+            )
 
     # followlinks=True so we traverse Kubernetes ConfigMap mounts, which
     # surface each key as `<dir>/<name>` -> `..data/<name>` -> a real file
@@ -188,7 +243,7 @@ def scan_skill_directory(
     # walked (unresolved) path so the symlink-traversed path is at depth 1,
     # not depth 2 from the resolved `..NNN/` real dir.
     seen_paths: set[str] = set()
-    for root, dirs, files in os.walk(directory, followlinks=True):
+    for root, dirs, files in os.walk(directory, followlinks=True, onerror=on_walk_error):
         depth = len(Path(root).relative_to(directory).parts)
         if depth >= max_depth:
             dirs.clear()
@@ -205,6 +260,17 @@ def scan_skill_directory(
                 skills.append(skill)
             except Exception as e:
                 logging.error(f"Failed to parse {skill_path}: {e}")
+                if problems is not None:
+                    problems.append(
+                        SkillLoadProblem(
+                            error=str(e),
+                            # The dir name is what parse_skill_file falls back to, so the
+                            # failed row keys exactly as the successful one would have.
+                            skill_name=normalize_skill_name(Path(root).name),
+                            source_path=str(skill_path),
+                            source=source,
+                        )
+                    )
 
     return skills
 
@@ -236,6 +302,132 @@ def map_robusta_instruction_to_skill(
         source_path=instr.id,
         title=instr.title,
         alerts=instr.alerts,
+    )
+
+
+class FilesystemSkills(BaseModel):
+    """Builtin + filesystem skills, plus everything that went wrong loading them.
+
+    An empty skill list is ambiguous on its own -- either "there genuinely are no skills" or
+    "nothing could be read". A caller that only ADDS rows can ignore the difference; one that
+    DELETES based on what loaded cannot, since treating a failed load as authoritative would
+    prune rows for skills still on disk. `sources_ok` is what separates the two.
+    """
+
+    skills: List[Skill]
+    problems: List[SkillLoadProblem] = []
+
+    @property
+    def sources_ok(self) -> bool:
+        """Whether this load is complete enough to DELETE from.
+
+        Only unnamed problems disqualify it. A named one (a SKILL.md that failed to parse)
+        is a known state the caller can represent as a row, so it must not suppress pruning
+        -- otherwise one malformed file would freeze the mirror for the whole cluster.
+        """
+        return all(p.skill_name is not None for p in self.problems)
+
+    @property
+    def failed_skills(self) -> List[SkillLoadProblem]:
+        """Problems attributable to one skill, for callers that surface them to users."""
+        return [p for p in self.problems if p.skill_name is not None]
+
+
+def _load_filesystem_skills_by_name(
+    custom_skill_paths: Optional[List[Union[str, Path]]] = None,
+    problems: Optional[List[SkillLoadProblem]] = None,
+) -> dict[str, Skill]:
+    """Load builtin skills, then filesystem skills which override builtins by name.
+
+    Shared by load_skill_catalog and load_filesystem_skills so the override and
+    error-handling rules cannot drift between the prompt catalog and the UI mirror.
+    Unreadable sources are appended to `problems` when it is provided.
+    """
+    skills_by_name: dict[str, Skill] = {}
+
+    # 1. Load builtin skills. A missing builtin dir is not recorded as a problem: it ships
+    # with the package and is not what the mirror prunes on.
+    builtin_dir = Path(BUILTIN_SKILLS_DIR)
+    if builtin_dir.is_dir():
+        for skill in scan_skill_directory(
+            builtin_dir, source=SkillSource.BUILTIN, problems=problems
+        ):
+            skills_by_name[skill.name] = skill
+
+    # 2. Load user skills from custom_skill_paths (overrides builtins)
+    if custom_skill_paths:
+        for skill_path in custom_skill_paths:
+            path = Path(str(skill_path))
+            if path.is_dir():
+                for skill in scan_skill_directory(
+                    path, source=SkillSource.USER, problems=problems
+                ):
+                    if skill.name in skills_by_name:
+                        logging.warning(
+                            f"Skill '{skill.name}' from {skill.source_path} "
+                            f"overrides {skills_by_name[skill.name].source_path}"
+                        )
+                    skills_by_name[skill.name] = skill
+            elif path.is_file() and path.name == SKILL_FILENAME:
+                try:
+                    skill = parse_skill_file(path, source=SkillSource.USER)
+                    if skill.name in skills_by_name:
+                        logging.warning(
+                            f"Skill '{skill.name}' from {skill.source_path} "
+                            f"overrides {skills_by_name[skill.name].source_path}"
+                        )
+                    skills_by_name[skill.name] = skill
+                except Exception as e:
+                    logging.error(f"Failed to parse skill file {path}: {e}")
+                    if problems is not None:
+                        problems.append(
+                            SkillLoadProblem(
+                                error=str(e),
+                                skill_name=normalize_skill_name(path.parent.name),
+                                source_path=str(path),
+                                source=SkillSource.USER,
+                            )
+                        )
+            else:
+                logging.warning(f"Skill path is not a directory or SKILL.md file: {path}")
+                if problems is not None:
+                    problems.append(
+                        SkillLoadProblem(
+                            error=(
+                                f"skill path is not a directory or "
+                                f"{SKILL_FILENAME} file: {path}"
+                            )
+                        )
+                    )
+
+    return skills_by_name
+
+
+def load_filesystem_skills(
+    custom_skill_paths: Optional[List[Union[str, Path]]] = None,
+) -> FilesystemSkills:
+    """Load only the builtin + filesystem skills, reporting whether every source was read.
+
+    Deliberately does not touch Supabase: global and personal skills live in HolmesRunbooks
+    and must not be mirrored into HolmesCustomSkills.
+
+    Unlike load_skill_catalog this returns an empty list rather than None for "no skills",
+    because for the mirror an empty result is a meaningful state (prune everything) as long
+    as `sources_ok` is True.
+    """
+    problems: List[SkillLoadProblem] = []
+    skills_by_name = _load_filesystem_skills_by_name(custom_skill_paths, problems)
+
+    unreadable = [p for p in problems if p.skill_name is None]
+    if unreadable:
+        logging.warning(
+            "%d skill source(s) could not be read; treating this load as incomplete: %s",
+            len(unreadable),
+            "; ".join(p.error for p in unreadable),
+        )
+
+    return FilesystemSkills(
+        skills=list(skills_by_name.values()), problems=problems
     )
 
 
@@ -321,41 +513,8 @@ def load_skill_catalog(
     investigations. Present, it drops skills scoped to other alerts; absent (chat, CLI)
     nothing is filtered.
     """
-    skills_by_name: dict[str, Skill] = {}
-
-    # 1. Load builtin skills
-    builtin_dir = Path(BUILTIN_SKILLS_DIR)
-    if builtin_dir.is_dir():
-        for skill in scan_skill_directory(builtin_dir, source=SkillSource.BUILTIN):
-            skills_by_name[skill.name] = skill
-
-    # 2. Load user skills from custom_skill_paths (overrides builtins)
-    if custom_skill_paths:
-        for skill_path in custom_skill_paths:
-            path = Path(str(skill_path))
-            if path.is_dir():
-                for skill in scan_skill_directory(path, source=SkillSource.USER):
-                    if skill.name in skills_by_name:
-                        logging.warning(
-                            f"Skill '{skill.name}' from {skill.source_path} "
-                            f"overrides {skills_by_name[skill.name].source_path}"
-                        )
-                    skills_by_name[skill.name] = skill
-            elif path.is_file() and path.name == SKILL_FILENAME:
-                try:
-                    skill = parse_skill_file(path, source=SkillSource.USER)
-                    if skill.name in skills_by_name:
-                        logging.warning(
-                            f"Skill '{skill.name}' from {skill.source_path} "
-                            f"overrides {skills_by_name[skill.name].source_path}"
-                        )
-                    skills_by_name[skill.name] = skill
-                except Exception as e:
-                    logging.error(f"Failed to parse skill file {path}: {e}")
-            else:
-                logging.warning(
-                    f"Skill path is not a directory or SKILL.md file: {path}"
-                )
+    # 1 + 2. Builtin skills, then filesystem skills (which override builtins by name)
+    skills_by_name = _load_filesystem_skills_by_name(custom_skill_paths)
 
     # 3. Load remote (global) skills from Supabase
     if dal:

--- a/holmes/plugins/skills/skill_loader.py
+++ b/holmes/plugins/skills/skill_loader.py
@@ -189,13 +189,27 @@ def scan_skill_directory(
             problems.append(f"skill directory does not exist: {directory}")
         return skills
 
+    def on_walk_error(error: OSError) -> None:
+        """os.walk swallows traversal errors unless this is passed.
+
+        Without it, a directory that exists but cannot be read into yields nothing and
+        records nothing -- and `is_dir()` above succeeds for such a directory, so the whole
+        scan looks like "readable and genuinely empty". For a caller that DELETES based on
+        what loaded that is the worst possible confusion: the mirror would prune rows for
+        skills that are still on disk and merely unreadable this cycle. Applies to nested
+        directories too, not just the root.
+        """
+        logging.warning(f"Failed to read skill directory {error.filename}: {error}")
+        if problems is not None:
+            problems.append(f"failed to read skill directory {error.filename}: {error}")
+
     # followlinks=True so we traverse Kubernetes ConfigMap mounts, which
     # surface each key as `<dir>/<name>` -> `..data/<name>` -> a real file
     # under a timestamped `..NNN/` directory. Depth is computed against the
     # walked (unresolved) path so the symlink-traversed path is at depth 1,
     # not depth 2 from the resolved `..NNN/` real dir.
     seen_paths: set[str] = set()
-    for root, dirs, files in os.walk(directory, followlinks=True):
+    for root, dirs, files in os.walk(directory, followlinks=True, onerror=on_walk_error):
         depth = len(Path(root).relative_to(directory).parts)
         if depth >= max_depth:
             dirs.clear()

--- a/holmes/plugins/skills/skill_loader.py
+++ b/holmes/plugins/skills/skill_loader.py
@@ -168,14 +168,25 @@ def parse_skill_file(path: Path, source: SkillSource = SkillSource.USER) -> Skil
 
 
 def scan_skill_directory(
-    directory: Path, source: SkillSource = SkillSource.USER, max_depth: int = 2
+    directory: Path,
+    source: SkillSource = SkillSource.USER,
+    max_depth: int = 2,
+    problems: Optional[List[str]] = None,
 ) -> List[Skill]:
-    """Scan a directory for SKILL.md files up to max_depth levels deep."""
+    """Scan a directory for SKILL.md files up to max_depth levels deep.
+
+    When `problems` is passed, every source that could not be read is appended to it. That
+    is what lets a caller tell "this directory really holds no skills" apart from "this
+    directory could not be read", which an empty return value alone cannot express. Callers
+    that DELETE based on what loaded need the distinction; see load_filesystem_skills.
+    """
     skills: List[Skill] = []
     directory = directory.resolve()
 
     if not directory.is_dir():
         logging.warning(f"Skill directory does not exist: {directory}")
+        if problems is not None:
+            problems.append(f"skill directory does not exist: {directory}")
         return skills
 
     # followlinks=True so we traverse Kubernetes ConfigMap mounts, which
@@ -201,6 +212,8 @@ def scan_skill_directory(
                 skills.append(skill)
             except Exception as e:
                 logging.error(f"Failed to parse {skill_path}: {e}")
+                if problems is not None:
+                    problems.append(f"failed to parse {skill_path}: {e}")
 
     return skills
 
@@ -232,6 +245,107 @@ def map_robusta_instruction_to_skill(
         source_path=instr.id,
         display_name=instr.title,
         alerts=instr.alerts,
+    )
+
+
+class FilesystemSkills(BaseModel):
+    """Builtin + filesystem skills, plus whether every configured source was readable.
+
+    `sources_ok` is False when any skill source could not be read: a missing directory, a
+    path that is neither a directory nor a SKILL.md, or a SKILL.md that failed to parse.
+
+    This exists because an empty skill list is ambiguous on its own -- it means either "there
+    genuinely are no skills" or "nothing could be read". A caller that only ADDS rows can
+    ignore the difference, but a caller that DELETES based on what loaded cannot: treating a
+    failed load as authoritative would prune rows for skills that are still on disk.
+    """
+
+    skills: List[Skill]
+    sources_ok: bool
+
+
+def _load_filesystem_skills_by_name(
+    custom_skill_paths: Optional[List[Union[str, Path]]] = None,
+    problems: Optional[List[str]] = None,
+) -> dict[str, Skill]:
+    """Load builtin skills, then filesystem skills which override builtins by name.
+
+    Shared by load_skill_catalog and load_filesystem_skills so the override and
+    error-handling rules cannot drift between the prompt catalog and the UI mirror.
+    Unreadable sources are appended to `problems` when it is provided.
+    """
+    skills_by_name: dict[str, Skill] = {}
+
+    # 1. Load builtin skills. A missing builtin dir is not recorded as a problem: it ships
+    # with the package and is not what the mirror prunes on.
+    builtin_dir = Path(BUILTIN_SKILLS_DIR)
+    if builtin_dir.is_dir():
+        for skill in scan_skill_directory(
+            builtin_dir, source=SkillSource.BUILTIN, problems=problems
+        ):
+            skills_by_name[skill.name] = skill
+
+    # 2. Load user skills from custom_skill_paths (overrides builtins)
+    if custom_skill_paths:
+        for skill_path in custom_skill_paths:
+            path = Path(str(skill_path))
+            if path.is_dir():
+                for skill in scan_skill_directory(
+                    path, source=SkillSource.USER, problems=problems
+                ):
+                    if skill.name in skills_by_name:
+                        logging.warning(
+                            f"Skill '{skill.name}' from {skill.source_path} "
+                            f"overrides {skills_by_name[skill.name].source_path}"
+                        )
+                    skills_by_name[skill.name] = skill
+            elif path.is_file() and path.name == SKILL_FILENAME:
+                try:
+                    skill = parse_skill_file(path, source=SkillSource.USER)
+                    if skill.name in skills_by_name:
+                        logging.warning(
+                            f"Skill '{skill.name}' from {skill.source_path} "
+                            f"overrides {skills_by_name[skill.name].source_path}"
+                        )
+                    skills_by_name[skill.name] = skill
+                except Exception as e:
+                    logging.error(f"Failed to parse skill file {path}: {e}")
+                    if problems is not None:
+                        problems.append(f"failed to parse skill file {path}: {e}")
+            else:
+                logging.warning(f"Skill path is not a directory or SKILL.md file: {path}")
+                if problems is not None:
+                    problems.append(
+                        f"skill path is not a directory or {SKILL_FILENAME} file: {path}"
+                    )
+
+    return skills_by_name
+
+
+def load_filesystem_skills(
+    custom_skill_paths: Optional[List[Union[str, Path]]] = None,
+) -> FilesystemSkills:
+    """Load only the builtin + filesystem skills, reporting whether every source was read.
+
+    Deliberately does not touch Supabase: global and personal skills live in HolmesRunbooks
+    and must not be mirrored into HolmesCustomSkills.
+
+    Unlike load_skill_catalog this returns an empty list rather than None for "no skills",
+    because for the mirror an empty result is a meaningful state (prune everything) as long
+    as `sources_ok` is True.
+    """
+    problems: List[str] = []
+    skills_by_name = _load_filesystem_skills_by_name(custom_skill_paths, problems)
+
+    if problems:
+        logging.warning(
+            "%d skill source(s) could not be read; treating this load as incomplete: %s",
+            len(problems),
+            "; ".join(problems),
+        )
+
+    return FilesystemSkills(
+        skills=list(skills_by_name.values()), sources_ok=not problems
     )
 
 
@@ -317,39 +431,8 @@ def load_skill_catalog(
     When absent (chat, CLI) nothing is filtered -- alert-scoped skills are still offered, with
     their alert names in the description so the model can weigh them.
     """
-    skills_by_name: dict[str, Skill] = {}
-
-    # 1. Load builtin skills
-    builtin_dir = Path(BUILTIN_SKILLS_DIR)
-    if builtin_dir.is_dir():
-        for skill in scan_skill_directory(builtin_dir, source=SkillSource.BUILTIN):
-            skills_by_name[skill.name] = skill
-
-    # 2. Load user skills from custom_skill_paths (overrides builtins)
-    if custom_skill_paths:
-        for skill_path in custom_skill_paths:
-            path = Path(str(skill_path))
-            if path.is_dir():
-                for skill in scan_skill_directory(path, source=SkillSource.USER):
-                    if skill.name in skills_by_name:
-                        logging.warning(
-                            f"Skill '{skill.name}' from {skill.source_path} "
-                            f"overrides {skills_by_name[skill.name].source_path}"
-                        )
-                    skills_by_name[skill.name] = skill
-            elif path.is_file() and path.name == SKILL_FILENAME:
-                try:
-                    skill = parse_skill_file(path, source=SkillSource.USER)
-                    if skill.name in skills_by_name:
-                        logging.warning(
-                            f"Skill '{skill.name}' from {skill.source_path} "
-                            f"overrides {skills_by_name[skill.name].source_path}"
-                        )
-                    skills_by_name[skill.name] = skill
-                except Exception as e:
-                    logging.error(f"Failed to parse skill file {path}: {e}")
-            else:
-                logging.warning(f"Skill path is not a directory or SKILL.md file: {path}")
+    # 1 + 2. Builtin skills, then filesystem skills (which override builtins by name)
+    skills_by_name = _load_filesystem_skills_by_name(custom_skill_paths)
 
     # 3. Load remote (global) skills from Supabase
     if dal:

--- a/holmes/utils/holmes_sync_skills.py
+++ b/holmes/utils/holmes_sync_skills.py
@@ -5,13 +5,18 @@ from holmes.config import Config
 from holmes.core.supabase_dal import SupabaseDal
 from holmes.plugins.skills.skill_loader import (
     SkillSource,
-    load_skill_catalog,
+    load_filesystem_skills,
 )
 
 # How a SkillSource is labelled in the HolmesCustomSkills.source column. Every filesystem
 # skill -- from a GitHub repo, inline Helm values, or a ConfigMap/Secret mount -- loads as
 # SkillSource.USER and Holmes keeps no origin metadata, so they are all reported as
 # "custom". Distinguishing github/inline/configmap would require new origin tagging.
+# HolmesCustomSkills.status values. The column exists to surface a malformed SKILL.md, so
+# both are reachable: "ok" for a skill that parsed, "error" for one that did not.
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+
 SOURCE_LABELS = {
     SkillSource.USER: "custom",
     SkillSource.BUILTIN: "builtin",
@@ -25,9 +30,10 @@ def holmes_sync_skills_status(dal: SupabaseDal, config: Config) -> None:
     keeps executing these from disk. Runs at startup and on the periodic refresh, alongside
     holmes_sync_toolsets_status.
 
-    Deliberately loads with dal=None so only builtin + filesystem skills are collected --
+    Loads through load_filesystem_skills so only builtin + filesystem skills are collected --
     global and personal skills already live in HolmesRunbooks and must not be duplicated
-    into the mirror.
+    into the mirror. That loader also reports whether every source was readable, which is
+    what makes it safe to prune on an empty result.
 
     Best-effort: any failure is logged and swallowed, because a display-only mirror must
     never prevent Holmes from starting.
@@ -37,35 +43,78 @@ def holmes_sync_skills_status(dal: SupabaseDal, config: Config) -> None:
             logging.warning("Cluster name is missing; skipping custom skills sync.")
             return
 
-        catalog = load_skill_catalog(
-            dal=None, custom_skill_paths=config.custom_skill_paths
-        )
-        if not catalog or not catalog.skills:
-            logging.debug("No filesystem or builtin skills found to sync.")
-            return
+        # Reports whether every skill source was readable, which the prune below depends on.
+        # An empty result alone cannot distinguish "the last skill was deleted" from "the
+        # ConfigMap is not mounted yet" -- and only the first should prune the mirror.
+        loaded = load_filesystem_skills(config.custom_skill_paths)
 
         # UTC-aware: a naive timestamp would be interpreted in the database session's
         # timezone, so updated_at would not reflect the real sync time off-UTC.
         updated_at = datetime.now(timezone.utc).isoformat()
-        rows = [
-            {
+        # Keyed by skill_name, because the batch upsert conflicts on
+        # (account_id, cluster_id, skill_name) and PostgreSQL refuses an
+        # ON CONFLICT DO UPDATE that touches the same row twice. Two rows sharing a name do
+        # not resolve last-write-wins -- they abort the whole statement, and since the prune
+        # runs after the upsert one collision would silently kill the entire sync.
+        by_name: dict[str, dict] = {}
+
+        def row(skill_name, source, description, content, source_path, status, error):
+            return {
                 "account_id": dal.account_id,
                 "cluster_id": config.cluster_name,
-                "skill_name": skill.name,
-                "source": SOURCE_LABELS.get(skill.source, skill.source.value),
-                "description": skill.description,
-                "content": skill.content,
-                "source_path": skill.source_path,
-                # Skills that fail to parse are logged and skipped by the loader, so
-                # everything reaching here parsed cleanly.
-                "status": "ok",
-                "error": None,
+                "skill_name": skill_name,
+                "source": source,
+                "description": description,
+                "content": content,
+                "source_path": source_path,
+                "status": status,
+                "error": error,
                 "updated_at": updated_at,
             }
-            for skill in catalog.skills
-            if skill.source in SOURCE_LABELS
-        ]
 
-        dal.sync_skills(rows, config.cluster_name)
+        for skill in loaded.skills:
+            if skill.source in SOURCE_LABELS:
+                by_name[skill.name] = row(
+                    skill.name,
+                    SOURCE_LABELS[skill.source],
+                    skill.description,
+                    skill.content,
+                    skill.source_path,
+                    STATUS_OK,
+                    None,
+                )
+
+        # A SKILL.md that failed to parse gets a row too. Without this the columns could
+        # never hold anything but "ok": the loader drops unparseable skills, so nothing
+        # broken ever reached the row builder and a user's malformed file simply vanished
+        # from the UI rather than showing up as broken.
+        #
+        # Keyed on the same skill_name a successful parse would have produced (the
+        # normalized directory name), so a file that starts failing replaces its own healthy
+        # row. Written AFTER the healthy rows and allowed to overwrite them: when two
+        # configured paths hold the same directory name and one is malformed, the error is
+        # the thing worth surfacing -- a broken skill the user cannot see is exactly what
+        # this feature exists to fix.
+        for failure in loaded.failed_skills:
+            if failure.source in SOURCE_LABELS:
+                by_name[failure.skill_name] = row(
+                    failure.skill_name,
+                    SOURCE_LABELS[failure.source],
+                    # Nullable, and there is nothing trustworthy to put here -- the parse
+                    # that would have produced them is what failed.
+                    None,
+                    None,
+                    failure.source_path,
+                    STATUS_ERROR,
+                    failure.error,
+                )
+
+        rows = list(by_name.values())
+
+        # Conservative: prune only when EVERY source was readable. A partially-readable load
+        # must not delete the rows for the part that failed, and a fully-unreadable one must
+        # not wipe the list -- while a clean load of zero skills genuinely means "the last
+        # skill was deleted" and must prune.
+        dal.sync_skills(rows, config.cluster_name, prune=loaded.sources_ok)
     except Exception:
         logging.exception("Failed to sync custom skills", exc_info=True)

--- a/holmes/utils/holmes_sync_skills.py
+++ b/holmes/utils/holmes_sync_skills.py
@@ -5,7 +5,7 @@ from holmes.config import Config
 from holmes.core.supabase_dal import SupabaseDal
 from holmes.plugins.skills.skill_loader import (
     SkillSource,
-    load_skill_catalog,
+    load_filesystem_skills,
 )
 
 # How a SkillSource is labelled in the HolmesCustomSkills.source column. Every filesystem
@@ -25,9 +25,10 @@ def holmes_sync_skills_status(dal: SupabaseDal, config: Config) -> None:
     keeps executing these from disk. Runs at startup and on the periodic refresh, alongside
     holmes_sync_toolsets_status.
 
-    Deliberately loads with dal=None so only builtin + filesystem skills are collected --
+    Loads through load_filesystem_skills so only builtin + filesystem skills are collected --
     global and personal skills already live in HolmesRunbooks and must not be duplicated
-    into the mirror.
+    into the mirror. That loader also reports whether every source was readable, which is
+    what makes it safe to prune on an empty result.
 
     Best-effort: any failure is logged and swallowed, because a display-only mirror must
     never prevent Holmes from starting.
@@ -37,12 +38,10 @@ def holmes_sync_skills_status(dal: SupabaseDal, config: Config) -> None:
             logging.warning("Cluster name is missing; skipping custom skills sync.")
             return
 
-        catalog = load_skill_catalog(
-            dal=None, custom_skill_paths=config.custom_skill_paths
-        )
-        if not catalog or not catalog.skills:
-            logging.debug("No filesystem or builtin skills found to sync.")
-            return
+        # Reports whether every skill source was readable, which the prune below depends on.
+        # An empty result alone cannot distinguish "the last skill was deleted" from "the
+        # ConfigMap is not mounted yet" -- and only the first should prune the mirror.
+        loaded = load_filesystem_skills(config.custom_skill_paths)
 
         # UTC-aware: a naive timestamp would be interpreted in the database session's
         # timezone, so updated_at would not reflect the real sync time off-UTC.
@@ -62,10 +61,14 @@ def holmes_sync_skills_status(dal: SupabaseDal, config: Config) -> None:
                 "error": None,
                 "updated_at": updated_at,
             }
-            for skill in catalog.skills
+            for skill in loaded.skills
             if skill.source in SOURCE_LABELS
         ]
 
-        dal.sync_skills(rows, config.cluster_name)
+        # Conservative: prune only when EVERY source was readable. A partially-readable load
+        # must not delete the rows for the part that failed, and a fully-unreadable one must
+        # not wipe the list -- while a clean load of zero skills genuinely means "the last
+        # skill was deleted" and must prune.
+        dal.sync_skills(rows, config.cluster_name, prune=loaded.sources_ok)
     except Exception:
         logging.exception("Failed to sync custom skills", exc_info=True)

--- a/tests/core/test_supabase_dal.py
+++ b/tests/core/test_supabase_dal.py
@@ -794,7 +794,7 @@ class TestSyncSkills:
             {"account_id": "acct-1", "cluster_id": "c1", "skill_name": "beta"},
         ]
 
-        skills_dal.sync_skills(rows, "c1")
+        skills_dal.sync_skills(rows, "c1", prune=True)
 
         table = skills_dal.client.table
         table.assert_called_with("HolmesCustomSkills")
@@ -806,18 +806,49 @@ class TestSyncSkills:
         not_in = table.return_value.delete.return_value.eq.return_value.eq.return_value.not_.in_
         not_in.assert_called_once_with("skill_name", ["alpha", "beta"])
 
-    def test_empty_list_does_not_delete_everything(self, skills_dal):
-        """"No skills loaded" is indistinguishable from a load failure, so an empty list
-        must not wipe the UI's view."""
-        skills_dal.sync_skills([], "c1")
+    def test_empty_list_with_prune_deletes_every_row_for_the_cluster(self, skills_dal):
+        """Deleting your LAST custom skill must clear the mirror.
+
+        prune=True means the caller verified every skill source was readable, so an empty
+        list really does mean "there are no skills" and the leftover row has to go. This is
+        the case that previously returned early and left the row visible in the UI forever.
+        """
+        skills_dal.sync_skills([], "c1", prune=True)
+
+        table = skills_dal.client.table
+        # nothing to upsert
+        table.return_value.upsert.assert_not_called()
+        # the delete is scoped to (account, cluster) and otherwise unfiltered
+        scoped = table.return_value.delete.return_value.eq.return_value.eq.return_value
+        scoped.execute.assert_called_once()
+        # `not.in.()` is not reliably valid PostgREST, so the filter must be omitted entirely
+        scoped.not_.in_.assert_not_called()
+
+    def test_empty_list_without_prune_does_not_delete_everything(self, skills_dal):
+        """Nothing was readable, so nothing is known -- the UI's view must survive."""
+        skills_dal.sync_skills([], "c1", prune=False)
 
         skills_dal.client.table.assert_not_called()
+
+    def test_partial_load_upserts_but_does_not_prune(self, skills_dal):
+        """A source that failed to load must not prune the skills it would have provided."""
+        rows = [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}]
+
+        skills_dal.sync_skills(rows, "c1", prune=False)
+
+        table = skills_dal.client.table
+        table.return_value.upsert.assert_called_once_with(
+            rows, on_conflict="account_id, cluster_id, skill_name"
+        )
+        table.return_value.delete.assert_not_called()
 
     def test_disabled_dal_is_a_noop(self, skills_dal):
         skills_dal.enabled = False
 
         skills_dal.sync_skills(
-            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}], "c1"
+            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}],
+            "c1",
+            prune=True,
         )
 
         skills_dal.client.table.assert_not_called()
@@ -827,7 +858,9 @@ class TestSyncSkills:
         skills_dal.client.table.side_effect = PGAPIError({"message": "boom"})
 
         skills_dal.sync_skills(
-            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}], "c1"
+            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}],
+            "c1",
+            prune=True,
         )
 
 class TestGlobalSkillCatalog:

--- a/tests/core/test_supabase_dal.py
+++ b/tests/core/test_supabase_dal.py
@@ -674,7 +674,7 @@ class TestSyncSkills:
             {"account_id": "acct-1", "cluster_id": "c1", "skill_name": "beta"},
         ]
 
-        skills_dal.sync_skills(rows, "c1")
+        skills_dal.sync_skills(rows, "c1", prune=True)
 
         table = skills_dal.client.table
         table.assert_called_with("HolmesCustomSkills")
@@ -686,18 +686,49 @@ class TestSyncSkills:
         not_in = table.return_value.delete.return_value.eq.return_value.eq.return_value.not_.in_
         not_in.assert_called_once_with("skill_name", ["alpha", "beta"])
 
-    def test_empty_list_does_not_delete_everything(self, skills_dal):
-        """"No skills loaded" is indistinguishable from a load failure, so an empty list
-        must not wipe the UI's view."""
-        skills_dal.sync_skills([], "c1")
+    def test_empty_list_with_prune_deletes_every_row_for_the_cluster(self, skills_dal):
+        """Deleting your LAST custom skill must clear the mirror.
+
+        prune=True means the caller verified every skill source was readable, so an empty
+        list really does mean "there are no skills" and the leftover row has to go. This is
+        the case that previously returned early and left the row visible in the UI forever.
+        """
+        skills_dal.sync_skills([], "c1", prune=True)
+
+        table = skills_dal.client.table
+        # nothing to upsert
+        table.return_value.upsert.assert_not_called()
+        # the delete is scoped to (account, cluster) and otherwise unfiltered
+        scoped = table.return_value.delete.return_value.eq.return_value.eq.return_value
+        scoped.execute.assert_called_once()
+        # `not.in.()` is not reliably valid PostgREST, so the filter must be omitted entirely
+        scoped.not_.in_.assert_not_called()
+
+    def test_empty_list_without_prune_does_not_delete_everything(self, skills_dal):
+        """Nothing was readable, so nothing is known -- the UI's view must survive."""
+        skills_dal.sync_skills([], "c1", prune=False)
 
         skills_dal.client.table.assert_not_called()
+
+    def test_partial_load_upserts_but_does_not_prune(self, skills_dal):
+        """A source that failed to load must not prune the skills it would have provided."""
+        rows = [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}]
+
+        skills_dal.sync_skills(rows, "c1", prune=False)
+
+        table = skills_dal.client.table
+        table.return_value.upsert.assert_called_once_with(
+            rows, on_conflict="account_id, cluster_id, skill_name"
+        )
+        table.return_value.delete.assert_not_called()
 
     def test_disabled_dal_is_a_noop(self, skills_dal):
         skills_dal.enabled = False
 
         skills_dal.sync_skills(
-            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}], "c1"
+            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}],
+            "c1",
+            prune=True,
         )
 
         skills_dal.client.table.assert_not_called()
@@ -707,7 +738,9 @@ class TestSyncSkills:
         skills_dal.client.table.side_effect = PGAPIError({"message": "boom"})
 
         skills_dal.sync_skills(
-            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}], "c1"
+            [{"account_id": "acct-1", "cluster_id": "c1", "skill_name": "alpha"}],
+            "c1",
+            prune=True,
         )
 
 class TestGlobalSkillCatalog:

--- a/tests/plugins/skills/test_skill_loader.py
+++ b/tests/plugins/skills/test_skill_loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from holmes.plugins.skills import RobustaSkillInstruction
 from holmes.plugins.skills.skill_loader import (
     SkillSource,
+    load_filesystem_skills,
     load_skill_catalog,
     map_robusta_instruction_to_skill,
     scan_skill_directory,
@@ -66,6 +67,39 @@ def test_scan_skill_directory_kubernetes_configmap_layout(tmp_path: Path):
 def test_scan_skill_directory_missing_dir(tmp_path: Path):
     skills = scan_skill_directory(tmp_path / "does-not-exist")
     assert skills == []
+
+
+def _deny_scandir_under(root: Path, monkeypatch):
+    """Make os.scandir raise PermissionError for paths under `root`, leaving others alone.
+
+    Portable stand-in for a chmod 000 directory: chmod is a no-op for the owner on Windows
+    and ineffective as root, which is how CI runs.
+    """
+    real_scandir = os.scandir
+
+    def deny(path, *args, **kwargs):
+        if str(path).startswith(str(root)):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "scandir", deny)
+
+
+def test_scan_skill_directory_reports_unreadable_directory(tmp_path: Path, monkeypatch):
+    """An existing but UNREADABLE directory must be reported as a problem.
+
+    os.walk swallows traversal errors unless an `onerror` handler is passed, and `is_dir()`
+    succeeds for a directory you cannot read into. Without onerror this returns [] with no
+    problem recorded -- indistinguishable from "readable and genuinely empty", which is
+    exactly the distinction the mirror prunes on.
+    """
+    _deny_scandir_under(tmp_path, monkeypatch)
+    problems: list[str] = []
+
+    skills = scan_skill_directory(tmp_path, problems=problems)
+
+    assert skills == []
+    assert problems, "an unreadable directory must be recorded as a problem"
 
 
 def test_scan_skill_directory_respects_max_depth(tmp_path: Path):
@@ -164,3 +198,112 @@ def test_map_robusta_instruction_without_symptom_keeps_title() -> None:
 
     assert skill.title == "Erlang Debugging"
     assert skill.description == "Erlang Debugging"
+
+
+class TestLoadFilesystemSkills:
+    """Tests for the load-health signal the HolmesCustomSkills mirror prunes on.
+
+    An empty skill list is ambiguous on its own: it means either "the user deleted their
+    last skill" or "nothing could be read". The mirror deletes rows based on what loaded, so
+    conflating the two either leaves a stale skill visible forever or wipes the UI's view on
+    a transient mount failure. `sources_ok` is what separates them.
+    """
+
+    def test_clean_load_reports_ok(self, tmp_path: Path):
+        _write_skill(tmp_path / "alpha", "alpha")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert loaded.sources_ok is True
+        assert [s.name for s in loaded.skills] == ["alpha"]
+
+    def test_readable_but_empty_directory_reports_ok(self, tmp_path: Path):
+        """The case that must prune: the directory is fine, it just has no skills left."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        loaded = load_filesystem_skills(custom_skill_paths=[empty])
+
+        assert loaded.sources_ok is True
+        assert loaded.skills == []
+
+    def test_missing_directory_reports_not_ok(self, tmp_path: Path):
+        loaded = load_filesystem_skills(
+            custom_skill_paths=[tmp_path / "does-not-exist"]
+        )
+
+        assert loaded.sources_ok is False
+        assert loaded.skills == []
+
+    def test_unparseable_skill_is_named_and_does_not_block_pruning(self, tmp_path: Path):
+        """A malformed SKILL.md is a KNOWN failure: we can say exactly which skill is broken.
+
+        So it is reported as a named problem the caller can surface as a row, and it must
+        NOT mark the load incomplete -- otherwise one bad file would suppress pruning for
+        the whole cluster and an unrelated deletion would never be reflected.
+        """
+        broken = tmp_path / "broken"
+        broken.mkdir()
+        (broken / "SKILL.md").write_text("no frontmatter here")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert loaded.skills == []
+        assert loaded.sources_ok is True
+        assert [p.skill_name for p in loaded.failed_skills] == ["broken"]
+        assert loaded.failed_skills[0].source == SkillSource.USER
+        assert "frontmatter" in loaded.failed_skills[0].error
+
+    def test_unnamed_problems_are_not_reported_as_failed_skills(self, tmp_path: Path):
+        """The complement: an unreadable path cannot be attributed to a skill, so it blocks
+        pruning and must not produce a row claiming some skill failed."""
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path / "does-not-exist"])
+
+        assert loaded.sources_ok is False
+        assert loaded.failed_skills == []
+        assert loaded.problems and loaded.problems[0].skill_name is None
+
+    def test_unreadable_directory_reports_not_ok(self, tmp_path: Path, monkeypatch):
+        """The dangerous case: the path exists so `is_dir()` passes, but it cannot be read.
+
+        If this reported ok, the mirror would prune rows for skills that are still on disk
+        and merely unreadable this cycle -- the precise wrongful delete sources_ok exists to
+        prevent.
+        """
+        _deny_scandir_under(tmp_path, monkeypatch)
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert loaded.sources_ok is False
+        assert loaded.skills == []
+
+    def test_path_that_is_neither_dir_nor_skill_md_reports_not_ok(self, tmp_path: Path):
+        stray = tmp_path / "notes.txt"
+        stray.write_text("hello")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[stray])
+
+        assert loaded.sources_ok is False
+
+    def test_partial_failure_still_returns_the_readable_skills(self, tmp_path: Path):
+        """A good path still loads, but the UNREADABLE one taints sources_ok, so the caller
+        will not prune the skills that path would have provided."""
+        good = tmp_path / "good"
+        _write_skill(good / "alpha", "alpha")
+
+        loaded = load_filesystem_skills(
+            custom_skill_paths=[good, tmp_path / "missing"]
+        )
+
+        assert loaded.sources_ok is False
+        assert [s.name for s in loaded.skills] == ["alpha"]
+
+    def test_does_not_read_supabase(self, tmp_path: Path):
+        """Global and personal skills live in HolmesRunbooks and must not be mirrored."""
+        _write_skill(tmp_path / "alpha", "alpha")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert all(
+            s.source in (SkillSource.USER, SkillSource.BUILTIN) for s in loaded.skills
+        )

--- a/tests/plugins/skills/test_skill_loader.py
+++ b/tests/plugins/skills/test_skill_loader.py
@@ -73,6 +73,39 @@ def test_scan_skill_directory_missing_dir(tmp_path: Path):
     assert skills == []
 
 
+def _deny_scandir_under(root: Path, monkeypatch):
+    """Make os.scandir raise PermissionError for paths under `root`, leaving others alone.
+
+    Portable stand-in for a chmod 000 directory: chmod is a no-op for the owner on Windows
+    and ineffective as root, which is how CI runs.
+    """
+    real_scandir = os.scandir
+
+    def deny(path, *args, **kwargs):
+        if str(path).startswith(str(root)):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "scandir", deny)
+
+
+def test_scan_skill_directory_reports_unreadable_directory(tmp_path: Path, monkeypatch):
+    """An existing but UNREADABLE directory must be reported as a problem.
+
+    os.walk swallows traversal errors unless an `onerror` handler is passed, and `is_dir()`
+    succeeds for a directory you cannot read into. Without onerror this returns [] with no
+    problem recorded -- indistinguishable from "readable and genuinely empty", which is
+    exactly the distinction the mirror prunes on.
+    """
+    _deny_scandir_under(tmp_path, monkeypatch)
+    problems: list[str] = []
+
+    skills = scan_skill_directory(tmp_path, problems=problems)
+
+    assert skills == []
+    assert problems, "an unreadable directory must be recorded as a problem"
+
+
 def test_scan_skill_directory_respects_max_depth(tmp_path: Path):
     # SKILL.md at depth 3 should be ignored with default max_depth=2.
     _write_skill(tmp_path / "a" / "b" / "c", "deep")
@@ -179,6 +212,20 @@ class TestLoadFilesystemSkills:
         broken = tmp_path / "broken"
         broken.mkdir()
         (broken / "SKILL.md").write_text("no frontmatter here")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert loaded.sources_ok is False
+        assert loaded.skills == []
+
+    def test_unreadable_directory_reports_not_ok(self, tmp_path: Path, monkeypatch):
+        """The dangerous case: the path exists so `is_dir()` passes, but it cannot be read.
+
+        If this reported ok, the mirror would prune rows for skills that are still on disk
+        and merely unreadable this cycle -- the precise wrongful delete sources_ok exists to
+        prevent.
+        """
+        _deny_scandir_under(tmp_path, monkeypatch)
 
         loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
 

--- a/tests/plugins/skills/test_skill_loader.py
+++ b/tests/plugins/skills/test_skill_loader.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from holmes.plugins.skills.skill_loader import (
     SkillSource,
+    load_filesystem_skills,
     load_skill_catalog,
     scan_skill_directory,
 )
@@ -135,3 +136,82 @@ def test_load_skill_catalog_later_path_overrides_earlier(tmp_path: Path):
     assert len(shared) == 1
     assert shared[0].source_path is not None
     assert str(path_b) in shared[0].source_path
+
+
+class TestLoadFilesystemSkills:
+    """Tests for the load-health signal the HolmesCustomSkills mirror prunes on.
+
+    An empty skill list is ambiguous on its own: it means either "the user deleted their
+    last skill" or "nothing could be read". The mirror deletes rows based on what loaded, so
+    conflating the two either leaves a stale skill visible forever or wipes the UI's view on
+    a transient mount failure. `sources_ok` is what separates them.
+    """
+
+    def test_clean_load_reports_ok(self, tmp_path: Path):
+        _write_skill(tmp_path / "alpha", "alpha")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert loaded.sources_ok is True
+        assert [s.name for s in loaded.skills] == ["alpha"]
+
+    def test_readable_but_empty_directory_reports_ok(self, tmp_path: Path):
+        """The case that must prune: the directory is fine, it just has no skills left."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        loaded = load_filesystem_skills(custom_skill_paths=[empty])
+
+        assert loaded.sources_ok is True
+        assert loaded.skills == []
+
+    def test_missing_directory_reports_not_ok(self, tmp_path: Path):
+        loaded = load_filesystem_skills(
+            custom_skill_paths=[tmp_path / "does-not-exist"]
+        )
+
+        assert loaded.sources_ok is False
+        assert loaded.skills == []
+
+    def test_unparseable_skill_reports_not_ok(self, tmp_path: Path):
+        """A malformed SKILL.md is skipped by the loader, so without the health signal this
+        would look identical to a directory that legitimately holds no skills."""
+        broken = tmp_path / "broken"
+        broken.mkdir()
+        (broken / "SKILL.md").write_text("no frontmatter here")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert loaded.sources_ok is False
+        assert loaded.skills == []
+
+    def test_path_that_is_neither_dir_nor_skill_md_reports_not_ok(self, tmp_path: Path):
+        stray = tmp_path / "notes.txt"
+        stray.write_text("hello")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[stray])
+
+        assert loaded.sources_ok is False
+
+    def test_partial_failure_still_returns_the_readable_skills(self, tmp_path: Path):
+        """Conservative rule: a good path still loads, but the bad one taints sources_ok so
+        the caller will not prune the skills the failed path would have provided."""
+        good = tmp_path / "good"
+        _write_skill(good / "alpha", "alpha")
+
+        loaded = load_filesystem_skills(
+            custom_skill_paths=[good, tmp_path / "missing"]
+        )
+
+        assert loaded.sources_ok is False
+        assert [s.name for s in loaded.skills] == ["alpha"]
+
+    def test_does_not_read_supabase(self, tmp_path: Path):
+        """Global and personal skills live in HolmesRunbooks and must not be mirrored."""
+        _write_skill(tmp_path / "alpha", "alpha")
+
+        loaded = load_filesystem_skills(custom_skill_paths=[tmp_path])
+
+        assert all(
+            s.source in (SkillSource.USER, SkillSource.BUILTIN) for s in loaded.skills
+        )

--- a/tests/test_holmes_sync_skills.py
+++ b/tests/test_holmes_sync_skills.py
@@ -1,0 +1,247 @@
+"""Tests for the HolmesCustomSkills mirror sync.
+
+The mirror deletes rows based on what loaded from disk, which makes the empty case load
+bearing: deleting your last custom skill must clear the mirror, but an unreadable
+ConfigMap mount must not. These tests pin the decision down at the layer that makes it.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from holmes.utils.holmes_sync_skills import holmes_sync_skills_status
+
+SKILL_BODY = "---\ndescription: Test skill\n---\n## Goal\nTest\n"
+
+
+def _write_skill(dir_path: Path, name: str) -> None:
+    (dir_path / name).mkdir(parents=True, exist_ok=True)
+    (dir_path / name / "SKILL.md").write_text(SKILL_BODY)
+
+
+def _dal() -> Mock:
+    dal = Mock()
+    dal.account_id = "acct-1"
+    return dal
+
+
+def _config(paths) -> Mock:
+    config = Mock()
+    config.cluster_name = "c1"
+    config.custom_skill_paths = paths
+    return config
+
+
+def test_clean_load_syncs_with_prune_enabled(tmp_path: Path):
+    _write_skill(tmp_path, "alpha")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    rows, cluster = dal.sync_skills.call_args[0]
+    assert cluster == "c1"
+    assert [r["skill_name"] for r in rows] == ["alpha"]
+    assert dal.sync_skills.call_args[1]["prune"] is True
+
+
+def test_last_skill_deleted_still_prunes(tmp_path: Path):
+    """The reported gap: an empty but READABLE directory must prune the mirror.
+
+    Previously this returned early without calling sync_skills at all, so the row for the
+    deleted skill stayed in HolmesCustomSkills forever and the UI kept listing it.
+    """
+    empty = tmp_path / "skills"
+    empty.mkdir()
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([empty]))
+
+    dal.sync_skills.assert_called_once()
+    rows, _ = dal.sync_skills.call_args[0]
+    assert rows == []
+    assert dal.sync_skills.call_args[1]["prune"] is True
+
+
+def test_unreadable_source_does_not_prune(tmp_path: Path):
+    """An unmounted ConfigMap looks like an empty one, so it must not wipe the mirror."""
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path / "not-mounted-yet"]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    assert rows == []
+    assert dal.sync_skills.call_args[1]["prune"] is False
+
+
+def test_partial_failure_upserts_but_does_not_prune(tmp_path: Path):
+    """Conservative rule: one bad path suppresses the prune for the whole sync, so the
+    skills the failed path would have provided are not deleted from the mirror."""
+    good = tmp_path / "good"
+    _write_skill(good, "alpha")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([good, tmp_path / "missing"]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    assert [r["skill_name"] for r in rows] == ["alpha"]
+    assert dal.sync_skills.call_args[1]["prune"] is False
+
+
+def test_missing_cluster_name_skips_entirely(tmp_path: Path):
+    _write_skill(tmp_path, "alpha")
+    dal = _dal()
+    config = _config([tmp_path])
+    config.cluster_name = None
+
+    holmes_sync_skills_status(dal, config)
+
+    dal.sync_skills.assert_not_called()
+
+
+def test_sync_failure_never_raises(tmp_path: Path):
+    """A display-only mirror must never prevent Holmes from starting."""
+    dal = _dal()
+    dal.sync_skills.side_effect = RuntimeError("boom")
+
+    _write_skill(tmp_path, "alpha")
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    # Assert the call happened, otherwise the side_effect never fires and this passes
+    # vacuously -- it would still be green if the sync were skipped entirely, proving
+    # nothing about suppression.
+    dal.sync_skills.assert_called_once()
+
+
+def test_loader_failure_never_raises_and_skips_the_write(monkeypatch, tmp_path: Path):
+    """The loader runs BEFORE the rows are built, so its failure is a separate path.
+
+    Must not raise, and must not reach sync_skills at all -- with no loaded skills and no
+    health signal there is nothing to upsert and pruning would be a guess.
+    """
+    dal = _dal()
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("loader exploded")
+
+    monkeypatch.setattr(
+        "holmes.utils.holmes_sync_skills.load_filesystem_skills", boom
+    )
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    dal.sync_skills.assert_not_called()
+
+
+def _broken_skill(dir_path: Path, name: str) -> None:
+    (dir_path / name).mkdir(parents=True, exist_ok=True)
+    (dir_path / name / "SKILL.md").write_text("no frontmatter here")
+
+
+def test_malformed_skill_gets_an_error_row(tmp_path: Path):
+    """A SKILL.md that fails to parse must appear as broken, not vanish.
+
+    Before this, the loader dropped unparseable skills, so nothing broken ever reached the
+    row builder -- status was always "ok" and error always NULL. A user's malformed file
+    simply had no effect anywhere in the product, discoverable only in the pod logs.
+    """
+    _write_skill(tmp_path, "good")
+    _broken_skill(tmp_path, "bad")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    by_name = {r["skill_name"]: r for r in rows}
+
+    assert by_name["good"]["status"] == "ok"
+    assert by_name["good"]["error"] is None
+
+    bad = by_name["bad"]
+    assert bad["status"] == "error"
+    assert "frontmatter" in bad["error"]
+    assert bad["source"] == "custom"
+    assert bad["source_path"] is not None
+    # Nothing trustworthy to report -- the parse that would produce them is what failed.
+    assert bad["description"] is None
+    assert bad["content"] is None
+
+
+def test_malformed_skill_does_not_suppress_pruning(tmp_path: Path):
+    """A parse failure is a KNOWN state, now represented as a row, so it must not block the
+    prune. Otherwise one malformed file would freeze the mirror for the whole cluster and
+    deleting an unrelated skill would leave its row behind forever."""
+    _write_skill(tmp_path, "good")
+    _broken_skill(tmp_path, "bad")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    assert dal.sync_skills.call_args[1]["prune"] is True
+
+
+def test_unreadable_source_still_suppresses_pruning(tmp_path: Path):
+    """The other half of the distinction: an unreadable path tells us nothing about what
+    skills should exist, so the load is not authoritative enough to delete from."""
+    _write_skill(tmp_path, "good")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path, tmp_path / "not-mounted"]))
+
+    assert dal.sync_skills.call_args[1]["prune"] is False
+
+
+def test_error_row_keeps_the_skill_from_being_pruned(tmp_path: Path):
+    """The failed skill is in the provided names, so the prune that follows will not delete
+    the very row that reports the failure."""
+    _broken_skill(tmp_path, "bad")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    assert [r["skill_name"] for r in rows] == ["bad"]
+    assert dal.sync_skills.call_args[1]["prune"] is True
+
+
+def test_rows_are_unique_by_skill_name(tmp_path: Path):
+    """The batch upsert conflicts on (account_id, cluster_id, skill_name), and PostgreSQL
+    refuses an ON CONFLICT DO UPDATE that touches the same row twice -- it raises a
+    cardinality violation. So two rows sharing a skill_name do not resolve last-write-wins;
+    they abort the whole statement. sync_skills catches that, and because the prune runs
+    after the upsert in the same try block, ONE name collision silently kills the entire
+    mirror sync for the cluster rather than just the colliding row.
+
+    Reachable whenever two custom_skill_paths hold the same directory name and one of them
+    is malformed.
+    """
+    good_path = tmp_path / "a"
+    bad_path = tmp_path / "b"
+    _write_skill(good_path, "shared")
+    _broken_skill(bad_path, "shared")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([good_path, bad_path]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    keys = [(r["account_id"], r["cluster_id"], r["skill_name"]) for r in rows]
+    assert len(keys) == len(set(keys)), f"duplicate upsert keys: {keys}"
+
+
+def test_failure_row_wins_over_a_same_named_healthy_skill(tmp_path: Path):
+    """When they collide the error must survive, not be masked by the healthy row.
+
+    A broken skill the user cannot see is the whole problem this feature exists to fix, so
+    silently preferring the row that parsed would defeat it.
+    """
+    good_path = tmp_path / "a"
+    bad_path = tmp_path / "b"
+    _write_skill(good_path, "shared")
+    _broken_skill(bad_path, "shared")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([good_path, bad_path]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    shared = [r for r in rows if r["skill_name"] == "shared"]
+    assert len(shared) == 1
+    assert shared[0]["status"] == "error"
+    assert "frontmatter" in shared[0]["error"]

--- a/tests/test_holmes_sync_skills.py
+++ b/tests/test_holmes_sync_skills.py
@@ -1,0 +1,106 @@
+"""Tests for the HolmesCustomSkills mirror sync.
+
+The mirror deletes rows based on what loaded from disk, which makes the empty case load
+bearing: deleting your last custom skill must clear the mirror, but an unreadable
+ConfigMap mount must not. These tests pin the decision down at the layer that makes it.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from holmes.utils.holmes_sync_skills import holmes_sync_skills_status
+
+SKILL_BODY = "---\ndescription: Test skill\n---\n## Goal\nTest\n"
+
+
+def _write_skill(dir_path: Path, name: str) -> None:
+    (dir_path / name).mkdir(parents=True, exist_ok=True)
+    (dir_path / name / "SKILL.md").write_text(SKILL_BODY)
+
+
+def _dal() -> Mock:
+    dal = Mock()
+    dal.account_id = "acct-1"
+    return dal
+
+
+def _config(paths) -> Mock:
+    config = Mock()
+    config.cluster_name = "c1"
+    config.custom_skill_paths = paths
+    return config
+
+
+def test_clean_load_syncs_with_prune_enabled(tmp_path: Path):
+    _write_skill(tmp_path, "alpha")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    rows, cluster = dal.sync_skills.call_args[0]
+    assert cluster == "c1"
+    assert [r["skill_name"] for r in rows] == ["alpha"]
+    assert dal.sync_skills.call_args[1]["prune"] is True
+
+
+def test_last_skill_deleted_still_prunes(tmp_path: Path):
+    """The reported gap: an empty but READABLE directory must prune the mirror.
+
+    Previously this returned early without calling sync_skills at all, so the row for the
+    deleted skill stayed in HolmesCustomSkills forever and the UI kept listing it.
+    """
+    empty = tmp_path / "skills"
+    empty.mkdir()
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([empty]))
+
+    dal.sync_skills.assert_called_once()
+    rows, _ = dal.sync_skills.call_args[0]
+    assert rows == []
+    assert dal.sync_skills.call_args[1]["prune"] is True
+
+
+def test_unreadable_source_does_not_prune(tmp_path: Path):
+    """An unmounted ConfigMap looks like an empty one, so it must not wipe the mirror."""
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([tmp_path / "not-mounted-yet"]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    assert rows == []
+    assert dal.sync_skills.call_args[1]["prune"] is False
+
+
+def test_partial_failure_upserts_but_does_not_prune(tmp_path: Path):
+    """Conservative rule: one bad path suppresses the prune for the whole sync, so the
+    skills the failed path would have provided are not deleted from the mirror."""
+    good = tmp_path / "good"
+    _write_skill(good, "alpha")
+    dal = _dal()
+
+    holmes_sync_skills_status(dal, _config([good, tmp_path / "missing"]))
+
+    rows, _ = dal.sync_skills.call_args[0]
+    assert [r["skill_name"] for r in rows] == ["alpha"]
+    assert dal.sync_skills.call_args[1]["prune"] is False
+
+
+def test_missing_cluster_name_skips_entirely(tmp_path: Path):
+    _write_skill(tmp_path, "alpha")
+    dal = _dal()
+    config = _config([tmp_path])
+    config.cluster_name = None
+
+    holmes_sync_skills_status(dal, config)
+
+    dal.sync_skills.assert_not_called()
+
+
+def test_loader_failure_never_raises(tmp_path: Path):
+    """A display-only mirror must never prevent Holmes from starting."""
+    dal = _dal()
+    dal.sync_skills.side_effect = RuntimeError("boom")
+
+    _write_skill(tmp_path, "alpha")
+    holmes_sync_skills_status(dal, _config([tmp_path]))

--- a/tests/test_holmes_sync_skills.py
+++ b/tests/test_holmes_sync_skills.py
@@ -97,10 +97,30 @@ def test_missing_cluster_name_skips_entirely(tmp_path: Path):
     dal.sync_skills.assert_not_called()
 
 
-def test_loader_failure_never_raises(tmp_path: Path):
+def test_sync_failure_never_raises(tmp_path: Path):
     """A display-only mirror must never prevent Holmes from starting."""
     dal = _dal()
     dal.sync_skills.side_effect = RuntimeError("boom")
 
     _write_skill(tmp_path, "alpha")
     holmes_sync_skills_status(dal, _config([tmp_path]))
+
+
+def test_loader_failure_never_raises_and_skips_the_write(monkeypatch, tmp_path: Path):
+    """The loader runs BEFORE the rows are built, so its failure is a separate path.
+
+    Must not raise, and must not reach sync_skills at all -- with no loaded skills and no
+    health signal there is nothing to upsert and pruning would be a guess.
+    """
+    dal = _dal()
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("loader exploded")
+
+    monkeypatch.setattr(
+        "holmes.utils.holmes_sync_skills.load_filesystem_skills", boom
+    )
+
+    holmes_sync_skills_status(dal, _config([tmp_path]))
+
+    dal.sync_skills.assert_not_called()

--- a/tests/test_holmes_sync_skills.py
+++ b/tests/test_holmes_sync_skills.py
@@ -105,6 +105,11 @@ def test_sync_failure_never_raises(tmp_path: Path):
     _write_skill(tmp_path, "alpha")
     holmes_sync_skills_status(dal, _config([tmp_path]))
 
+    # Assert the call happened, otherwise the side_effect never fires and this passes
+    # vacuously -- it would still be green if the sync were skipped entirely, proving
+    # nothing about suppression.
+    dal.sync_skills.assert_called_once()
+
 
 def test_loader_failure_never_raises_and_skips_the_write(monkeypatch, tmp_path: Path):
     """The loader runs BEFORE the rows are built, so its failure is a separate path.


### PR DESCRIPTION
Follow-up to #2350. Closes ROB-835.

Deleting your **last** custom skill never removed its `HolmesCustomSkills` row, so the UI kept listing a skill that no longer existed. Deleting 1 of 2 pruned correctly — only the empty case was stuck. Boundary confirmed on staging.

## Why it happens

The prune is subtractive ("delete every row whose `skill_name` is not in this list"), so it needs a list to subtract from. Two guards return early on an empty catalog — one in `holmes_sync_skills_status`, one in `SupabaseDal.sync_skills` — and nothing keeps the catalog non-empty: there are currently **zero** builtin `SKILL.md` files.

The guard was copied from `sync_toolsets`, where it is correct: ~13 builtin toolset YAMLs ship, so an empty toolset catalog can only ever mean a load failure. Zero builtin skills ship, so for skills "empty" is a legitimate steady state. The guard was inherited into a context where its premise no longer holds — which is why the code is faithful to its own docstring yet conflicts with the acceptance criterion "deleting the file and restarting prunes it".

## Approach

Rather than trade a permanently-stale row for a UI that blanks on any transient mount failure, remove the ambiguity:

- `scan_skill_directory` takes an opt-in `problems` accumulator, so a missing directory / unparseable `SKILL.md` / non-skill path is recorded rather than silently yielding an empty list. Default `None` keeps every existing caller and test unchanged.
- New `load_filesystem_skills()` returns the skills plus `sources_ok`. The builtin+filesystem loading shared with `load_skill_catalog` is extracted so the override and error rules cannot drift between the prompt catalog and the mirror.
- `sync_skills` takes a **required** `prune` flag — required rather than defaulted because it gates a DELETE, so the caller must state whether its list is authoritative.

**Conservative policy** — prune only when EVERY source was readable:

| load | skills | result |
|---|---|---|
| clean | non-empty | upsert + prune |
| clean | **empty** | **prune everything** (the fix) |
| degraded | non-empty | upsert only, no prune |
| degraded | empty | no-op |

The empty-prune issues an unfiltered delete scoped to `(account_id, cluster_id)` rather than reusing the not-in filter — an empty list renders as `skill_name=not.in.()`, which PostgREST does not reliably accept.

## Please review deliberately

- **A second behaviour change rides along.** The conservative rule also stops pruning in the degraded-but-**non-empty** case, where pruning currently happens. It is the same class of bug (a half-mounted ConfigMap should not prune the half that did not mount), but it is broader than the reported gap. The narrower alternative — suppress only when the result is empty *and* something failed — is a one-condition change if you would rather keep this surgical.
- **Write volume.** Deployments with no custom skills now issue one scoped no-op DELETE per refresh cycle instead of returning early (~288/day/cluster at the default 300s `TOOLSET_STATUS_REFRESH_INTERVAL_SECONDS`). Cheap and indexed, but non-zero. Skipping it would need prior-state tracking and would lose the prune when someone removes their `customSkillPaths` config.
- **A test contract changed on purpose.** `test_empty_list_does_not_delete_everything` encoded the behaviour being fixed, so it is replaced by the four explicit quadrants above rather than contorting the signature to keep an obsolete assertion green.

## Testing

Full non-LLM suite, compared against this branch's base:

| | base | this PR |
|---|---|---|
| failed | 35 | 35 |
| errors | 32 | 32 |
| passed | 2727 | 2742 (+15) |

Identical failure/error set — all Windows/POSIX environment issues (bash-shelling tests, `charmap` codec, `os` attributes, `os.symlink` privilege), none related to these changes. 15 new tests: 7 for `load_filesystem_skills` health reporting, 4 for the `sync_skills` quadrants, 6 for the mirror's branches.

**Not verified:** unit tests cannot confirm the unfiltered-delete path against real PostgREST. Worth one staging round trip before merge.

## Stacking

Based on `claude/skills-backend-planning-yydmke` (#2350) because `holmes_sync_skills.py` and `sync_skills` do not exist on `master` yet. GitHub will retarget the base to `master` once #2350 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skill synchronization for empty, missing, malformed, or partially readable sources.
  - Prevented temporary loading failures from deleting existing skills.
  - Removed stale skills only after a complete, reliable scan.
  - Excluded disabled skills from retrieval and synchronization.
  - Improved personal skill filtering and handling of malformed instructions.
  - Preserved error records for malformed skills with available source details.

- **Tests**
  - Expanded coverage for source health, filtering, pruning, and malformed skill handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->