### PR TITLE
Add opt-in request-scoped Kubernetes credentials for per-user RBAC

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -368,7 +368,7 @@ export HOLMES_K8S_AUTH_MODE="request_token"
 
 Ordered, comma-separated list of headers to read the user's token from when
 `HOLMES_K8S_AUTH_MODE=request_token`. The first non-empty match wins, and a
-leading `Bearer ` prefix is stripped. `oauth2-proxy` injects
+leading `Bearer` prefix and following whitespace are stripped. `oauth2-proxy` injects
 `X-Auth-Request-Id-Token`; a plain reverse proxy forwards `Authorization`.
 
 **Example:**

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -345,6 +345,61 @@ export HOLMES_PASSTHROUGH_BLOCKED_HEADERS="authorization,cookie,set-cookie,x-int
 
 See [HTTP Header Propagation](../data-sources/header-propagation.md) for details.
 
+### HOLMES_K8S_AUTH_MODE
+**Default:** `"service_account"`
+
+Controls which credentials the built-in `kubernetes` toolset uses for `kubectl`.
+
+- `service_account` (default) — use the pod's ServiceAccount / ambient kubeconfig. Every user shares Holmes' identity.
+- `request_token` — build a short-lived kubeconfig **per tool invocation** from the caller's token, so the API server enforces that user's RBAC.
+
+`request_token` is intended for multi-user front-ends (e.g. the Headlamp
+ai-assistant plugin) sitting behind an OIDC proxy. It only takes effect when a
+token is actually present on the request; otherwise Holmes falls back to the
+existing behaviour.
+
+**Example:**
+```bash
+export HOLMES_K8S_AUTH_MODE="request_token"
+```
+
+### HOLMES_K8S_REQUEST_TOKEN_HEADERS
+**Default:** `"X-Auth-Request-Id-Token,Authorization"`
+
+Ordered, comma-separated list of headers to read the user's token from when
+`HOLMES_K8S_AUTH_MODE=request_token`. The first non-empty match wins, and a
+leading `Bearer ` prefix is stripped. `oauth2-proxy` injects
+`X-Auth-Request-Id-Token`; a plain reverse proxy forwards `Authorization`.
+
+**Example:**
+```bash
+export HOLMES_K8S_REQUEST_TOKEN_HEADERS="X-Forwarded-Access-Token"
+```
+
+### HOLMES_K8S_API_SERVER
+**Default:** derived from `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT`, falling back to `https://kubernetes.default.svc`
+
+API server URL written into the generated per-request kubeconfig.
+
+### HOLMES_K8S_CA_CERT
+**Default:** `"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"`
+
+Path to the cluster CA bundle used to verify the API server. When Holmes runs
+with no ServiceAccount token mounted, mount the `kube-root-ca.crt` ConfigMap and
+point this at it. If the file is missing, `kubectl` falls back to the system
+trust store.
+
+### HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY
+**Default:** `false`
+
+Set to `true` to write `insecure-skip-tls-verify` into the generated kubeconfig
+when no CA bundle is available.
+
+!!! warning
+    This disables API server certificate verification and exposes the user's
+    token to interception. Prefer mounting `kube-root-ca.crt` and setting
+    `HOLMES_K8S_CA_CERT`.
+
 ## Data Source Configuration
 
 ### Prometheus

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -379,7 +379,10 @@ export HOLMES_K8S_REQUEST_TOKEN_HEADERS="X-Forwarded-Access-Token"
 ### HOLMES_K8S_API_SERVER
 **Default:** derived from `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT`, falling back to `https://kubernetes.default.svc`
 
-API server URL written into the generated per-request kubeconfig.
+API server URL written into the generated per-request kubeconfig. Must be an
+absolute `https://` URL; any other value is ignored (with an error logged) and
+the in-cluster endpoint is used instead, so the user's token is never sent in
+cleartext.
 
 ### HOLMES_K8S_CA_CERT
 **Default:** `"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"`

--- a/experimental/ag-ui/server-agui.py
+++ b/experimental/ag-ui/server-agui.py
@@ -98,10 +98,28 @@ def agui_chat_health(request: Request):
     return JSONResponse(content="ok")
 
 
+def _build_agui_request_context(request: Request) -> dict:
+    """Capture per-request headers so the caller's identity can reach tool
+    execution (used for per-user Kubernetes RBAC).
+
+    Unlike the main server's ``extract_passthrough_headers``, which blocks
+    ``Authorization`` by default, the AG-UI server is the per-user entrypoint and
+    must forward identity headers; only cookies are dropped.
+    """
+    blocked = {"cookie", "set-cookie"}
+    headers = {
+        name: value
+        for name, value in request.headers.items()
+        if name.lower() not in blocked
+    }
+    return {"headers": headers}
+
+
 @app.post("/api/agui/chat")
 def agui_chat(input_data: RunAgentInput, request: Request):
     accept_header = request.headers.get("accept", "")
     encoder = EventEncoder(accept=accept_header)
+    request_context = _build_agui_request_context(request)
 
     logging.debug(f"AG-UI context: {input_data.context}")
     logging.debug(f"AG-UI state: {input_data.state}")
@@ -164,6 +182,9 @@ def agui_chat(input_data: RunAgentInput, request: Request):
                     type(ctx).__name__,
                     e,
                 )
+            if agui_user_id:
+                # Consumed by the MCP OAuth token manager to scope stored tokens.
+                request_context["user_id"] = agui_user_id
             ai_model = getattr(ai.llm, "model", None) or chat_request.model or "unknown"
             ai_provider = resolve_provider(ai_model)
             recorder_state = UsageRecorderState(
@@ -183,6 +204,7 @@ def agui_chat(input_data: RunAgentInput, request: Request):
                 ai.call_stream(
                     msgs=message_history,
                     enable_tool_approval=chat_request.enable_tool_approval or False,
+                    request_context=request_context,
                 ),
                 recorder_state,
             )

