### PR TITLE
Add eval for PodDisruptionBudgets that actively block evictions

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/285_pdb_blocking_disruptions/manifest.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/285_pdb_blocking_disruptions/manifest.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-285
+---
+# minAvailable equals the replica count, so no pod can be evicted:
+# disruptionsAllowed=0 with expectedPods=1.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nimbus-worker
+  namespace: app-285
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nimbus-worker
+  template:
+    metadata:
+      labels:
+        app: nimbus-worker
+    spec:
+      containers:
+      - name: worker
+        image: registry.k8s.io/pause:3.9
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nimbus-worker-pdb
+  namespace: app-285
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: nimbus-worker
+---
+# Same shape as nimbus: disruptionsAllowed=0 with expectedPods=1.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: solstice-worker
+  namespace: app-285
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: solstice-worker
+  template:
+    metadata:
+      labels:
+        app: solstice-worker
+    spec:
+      containers:
+      - name: worker
+        image: registry.k8s.io/pause:3.9
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: solstice-worker-pdb
+  namespace: app-285
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: solstice-worker
+---
+# The deployment is scaled to zero, so this PDB guards nothing. It still
+# reports disruptionsAllowed=0, but with expectedPods=0 it cannot block an
+# eviction that can never happen.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: driftwood-worker
+  namespace: app-285
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: driftwood-worker
+  template:
+    metadata:
+      labels:
+        app: driftwood-worker
+    spec:
+      containers:
+      - name: worker
+        image: registry.k8s.io/pause:3.9
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: driftwood-worker-pdb
+  namespace: app-285
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: driftwood-worker
+---
+# Two replicas against minAvailable=1 leaves one eviction of headroom:
+# disruptionsAllowed=1.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lighthouse-worker
+  namespace: app-285
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: lighthouse-worker
+  template:
+    metadata:
+      labels:
+        app: lighthouse-worker
+    spec:
+      containers:
+      - name: worker
+        image: registry.k8s.io/pause:3.9
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: lighthouse-worker-pdb
+  namespace: app-285
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: lighthouse-worker

--- a/tests/llm/fixtures/test_ask_holmes/285_pdb_blocking_disruptions/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/285_pdb_blocking_disruptions/test_case.yaml
@@ -1,0 +1,50 @@
+user_prompt: "I need to drain nodes for maintenance in namespace app-285. Which PodDisruptionBudgets are currently blocking pod evictions?"
+
+expected_output:
+  - nimbus-worker-pdb and solstice-worker-pdb are the PodDisruptionBudgets currently blocking evictions, because each allows 0 disruptions while still guarding a running pod
+  - Must NOT report driftwood-worker-pdb as blocking. It also allows 0 disruptions, but it expects 0 pods because its deployment is scaled to zero, so it guards nothing and cannot block an eviction
+  - Must NOT report lighthouse-worker-pdb as blocking, since it currently allows a disruption
+
+tags:
+  - kubernetes
+  - hard
+
+before_test: |
+  set -e
+  kubectl apply -f ./manifest.yaml
+
+  # PDB status is written asynchronously by the disruption controller, and
+  # lighthouse-worker-pdb only allows a disruption once both of its replicas
+  # are ready - until then it is indistinguishable from a blocking budget.
+  # Wait for all four to settle so the expected answer is stable.
+  #
+  # currentHealthy is part of the state on purpose. disruptionsAllowed and
+  # expectedPods alone cannot tell a pending pod from a running one: nimbus
+  # reports disruptionsAllowed=0/expectedPods=1 both while its pod is still
+  # starting and once it is ready. The eval expects a *running* pod, so the
+  # gate has to assert that rather than infer it.
+  pdb_state() {
+    kubectl get pdb "$1" -n app-285 \
+      -o jsonpath='{.status.disruptionsAllowed}/{.status.currentHealthy}/{.status.expectedPods}' 2>/dev/null || true
+  }
+
+  SETTLED=false
+  for i in $(seq 1 90); do
+    if [ "$(pdb_state nimbus-worker-pdb)" = "0/1/1" ] \
+      && [ "$(pdb_state solstice-worker-pdb)" = "0/1/1" ] \
+      && [ "$(pdb_state driftwood-worker-pdb)" = "0/0/0" ] \
+      && [ "$(pdb_state lighthouse-worker-pdb)" = "1/2/2" ]; then
+      SETTLED=true
+      break
+    fi
+    sleep 1
+  done
+
+  if [ "$SETTLED" = false ]; then
+    echo "PodDisruptionBudget statuses did not settle:"
+    kubectl get pdb -n app-285
+    exit 1
+  fi
+
+after_test: |
+  kubectl delete namespace app-285 --ignore-not-found


