### PR TITLE
ROB-836 Pin *.sha256 manifests to LF so the Docker build works on Windows clones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 holmes/.git_archival.json  export-subst
+
+# Checksum manifests are consumed by `sha256sum -c` inside the Linux build image
+# (see the bin/go-cve-rebuild COPY steps in the Dockerfile). A Windows clone with
+# core.autocrlf=true would otherwise check them out CRLF, and Docker COPY is
+# byte-verbatim, so sha256sum reads the filename as "<name>.gz\r" and fails with
+# "No such file or directory" before the build ever gets going.
+*.sha256 text eol=lf


### PR DESCRIPTION
The `bin/go-cve-rebuild` COPY steps hand these checksum manifests to `sha256sum -c` inside the Linux builder image. Git stores them with LF, but a clone with `core.autocrlf=true` (the Windows default) checks them out CRLF, and Docker `COPY` is byte-verbatim — so `sha256sum` parses the filename as `kube-lineage.gz\r` and the build dies at step 8/20:

```
sha256sum: 'kube-lineage.gz'$'\r': No such file or directory
kube-lineage.gz: FAILED open or read
```

All three manifests (`kube-lineage`, `argocd`, `helm`) are affected — `kube-lineage` is just the first COPY step. The `.gz` payloads are unaffected because git detects them as binary, which is why the checksums pass the moment the CR is gone.

CI and Linux/macOS clones were never affected, which is why this went unnoticed.

## Fix

One `.gitattributes` rule pinning `*.sha256` to LF on checkout, regardless of anyone's `core.autocrlf`.

## Testing

Verified end to end on a Windows clone:

- `git check-attr` resolves to `text: set`, `eol: lf`
- a forced fresh checkout (`rm` + `git checkout --`) now produces LF
- `docker build --target builder` completes, with all three steps passing:

```
#12 [builder  8/20] ... sha256sum -c kube-lineage.gz.sha256  ->  kube-lineage.gz: OK
#16 [builder 12/20] ... sha256sum -c argocd.gz.sha256        ->  argocd.gz: OK
#19 [builder 15/20] ... sha256sum -c helm.gz.sha256          ->  helm.gz: OK
```

`/kube-lineage --version` passes too, so the extracted binary is sound.

Note that simply stripping the CR by hand is not a durable fix — git reports the files as modified with *"LF will be replaced by CRLF the next time Git touches it"* and silently reverts them on the next `checkout`/`pull`/`merge` touching those paths. The attribute is what makes it stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository rules to ensure SHA-256 checksum files consistently use LF line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->