### PR TITLE
ROB-841 Add RFC 8707 resource indicator support to MCP OAuth flow

### DIFF
--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -134,6 +134,7 @@ class OAuthCallbackRequest(BaseModel):
     redirect_uri: str
     client_id: Optional[str] = None
     client_secret: Optional[str] = None  # Required by some IdPs (e.g. Supabase) that don't support public clients
+    resource: Optional[str] = None  # RFC 8707 resource indicator (canonical MCP server URL)
     user_id: Optional[str] = None
 
 

--- a/holmes/core/oauth_config.py
+++ b/holmes/core/oauth_config.py
@@ -43,8 +43,13 @@ def exchange_code_for_tokens(
     client_id: str,
     code_verifier: Optional[str] = None,
     client_secret: Optional[str] = None,
+    resource: Optional[str] = None,
 ) -> dict:
     """Exchange an OAuth authorization code for tokens at the IdP's token endpoint.
+
+    ``resource`` is the RFC 8707 resource indicator (the MCP server's canonical
+    URL). The MCP authorization spec (rev 2025-06-18) requires it in the token
+    request; when absent nothing is sent, preserving legacy behavior.
 
     Returns the parsed JSON token response (containing at least ``access_token``).
     Raises :class:`OAuthTokenExchangeError` on HTTP failure or missing ``access_token``.
@@ -57,6 +62,8 @@ def exchange_code_for_tokens(
     }
     if code_verifier:
         data["code_verifier"] = code_verifier
+    if resource:
+        data["resource"] = resource
 
     # Some IdPs (e.g. Notion) require client credentials via HTTP Basic Auth,
     # while others (e.g. Supabase) accept them in the POST body.
@@ -130,6 +137,7 @@ class OAuthEndpoints:
     client_secret: Optional[str] = None
     scopes: Optional[List[str]] = None
     registration_endpoint: Optional[str] = None
+    resource: Optional[str] = None
 
 
 class MCPOAuthConfig(BaseModel):
@@ -148,6 +156,7 @@ class MCPOAuthConfig(BaseModel):
     client_secret: Optional[str] = Field(default=None, description="OAuth client secret for confidential clients.")
     scopes: Optional[List[str]] = Field(default=None, description="OAuth scopes to request.")
     registration_endpoint: Optional[str] = Field(default=None, description="DCR endpoint (auto-populated during discovery, sent to frontend for client registration).")
+    resource: Optional[str] = Field(default=None, description="RFC 8707 resource indicator: the MCP server's canonical URL, sent in authorization and token requests. Defaults to the toolset's MCP server url.")
 
     @model_validator(mode="after")
     def auto_enable_when_configured(self):
@@ -164,7 +173,7 @@ class MCPOAuthConfig(BaseModel):
         environment variables (typically injected from a Kubernetes Secret) —
         same Jinja syntax the headers code path already supports.
         """
-        for field in ("client_secret", "authorization_url", "token_url", "client_id", "registration_endpoint"):
+        for field in ("client_secret", "authorization_url", "token_url", "client_id", "registration_endpoint", "resource"):
             setattr(self, field, render_env_template(getattr(self, field), f"MCPOAuthConfig.{field}"))
         return self
 
@@ -181,6 +190,7 @@ class OAuthDecisionCode(BaseModel):
     code_verifier: Optional[str] = None
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    resource: Optional[str] = None
 
 
 def parse_oauth_decision(decision: Optional[Dict[str, Any]]) -> Optional[OAuthDecisionCode]:
@@ -276,6 +286,7 @@ class OAuthExchangeManager:
                 client_id=client_id,
                 code_verifier=pending.code_verifier,
                 client_secret=client_secret,
+                resource=oauth_code.resource or pending.oauth_config.resource,
             )
         except (OAuthTokenExchangeError, KeyError, Exception):
             logger.exception("OAuth exchange failed (tool_call_id=%s, token_url=%s)", tool_call_id, pending.oauth_config.token_url)

--- a/holmes/core/oauth_config.py
+++ b/holmes/core/oauth_config.py
@@ -278,8 +278,14 @@ class OAuthExchangeManager:
         # to the server-side config (for pre-registered confidential clients like Azure AD).
         client_secret = oauth_code.client_secret or pending.oauth_config.client_secret
 