### PR DESCRIPTION
## What

Adds one new ask_holmes eval fixture, `285_pdb_blocking_disruptions`, covering PodDisruptionBudgets that actively block pod evictions.

## Why

Two reasons.

**There is currently no PDB coverage in the eval suite.** No fixture manifest anywhere under `tests/llm/fixtures` defines a `PodDisruptionBudget` (the only two textual matches are incidental mentions inside pre-recorded `conversation_history.json` files for the compaction tests). So "which budgets are blocking my node drain" — a routine question before any maintenance window — is untested.

**The correct answer requires reading two status fields, not one.** A budget reporting `disruptionsAllowed=0` is only actually blocking if it still guards pods. If the workload behind it is scaled to zero, the budget reports `disruptionsAllowed=0` *and* `expectedPods=0`: it protects nothing and cannot block an eviction that can never happen. That stale-budget case is common in real clusters and it is exactly what a one-field answer gets wrong.

## The scenario

Namespace `app-285` holds four deployment/PDB pairs:

| PDB | disruptionsAllowed | expectedPods | Blocking? |
|---|---|---|---|
| `nimbus-worker-pdb` | 0 | 1 | **yes** |
| `solstice-worker-pdb` | 0 | 1 | **yes** |
| `driftwood-worker-pdb` | 0 | 0 | no — deployment scaled to zero |
| `lighthouse-worker-pdb` | 1 | 2 | no — has eviction headroom |

The expected answer is `nimbus-worker-pdb` and `solstice-worker-pdb`.

`driftwood-worker-pdb` is the discriminating case: filtering on `disruptionsAllowed=0` alone returns three budgets instead of two. `lighthouse-worker-pdb` is the straightforward negative control.

## Setup determinism

`before_test` waits for all four budgets to reach their expected status before the question is asked, rather than sleeping a fixed interval. PDB status is written asynchronously by the disruption controller, and `lighthouse-worker-pdb` reports `disruptionsAllowed=0` until *both* of its replicas are ready — indistinguishable from a genuinely blocking budget. Without the gate the eval would intermittently expect the wrong answer.

This is slightly more setup verification than the "verify the needle, not the haystack" guidance in the create-eval skill suggests, but here the four budget statuses *are* the needle — they are the entire answer the eval grades. Happy to trim it if you would rather see a plain `sleep`.

## Notes for reviewers

- **Run end to end on a KIND cluster.** `before_test` settles (setup passed, teardown clean), the manifest applies, and all four budgets reach their expected statuses — including `driftwood-worker-pdb` at `disruptionsAllowed=0`/`expectedPods=0`, which was the state I was least sure the disruption controller would populate for a budget guarding zero pods. It does.
- **Both models I tested fail it, in the same way.** A small self-hosted 26B model and Claude Sonnet 4.5 each reported three blocking budgets, including `driftwood-worker-pdb`. Neither was short of data: the 26B model retrieved `expectedPods` in its first tool call and dropped the field in its second, and Sonnet retrieved `currentHealthy: 0` and wrote "0 healthy pods, none can be evicted" in its own summary table — then still filed the budget under "Blocking Evictions". Sonnet additionally inferred the workload was "already degraded — investigate why pods are unhealthy", when it is deliberately scaled to zero.
- **Tagged `hard`** on that basis, rather than `medium`. `easy` needs a 20/20 pass rate I have not measured; `hard` asserts Holmes does not pass today, which is what the two runs above actually show. Happy to retag if your baseline model handles it — and happy to iterate on the expected-output wording if the classifier is what is tripping here rather than the reasoning.
- Uses `registry.k8s.io/pause:3.9` for all four workloads, since no container behaviour is needed, only pod counts.
- All resources live in `app-285` per the namespace convention, and resource names are neutral so as not to hint at which budgets are the blocking ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for identifying Kubernetes disruption budgets that block pod evictions.
  * Added scenarios for single-replica, zero-replica, and multi-replica workloads.
  * Added validation of expected disruption status, including diagnostics for unsettled results and cleanup after testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->