--- a/holmes/core/request_scoped_k8s.py
+++ b/holmes/core/request_scoped_k8s.py
@@ -34,6 +34,7 @@ import os
 import stat
 import tempfile
 from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlparse
 
 from requests.structures import CaseInsensitiveDict
 
@@ -135,10 +136,24 @@ def extract_request_token(request_context: Optional[Dict[str, Any]]) -> Optional
     return None
 
 
+def _is_https_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
 def _api_server_url() -> str:
     override = os.environ.get(_API_SERVER_ENV)
     if override:
-        return override
+        if _is_https_url(override):
+            return override
+        # An http:// (or malformed) endpoint would put the user's bearer token
+        # on the wire in cleartext, so ignore it and fall back to discovery.
+        logger.error(
+            "request-scoped k8s auth: ignoring %s=%r, an absolute https:// URL "
+            "is required to avoid sending the token in cleartext.",
+            _API_SERVER_ENV,
+            override,
+        )
     host = os.environ.get("KUBERNETES_SERVICE_HOST")
     port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
     if host:

--- a/holmes/core/request_scoped_k8s.py
+++ b/holmes/core/request_scoped_k8s.py
@@ -1,0 +1,252 @@
+"""Request-scoped Kubernetes credentials for the built-in ``kubernetes`` toolset.
+
+When Holmes is embedded in a multi-user UI (e.g. the Headlamp ai-assistant
+plugin) behind an OIDC proxy, every request carries the end user's identity as
+a bearer/OIDC token (``Authorization: Bearer <id_token>`` and/or an identity
+header such as ``X-Auth-Request-Id-Token``). We want ``kubectl`` invocations to
+run *as that user* so the API server enforces per-user RBAC, instead of Holmes
+using its pod ServiceAccount for everyone.
+
+Design:
+
+* The token is threaded through Holmes' existing ``request_context`` dict, which
+  is passed *explicitly* as a function argument all the way from the server
+  down to tool invocation (including across the tool-calling ThreadPoolExecutor).
+  Because it is an explicit argument -- not global/process state and not a
+  ``contextvar`` -- it is safe under concurrency: interleaved requests can never
+  observe each other's credentials.
+* For each tool invocation we build a **per-invocation** kubeconfig in a private
+  temp file and expose it to the subprocess via ``KUBECONFIG`` in that call's
+  ``env`` only. We never mutate ``os.environ`` or ``~/.kube/config`` -- doing so
+  would let request A's credential bleed into request B (a cross-user
+  privilege-escalation bug), which is exactly what this feature avoids.
+
+The feature is opt-in and backward compatible: if ``HOLMES_K8S_AUTH_MODE`` is
+not ``request_token`` (the default is ``service_account``) or no token is
+present on the request, this module is a no-op and ``kubectl`` keeps using the
+pod ServiceAccount / local kubeconfig as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+import tempfile
+from typing import Any, Dict, Optional, Tuple
+
+from requests.structures import CaseInsensitiveDict
+
+logger = logging.getLogger(__name__)
+
+# --- Configuration (env-var driven, so no per-toolset plumbing is required) ---
+
+#: ``service_account`` (default) keeps the legacy behaviour. ``request_token``
+#: enables per-request kubeconfig generation from the forwarded OIDC token.
+_AUTH_MODE_ENV = "HOLMES_K8S_AUTH_MODE"
+
+#: Comma-separated, ordered list of headers to look for the user's token in.
+#: First non-empty match wins. oauth2-proxy injects ``X-Auth-Request-Id-Token``;
+#: a plain reverse proxy forwards ``Authorization``.
+_TOKEN_HEADERS_ENV = "HOLMES_K8S_REQUEST_TOKEN_HEADERS"
+_DEFAULT_TOKEN_HEADERS = "X-Auth-Request-Id-Token,Authorization"
+
+#: Override for the API server URL. Defaults to the in-cluster endpoint derived
+#: from KUBERNETES_SERVICE_HOST/PORT, falling back to kubernetes.default.svc.
+_API_SERVER_ENV = "HOLMES_K8S_API_SERVER"
+
+#: Path to the cluster CA bundle. Defaults to the projected ServiceAccount CA.
+#: When Holmes runs with no ServiceAccount token mounted, mount the
+#: ``kube-root-ca.crt`` ConfigMap and point this at it.
+_CA_CERT_ENV = "HOLMES_K8S_CA_CERT"
+_DEFAULT_CA_CERT = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+#: Opt-in escape hatch for clusters where no CA bundle can be mounted. Disabling
+#: verification exposes the user's token to a MITM, so it is never the default.
+_INSECURE_ENV = "HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY"
+
+REQUEST_TOKEN_MODE = "request_token"
+SERVICE_ACCOUNT_MODE = "service_account"
+
+
+def is_request_token_mode() -> bool:
+    """True when per-request Kubernetes auth is enabled via config."""
+    return (
+        os.environ.get(_AUTH_MODE_ENV, SERVICE_ACCOUNT_MODE).strip().lower()
+        == REQUEST_TOKEN_MODE
+    )
+
+
+def _token_header_names() -> list[str]:
+    raw = os.environ.get(_TOKEN_HEADERS_ENV, _DEFAULT_TOKEN_HEADERS)
+    return [h.strip() for h in raw.split(",") if h.strip()]
+
+
+def _bool_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+def _strip_bearer(token: str) -> str:
+    """Return the bare credential. The k8s API server rejects a token that still
+    carries the ``Bearer `` prefix, so it must never end up in the kubeconfig."""
+    token = token.strip()
+    if token.lower().startswith("bearer "):
+        return token[len("bearer ") :].strip()
+    return token
+
+
+def _is_well_formed_token(token: str) -> bool:
+    """Reject anything that isn't a single-line printable credential.
+
+    The kubeconfig is rendered as text, so a token containing a newline or
+    control character could inject arbitrary YAML (e.g. a rogue ``cluster``
+    entry pointing kubectl elsewhere). HTTP forbids such values anyway; this is
+    defence in depth against a malformed or malicious upstream proxy.
+    """
+    return bool(token) and all(ch.isprintable() and ch != " " for ch in token)
+
+
+def _yaml_single_quote(value: str) -> str:
+    """Render ``value`` as a YAML single-quoted scalar ('' escapes a quote)."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def extract_request_token(request_context: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Pull the user's token out of ``request_context['headers']`` using the
+    configured, ordered header allow-list. Returns ``None`` if none present."""
+    if not request_context:
+        return None
+    # Header names arrive with inconsistent casing (Starlette lowercases them,
+    # server.py preserves original case). Do the lookup case-insensitively.
+    headers = CaseInsensitiveDict(request_context.get("headers") or {})
+    for name in _token_header_names():
+        value = headers.get(name)
+        if value:
+            token = _strip_bearer(str(value))
+            if not token:
+                continue
+            if not _is_well_formed_token(token):
+                logger.warning(
+                    "request-scoped k8s auth: ignoring malformed token in header %r",
+                    name,
+                )
+                continue
+            return token
+    return None
+
+
+def _api_server_url() -> str:
+    override = os.environ.get(_API_SERVER_ENV)
+    if override:
+        return override
+    host = os.environ.get("KUBERNETES_SERVICE_HOST")
+    port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+    if host:
+        # IPv6 literals must be bracketed for a URL authority.
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"https://{host}:{port}"
+    return "https://kubernetes.default.svc"
+
+
+def _render_kubeconfig(token: str) -> str:
+    server = _api_server_url()
+    ca_path = os.environ.get(_CA_CERT_ENV, _DEFAULT_CA_CERT)
+
+    cluster_lines = [f"    server: {_yaml_single_quote(server)}"]
+    if ca_path and os.path.isfile(ca_path):
+        cluster_lines.append(
+            f"    certificate-authority: {_yaml_single_quote(ca_path)}"
+        )
+    elif _bool_env(_INSECURE_ENV):
+        logger.warning(
+            "request-scoped k8s auth: %s is set; API server certificate will NOT "
+            "be verified and the user's token is exposed to interception.",
+            _INSECURE_ENV,
+        )
+        cluster_lines.append("    insecure-skip-tls-verify: true")
+    else:
+        # Deliberately neither pin a CA nor disable verification: kubectl falls
+        # back to the system trust store and fails loudly on an untrusted API
+        # server. Silently skipping verification would leak the user's token.
+        logger.warning(
+            "request-scoped k8s auth: CA bundle %r not found; relying on the "
+            "system trust store. Mount the kube-root-ca.crt ConfigMap and set "
+            "%s, or set %s=true to accept the risk.",
+            ca_path,
+            _CA_CERT_ENV,
+            _INSECURE_ENV,
+        )
+
+    cluster_block = "\n".join(cluster_lines)
+    return (
+        "apiVersion: v1\n"
+        "kind: Config\n"
+        "clusters:\n"
+        "- name: holmes-request-scoped\n"
+        "  cluster:\n"
+        f"{cluster_block}\n"
+        "users:\n"
+        "- name: holmes-request-user\n"
+        "  user:\n"
+        f"    token: {_yaml_single_quote(token)}\n"
+        "contexts:\n"
+        "- name: holmes-request-scoped\n"
+        "  context:\n"
+        "    cluster: holmes-request-scoped\n"
+        "    user: holmes-request-user\n"
+        "current-context: holmes-request-scoped\n"
+    )
+
+
+def build_request_scoped_env(
+    request_context: Optional[Dict[str, Any]],
+) -> Tuple[Optional[Dict[str, str]], Optional[str]]:
+    """Build a per-invocation environment overlay carrying request-scoped
+    Kubernetes credentials.
+
+    Returns ``(env_overrides, kubeconfig_path)`` where:
+
+    * ``env_overrides`` is a dict to merge onto ``os.environ`` for *this*
+      subprocess call only (currently ``{"KUBECONFIG": <temp path>}``), or
+      ``None`` when the feature is disabled / no token is present.
+    * ``kubeconfig_path`` is the temp file the caller MUST delete once the
+      subprocess has finished, or ``None``.
+
+    The temp kubeconfig is created with ``0600`` permissions and holds the raw
+    bearer token, so it must be short-lived and unreadable by other users.
+    """
+    if not is_request_token_mode():
+        return None, None
+
+    token = extract_request_token(request_context)
+    if not token:
+        # request_token mode but no user token forwarded -- leave kubectl to its
+        # default behaviour rather than silently generating a broken kubeconfig.
+        return None, None
+
+    fd, path = tempfile.mkstemp(prefix="holmes-kubeconfig-", suffix=".yaml")
+    try:
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        with os.fdopen(fd, "w") as fh:
+            fh.write(_render_kubeconfig(token))
+    except Exception:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        raise
+
+    return {"KUBECONFIG": path}, path
+
+
+def cleanup_kubeconfig(path: Optional[str]) -> None:
+    """Best-effort removal of a per-invocation kubeconfig temp file."""
+    if not path:
+        return
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.debug("failed to remove request-scoped kubeconfig %s: %s", path, e)

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -42,6 +42,10 @@ from rich.table import Table
 
 from holmes.core.llm import LLM
 from holmes.core.openai_formatting import format_tool_to_open_ai_standard
+from holmes.core.request_scoped_k8s import (
+    build_request_scoped_env,
+    cleanup_kubeconfig,
+)
 from holmes.core.transformers import (
     Transformer,
     TransformerError,
@@ -590,14 +594,23 @@ class YAMLTool(Tool, BaseModel):
         params: dict,
         context: ToolInvokeContext,
     ) -> StructuredToolResult:
-        if self.command is not None:
-            raw_output, return_code, invocation = self.__invoke_command(
-                params, context.request_context
-            )
-        else:
-            raw_output, return_code, invocation = self.__invoke_script(
-                params, context.request_context
-            )
+        # The kubeconfig backing these credentials holds a raw user token, so it
+        # must be deleted as soon as the subprocess exits. No-op (None) unless
+        # request-scoped auth is enabled.
+        env_overrides, kubeconfig_path = build_request_scoped_env(
+            context.request_context
+        )
+        try:
+            if self.command is not None:
+                raw_output, return_code, invocation = self.__invoke_command(
+                    params, context.request_context, env=env_overrides
+                )
+            else:
+                raw_output, return_code, invocation = self.__invoke_script(
+                    params, context.request_context, env=env_overrides
+                )
+        finally:
+            cleanup_kubeconfig(kubeconfig_path)
 
         error = (
             None
@@ -619,18 +632,20 @@ class YAMLTool(Tool, BaseModel):
         self,
         params: dict,
         request_context: Optional[Dict[str, Any]] = None,
+        env: Optional[Dict[str, str]] = None,
     ) -> Tuple[str, int, str]:
         context = self._build_context(params, request_context)
         command = os.path.expandvars(self.command)  # type: ignore
         template = Template(command)  # type: ignore
         rendered_command = template.render(context)
-        output, return_code = self.__execute_subprocess(rendered_command)
+        output, return_code = self.__execute_subprocess(rendered_command, env=env)
         return output, return_code, rendered_command
 
     def __invoke_script(
         self,
         params: dict,
         request_context: Optional[Dict[str, Any]] = None,
+        env: Optional[Dict[str, str]] = None,
     ) -> Tuple[str, int, str]:
         context = self._build_context(params, request_context)
         script = os.path.expandvars(self.script)  # type: ignore
@@ -645,7 +660,7 @@ class YAMLTool(Tool, BaseModel):
         subprocess.run(["chmod", "+x", temp_script_path], check=True)
 
         try:
-            output, return_code = self.__execute_subprocess(temp_script_path)
+            output, return_code = self.__execute_subprocess(temp_script_path, env=env)
         finally:
             try:
                 os.remove(temp_script_path)
@@ -653,10 +668,19 @@ class YAMLTool(Tool, BaseModel):
                 pass
         return output, return_code, rendered_script
 
-    def __execute_subprocess(self, cmd: str) -> Tuple[str, int]:
+    def __execute_subprocess(
+        self, cmd: str, env: Optional[Dict[str, str]] = None
+    ) -> Tuple[str, int]:
         try:
             logger.debug(f"Running `{cmd}`")
             protected_cmd = get_ulimit_prefix() + cmd
+
+            # Overlay onto a *copy* of os.environ so concurrent invocations
+            # cannot observe each other's credentials.
+            subprocess_env = None
+            if env:
+                subprocess_env = os.environ.copy()
+                subprocess_env.update(env)
 
             result = subprocess.run(
                 protected_cmd,
@@ -667,6 +691,7 @@ class YAMLTool(Tool, BaseModel):
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                env=subprocess_env,
             )
 
             output = result.stdout.strip()

--- a/tests/test_request_scoped_k8s.py
+++ b/tests/test_request_scoped_k8s.py
@@ -53,21 +53,23 @@ def test_extract_strips_bearer_and_is_case_insensitive(monkeypatch):
 
 def test_header_priority_order(monkeypatch):
     monkeypatch.setenv(AUTH_MODE, "request_token")
-    ctx = {
+    request_context = {
         "headers": {
             "Authorization": "Bearer from-authz",
             "X-Auth-Request-Id-Token": "from-oauth2proxy",
         }
     }
     # Default order prefers X-Auth-Request-Id-Token over Authorization.
-    assert extract_request_token(ctx) == "from-oauth2proxy"
+    assert extract_request_token(request_context) == "from-oauth2proxy"
 
 
 def test_custom_header_list(monkeypatch):
     monkeypatch.setenv(AUTH_MODE, "request_token")
     monkeypatch.setenv(TOKEN_HEADERS, "X-Id-Token")
-    ctx = {"headers": {"X-Id-Token": "custom", "Authorization": "Bearer ignored"}}
-    assert extract_request_token(ctx) == "custom"
+    request_context = {
+        "headers": {"X-Id-Token": "custom", "Authorization": "Bearer ignored"}
+    }
+    assert extract_request_token(request_context) == "custom"
 
 
 def test_kubeconfig_is_per_invocation_and_cleaned_up(monkeypatch, tmp_path):
@@ -77,8 +79,8 @@ def test_kubeconfig_is_per_invocation_and_cleaned_up(monkeypatch, tmp_path):
     monkeypatch.setenv("HOLMES_K8S_CA_CERT", str(ca))
     monkeypatch.setenv("HOLMES_K8S_API_SERVER", "https://api.example:6443")
 
-    ctx = {"headers": {"Authorization": "Bearer SECRET"}}
-    env, path = build_request_scoped_env(ctx)
+    request_context = {"headers": {"Authorization": "Bearer SECRET"}}
+    env, path = build_request_scoped_env(request_context)
 
     assert env is not None and "KUBECONFIG" in env
     assert path is not None and os.path.isfile(path)
@@ -93,7 +95,7 @@ def test_kubeconfig_is_per_invocation_and_cleaned_up(monkeypatch, tmp_path):
     assert f"certificate-authority: '{ca}'" in content
 
     # Two concurrent requests must get distinct kubeconfig files (no shared state).
-    env2, path2 = build_request_scoped_env(ctx)
+    _, path2 = build_request_scoped_env(request_context)
     assert path2 != path
 
     cleanup_kubeconfig(path)
@@ -110,7 +112,7 @@ def test_cleanup_missing_path_is_safe():
 def test_missing_ca_does_not_silently_disable_tls_verification(monkeypatch):
     monkeypatch.setenv(AUTH_MODE, "request_token")
     monkeypatch.setenv("HOLMES_K8S_CA_CERT", "/definitely/not/here.crt")
-    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
     try:
         content = open(path).read()
         assert "insecure-skip-tls-verify" not in content
@@ -123,7 +125,7 @@ def test_insecure_skip_requires_explicit_opt_in(monkeypatch):
     monkeypatch.setenv(AUTH_MODE, "request_token")
     monkeypatch.setenv("HOLMES_K8S_CA_CERT", "/definitely/not/here.crt")
     monkeypatch.setenv("HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY", "true")
-    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
     try:
         assert "insecure-skip-tls-verify: true" in open(path).read()
     finally:
@@ -149,7 +151,7 @@ def test_malformed_tokens_are_rejected(monkeypatch, bad_token):
 def test_token_with_quote_is_escaped_not_injected(monkeypatch, tmp_path):
     """A quote in the credential must stay inside the scalar, not break out."""
     monkeypatch.setenv(AUTH_MODE, "request_token")
-    env, path = build_request_scoped_env({"headers": {"Authorization": "ab'cd"}})
+    _, path = build_request_scoped_env({"headers": {"Authorization": "ab'cd"}})
     try:
         content = open(path).read()
         assert "token: 'ab''cd'" in content
@@ -167,7 +169,7 @@ def test_rendered_kubeconfig_is_valid_yaml(monkeypatch, tmp_path):
     ca.write_text("CADATA")
     monkeypatch.setenv("HOLMES_K8S_CA_CERT", str(ca))
     monkeypatch.setenv("HOLMES_K8S_API_SERVER", "https://api.example:6443")
-    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T0K"}})
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T0K"}})
     try:
         cfg = yaml.safe_load(open(path).read())
         assert cfg["current-context"] == "holmes-request-scoped"
@@ -182,9 +184,19 @@ def test_api_server_defaults_to_in_cluster_endpoint(monkeypatch):
     monkeypatch.setenv(AUTH_MODE, "request_token")
     monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
     monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "6443")
-    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
     try:
         assert "server: 'https://10.0.0.1:6443'" in open(path).read()
+    finally:
+        cleanup_kubeconfig(path)
+
+
+def test_api_server_falls_back_to_default_service_dns(monkeypatch):
+    """With no override and no in-cluster env vars, use kubernetes.default.svc."""
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        assert "server: 'https://kubernetes.default.svc'" in open(path).read()
     finally:
         cleanup_kubeconfig(path)
 
@@ -192,8 +204,37 @@ def test_api_server_defaults_to_in_cluster_endpoint(monkeypatch):
 def test_ipv6_api_server_host_is_bracketed(monkeypatch):
     monkeypatch.setenv(AUTH_MODE, "request_token")
     monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "fd00::1")
-    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
     try:
         assert "server: 'https://[fd00::1]:443'" in open(path).read()
+    finally:
+        cleanup_kubeconfig(path)
+
+
+@pytest.mark.parametrize(
+    "bad_server",
+    ["http://api.example:6443", "api.example:6443", "https://", "ftp://api.example"],
+)
+def test_non_https_api_server_override_is_rejected(monkeypatch, bad_server):
+    """A cleartext or malformed endpoint must never receive the user's token."""
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv("HOLMES_K8S_API_SERVER", bad_server)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "6443")
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        server = yaml.safe_load(open(path).read())["clusters"][0]["cluster"]["server"]
+        # Falls back to in-cluster discovery rather than honouring the override.
+        assert server == "https://10.0.0.1:6443"
+    finally:
+        cleanup_kubeconfig(path)
+
+
+def test_https_api_server_override_is_accepted_case_insensitively(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv("HOLMES_K8S_API_SERVER", "HTTPS://API.EXAMPLE:6443")
+    _, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        assert "server: 'HTTPS://API.EXAMPLE:6443'" in open(path).read()
     finally:
         cleanup_kubeconfig(path)

--- a/tests/test_request_scoped_k8s.py
+++ b/tests/test_request_scoped_k8s.py
@@ -1,0 +1,199 @@
+"""Tests for request-scoped Kubernetes credentials."""
+
+import os
+
+import pytest
+import yaml
+
+from holmes.core.request_scoped_k8s import (
+    build_request_scoped_env,
+    cleanup_kubeconfig,
+    extract_request_token,
+    is_request_token_mode,
+)
+
+AUTH_MODE = "HOLMES_K8S_AUTH_MODE"
+TOKEN_HEADERS = "HOLMES_K8S_REQUEST_TOKEN_HEADERS"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in (
+        AUTH_MODE,
+        TOKEN_HEADERS,
+        "HOLMES_K8S_API_SERVER",
+        "HOLMES_K8S_CA_CERT",
+        "HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY",
+        "KUBERNETES_SERVICE_HOST",
+        "KUBERNETES_SERVICE_PORT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def test_disabled_by_default(monkeypatch):
+    assert is_request_token_mode() is False
+    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer abc"}})
+    assert env is None
+    assert path is None
+
+
+def test_request_token_mode_no_token_is_noop(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    env, path = build_request_scoped_env({"headers": {"X-Other": "value"}})
+    assert env is None and path is None
+
+
+def test_extract_strips_bearer_and_is_case_insensitive(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    # Starlette lowercases header names; default allow-list uses mixed case.
+    token = extract_request_token({"headers": {"authorization": "Bearer TOK123"}})
+    assert token == "TOK123"
+
+
+def test_header_priority_order(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    ctx = {
+        "headers": {
+            "Authorization": "Bearer from-authz",
+            "X-Auth-Request-Id-Token": "from-oauth2proxy",
+        }
+    }
+    # Default order prefers X-Auth-Request-Id-Token over Authorization.
+    assert extract_request_token(ctx) == "from-oauth2proxy"
+
+
+def test_custom_header_list(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv(TOKEN_HEADERS, "X-Id-Token")
+    ctx = {"headers": {"X-Id-Token": "custom", "Authorization": "Bearer ignored"}}
+    assert extract_request_token(ctx) == "custom"
+
+
+def test_kubeconfig_is_per_invocation_and_cleaned_up(monkeypatch, tmp_path):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    ca = tmp_path / "ca.crt"
+    ca.write_text("CADATA")
+    monkeypatch.setenv("HOLMES_K8S_CA_CERT", str(ca))
+    monkeypatch.setenv("HOLMES_K8S_API_SERVER", "https://api.example:6443")
+
+    ctx = {"headers": {"Authorization": "Bearer SECRET"}}
+    env, path = build_request_scoped_env(ctx)
+
+    assert env is not None and "KUBECONFIG" in env
+    assert path is not None and os.path.isfile(path)
+    # 0600 permissions: not readable/writable by group or others.
+    mode = os.stat(path).st_mode & 0o777
+    assert mode == 0o600
+
+    content = open(path).read()
+    assert "token: 'SECRET'" in content
+    assert "Bearer" not in content  # bearer prefix must be stripped
+    assert "server: 'https://api.example:6443'" in content
+    assert f"certificate-authority: '{ca}'" in content
+
+    # Two concurrent requests must get distinct kubeconfig files (no shared state).
+    env2, path2 = build_request_scoped_env(ctx)
+    assert path2 != path
+
+    cleanup_kubeconfig(path)
+    cleanup_kubeconfig(path2)
+    assert not os.path.exists(path)
+    assert not os.path.exists(path2)
+
+
+def test_cleanup_missing_path_is_safe():
+    cleanup_kubeconfig(None)
+    cleanup_kubeconfig("/nonexistent/holmes-kubeconfig-xyz.yaml")
+
+
+def test_missing_ca_does_not_silently_disable_tls_verification(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv("HOLMES_K8S_CA_CERT", "/definitely/not/here.crt")
+    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        content = open(path).read()
+        assert "insecure-skip-tls-verify" not in content
+        assert "certificate-authority" not in content
+    finally:
+        cleanup_kubeconfig(path)
+
+
+def test_insecure_skip_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv("HOLMES_K8S_CA_CERT", "/definitely/not/here.crt")
+    monkeypatch.setenv("HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY", "true")
+    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        assert "insecure-skip-tls-verify: true" in open(path).read()
+    finally:
+        cleanup_kubeconfig(path)
+
+
+@pytest.mark.parametrize(
+    "bad_token",
+    [
+        "tok\nusers:\n- name: attacker",  # YAML injection via newline
+        "tok\rmore",
+        "tok\x00null",
+        "has space",
+    ],
+)
+def test_malformed_tokens_are_rejected(monkeypatch, bad_token):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    assert extract_request_token({"headers": {"Authorization": bad_token}}) is None
+    env, path = build_request_scoped_env({"headers": {"Authorization": bad_token}})
+    assert env is None and path is None
+
+
+def test_token_with_quote_is_escaped_not_injected(monkeypatch, tmp_path):
+    """A quote in the credential must stay inside the scalar, not break out."""
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    env, path = build_request_scoped_env({"headers": {"Authorization": "ab'cd"}})
+    try:
+        content = open(path).read()
+        assert "token: 'ab''cd'" in content
+        parsed = yaml.safe_load(content)
+        assert parsed["users"][0]["user"]["token"] == "ab'cd"
+        # The document must still contain exactly the structure we intended.
+        assert len(parsed["clusters"]) == 1 and len(parsed["users"]) == 1
+    finally:
+        cleanup_kubeconfig(path)
+
+
+def test_rendered_kubeconfig_is_valid_yaml(monkeypatch, tmp_path):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    ca = tmp_path / "ca.crt"
+    ca.write_text("CADATA")
+    monkeypatch.setenv("HOLMES_K8S_CA_CERT", str(ca))
+    monkeypatch.setenv("HOLMES_K8S_API_SERVER", "https://api.example:6443")
+    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T0K"}})
+    try:
+        cfg = yaml.safe_load(open(path).read())
+        assert cfg["current-context"] == "holmes-request-scoped"
+        assert cfg["clusters"][0]["cluster"]["server"] == "https://api.example:6443"
+        assert cfg["clusters"][0]["cluster"]["certificate-authority"] == str(ca)
+        assert cfg["users"][0]["user"]["token"] == "T0K"
+    finally:
+        cleanup_kubeconfig(path)
+
+
+def test_api_server_defaults_to_in_cluster_endpoint(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "6443")
+    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        assert "server: 'https://10.0.0.1:6443'" in open(path).read()
+    finally:
+        cleanup_kubeconfig(path)
+
+
+def test_ipv6_api_server_host_is_bracketed(monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "fd00::1")
+    env, path = build_request_scoped_env({"headers": {"Authorization": "Bearer T"}})
+    try:
+        assert "server: 'https://[fd00::1]:443'" in open(path).read()
+    finally:
+        cleanup_kubeconfig(path)

--- a/tests/test_request_scoped_k8s_integration.py
+++ b/tests/test_request_scoped_k8s_integration.py
@@ -1,0 +1,127 @@
+"""End-to-end test: a YAMLTool invocation must run kubectl with the *caller's*
+request-scoped credential, and two concurrent callers must never see each
+other's identity.
+
+A fake ``kubectl`` on PATH echoes back the token it was handed via KUBECONFIG,
+so we can assert on the identity the command actually ran as.
+"""
+
+import concurrent.futures
+import os
+import stat
+import textwrap
+
+import pytest
+
+from holmes.core.tools import ToolInvokeContext, YAMLTool
+from tests.conftest import MockLLM
+
+AUTH_MODE = "HOLMES_K8S_AUTH_MODE"
+
+
+@pytest.fixture
+def fake_kubectl(tmp_path, monkeypatch):
+    """A stand-in kubectl that prints the token from its kubeconfig."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    kubectl = bin_dir / "kubectl"
+    kubectl.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/bash
+            # Report which identity (and kubeconfig) this invocation received.
+            # Quotes are stripped so we compare the resolved YAML scalar value.
+            echo "KUBECONFIG=${KUBECONFIG:-<unset>}"
+            if [ -n "$KUBECONFIG" ] && [ -f "$KUBECONFIG" ]; then
+                grep -E "^\\s+token:" "$KUBECONFIG" | tr -d " '"
+            else
+                echo "token:<none>"
+            fi
+            """
+        )
+    )
+    kubectl.chmod(kubectl.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    return kubectl
+
+
+@pytest.fixture
+def ca_file(tmp_path, monkeypatch):
+    ca = tmp_path / "ca.crt"
+    ca.write_text("FAKE-CA")
+    monkeypatch.setenv("HOLMES_K8S_CA_CERT", str(ca))
+    monkeypatch.setenv("HOLMES_K8S_API_SERVER", "https://api.test:6443")
+    return ca
+
+
+def _tool() -> YAMLTool:
+    return YAMLTool(
+        name="k8s_probe",
+        description="probe identity",
+        command="kubectl get pods",
+    )
+
+
+def _ctx(token: str) -> ToolInvokeContext:
+    return ToolInvokeContext(
+        llm=MockLLM(),
+        max_token_count=10000,
+        tool_call_id="call-1",
+        tool_name="k8s_probe",
+        request_context={"headers": {"X-Auth-Request-Id-Token": token}},
+    )
+
+
+def test_tool_runs_with_request_scoped_identity(fake_kubectl, ca_file, monkeypatch):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    result = _tool().invoke({}, context=_ctx("Bearer USER-ALICE"))
+    # kubectl saw a KUBECONFIG, and it carried Alice's (de-prefixed) token.
+    assert "token:USER-ALICE" in result.data
+    assert "KUBECONFIG=<unset>" not in result.data
+    # The rendered invocation must NOT contain the credential.
+    assert "USER-ALICE" not in (result.invocation or "")
+
+
+def test_disabled_mode_does_not_inject_kubeconfig(fake_kubectl, ca_file, monkeypatch):
+    monkeypatch.delenv(AUTH_MODE, raising=False)  # default: service_account
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    result = _tool().invoke({}, context=_ctx("Bearer USER-ALICE"))
+    assert "KUBECONFIG=<unset>" in result.data
+
+
+def test_concurrent_users_never_cross_identities(fake_kubectl, ca_file, monkeypatch):
+    """The core anti-regression test for cross-user credential bleed."""
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    tool = _tool()
+    users = [f"USER-{i:03d}" for i in range(60)]
+
+    def run(user: str):
+        res = tool.invoke({}, context=_ctx(f"Bearer {user}"))
+        return user, res.data
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+        results = list(ex.map(run, users))
+
+    for user, data in results:
+        assert f"token:{user}" in data, f"{user} did not get its own token"
+        # No other user's identity may appear in this invocation's output.
+        others = [u for u in users if u != user and f"token:{u}" in data]
+        assert not others, f"{user} saw foreign identities: {others}"
+
+
+def test_no_global_state_mutation_and_no_leftover_files(
+    fake_kubectl, ca_file, monkeypatch
+):
+    monkeypatch.setenv(AUTH_MODE, "request_token")
+    before_env = dict(os.environ)
+    tmpdir = os.environ.get("TMPDIR", "/tmp")
+    before_files = {f for f in os.listdir(tmpdir) if f.startswith("holmes-kubeconfig-")}
+
+    _tool().invoke({}, context=_ctx("Bearer USER-BOB"))
+
+    # os.environ must be untouched (no global KUBECONFIG).
+    assert dict(os.environ) == before_env
+    assert "KUBECONFIG" not in os.environ or before_env.get("KUBECONFIG")
+    # Temp kubeconfig must be gone.
+    after_files = {f for f in os.listdir(tmpdir) if f.startswith("holmes-kubeconfig-")}
+    assert after_files == before_files

--- a/tests/test_request_scoped_k8s_integration.py
+++ b/tests/test_request_scoped_k8s_integration.py
@@ -9,6 +9,7 @@ so we can assert on the identity the command actually ran as.
 import concurrent.futures
 import os
 import stat
+import tempfile
 import textwrap
 
 import pytest
@@ -114,14 +115,14 @@ def test_no_global_state_mutation_and_no_leftover_files(
 ):
     monkeypatch.setenv(AUTH_MODE, "request_token")
     before_env = dict(os.environ)
-    tmpdir = os.environ.get("TMPDIR", "/tmp")
+    # Must match where mkstemp actually writes, which is not necessarily $TMPDIR.
+    tmpdir = tempfile.gettempdir()
     before_files = {f for f in os.listdir(tmpdir) if f.startswith("holmes-kubeconfig-")}
 
     _tool().invoke({}, context=_ctx("Bearer USER-BOB"))
 
     # os.environ must be untouched (no global KUBECONFIG).
     assert dict(os.environ) == before_env
-    assert "KUBECONFIG" not in os.environ or before_env.get("KUBECONFIG")
     # Temp kubeconfig must be gone.
     after_files = {f for f in os.listdir(tmpdir) if f.startswith("holmes-kubeconfig-")}
     assert after_files == before_files


### PR DESCRIPTION
## Summary

Closes #2347.

The built-in `kubernetes` toolset always runs `kubectl` as Holmes' own ServiceAccount. When Holmes is embedded in a multi-user front-end (e.g. the Headlamp `ai-assistant` plugin) behind an OIDC proxy, every user therefore inherits Holmes' cluster permissions instead of their own. Today the only options are to grant Holmes broad read access for everybody, or disable the toolset — in which case `kubectl` falls back to an unconfigured client and fails with `dial tcp [::1]:8080: connect: connection refused`.

This PR adds an **opt-in** `HOLMES_K8S_AUTH_MODE=request_token` mode that runs each `kubectl` invocation as the *calling user*, so the API server enforces that user's RBAC.

Note this is complementary to the existing `kubernetes-mcp-server` OAuth passthrough (`cluster_auth_mode = "passthrough"`): that requires deploying an extra MCP server, whereas this covers the built-in kubectl-based toolset with no additional components.

## How it works

1. `experimental/ag-ui/server-agui.py` captures the incoming request headers into the existing `request_context` dict. Unlike the main server's `extract_passthrough_headers` — which blocks `Authorization` by default — the AG-UI server is the per-user entrypoint, so identity headers are forwarded and only cookies are dropped.
2. `holmes/core/request_scoped_k8s.py` (new) extracts the token, strips any `Bearer ` prefix, and renders a kubeconfig into a `0600` temp file.
3. `holmes/core/tools.py` passes that kubeconfig to the subprocess through `env` for **that call only**, and deletes the file in a `finally` block as soon as the command exits.

## Why this is concurrency-safe

This was the main design constraint, since the target deployment has many simultaneous users:

- The token rides in Holmes' existing `request_context` dict, which is already threaded as an **explicit argument** from the server down to tool invocation (including across the tool-calling `ThreadPoolExecutor`). No `contextvar`, no global, no thread-local.
- Each invocation gets its **own** `tempfile.mkstemp` kubeconfig; there is no shared, reused, or overwritten path.
- `env` is overlaid onto a **copy** of `os.environ`. `os.environ` and `~/.kube/config` are never mutated, so request A's credential cannot bleed into request B.

`tests/test_request_scoped_k8s_integration.py` asserts this directly: 60 concurrent invocations, each with a distinct identity, must each observe only their own token. It fails loudly on any cross-user bleed.

## Security notes

- The kubeconfig holds a raw bearer token, so it is created `0600` and unlinked immediately after the subprocess exits.
- The token is never interpolated into the rendered command, so it does not leak into `invocation`, logs, or process listings (a covering assertion is included).
- Tokens are rendered as quoted YAML scalars and rejected if they contain whitespace or control characters, so a malformed or hostile upstream proxy cannot inject additional kubeconfig entries.
- Missing CA bundle does **not** silently disable TLS verification; `kubectl` falls back to the system trust store, and skipping verification requires explicitly setting `HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY=true`.

## Backward compatibility

Fully backward compatible and off by default. With `HOLMES_K8S_AUTH_MODE` unset (default `service_account`), or when no token is present on the request, `build_request_scoped_env()` returns `(None, None)` and `subprocess.run` is called with `env=None` exactly as before.

## Configuration

| Variable | Default | Purpose |
| --- | --- | --- |
| `HOLMES_K8S_AUTH_MODE` | `service_account` | Set to `request_token` to enable |
| `HOLMES_K8S_REQUEST_TOKEN_HEADERS` | `X-Auth-Request-Id-Token,Authorization` | Ordered header allow-list; first match wins |
| `HOLMES_K8S_API_SERVER` | in-cluster endpoint | API server URL for the generated kubeconfig |
| `HOLMES_K8S_CA_CERT` | SA CA path | Cluster CA bundle |
| `HOLMES_K8S_INSECURE_SKIP_TLS_VERIFY` | `false` | Escape hatch when no CA can be mounted |

Documented in `docs/reference/environment-variables.md`.

## Test plan

- [x] `tests/test_request_scoped_k8s.py` — 17 unit tests: disabled-by-default, no-op without a token, `Bearer` stripping, case-insensitive and ordered header lookup, `0600` permissions, distinct file per call, cleanup, YAML validity, quote escaping, malformed-token rejection, IPv6 bracketing, TLS-verification defaults.
- [x] `tests/test_request_scoped_k8s_integration.py` — 4 integration tests driving a real `YAMLTool` against a fake `kubectl` on `PATH`, including the 60-way concurrency test and a check that `os.environ` is unmutated with no leftover temp files.
- [x] No regressions: 173 existing tests pass (`test_tool_calling_llm.py`, `test_structured_toolcall_result.py`, `test_bash_toolset_validation.py`, `test_approval_required_tools.py`).
- [x] `ruff check` / `ruff format` (pinned v0.7.2) and `mypy` clean on all touched files.
- [x] Verified live on an EKS cluster with Headlamp + oauth2-proxy: `kubectl` calls succeed as the logged-in user with no ServiceAccount token mounted, and no leftover kubeconfig files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional per-request Kubernetes authentication using tokens from configurable request headers.
  - Requests now use isolated temporary credentials that are automatically cleaned up, supporting safe concurrent access.
  - Added configuration for the Kubernetes API server, certificate authority, token headers, and user identity context.
  - Added AG-UI request context forwarding for scoped authentication.

- **Documentation**
  - Documented Kubernetes authentication and connection environment variables.
  - Clarified that TLS verification is enabled by default; insecure verification requires explicit opt-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->