-        # RFC 8707 resource indicator: a frontend-supplied value wins over config
-        effective_resource = oauth_code.resource or pending.oauth_config.resource
+        # RFC 8707 resource indicator: a frontend-supplied value wins over config.
+        # None-based precedence so an explicit empty-string override (opt out of
+        # sending a resource) is not silently replaced by the configured value.
+        effective_resource = (
+            oauth_code.resource
+            if oauth_code.resource is not None
+            else pending.oauth_config.resource
+        )
 
         try:
             token_data = exchange_code_for_tokens(
@@ -297,7 +303,7 @@ class OAuthExchangeManager:
 
         # Record the resource the token was actually issued for, so cache and
         # persistent storage use it for refreshes instead of the configured default.
-        if effective_resource:
+        if effective_resource is not None:
             token_data["resource"] = effective_resource
 
         if token_manager is None:

--- a/holmes/core/oauth_config.py
+++ b/holmes/core/oauth_config.py
@@ -278,6 +278,9 @@ class OAuthExchangeManager:
         # to the server-side config (for pre-registered confidential clients like Azure AD).
         client_secret = oauth_code.client_secret or pending.oauth_config.client_secret
 
+        # RFC 8707 resource indicator: a frontend-supplied value wins over config
+        effective_resource = oauth_code.resource or pending.oauth_config.resource
+
         try:
             token_data = exchange_code_for_tokens(
                 token_url=pending.oauth_config.token_url,
@@ -286,11 +289,16 @@ class OAuthExchangeManager:
                 client_id=client_id,
                 code_verifier=pending.code_verifier,
                 client_secret=client_secret,
-                resource=oauth_code.resource or pending.oauth_config.resource,
+                resource=effective_resource,
             )
         except (OAuthTokenExchangeError, KeyError, Exception):
             logger.exception("OAuth exchange failed (tool_call_id=%s, token_url=%s)", tool_call_id, pending.oauth_config.token_url)
             return
+
+        # Record the resource the token was actually issued for, so cache and
+        # persistent storage use it for refreshes instead of the configured default.
+        if effective_resource:
+            token_data["resource"] = effective_resource
 
         if token_manager is None:
             from holmes.core.oauth_utils import _get_token_manager

--- a/holmes/core/oauth_server_callbacks.py
+++ b/holmes/core/oauth_server_callbacks.py
@@ -74,6 +74,10 @@ def process_oauth_callback(
     # to the server-side config (for pre-registered confidential clients like Azure AD).
     effective_client_secret = request.client_secret or oauth.client_secret
 
+    # RFC 8707 resource indicator: frontend value wins, else the toolset's
+    # configured resource (defaults to the MCP server url).
+    effective_resource = request.resource or oauth.resource
+
     logger.info("OAuth exchange: token_url=%s client_id=%s", oauth.token_url, effective_client_id)
     token_data = exchange_code_for_tokens(
         token_url=oauth.token_url,
@@ -82,9 +86,12 @@ def process_oauth_callback(
         client_id=effective_client_id,
         code_verifier=request.code_verifier,
         client_secret=effective_client_secret,
+        resource=effective_resource,
     )
     # Include client_id in token_data so store_token persists it for refresh
     token_data["client_id"] = effective_client_id
+    if effective_resource:
+        token_data["resource"] = effective_resource
 
     request_context = {"user_id": request.user_id} if request.user_id else None
     mgr.store_token(oauth, token_data, request_context=request_context)

--- a/holmes/core/oauth_server_callbacks.py
+++ b/holmes/core/oauth_server_callbacks.py
@@ -75,8 +75,9 @@ def process_oauth_callback(
     effective_client_secret = request.client_secret or oauth.client_secret
 
     # RFC 8707 resource indicator: frontend value wins, else the toolset's
-    # configured resource (defaults to the MCP server url).
-    effective_resource = request.resource or oauth.resource
+    # configured resource (defaults to the MCP server url). None-based precedence
+    # so an explicit empty-string override is preserved.
+    effective_resource = request.resource if request.resource is not None else oauth.resource
 
     logger.info("OAuth exchange: token_url=%s client_id=%s", oauth.token_url, effective_client_id)
     token_data = exchange_code_for_tokens(
@@ -90,7 +91,7 @@ def process_oauth_callback(
     )
     # Include client_id in token_data so store_token persists it for refresh
     token_data["client_id"] = effective_client_id
-    if effective_resource:
+    if effective_resource is not None:
         token_data["resource"] = effective_resource
 
     request_context = {"user_id": request.user_id} if request.user_id else None

--- a/holmes/core/oauth_utils.py
+++ b/holmes/core/oauth_utils.py
@@ -194,8 +194,9 @@ def build_authorization_url(
     code_challenge: str,
     state: str,
     scopes: Optional[List[str]] = None,
+    resource: Optional[str] = None,
 ) -> str:
-    """Build the full authorization URL with PKCE and scope parameters."""
+    """Build the full authorization URL with PKCE, scope, and RFC 8707 resource parameters."""
     params = {
         "response_type": "code",
         "client_id": client_id,
@@ -206,6 +207,8 @@ def build_authorization_url(
     }
     if scopes:
         params["scope"] = " ".join(scopes)
+    if resource:
+        params["resource"] = resource
     return f"{authorization_url}?{urlencode(params)}"
 
 
@@ -253,6 +256,7 @@ def cli_oauth_flow(oauth: OAuthEndpoints, server_name: str) -> Optional[Dict[str
         state = secrets.token_urlsafe(32)
         auth_url = build_authorization_url(
             oauth.authorization_url, oauth.client_id, redirect_uri, code_challenge, state, oauth.scopes,
+            resource=oauth.resource,
         )
 
         logger.info("CLI OAuth %s: opening browser for authentication", server_name)
@@ -284,6 +288,7 @@ def cli_oauth_flow(oauth: OAuthEndpoints, server_name: str) -> Optional[Dict[str
             client_id=oauth.client_id,
             code_verifier=code_verifier,
             client_secret=oauth.client_secret,
+            resource=oauth.resource,
         )
     except OAuthTokenExchangeError as e:
         logger.warning("CLI OAuth %s: token exchange failed: %s", server_name, e)

--- a/holmes/plugins/toolsets/mcp/oauth_token_manager.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_manager.py
@@ -118,6 +118,7 @@ class OAuthTokenManager:
                 client_id=token_data.get("client_id"),
                 authorization_url=provider_name,
                 user_id=user_id if user_id != DEFAULT_CLI_USER else None,
+                resource=token_data.get("resource"),
             )
             loaded += 1
 
@@ -174,6 +175,7 @@ class OAuthTokenManager:
                 client_id=stored_token.get("client_id", oauth_config.client_id),
                 authorization_url=oauth_config.authorization_url,
                 user_id=user_id,
+                resource=stored_token.get("resource", getattr(oauth_config, "resource", None)),
             )
             logger.debug("OAuthTokenManager: loaded token from store (provider=%s)", oauth_config.authorization_url)
             return stored_token["access_token"]
@@ -224,6 +226,7 @@ class OAuthTokenManager:
             client_id=oauth_config.client_id,
             authorization_url=oauth_config.authorization_url,
             user_id=user_id,
+            resource=getattr(oauth_config, "resource", None),
         )
 
         if self._store:
@@ -233,6 +236,7 @@ class OAuthTokenManager:
                 user_id=user_id,
                 token_url=oauth_config.token_url,
                 client_id=oauth_config.client_id,
+                resource=getattr(oauth_config, "resource", None),
             )
 
         logger.debug(
@@ -311,7 +315,7 @@ class OAuthTokenManager:
         """Refresh a single expiring token and push to persistent store."""
         refresh_token = entry.refresh_token
         if refresh_token and entry.token_url:
-            result = self._do_refresh_request(entry.token_url, entry.client_id, refresh_token, cache_key)
+            result = self._do_refresh_request(entry.token_url, entry.client_id, refresh_token, cache_key, resource=entry.resource)
             if result:
                 token_data, _access_token, _expires_in = result
                 if self._store:
@@ -321,6 +325,7 @@ class OAuthTokenManager:
                         user_id=entry.user_id,
                         token_url=entry.token_url,
                         client_id=entry.client_id,
+                        resource=entry.resource,
                     )
                 logger.info("OAuthTokenManager: sweep refreshed token (cache_key=%s)", cache_key)
                 return
@@ -341,6 +346,7 @@ class OAuthTokenManager:
                 client_id=entry.client_id,
                 authorization_url=entry.authorization_url,
                 user_id=entry.user_id,
+                resource=stored.get("resource", entry.resource),
             )
             logger.info("OAuthTokenManager: sweep reloaded token from store (cache_key=%s)", cache_key)
 
@@ -353,7 +359,10 @@ class OAuthTokenManager:
             return None
 
         try:
-            result = self._do_refresh_request(oauth_config.token_url, oauth_config.client_id, refresh_token, cache_key)
+            result = self._do_refresh_request(
+                oauth_config.token_url, oauth_config.client_id, refresh_token, cache_key,
+                resource=getattr(oauth_config, "resource", None),
+            )
             if not result:
                 self._cache.evict(cache_key)
                 return None
@@ -366,6 +375,7 @@ class OAuthTokenManager:
                     user_id=user_id,
                     token_url=oauth_config.token_url,
                     client_id=oauth_config.client_id,
+                    resource=getattr(oauth_config, "resource", None),
                 )
             return access_token
         except Exception:
@@ -375,19 +385,26 @@ class OAuthTokenManager:
 
     def _do_refresh_request(
         self, token_url: str, client_id: Optional[str], refresh_token: str, cache_key: str,
+        resource: Optional[str] = None,
     ) -> Optional[Tuple[Dict[str, Any], str, int]]:
         """POST to token endpoint, validate response, update cache.
+
+        ``resource`` is the RFC 8707 resource indicator; when set it is included
+        in the refresh request as required by the MCP authorization spec.
 
         Returns (token_data, access_token, expires_in) on success, None on failure.
         """
         logger.debug("OAuthTokenManager: refreshing token at %s (cache_key=%s)", token_url, cache_key)
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+        }
+        if resource:
+            data["resource"] = resource
         response = httpx.post(
             token_url,
-            data={
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-                "client_id": client_id,
-            },
+            data=data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=30,
         )
@@ -408,6 +425,7 @@ class OAuthTokenManager:
             expires_in=expires_in,
             refresh_token=token_data.get("refresh_token", refresh_token),
             refresh_expires_in=token_data.get("refresh_expires_in"),
+            resource=resource,
         )
         logger.debug("OAuthTokenManager: token refreshed (cache_key=%s, expires_in=%s)", cache_key, expires_in)
         return token_data, access_token, expires_in

--- a/holmes/plugins/toolsets/mcp/oauth_token_manager.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_manager.py
@@ -216,6 +216,10 @@ class OAuthTokenManager:
 
         expires_in = token_data.get("expires_in", 300)
 
+        # RFC 8707: prefer the effective resource recorded on the token during the
+        # exchange (e.g. a frontend override) over the configured default.
+        resource = token_data.get("resource", getattr(oauth_config, "resource", None))
+
         self._cache.set(
             cache_key,
             access_token,
@@ -226,7 +230,7 @@ class OAuthTokenManager:
             client_id=oauth_config.client_id,
             authorization_url=oauth_config.authorization_url,
             user_id=user_id,
-            resource=getattr(oauth_config, "resource", None),
+            resource=resource,
         )
 
         if self._store:
@@ -236,7 +240,7 @@ class OAuthTokenManager:
                 user_id=user_id,
                 token_url=oauth_config.token_url,
                 client_id=oauth_config.client_id,
-                resource=getattr(oauth_config, "resource", None),
+                resource=resource,
             )
 
         logger.debug(
@@ -358,10 +362,16 @@ class OAuthTokenManager:
         if not refresh_token:
             return None
 
+        # RFC 8707: prefer the resource the cached token was issued for (which may
+        # be a frontend override) over the configured default.
+        resource = self._cache.get_resource(cache_key)
+        if resource is None:
+            resource = getattr(oauth_config, "resource", None)
+
         try:
             result = self._do_refresh_request(
                 oauth_config.token_url, oauth_config.client_id, refresh_token, cache_key,
-                resource=getattr(oauth_config, "resource", None),
+                resource=resource,
             )
             if not result:
                 self._cache.evict(cache_key)
@@ -375,7 +385,7 @@ class OAuthTokenManager:
                     user_id=user_id,
                     token_url=oauth_config.token_url,
                     client_id=oauth_config.client_id,
-                    resource=getattr(oauth_config, "resource", None),
+                    resource=resource,
                 )
             return access_token
         except Exception:

--- a/holmes/plugins/toolsets/mcp/oauth_token_manager.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_manager.py
@@ -148,23 +148,40 @@ class OAuthTokenManager:
             return None
 
         cache_key = self._build_cache_key(user_id, oauth_config.authorization_url)
+        requested_resource = getattr(oauth_config, "resource", None)
 
-        # 1. Check in-memory cache
+        # 1. Check in-memory cache. Serve a hit only if the token was issued for
+        #    the resource this toolset needs (RFC 8707 audience binding) — toolsets
+        #    sharing an IdP but targeting different MCP resources must not reuse it.
         cached = self._cache.get_valid_access_token(cache_key)
         if cached:
-            return cached
+            cached_resource = self._cache.get_resource(cache_key)
+            if self._resource_compatible(cached_resource, requested_resource):
+                return cached
+            logger.warning(
+                "OAuthTokenManager: cached token was issued for resource %r, not %r — refusing cross-resource reuse, attempting refresh",
+                cached_resource, requested_resource,
+            )
 
-        # 2. Try refresh
+        # 2. Try refresh (mints an audience-correct token when the cached one was
+        #    issued for a different resource)
         refreshed = self._refresh_token(cache_key, oauth_config, user_id=user_id)
         if refreshed:
             return refreshed
 
-        # 3. Check persistent store
+        # 3. Check persistent store — same audience check as the cache
         if not self._store:
             return None
         provider_name = oauth_config.authorization_url or (disk_key or "unknown")
         stored_token = self._store.get_token(provider_name, user_id=user_id, provider_aliases=provider_aliases)
         if stored_token and stored_token.get("access_token"):
+            stored_resource = stored_token.get("resource")
+            if not self._resource_compatible(stored_resource, requested_resource):
+                logger.warning(
+                    "OAuthTokenManager: stored token was issued for resource %r, not %r — refusing cross-resource reuse",
+                    stored_resource, requested_resource,
+                )
+                return None
             self._cache.set(
                 cache_key,
                 stored_token["access_token"],
@@ -175,12 +192,26 @@ class OAuthTokenManager:
                 client_id=stored_token.get("client_id", oauth_config.client_id),
                 authorization_url=oauth_config.authorization_url,
                 user_id=user_id,
-                resource=stored_token.get("resource", getattr(oauth_config, "resource", None)),
+                resource=stored_token.get("resource", requested_resource),
             )
             logger.debug("OAuthTokenManager: loaded token from store (provider=%s)", oauth_config.authorization_url)
             return stored_token["access_token"]
 
         return None
+
+    @staticmethod
+    def _resource_compatible(token_resource: Optional[str], requested_resource: Optional[str]) -> bool:
+        """RFC 8707 audience check for serving a token.
+
+        A token may be served when either side doesn't specify a resource —
+        None (legacy entries / resource-less callers) and "" (explicit opt-out)
+        both mean unspecified — or when the resources match exactly. Two
+        different non-empty resources mean the token was issued for a different
+        MCP server and must not be reused.
+        """
+        if not token_resource or not requested_resource:
+            return True
+        return token_resource == requested_resource
 
     def has_token(
         self,
@@ -362,11 +393,19 @@ class OAuthTokenManager:
         if not refresh_token:
             return None
 
-        # RFC 8707: prefer the resource the cached token was issued for (which may
-        # be a frontend override) over the configured default.
-        resource = self._cache.get_resource(cache_key)
-        if resource is None:
-            resource = getattr(oauth_config, "resource", None)
+        # RFC 8707: refresh for the resource the cached token was issued for
+        # (which may be a frontend override or an explicit "" opt-out). When the
+        # caller demands a *different* non-empty resource, request that instead —
+        # a token minted for the cached resource would be rejected by the
+        # caller's MCP server anyway (audience binding).
+        requested = getattr(oauth_config, "resource", None)
+        cached_resource = self._cache.get_resource(cache_key)
+        if requested and cached_resource and cached_resource != requested:
+            resource = requested
+        elif cached_resource is not None:
+            resource = cached_resource
+        else:
+            resource = requested
 
         try:
             result = self._do_refresh_request(

--- a/holmes/plugins/toolsets/mcp/oauth_token_store.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_store.py
@@ -92,6 +92,14 @@ class OAuthTokenCache:
                 return None
             return entry.refresh_token
 
+    def get_resource(self, key: str) -> Optional[str]:
+        """Return the RFC 8707 resource the cached token was issued for, if any."""
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            return entry.resource
+
     def set(
         self,
         key: str,
@@ -260,7 +268,7 @@ class DalTokenStore(TokenStore):
                 enriched["token_url"] = token_url
             if client_id:
                 enriched["client_id"] = client_id
-            if resource:
+            if resource is not None:
                 enriched["resource"] = resource
             encrypted = self._encrypt_token(enriched)
             if not encrypted:
@@ -404,7 +412,16 @@ class DiskTokenStore(TokenStore):
             return False
         with self._lock:
             data = self._load()
-            data[provider_name] = token_data
+            # Include metadata needed for refresh after a process restart
+            # (mirrors DalTokenStore's enrichment)
+            enriched = dict(token_data)
+            if token_url:
+                enriched["token_url"] = token_url
+            if client_id:
+                enriched["client_id"] = client_id
+            if resource is not None:
+                enriched["resource"] = resource
+            data[provider_name] = enriched
             fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             with os.fdopen(fd, "w") as f:
                 json.dump(data, f, indent=2)

--- a/holmes/plugins/toolsets/mcp/oauth_token_store.py
+++ b/holmes/plugins/toolsets/mcp/oauth_token_store.py
@@ -38,6 +38,7 @@ class _CachedToken:
         client_id: Optional[str] = None,
         authorization_url: Optional[str] = None,
         user_id: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> None:
         self.access_token = access_token
         self.expires_at = expires_at
@@ -48,6 +49,7 @@ class _CachedToken:
         self.client_id = client_id
         self.authorization_url = authorization_url
         self.user_id = user_id
+        self.resource = resource
 
     @property
     def access_expired(self) -> bool:
@@ -101,6 +103,7 @@ class OAuthTokenCache:
         client_id: Optional[str] = None,
         authorization_url: Optional[str] = None,
         user_id: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> None:
         now = time.monotonic()
         # Subtract a small buffer so we refresh before actual expiry
@@ -115,6 +118,7 @@ class OAuthTokenCache:
                 access_token, access_expires_at, refresh_token, refresh_expires_at,
                 token_url=token_url, client_id=client_id,
                 authorization_url=authorization_url, user_id=user_id,
+                resource=resource,
             )
 
     def evict(self, key: str) -> None:
@@ -168,6 +172,7 @@ class TokenStore(ABC):
         user_id: Optional[str] = None,
         token_url: Optional[str] = None,
         client_id: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> bool:
         """Store a token. Returns True on success."""
 
@@ -242,6 +247,7 @@ class DalTokenStore(TokenStore):
         user_id: Optional[str] = None,
         token_url: Optional[str] = None,
         client_id: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> bool:
         signing_key_hash = self._get_signing_key_hash()
         if not signing_key_hash:
@@ -254,6 +260,8 @@ class DalTokenStore(TokenStore):
                 enriched["token_url"] = token_url
             if client_id:
                 enriched["client_id"] = client_id
+            if resource:
+                enriched["resource"] = resource
             encrypted = self._encrypt_token(enriched)
             if not encrypted:
                 logger.warning("Cannot encrypt token (no signing key)")
@@ -390,6 +398,7 @@ class DiskTokenStore(TokenStore):
         user_id: Optional[str] = None,
         token_url: Optional[str] = None,
         client_id: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> bool:
         if not self._enabled:
             return False

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -196,6 +196,17 @@ class MCPConfig(ToolsetConfig):
         examples=["get_me", "get_current_user"],
     )
 
+    @model_validator(mode="after")
+    def default_oauth_resource(self) -> "MCPConfig":
+        """Default the RFC 8707 resource indicator to the MCP server's canonical URL.
+
+        Only fills the value when it wasn't configured explicitly (None); an
+        explicit empty string opts out of sending a resource parameter entirely.
+        """
+        if self.oauth is not None and self.oauth.resource is None:
+            self.oauth.resource = str(self.url).rstrip("/")
+        return self
+
     def get_lock_string(self) -> str:
         return str(self.url)
 
@@ -372,6 +383,7 @@ class RemoteMCPTool(Tool):
                 client_secret=oauth_config.client_secret,
                 scopes=oauth_config.scopes,
                 registration_endpoint=oauth_config.registration_endpoint,
+                resource=oauth_config.resource,
             )
             token_data = cli_oauth_flow(oauth_endpoints, self.toolset.name)
             if token_data:
@@ -404,6 +416,8 @@ class RemoteMCPTool(Tool):
             metadata["scopes"] = oauth_config.scopes
         if oauth_config.registration_endpoint:
             metadata["registration_endpoint"] = oauth_config.registration_endpoint
+        if oauth_config.resource:
+            metadata["resource"] = oauth_config.resource
         params["__oauth_metadata"] = metadata
 
         return ApprovalRequirement(

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -703,6 +703,48 @@ class TestResourceIndicator:
         assert mock_post.call_args[1]["data"]["resource"] == "http://mcp-server:8000/mcp"
         manager2.shutdown()
 
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="override-signing-key")
+    def test_frontend_resource_override_persists_and_wins_on_refresh(self, _mock):
+        """A frontend-supplied resource must be the one persisted with the token and
+        used by refreshes — not the configured default — including after a restart."""
+        oauth_config = self._oauth(resource="http://config-resource/mcp")
+        ctx = {"user_id": "override-user"}
+        dal, _rows = self._fake_dal()
+        manager = self._manager_on(dal)
+
+        tool_call_id = "tc-override-refresh"
+        _get_exchange_manager().register_pending(
+            tool_call_id=tool_call_id, code_verifier="v", oauth_config=oauth_config,
+        )
+        oauth_code = OAuthDecisionCode(
+            toolset_name="t", code="c", redirect_uri="http://cb",
+            resource="http://frontend-resource/mcp",
+        )
+        exchange_response = self._mock_token_response()
+        exchange_response.json.return_value = {
+            "access_token": "tok", "expires_in": 3600, "refresh_token": "rt",
+        }
+        with patch("holmes.core.oauth_config.httpx.post", return_value=exchange_response):
+            _get_exchange_manager().complete_exchange(tool_call_id, oauth_code, ctx, token_manager=manager)
+
+        # Cache holds the effective (frontend) resource, not the configured one
+        cache_key = manager.get_cache_key(oauth_config, ctx)
+        assert manager.cache._cache[cache_key].resource == "http://frontend-resource/mcp"
+
+        # Reactive refresh uses the effective resource
+        manager.cache._cache[cache_key].expires_at = time.monotonic() - 1
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            refreshed = manager.get_access_token(oauth_config, ctx)
+        assert refreshed == "tok"
+        assert mock_post.call_args[1]["data"]["resource"] == "http://frontend-resource/mcp"
+        manager.shutdown()
+
+        # The override survives a restart: a fresh manager preloads it from the DB
+        manager2 = self._manager_on(dal)
+        manager2.preload_from_store()
+        assert manager2.cache._cache[cache_key].resource == "http://frontend-resource/mcp"
+        manager2.shutdown()
+
     @patch("holmes.config.Config.get_robusta_global_config_value", return_value="legacy-signing-key")
     def test_legacy_token_without_resource_falls_back_to_config_after_restart(self, _mock):
         """A token persisted by a pre-upgrade pod (no resource in the blob) must pick up

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -642,6 +642,94 @@ class TestResourceIndicator:
         post_data = mock_post.call_args[1]["data"]
         assert post_data["resource"] == "http://mcp-server:8000/mcp"
 
+    # ── Pod restart round-trip ─────────────────────────────────────────
+
+    def _fake_dal(self):
+        """MagicMock dal backed by an in-memory row store, shared across 'pods'."""
+        rows: dict = {}
+        dal = MagicMock()
+
+        def upsert(provider_name, encrypted_token, signing_key_hash, token_expiry, user_id):
+            rows[(provider_name, user_id)] = {
+                "provider_name": provider_name,
+                "user_id": user_id,
+                "encrypted_token": encrypted_token,
+                "token_expiry": token_expiry,
+            }
+
+        dal.upsert_oauth_token.side_effect = upsert
+        dal.get_oauth_token.side_effect = lambda provider_name, user_id, signing_key_hash: rows.get((provider_name, user_id))
+        dal.get_all_oauth_tokens_for_cluster.side_effect = lambda signing_key_hash: list(rows.values())
+        return dal, rows
+
+    def _manager_on(self, dal) -> OAuthTokenManager:
+        """A fresh OAuthTokenManager (empty cache — i.e. a freshly started pod) over the given dal."""
+        from holmes.plugins.toolsets.mcp.oauth_token_store import DalTokenStore
+
+        manager = OAuthTokenManager()
+        manager._shutdown_event.set()
+        manager._store = DalTokenStore(dal=dal)
+        return manager
+
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="restart-signing-key")
+    def test_resource_survives_pod_restart(self, _mock):
+        """Persist a token with a resource, 'restart' into a new manager with an empty
+        cache, preload from the DB, and verify the sweep refresh still sends the resource."""
+        oauth_config = self._oauth(resource="http://mcp-server:8000/mcp")
+        ctx = {"user_id": "restart-user"}
+        dal, rows = self._fake_dal()
+
+        # Pod 1: store the token as the OAuth exchange would
+        manager1 = self._manager_on(dal)
+        manager1.store_token(
+            oauth_config,
+            {"access_token": "tok-before-restart", "expires_in": 3600, "refresh_token": "rt"},
+            ctx,
+        )
+        assert rows, "token was not persisted to the DB"
+        manager1.shutdown()
+
+        # Pod 2: brand-new manager, empty cache, same DB — startup preload
+        manager2 = self._manager_on(dal)
+        manager2.preload_from_store()
+        cache_key = manager2.get_cache_key(oauth_config, ctx)
+        entry = manager2.cache._cache[cache_key]
+        assert entry.resource == "http://mcp-server:8000/mcp"
+        assert manager2.cache.get_valid_access_token(cache_key) == "tok-before-restart"
+
+        # Background sweep refresh right after restart still sends the resource
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            manager2._refresh_single_token(cache_key, entry)
+        assert mock_post.call_args[1]["data"]["resource"] == "http://mcp-server:8000/mcp"
+        manager2.shutdown()
+
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="legacy-signing-key")
+    def test_legacy_token_without_resource_falls_back_to_config_after_restart(self, _mock):
+        """A token persisted by a pre-upgrade pod (no resource in the blob) must pick up
+        the config-derived resource when loaded on demand after a restart."""
+        oauth_config = self._oauth(resource="http://mcp-server:8000/mcp")
+        ctx = {"user_id": "legacy-user"}
+        dal, _rows = self._fake_dal()
+
+        # Pre-upgrade pod: persist a token blob WITHOUT a resource key
+        manager_old = self._manager_on(dal)
+        manager_old._store.store_token(
+            oauth_config.authorization_url,
+            {"access_token": "legacy-tok", "expires_in": 3600, "refresh_token": "rt"},
+            user_id="legacy-user",
+            token_url=oauth_config.token_url,
+            client_id=oauth_config.client_id,
+        )
+        manager_old.shutdown()
+
+        # Post-upgrade pod: on-demand load falls back to the config's resource
+        manager_new = self._manager_on(dal)
+        token = manager_new.get_access_token(oauth_config, ctx)
+        assert token == "legacy-tok"
+        cache_key = manager_new.get_cache_key(oauth_config, ctx)
+        assert manager_new.cache._cache[cache_key].resource == "http://mcp-server:8000/mcp"
+        manager_new.shutdown()
+
     # ── Frontend metadata ──────────────────────────────────────────────
 
     def test_requires_approval_metadata_includes_resource(self):

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -39,6 +39,7 @@ from holmes.core.oauth_config import (
 )
 from holmes.core.oauth_utils import (
     _get_token_manager,
+    build_authorization_url,
     cli_oauth_flow,
     generate_pkce,
 )
@@ -438,6 +439,246 @@ class TestExchangeCodeForToken:
                     client_secret="slack-client-secret",
                 )
             assert "access_token" in str(excinfo.value.detail)
+
+
+class TestResourceIndicator:
+    """RFC 8707 resource indicator support (MCP authorization spec rev 2025-06-18)."""
+
+    def _oauth(self, **kwargs):
+        return MCPOAuthConfig(
+            enabled=True,
+            authorization_url="http://idp/authorize",
+            token_url="http://idp/token",
+            client_id="cid",
+            **kwargs,
+        )
+
+    def _mock_token_response(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "access_token": "tok",
+            "token_type": "Bearer",
+            "expires_in": 300,
+        }
+        return mock_response
+
+    # ── Config defaulting ──────────────────────────────────────────────
+
+    def test_resource_defaults_to_mcp_server_url(self):
+        config = MCPConfig(
+            url="http://mcp-server:8000/mcp",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=self._oauth(),
+        )
+        assert config.oauth.resource == "http://mcp-server:8000/mcp"
+
+    def test_resource_default_strips_trailing_slash(self):
+        config = MCPConfig(
+            url="http://mcp-server:8000",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=self._oauth(),
+        )
+        assert config.oauth.resource == "http://mcp-server:8000"
+
+    def test_resource_explicit_override_preserved(self):
+        config = MCPConfig(
+            url="http://mcp-server:8000/mcp",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=self._oauth(resource="https://canonical.example.com/mcp"),
+        )
+        assert config.oauth.resource == "https://canonical.example.com/mcp"
+
+    def test_resource_empty_string_opts_out_of_default(self):
+        config = MCPConfig(
+            url="http://mcp-server:8000/mcp",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=self._oauth(resource=""),
+        )
+        assert config.oauth.resource == ""
+
+    def test_resource_none_on_standalone_oauth_config(self):
+        assert self._oauth().resource is None
+
+    def test_resource_env_template_rendered(self, monkeypatch):
+        monkeypatch.setenv("MCP_OAUTH_RESOURCE", "https://env.example.com/mcp")
+        oauth = self._oauth(resource="{{ env.MCP_OAUTH_RESOURCE }}")
+        assert oauth.resource == "https://env.example.com/mcp"
+
+    def test_get_oauth_config_includes_resource(self):
+        toolset = RemoteMCPToolset(name="test-resource", enabled=True)
+        toolset._mcp_config = MCPConfig(
+            url="http://mcp-server:8000/mcp",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=self._oauth(),
+        )
+        published = toolset.get_oauth_config()
+        assert published["resource"] == "http://mcp-server:8000/mcp"
+
+    # ── Authorization URL ──────────────────────────────────────────────
+
+    def test_build_authorization_url_includes_resource(self):
+        url = build_authorization_url(
+            "http://idp/authorize", "cid", "http://cb", "chal", "state1",
+            resource="http://mcp-server:8000/mcp",
+        )
+        params = parse_qs(urlparse(url).query)
+        assert params["resource"] == ["http://mcp-server:8000/mcp"]
+
+    def test_build_authorization_url_omits_resource_when_absent(self):
+        url = build_authorization_url("http://idp/authorize", "cid", "http://cb", "chal", "state1")
+        params = parse_qs(urlparse(url).query)
+        assert "resource" not in params
+
+    # ── Token exchange ─────────────────────────────────────────────────
+
+    def test_exchange_includes_resource(self):
+        with patch("holmes.core.oauth_config.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            exchange_code_for_tokens(
+                token_url="http://idp/token",
+                code="c",
+                redirect_uri="http://cb",
+                client_id="cid",
+                resource="http://mcp-server:8000/mcp",
+            )
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["resource"] == "http://mcp-server:8000/mcp"
+
+    def test_exchange_omits_resource_when_absent(self):
+        with patch("holmes.core.oauth_config.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            exchange_code_for_tokens(
+                token_url="http://idp/token",
+                code="c",
+                redirect_uri="http://cb",
+                client_id="cid",
+            )
+        post_data = mock_post.call_args[1]["data"]
+        assert "resource" not in post_data
+
+    def test_complete_exchange_uses_config_resource(self):
+        tool_call_id = "tc-resource-config"
+        oauth_config = self._oauth(resource="http://mcp-server:8000/mcp")
+        _get_exchange_manager().register_pending(
+            tool_call_id=tool_call_id, code_verifier="v", oauth_config=oauth_config,
+        )
+        oauth_code = OAuthDecisionCode(toolset_name="t", code="c", redirect_uri="http://cb")
+        request_context = {"user_id": "test-user"}
+
+        with patch("holmes.core.oauth_config.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            _get_exchange_manager().complete_exchange(tool_call_id, oauth_code, request_context)
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["resource"] == "http://mcp-server:8000/mcp"
+
+    def test_complete_exchange_frontend_resource_wins(self):
+        tool_call_id = "tc-resource-frontend"
+        oauth_config = self._oauth(resource="http://config-resource/mcp")
+        _get_exchange_manager().register_pending(
+            tool_call_id=tool_call_id, code_verifier="v", oauth_config=oauth_config,
+        )
+        oauth_code = OAuthDecisionCode(
+            toolset_name="t", code="c", redirect_uri="http://cb",
+            resource="http://frontend-resource/mcp",
+        )
+        request_context = {"user_id": "test-user"}
+
+        with patch("holmes.core.oauth_config.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            _get_exchange_manager().complete_exchange(tool_call_id, oauth_code, request_context)
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["resource"] == "http://frontend-resource/mcp"
+
+    def test_complete_exchange_no_resource_is_byte_identical(self):
+        tool_call_id = "tc-resource-none"
+        oauth_config = self._oauth()
+        _get_exchange_manager().register_pending(
+            tool_call_id=tool_call_id, code_verifier="v", oauth_config=oauth_config,
+        )
+        oauth_code = OAuthDecisionCode(toolset_name="t", code="c", redirect_uri="http://cb")
+        request_context = {"user_id": "test-user"}
+
+        with patch("holmes.core.oauth_config.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            _get_exchange_manager().complete_exchange(tool_call_id, oauth_code, request_context)
+        post_data = mock_post.call_args[1]["data"]
+        assert "resource" not in post_data
+
+    # ── Refresh requests ───────────────────────────────────────────────
+
+    def test_refresh_request_includes_resource(self):
+        mgr = _get_token_manager()
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            result = mgr._do_refresh_request(
+                "http://idp/token", "cid", "rt", "cache-key-resource",
+                resource="http://mcp-server:8000/mcp",
+            )
+        assert result is not None
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["grant_type"] == "refresh_token"
+        assert post_data["resource"] == "http://mcp-server:8000/mcp"
+
+    def test_refresh_request_omits_resource_when_absent(self):
+        mgr = _get_token_manager()
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            result = mgr._do_refresh_request("http://idp/token", "cid", "rt", "cache-key-no-resource")
+        assert result is not None
+        post_data = mock_post.call_args[1]["data"]
+        assert "resource" not in post_data
+
+    def test_sweep_refresh_uses_cached_entry_resource(self):
+        """The background sweep refreshes from the cache entry — resource must survive the round-trip."""
+        mgr = _get_token_manager()
+        oauth_config = self._oauth(resource="http://mcp-server:8000/mcp")
+        request_context = {"user_id": "sweep-user"}
+        mgr.store_token(
+            oauth_config,
+            {"access_token": "tok", "expires_in": 60, "refresh_token": "rt"},
+            request_context,
+        )
+        cache_key = mgr.get_cache_key(oauth_config, request_context)
+        entry = mgr.cache._cache[cache_key]
+        assert entry.resource == "http://mcp-server:8000/mcp"
+
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_post:
+            mgr._refresh_single_token(cache_key, entry)
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["resource"] == "http://mcp-server:8000/mcp"
+
+    # ── Frontend metadata ──────────────────────────────────────────────
+
+    def test_requires_approval_metadata_includes_resource(self):
+        oauth = self._oauth(scopes=["mcp:tools"])
+        toolset = RemoteMCPToolset(name="test-resource-meta", enabled=True)
+        toolset._mcp_config = MCPConfig(
+            url="http://mcp-server:8000/mcp",
+            mode=MCPMode.STREAMABLE_HTTP,
+            oauth=oauth,
+        )
+        tool = RemoteMCPTool(name="t", description="", parameters={}, toolset=toolset)
+        context = MagicMock()
+        context.user_approved = False
+        context.tool_call_id = "tc-resource-meta"
+        context.request_context = {"user_id": "meta-user"}
+
+        cache_key = _get_token_manager().get_cache_key(oauth, context.request_context)
+        _get_token_manager().cache.evict(cache_key)
+        _get_token_manager()._store = MagicMock()
+        _get_token_manager()._store.get_token.return_value = None
+
+        params = {}
+        result = tool.requires_approval(params, context)
+        assert result is not None
+        assert params["__oauth_metadata"]["resource"] == "http://mcp-server:8000/mcp"
+
+    def test_oauth_decision_code_parses_resource(self):
+        decision = parse_oauth_decision(
+            {
+                "toolset_name": "t",
+                "code": "c",
+                "redirect_uri": "http://cb",
+                "resource": "http://mcp-server:8000/mcp",
+            }
+        )
+        assert decision is not None
+        assert decision.resource == "http://mcp-server:8000/mcp"
 
 
 class TestParseOAuthDecision:

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -729,13 +729,14 @@ class TestResourceIndicator:
 
         # Cache holds the effective (frontend) resource, not the configured one
         cache_key = manager.get_cache_key(oauth_config, ctx)
-        assert manager.cache._cache[cache_key].resource == "http://frontend-resource/mcp"
+        entry = manager.cache._cache[cache_key]
+        assert entry.resource == "http://frontend-resource/mcp"
 
-        # Reactive refresh uses the effective resource
-        manager.cache._cache[cache_key].expires_at = time.monotonic() - 1
+        # The background sweep refreshes with the resource the token was issued
+        # for. (A caller demanding a *different* resource instead gets an
+        # audience-correct refresh — see test_cache_hit_refused_for_different_resource.)
         with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_post:
-            refreshed = manager.get_access_token(oauth_config, ctx)
-        assert refreshed == "tok"
+            manager._refresh_single_token(cache_key, entry)
         assert mock_post.call_args[1]["data"]["resource"] == "http://frontend-resource/mcp"
         manager.shutdown()
 
@@ -744,6 +745,119 @@ class TestResourceIndicator:
         manager2.preload_from_store()
         assert manager2.cache._cache[cache_key].resource == "http://frontend-resource/mcp"
         manager2.shutdown()
+
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="empty-override-signing-key")
+    def test_frontend_empty_resource_override_preserved(self, _mock):
+        """An explicit frontend resource='' override (opt out of RFC 8707) must not be
+        replaced by the configured resource — through exchange, cache, refresh, and restart."""
+        oauth_config = self._oauth(resource="http://config-resource/mcp")
+        ctx = {"user_id": "empty-override-user"}
+        dal, _rows = self._fake_dal()
+        manager = self._manager_on(dal)
+
+        tool_call_id = "tc-empty-override"
+        _get_exchange_manager().register_pending(
+            tool_call_id=tool_call_id, code_verifier="v", oauth_config=oauth_config,
+        )
+        oauth_code = OAuthDecisionCode(
+            toolset_name="t", code="c", redirect_uri="http://cb", resource="",
+        )
+        exchange_response = self._mock_token_response()
+        exchange_response.json.return_value = {
+            "access_token": "tok", "expires_in": 3600, "refresh_token": "rt",
+        }
+        with patch("holmes.core.oauth_config.httpx.post", return_value=exchange_response) as mock_post:
+            _get_exchange_manager().complete_exchange(tool_call_id, oauth_code, ctx, token_manager=manager)
+        # Exchange sent no resource parameter at all
+        assert "resource" not in mock_post.call_args[1]["data"]
+
+        # The empty override is what's cached, not the configured value
+        cache_key = manager.get_cache_key(oauth_config, ctx)
+        assert manager.cache._cache[cache_key].resource == ""
+
+        # Refresh sends no resource parameter
+        manager.cache._cache[cache_key].expires_at = time.monotonic() - 1
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=self._mock_token_response()) as mock_refresh:
+            manager.get_access_token(oauth_config, ctx)
+        assert "resource" not in mock_refresh.call_args[1]["data"]
+        manager.shutdown()
+
+        # The empty override survives a restart
+        manager2 = self._manager_on(dal)
+        manager2.preload_from_store()
+        assert manager2.cache._cache[cache_key].resource == ""
+        manager2.shutdown()
+
+    # ── RFC 8707 audience binding on token lookup ──────────────────────
+
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="audience-signing-key")
+    def test_cache_hit_refused_for_different_resource(self, _mock):
+        """A cached token issued for one MCP resource must not be served to a toolset
+        that shares the IdP but targets a different resource; refresh mints an
+        audience-correct token for the requested resource instead."""
+        config_a = self._oauth(resource="http://mcp-a:8000/mcp")
+        config_b = self._oauth(resource="http://mcp-b:8000/mcp")
+        ctx = {"user_id": "audience-user"}
+        dal, _rows = self._fake_dal()
+        manager = self._manager_on(dal)
+
+        manager.store_token(
+            config_a,
+            {"access_token": "tok-for-a", "expires_in": 3600, "refresh_token": "rt"},
+            ctx,
+        )
+
+        refresh_response = self._mock_token_response()
+        refresh_response.json.return_value = {"access_token": "tok-for-b", "expires_in": 300}
+        with patch("holmes.plugins.toolsets.mcp.oauth_token_manager.httpx.post", return_value=refresh_response) as mock_post:
+            token = manager.get_access_token(config_b, ctx)
+
+        assert token != "tok-for-a"
+        assert token == "tok-for-b"
+        assert mock_post.call_args[1]["data"]["grant_type"] == "refresh_token"
+        assert mock_post.call_args[1]["data"]["resource"] == "http://mcp-b:8000/mcp"
+        manager.shutdown()
+
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="audience-signing-key-2")
+    def test_stored_token_refused_for_different_resource(self, _mock):
+        """A persisted token issued for one resource must not be loaded from the store
+        for a toolset requesting a different resource."""
+        config_a = self._oauth(resource="http://mcp-a:8000/mcp")
+        config_b = self._oauth(resource="http://mcp-b:8000/mcp")
+        ctx = {"user_id": "audience-store-user"}
+        dal, _rows = self._fake_dal()
+
+        manager_a = self._manager_on(dal)
+        manager_a._store.store_token(
+            config_a.authorization_url,
+            {"access_token": "tok-for-a", "expires_in": 3600},
+            user_id="audience-store-user",
+            token_url=config_a.token_url,
+            client_id=config_a.client_id,
+            resource=config_a.resource,
+        )
+        manager_a.shutdown()
+
+        # Fresh manager (empty cache, no refresh token) — the store hit is refused
+        manager_b = self._manager_on(dal)
+        assert manager_b.get_access_token(config_b, ctx) is None
+        # ...but the toolset the token was issued for still gets it
+        assert manager_b.get_access_token(config_a, ctx) == "tok-for-a"
+        manager_b.shutdown()
+
+    @patch("holmes.config.Config.get_robusta_global_config_value", return_value="audience-signing-key-3")
+    def test_legacy_cached_token_served_to_resource_aware_caller(self, _mock):
+        """Safe fallback: a legacy token with no resource metadata keeps working for
+        callers that do request a resource (no forced re-auth on upgrade)."""
+        config = self._oauth(resource="http://mcp-a:8000/mcp")
+        ctx = {"user_id": "legacy-audience-user"}
+        dal, _rows = self._fake_dal()
+        manager = self._manager_on(dal)
+
+        cache_key = manager.get_cache_key(config, ctx)
+        manager.cache.set(cache_key, "legacy-tok", expires_in=3600)  # no resource metadata
+        assert manager.get_access_token(config, ctx) == "legacy-tok"
+        manager.shutdown()
 
     @patch("holmes.config.Config.get_robusta_global_config_value", return_value="legacy-signing-key")
     def test_legacy_token_without_resource_falls_back_to_config_after_restart(self, _mock):


### PR DESCRIPTION
Linear: [ROB-841](https://linear.app/robusta/issue/ROB-841/add-rfc-8707-support-to-oauth)

The current MCP authorization spec requires clients to send an RFC 8707 'resource' parameter identifying the MCP server's canonical URL in both the authorization request and the token exchange. Spec-compliant servers reject requests without it.

- Add optional 'resource' field to MCPOAuthConfig, defaulting to the toolset's MCP server url (overridable; empty string opts out). It is published to HolmesToolsStatus.meta.oauth_config for the frontend.
- Send 'resource' in the token exchange (frontend value wins over config), in refresh-token requests, and in the CLI flow's authorization URL.
- Expose it in the __oauth_metadata approval payload, OAuthDecisionCode, and OAuthCallbackRequest; persist it in the token cache/store so the background refresh sweep keeps sending it.

When 'resource' is absent, no parameter is sent anywhere — never an empty one (behavior unchanged).

Companion frontend PR: robusta-dev/robusta-frontend (same branch name).

## Summary by CodeRabbit

* **New Features**
  * Added support for OAuth 2.0 resource indicators throughout authorization, token exchange, refresh, and approval flows.
  * Resource values can be configured, supplied by the frontend, or default to the MCP server URL.
  * OAuth tokens now retain resource information across caching, persistence, and refresh operations.

* **Bug Fixes**
  * Ensured explicitly empty resource values remain omitted rather than being replaced by defaults.

* **Tests**
  * Added comprehensive coverage for resource configuration, propagation, persistence, and precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for OAuth resource indicators (RFC 8707) across authorization, token exchange, refresh, and callback flows.
  - Resources can be configured, provided during approval, or default to the MCP server URL.
  - Resource metadata is preserved across token caching, persistence, refreshes, and restarts.
  - Prevented reuse of cached tokens when their resource does not match the requested audience.

- **Tests**
  - Expanded OAuth coverage for defaults, overrides, propagation, persistence, refreshes, restarts, and audience compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->