### PR TITLE
feat(cli): persist ask sessions and add --continue

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -293,6 +293,14 @@ Path to a custom HolmesGPT configuration file. If not set, defaults to `~/.holme
 export HOLMES_CONFIG_PATH="/path/to/custom/config.yaml"
 ```
 
+### HOLMES_DISABLE_SESSION_PERSISTENCE
+By default, `holmes ask` saves each conversation to `~/.holmes/sessions/` so it can be continued later with `--continue`. Set this to a truthy value (`1`, `true`, `yes`, `on`) to stop writing new sessions to disk, which is useful in CI or other automated environments where you don't want conversation history (including tool output) persisted. Existing sessions can still be read and continued.
+
+**Example:**
+```bash
+export HOLMES_DISABLE_SESSION_PERSISTENCE=true
+```
+
 ### LOG_LEVEL
 Controls the logging verbosity of HolmesGPT.
 

--- a/docs/walkthrough/interactive-mode.md
+++ b/docs/walkthrough/interactive-mode.md
@@ -18,6 +18,28 @@ You can also provide an initial question:
 holmes ask "what pods are failing?"
 ```
 
+## Continuing a Session
+
+Every `holmes ask` conversation is saved locally so you can pick it up again later. Sessions are stored as JSON files under `~/.holmes/sessions/` (override the location with the `HOLMES_CONFIGPATH_DIR` environment variable).
+
+To continue the most recent conversation with its full history:
+
+```bash
+holmes ask --continue
+# or
+holmes ask -c
+```
+
+You can also add a new question right away:
+
+```bash
+holmes ask -c "did the fix work?"
+```
+
+Use `/clear` inside interactive mode to start a fresh session without quitting. Continuing also works with `--no-interactive` for scripted runs.
+
+To stop saving conversations to disk (for example in CI), set `HOLMES_DISABLE_SESSION_PERSISTENCE=true`. Existing sessions can still be continued.
+
 ## Example Workflows
 
 ### Autonomous AI Investigation

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -59,7 +59,11 @@ from holmes.core.feedback import (
     FeedbackCallback,
     UserFeedback,
 )
-from holmes.core.prompt import PromptComponent, build_initial_ask_messages
+from holmes.core.prompt import (
+    PromptComponent,
+    append_all_files_to_user_prompt,
+    build_initial_ask_messages,
+)
 from holmes.core.models import PendingToolApproval
 from holmes.core.tool_calling_llm import (
     ApprovalCallback,
@@ -2528,10 +2532,15 @@ def run_interactive_loop(
     # session so previously persisted tool calls are not lost when this session
     # is saved again, and so /show works on the earlier tool outputs.
     all_tool_calls_history: List[ToolCallResult] = []
+    # Files passed with --file are attached to the first question of a continued
+    # session, since build_initial_ask_messages (which normally attaches them) is
+    # skipped when the history comes from disk.
+    pending_include_files = None
     if resume_session is not None:
         messages = list(resume_session.messages)
         current_session_id = resume_session.session_id
         all_tool_calls_history = deserialize_tool_calls(resume_session.tool_calls)
+        pending_include_files = include_files
         render_resumed_session(console, resume_session)
 
     if not initial_user_input and resume_session is None:
@@ -2702,6 +2711,15 @@ def run_interactive_loop(
                     prompt_component_overrides=prompt_component_overrides,
                 )
             else:
+                if pending_include_files:
+                    for file_path in pending_include_files:
+                        console.print(
+                            f"[bold yellow]Adding file {file_path} to context[/bold yellow]"
+                        )
+                    user_input = append_all_files_to_user_prompt(
+                        user_input, pending_include_files
+                    )
+                    pending_include_files = None
                 messages.append({"role": "user", "content": user_input})
 
             escape_hint = (

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -2535,7 +2535,7 @@ def run_interactive_loop(
     # Files passed with --file are attached to the first question of a continued
     # session, since build_initial_ask_messages (which normally attaches them) is
     # skipped when the history comes from disk.
-    pending_include_files = None
+    pending_include_files: Optional[List[Path]] = None
     if resume_session is not None:
         messages = list(resume_session.messages)
         current_session_id = resume_session.session_id
@@ -2626,8 +2626,11 @@ def run_interactive_loop(
                     last_response = None
                     all_tool_calls_history.clear()
                     # Start a fresh session on the next question rather than
-                    # overwriting the conversation we just cleared.
+                    # overwriting the conversation we just cleared. The new
+                    # session's first question goes through
+                    # build_initial_ask_messages, which attaches --file itself.
                     current_session_id = None
+                    pending_include_files = None
                     # Reset the show completer history
                     show_completer.update_history([])
                     ai.reset_interaction_state()

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -90,6 +90,12 @@ from holmes.utils.colors import (
 from holmes.toolset_config_tui import run_toolset_config_tui
 from holmes.utils.console.consts import agent_name
 from holmes.utils.file_utils import write_json_file
+from holmes.utils.sessions import (
+    ChatSession,
+    SessionManager,
+    derive_title,
+    session_persistence_disabled,
+)
 from holmes.version import check_version_async
 
 # Display loggers that are silenced in interactive mode.
@@ -2221,6 +2227,91 @@ def save_conversation_to_file(
         )
 
 
+def persist_session(
+    session_manager: SessionManager,
+    session_id: str,
+    messages: List,
+    all_tool_calls_history: List[ToolCallResult],
+    model: Optional[str],
+    session_type: str = "interactive",
+) -> None:
+    """Save (or update) the current conversation as a session that can be continued.
+
+    Saving is skipped entirely when persistence is disabled via
+    ``HOLMES_DISABLE_SESSION_PERSISTENCE``. Failures are swallowed (and logged
+    inside SessionManager.save) so that an inability to persist never interrupts
+    an active conversation.
+    """
+    if session_persistence_disabled():
+        return
+    # Serialize tool calls one at a time so a single unserializable entry only
+    # drops itself rather than discarding the whole history.
+    tool_calls = []
+    for tc in all_tool_calls_history:
+        try:
+            tool_calls.append(tc.model_dump(mode="json"))
+        except Exception as e:  # noqa: BLE001 - never let serialization break the loop
+            logging.debug(
+                "Skipping unserializable tool call when saving session: %s", e
+            )
+    session = ChatSession(
+        session_id=session_id,
+        title=derive_title(messages),
+        working_directory=os.getcwd(),
+        model=model,
+        messages=messages,
+        tool_calls=tool_calls,
+        metadata={"session_type": session_type},
+    )
+    session_manager.save(session)
+
+
+def deserialize_tool_calls(serialized: List[Dict]) -> List[ToolCallResult]:
+    """Rebuild ToolCallResult objects from a continued session's saved tool calls.
+
+    Malformed entries are skipped (and logged) so a single bad record never
+    blocks continuing a conversation.
+    """
+    restored: List[ToolCallResult] = []
+    for tc in serialized or []:
+        try:
+            restored.append(ToolCallResult.model_validate(tc))
+        except Exception as e:  # noqa: BLE001
+            logging.debug("Skipping unrestorable tool call in resumed session: %s", e)
+    return restored
+
+
+def render_resumed_session(console: Console, session: ChatSession) -> None:
+    """Show a short summary of a continued conversation before resuming it."""
+    last_answer = next(
+        (
+            m.get("content")
+            for m in reversed(session.messages)
+            if m.get("role") == "assistant" and m.get("content")
+        ),
+        None,
+    )
+    console.print(
+        f"[bold {STATUS_COLOR}]Resumed session [bold]{session.session_id}[/bold] "
+        f"({session.user_turns} question(s), {session.message_count} messages).[/bold {STATUS_COLOR}]"
+    )
+    if session.working_directory:
+        console.print(f"[dim]Started in: {session.working_directory}[/dim]")
+    if isinstance(last_answer, str) and last_answer.strip():
+        console.print(
+            Panel(
+                Markdown(last_answer),
+                padding=(1, 2),
+                border_style=AI_COLOR,
+                title=f"[bold {AI_COLOR}]Last AI Response[/bold {AI_COLOR}]",
+                title_align="left",
+            )
+        )
+    console.print(
+        f"[dim]Continue the conversation below, or {SlashCommands.CLEAR.command} to start fresh.[/dim]\n"
+    )
+
+
 def _wait_for_completion_or_escape(
     thread: threading.Thread,
     cancel_event: threading.Event,
@@ -2288,6 +2379,8 @@ def run_interactive_loop(
     prompt_component_overrides: Optional[Dict[PromptComponent, bool]] = None,
     config: Optional[Config] = None,
     config_file_path: Optional[Path] = None,
+    session_manager: Optional[SessionManager] = None,
+    resume_session: Optional[ChatSession] = None,
 ) -> None:
     # Enable CLI mode for bash prefix loading (server mode doesn't call this)
     enable_cli_mode()
@@ -2428,7 +2521,20 @@ def run_interactive_loop(
         welcome_banner += f", [bold]{SlashCommands.FEEDBACK.command}[/bold] for feedback"
     console.print(welcome_banner)
 
-    if not initial_user_input:
+    # Continue a previous conversation if one was loaded (--continue).
+    messages = None
+    current_session_id = None
+    # Track all tool calls throughout conversation; seed it from the resumed
+    # session so previously persisted tool calls are not lost when this session
+    # is saved again, and so /show works on the earlier tool outputs.
+    all_tool_calls_history: List[ToolCallResult] = []
+    if resume_session is not None:
+        messages = list(resume_session.messages)
+        current_session_id = resume_session.session_id
+        all_tool_calls_history = deserialize_tool_calls(resume_session.tool_calls)
+        render_resumed_session(console, resume_session)
+
+    if not initial_user_input and resume_session is None:
         sample = _show_sample_questions_menu(console)
         if sample:
             initial_user_input = sample
@@ -2437,11 +2543,25 @@ def run_interactive_loop(
         console.print(
             f"\n[bold {USER_COLOR}]User:[/bold {USER_COLOR}] {initial_user_input}"
         )
-    messages = None
     last_response = None
-    all_tool_calls_history: List[
-        ToolCallResult
-    ] = []  # Track all tool calls throughout conversation
+    if all_tool_calls_history:
+        show_completer.update_history(all_tool_calls_history)
+    model_name = getattr(ai.llm, "model", None)
+
+    def _save_session() -> None:
+        """Persist the current conversation so it can be continued later."""
+        nonlocal current_session_id
+        if session_manager is None or not messages:
+            return
+        if current_session_id is None:
+            current_session_id = SessionManager.new_session_id()
+        persist_session(
+            session_manager,
+            current_session_id,
+            messages,
+            all_tool_calls_history,
+            model_name,
+        )
 
     while True:
         try:
@@ -2496,6 +2616,9 @@ def run_interactive_loop(
                     messages = None
                     last_response = None
                     all_tool_calls_history.clear()
+                    # Start a fresh session on the next question rather than
+                    # overwriting the conversation we just cleared.
+                    current_session_id = None
                     # Reset the show completer history
                     show_completer.update_history([])
                     ai.reset_interaction_state()
@@ -2828,6 +2951,9 @@ def run_interactive_loop(
                 save_conversation_to_file(
                     json_output_file, messages, all_tool_calls_history, console
                 )
+
+            # Persist the session so it can be continued later with --continue
+            _save_session()
         except typer.Abort:
             console.print(
                 f"[bold {STATUS_COLOR}]Exiting interactive mode.[/bold {STATUS_COLOR}]"

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -30,6 +30,7 @@ from holmes.config import (
 )
 from holmes.core.prompt import (
     PromptComponent,
+    append_all_files_to_user_prompt,
     build_initial_ask_messages,
     build_system_prompt,
     generate_user_prompt,
@@ -425,10 +426,16 @@ def ask(
 
         if resumed_session is not None:
             # Continue the previous conversation: keep its history and append
-            # the new question. The system prompt from the original run is
-            # reused as-is.
+            # the new question, with any --file contents attached to it like a
+            # fresh run does. The system prompt from the original run is reused
+            # as-is.
             messages = list(resumed_session.messages)
-            messages.append({"role": "user", "content": prompt})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": append_all_files_to_user_prompt(prompt, include_file),  # type: ignore
+                }
+            )
         else:
             messages = build_initial_ask_messages(
                 prompt,  # type: ignore

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -46,7 +46,13 @@ from holmes.core.oauth_utils import enable_disk_token_store
 # guess whether a missing user_id means "CLI" or "buggy server caller".
 _CLI_REQUEST_CONTEXT = {"user_id": DEFAULT_CLI_USER}
 from holmes.core.tracing import SpanType, TracingFactory
-from holmes.interactive import InitProgressRenderer, run_interactive_loop, silence_display_loggers
+from holmes.interactive import (
+    InitProgressRenderer,
+    deserialize_tool_calls,
+    persist_session,
+    run_interactive_loop,
+    silence_display_loggers,
+)
 from holmes.plugins.destinations import DestinationType
 from holmes.plugins.interfaces import Issue
 from holmes.plugins.prompts import load_and_render_prompt
@@ -54,6 +60,7 @@ from holmes.plugins.sources.opsgenie import OPSGENIE_TEAM_INTEGRATION_KEY_HELP
 from holmes.utils.console.logging import init_logging
 from holmes.utils.console.result import handle_result
 from holmes.utils.file_utils import write_json_file
+from holmes.utils.sessions import ChatSession, SessionManager
 from holmes.checks.checks_cli import checks_app
 from holmes.common.cli_commons import (
     opt_api_key,
@@ -145,6 +152,13 @@ opt_documents: Optional[str] = typer.Option(
     None,
     "--documents",
     help="Additional documents to provide the LLM (typically URLs to runbooks)",
+)
+
+opt_continue_session: bool = typer.Option(
+    False,
+    "--continue",
+    "-c",
+    help="Resume the most recent session and continue the conversation",
 )
 
 
@@ -263,6 +277,7 @@ def ask(
         "--fast-mode",
         help="Skip TodoWrite planning phase for faster responses",
     ),
+    continue_session: bool = opt_continue_session,
 ):
     """
     Ask any question and answer using available tools
@@ -340,6 +355,16 @@ def ask(
     if echo_request and not interactive and prompt:
         console.print(f"[bold {USER_COLOR}]User:[/bold {USER_COLOR}] {prompt}")
 
+    # Resolve the session to continue (--continue)
+    session_manager = SessionManager()
+    resumed_session: Optional[ChatSession] = None
+    if continue_session:
+        resumed_session = session_manager.latest()
+        if resumed_session is None:
+            raise typer.BadParameter(
+                "No previous sessions found to continue. Start one with 'holmes ask'."
+            )
+
     # Build prompt component overrides for fast mode
     prompt_component_overrides = None
     if fast_mode:
@@ -387,6 +412,8 @@ def ask(
                 prompt_component_overrides=prompt_component_overrides,
                 config=config,
                 config_file_path=config_file,
+                session_manager=session_manager,
+                resume_session=resumed_session,
             )
             return
 
@@ -396,14 +423,21 @@ def ask(
                     f"[bold yellow]Adding file {file_path} to context[/bold yellow]"
                 )
 
-        messages = build_initial_ask_messages(
-            prompt,  # type: ignore
-            include_file,
-            ai.tool_executor,
-            config.get_skill_catalog(),
-            system_prompt_additions,
-            prompt_component_overrides=prompt_component_overrides,
-        )
+        if resumed_session is not None:
+            # Continue the previous conversation: keep its history and append
+            # the new question. The system prompt from the original run is
+            # reused as-is.
+            messages = list(resumed_session.messages)
+            messages.append({"role": "user", "content": prompt})
+        else:
+            messages = build_initial_ask_messages(
+                prompt,  # type: ignore
+                include_file,
+                ai.tool_executor,
+                config.get_skill_catalog(),
+                system_prompt_additions,
+                prompt_component_overrides=prompt_component_overrides,
+            )
 
         with tracer.start_trace(
             f'holmes ask "{prompt}"', span_type=SpanType.TASK
@@ -419,6 +453,28 @@ def ask(
 
         if json_output_file:
             write_json_file(json_output_file, response.model_dump())
+
+        # Persist the conversation so it can later be continued with --continue,
+        # even from non-interactive runs.
+        if messages:
+            if resumed_session is not None:
+                non_interactive_session_id = resumed_session.session_id
+                # Keep the resumed session's prior tool calls instead of
+                # overwriting them with only this run's tool calls.
+                tool_calls = deserialize_tool_calls(resumed_session.tool_calls) + (
+                    response.tool_calls or []
+                )
+            else:
+                non_interactive_session_id = SessionManager.new_session_id()
+                tool_calls = response.tool_calls or []
+            persist_session(
+                session_manager,
+                non_interactive_session_id,
+                messages,
+                tool_calls,
+                getattr(ai.llm, "model", None),
+                session_type="non-interactive",
+            )
 
         issue = Issue(
             id=str(uuid.uuid4()),

--- a/holmes/utils/sessions.py
+++ b/holmes/utils/sessions.py
@@ -1,0 +1,154 @@
+"""Local persistence for ``holmes ask`` conversations.
+
+Each session stores the full conversation (the same ``messages`` list that the
+interactive loop and non-interactive ``ask`` already build) plus a little
+metadata so it can be listed and continued later via ``--continue``.
+
+Sessions are written as one JSON file per session under
+``<config_path_dir>/sessions`` (``~/.holmes/sessions`` by default). The payload
+mirrors the shape produced by ``save_conversation_to_file`` /
+``LLMResult.model_dump()`` (``messages`` + ``tool_calls`` + ``metadata``) so the
+on-disk format stays consistent across HolmesGPT.
+"""
+
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from holmes.core.config import config_path_dir
+
+# Maximum length of the auto-generated session title (first user message).
+_TITLE_MAX_LENGTH = 80
+
+# Env var to opt out of writing sessions to disk (e.g. in CI). Reading existing
+# sessions for --continue still works; only saving is disabled.
+_DISABLE_PERSISTENCE_ENV = "HOLMES_DISABLE_SESSION_PERSISTENCE"
+
+
+def session_persistence_disabled() -> bool:
+    """Whether saving sessions to disk has been turned off via env var."""
+    return os.environ.get(_DISABLE_PERSISTENCE_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def derive_title(messages: List[Dict[str, Any]]) -> str:
+    """Build a short, single-line title from the first user message."""
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, list):
+            # Multi-modal content: pick the first text part if present.
+            content = next(
+                (
+                    part.get("text")
+                    for part in content
+                    if isinstance(part, dict) and part.get("type") == "text"
+                ),
+                None,
+            )
+        if not isinstance(content, str):
+            continue
+        title = " ".join(content.split())
+        if not title:
+            continue
+        if len(title) > _TITLE_MAX_LENGTH:
+            title = title[: _TITLE_MAX_LENGTH - 1].rstrip() + "…"
+        return title
+    return "(untitled session)"
+
+
+class ChatSession(BaseModel):
+    """A persisted conversation that can be continued later."""
+
+    session_id: str
+    title: str = "(untitled session)"
+    working_directory: str = ""
+    model: Optional[str] = None
+    created_at: str = Field(default_factory=_utc_now_iso)
+    updated_at: str = Field(default_factory=_utc_now_iso)
+    # Same shape as LLMResult.messages / .tool_calls so the on-disk format
+    # matches the rest of HolmesGPT's conversation serialization.
+    messages: List[Dict[str, Any]] = Field(default_factory=list)
+    tool_calls: List[Dict[str, Any]] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def message_count(self) -> int:
+        return len(self.messages)
+
+    @property
+    def user_turns(self) -> int:
+        return len([m for m in self.messages if m.get("role") == "user"])
+
+
+class SessionManager:
+    """Reads and writes :class:`ChatSession` files under the sessions directory."""
+
+    def __init__(self, sessions_dir: Optional[str] = None) -> None:
+        self.sessions_dir = sessions_dir or os.path.join(config_path_dir, "sessions")
+
+    def _path(self, session_id: str) -> str:
+        return os.path.join(self.sessions_dir, f"{session_id}.json")
+
+    @staticmethod
+    def new_session_id() -> str:
+        """Time-prefixed id so files sort chronologically and stay unique."""
+        return f"{datetime.now(timezone.utc):%Y%m%d-%H%M%S}-{uuid.uuid4().hex[:8]}"
+
+    def save(self, session: ChatSession) -> None:
+        """Atomically write a session to disk (write temp file, then rename)."""
+        os.makedirs(self.sessions_dir, exist_ok=True)
+        session.updated_at = _utc_now_iso()
+        target = self._path(session.session_id)
+        tmp = f"{target}.{os.getpid()}.tmp"
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(session.model_dump_json(indent=2))
+            os.replace(tmp, target)
+        except Exception:
+            logging.exception("Failed to save session %s", session.session_id)
+            if os.path.exists(tmp):
+                try:
+                    os.remove(tmp)
+                except OSError:
+                    pass
+
+    def list_sessions(self) -> List[ChatSession]:
+        """Return all valid sessions, most recently updated first.
+
+        Corrupt or unreadable files are skipped (and logged) rather than
+        breaking the listing.
+        """
+        if not os.path.isdir(self.sessions_dir):
+            return []
+        sessions: List[ChatSession] = []
+        for name in os.listdir(self.sessions_dir):
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(self.sessions_dir, name)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    sessions.append(ChatSession.model_validate_json(f.read()))
+            except Exception as e:
+                logging.debug("Skipping unreadable session file %s: %s", path, e)
+                continue
+        sessions.sort(key=lambda s: s.updated_at, reverse=True)
+        return sessions
+
+    def latest(self) -> Optional[ChatSession]:
+        """Return the most recently updated session, or ``None`` if there are none."""
+        sessions = self.list_sessions()
+        return sessions[0] if sessions else None

--- a/holmes/utils/sessions.py
+++ b/holmes/utils/sessions.py
@@ -28,6 +28,11 @@ _TITLE_MAX_LENGTH = 80
 # sessions for --continue still works; only saving is disabled.
 _DISABLE_PERSISTENCE_ENV = "HOLMES_DISABLE_SESSION_PERSISTENCE"
 
+# Sessions hold conversation history and tool output (cluster state, logs), so
+# the directory and its files stay readable by their owner only.
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
+
 
 def session_persistence_disabled() -> bool:
     """Whether saving sessions to disk has been turned off via env var."""
@@ -103,6 +108,18 @@ class SessionManager:
     def _path(self, session_id: str) -> str:
         return os.path.join(self.sessions_dir, f"{session_id}.json")
 
+    def _ensure_dir(self) -> None:
+        """Create the sessions directory, keeping it private to its owner."""
+        os.makedirs(self.sessions_dir, mode=_DIR_MODE, exist_ok=True)
+        # makedirs applies the umask, and ignores the mode entirely for a
+        # directory that already exists, so set the mode explicitly.
+        try:
+            os.chmod(self.sessions_dir, _DIR_MODE)
+        except OSError as e:
+            logging.debug(
+                "Could not restrict permissions on %s: %s", self.sessions_dir, e
+            )
+
     @staticmethod
     def new_session_id() -> str:
         """Time-prefixed id so files sort chronologically and stay unique."""
@@ -110,13 +127,16 @@ class SessionManager:
 
     def save(self, session: ChatSession) -> None:
         """Atomically write a session to disk (write temp file, then rename)."""
-        os.makedirs(self.sessions_dir, exist_ok=True)
+        self._ensure_dir()
         session.updated_at = _utc_now_iso()
         target = self._path(session.session_id)
         tmp = f"{target}.{os.getpid()}.tmp"
         try:
-            with open(tmp, "w", encoding="utf-8") as f:
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _FILE_MODE)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(session.model_dump_json(indent=2))
+            # os.open applies the umask to the mode above, os.chmod does not.
+            os.chmod(tmp, _FILE_MODE)
             os.replace(tmp, target)
         except Exception:
             logging.exception("Failed to save session %s", session.session_id)

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -7,6 +7,7 @@ import threading
 import time
 import unittest
 from io import StringIO
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -943,11 +944,15 @@ class TestRunInteractiveLoop(unittest.TestCase):
 
             self.mock_ai.call_stream = Mock(side_effect=_mock_stream)
 
+            log_file = os.path.join(sessions_dir, "error.log")
+            with open(log_file, "w") as f:
+                f.write("OOMKilled at 03:14")
+
             run_interactive_loop(
                 ai=self.mock_ai,
                 console=self.mock_console,
                 initial_user_input="follow up",
-                include_files=None,
+                include_files=[Path(log_file)],
                 show_tool_output=False,
                 check_version=False,
                 session_manager=manager,
@@ -960,7 +965,10 @@ class TestRunInteractiveLoop(unittest.TestCase):
             mock_build_messages.assert_not_called()
             msgs_arg = self.mock_ai.call_stream.call_args.kwargs["msgs"]
             self.assertEqual(msgs_arg[0], {"role": "system", "content": "sys"})
-            self.assertEqual(msgs_arg[-1], {"role": "user", "content": "follow up"})
+            self.assertEqual(msgs_arg[-1]["role"], "user")
+            self.assertTrue(msgs_arg[-1]["content"].startswith("follow up"))
+            # --file content must be attached to the first continued question.
+            self.assertIn("OOMKilled at 03:14", msgs_arg[-1]["content"])
 
             # The same session file was updated in place with the new turn.
             sessions = manager.list_sessions()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -27,6 +27,7 @@ from holmes.interactive import (
     handle_feedback_command,
     run_interactive_loop,
 )
+from holmes.utils.sessions import ChatSession, SessionManager
 from holmes.utils.stream import StreamEvents, StreamMessage
 from tests.mocks.toolset_mocks import SampleToolset
 
@@ -894,8 +895,6 @@ class TestRunInteractiveLoop(unittest.TestCase):
         mock_check_version,
     ):
         """A continued session keeps its history and is saved back in place."""
-        from holmes.utils.sessions import ChatSession, SessionManager
-
         sessions_dir = tempfile.mkdtemp()
         try:
             manager = SessionManager(sessions_dir=sessions_dir)
@@ -1000,8 +999,6 @@ class TestRunInteractiveLoop(unittest.TestCase):
         mock_check_version,
     ):
         """After /clear, --file is attached by the new session's first question only."""
-        from holmes.utils.sessions import ChatSession, SessionManager
-
         sessions_dir = tempfile.mkdtemp()
         try:
             manager = SessionManager(sessions_dir=sessions_dir)

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -964,7 +964,9 @@ class TestRunInteractiveLoop(unittest.TestCase):
             self.mock_ai.call_stream.assert_called_once()
             mock_build_messages.assert_not_called()
             msgs_arg = self.mock_ai.call_stream.call_args.kwargs["msgs"]
-            self.assertEqual(msgs_arg[0], {"role": "system", "content": "sys"})
+            # The whole prior conversation is preserved, in order, as a prefix.
+            self.assertEqual(msgs_arg[: len(prior.messages)], prior.messages)
+            self.assertEqual(len(msgs_arg), len(prior.messages) + 1)
             self.assertEqual(msgs_arg[-1]["role"], "user")
             self.assertTrue(msgs_arg[-1]["content"].startswith("follow up"))
             # --file content must be attached to the first continued question.
@@ -981,6 +983,100 @@ class TestRunInteractiveLoop(unittest.TestCase):
             self.assertEqual(
                 [tc["tool_call_id"] for tc in updated.tool_calls], ["prior_call"]
             )
+        finally:
+            shutil.rmtree(sessions_dir, ignore_errors=True)
+
+    @patch("holmes.interactive.check_version_async")
+    @patch("holmes.interactive.PromptSession")
+    @patch("holmes.interactive.build_initial_ask_messages")
+    @patch(
+        "holmes.interactive.config_path_dir", new_callable=lambda: tempfile.gettempdir()
+    )
+    def test_clear_does_not_reattach_files_to_later_questions(
+        self,
+        mock_config_dir,
+        mock_build_messages,
+        mock_prompt_session_class,
+        mock_check_version,
+    ):
+        """After /clear, --file is attached by the new session's first question only."""
+        from holmes.utils.sessions import ChatSession, SessionManager
+
+        sessions_dir = tempfile.mkdtemp()
+        try:
+            manager = SessionManager(sessions_dir=sessions_dir)
+            prior = ChatSession(
+                session_id="clear-test-id",
+                title="prior question",
+                messages=[
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "prior question"},
+                    {"role": "assistant", "content": "prior answer"},
+                ],
+            )
+            manager.save(prior)
+
+            log_file = os.path.join(sessions_dir, "error.log")
+            with open(log_file, "w") as f:
+                f.write("OOMKilled at 03:14")
+
+            mock_session = Mock()
+            mock_prompt_session_class.return_value = mock_session
+            mock_session.prompt.side_effect = [
+                SlashCommands.CLEAR.command,
+                "first after clear",
+                "second after clear",
+                "/exit",
+            ]
+            # Stands in for the real system prompt + file attachment that
+            # build_initial_ask_messages does for a new session's first question.
+            mock_build_messages.return_value = [
+                {"role": "system", "content": "fresh sys"},
+                {"role": "user", "content": "first after clear + file contents"},
+            ]
+
+            def _mock_stream(**kwargs):
+                history = list(kwargs["msgs"]) + [
+                    {"role": "assistant", "content": "Test response"}
+                ]
+                yield StreamMessage(
+                    event=StreamEvents.ANSWER_END,
+                    data={
+                        "content": "Test response",
+                        "messages": history,
+                        "tool_calls": [],
+                        "num_llm_calls": 1,
+                        "costs": {},
+                    },
+                )
+
+            self.mock_ai.call_stream = Mock(side_effect=_mock_stream)
+
+            run_interactive_loop(
+                ai=self.mock_ai,
+                console=self.mock_console,
+                initial_user_input=None,
+                include_files=[Path(log_file)],
+                show_tool_output=False,
+                check_version=False,
+                session_manager=manager,
+                resume_session=prior,
+            )
+
+            self.assertEqual(self.mock_ai.call_stream.call_count, 2)
+            # First question of the fresh session: files go through
+            # build_initial_ask_messages, which receives them.
+            mock_build_messages.assert_called_once()
+            self.assertEqual(mock_build_messages.call_args[0][1], [Path(log_file)])
+            # Second question must be the bare question, with no file contents
+            # appended a second time.
+            second_msgs = self.mock_ai.call_stream.call_args_list[1].kwargs["msgs"]
+            self.assertEqual(
+                second_msgs[-1], {"role": "user", "content": "second after clear"}
+            )
+            # The cleared conversation is not resumed, and its file is gone from
+            # the history the new session builds on.
+            self.assertNotIn("prior question", str(second_msgs))
         finally:
             shutil.rmtree(sessions_dir, ignore_errors=True)
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -885,6 +885,103 @@ class TestRunInteractiveLoop(unittest.TestCase):
     @patch(
         "holmes.interactive.config_path_dir", new_callable=lambda: tempfile.gettempdir()
     )
+    def test_run_interactive_loop_continues_and_persists_session(
+        self,
+        mock_config_dir,
+        mock_build_messages,
+        mock_prompt_session_class,
+        mock_check_version,
+    ):
+        """A continued session keeps its history and is saved back in place."""
+        from holmes.utils.sessions import ChatSession, SessionManager
+
+        sessions_dir = tempfile.mkdtemp()
+        try:
+            manager = SessionManager(sessions_dir=sessions_dir)
+            prior_tool_call = {
+                "tool_call_id": "prior_call",
+                "tool_name": "kubectl_get",
+                "description": "kubectl get pods",
+                "result": {
+                    "status": "success",
+                    "data": "pod1 Running",
+                    "error": None,
+                },
+            }
+            prior = ChatSession(
+                session_id="continue-test-id",
+                title="prior question",
+                messages=[
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "prior question"},
+                    {"role": "assistant", "content": "prior answer"},
+                ],
+                tool_calls=[prior_tool_call],
+            )
+            manager.save(prior)
+
+            mock_session = Mock()
+            mock_prompt_session_class.return_value = mock_session
+            mock_session.prompt.side_effect = ["/exit"]
+
+            full_history = prior.messages + [
+                {"role": "user", "content": "follow up"},
+                {"role": "assistant", "content": "Test response"},
+            ]
+
+            def _mock_stream(**kwargs):
+                yield StreamMessage(
+                    event=StreamEvents.ANSWER_END,
+                    data={
+                        "content": "Test response",
+                        "messages": full_history,
+                        "tool_calls": [],
+                        "num_llm_calls": 1,
+                        "costs": {},
+                    },
+                )
+
+            self.mock_ai.call_stream = Mock(side_effect=_mock_stream)
+
+            run_interactive_loop(
+                ai=self.mock_ai,
+                console=self.mock_console,
+                initial_user_input="follow up",
+                include_files=None,
+                show_tool_output=False,
+                check_version=False,
+                session_manager=manager,
+                resume_session=prior,
+            )
+
+            # The LLM was called with the prior history plus the new question,
+            # and build_initial_ask_messages was NOT used (we reuse old history).
+            self.mock_ai.call_stream.assert_called_once()
+            mock_build_messages.assert_not_called()
+            msgs_arg = self.mock_ai.call_stream.call_args.kwargs["msgs"]
+            self.assertEqual(msgs_arg[0], {"role": "system", "content": "sys"})
+            self.assertEqual(msgs_arg[-1], {"role": "user", "content": "follow up"})
+
+            # The same session file was updated in place with the new turn.
+            sessions = manager.list_sessions()
+            self.assertEqual(len(sessions), 1)
+            updated = sessions[0]
+            self.assertEqual(updated.session_id, "continue-test-id")
+            self.assertEqual(updated.user_turns, 2)
+            # The previously persisted tool call must survive the continue+save
+            # rather than being overwritten with an empty list.
+            self.assertEqual(
+                [tc["tool_call_id"] for tc in updated.tool_calls], ["prior_call"]
+            )
+        finally:
+            shutil.rmtree(sessions_dir, ignore_errors=True)
+
+    @patch("holmes.interactive.check_version_async")
+    @patch("holmes.interactive.PromptSession")
+    @patch("holmes.interactive.build_initial_ask_messages")
+    @patch(
+        "holmes.interactive.config_path_dir", new_callable=lambda: tempfile.gettempdir()
+    )
     def test_run_interactive_loop_exception_handling(
         self,
         mock_config_dir,

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -80,6 +80,38 @@ class TestAskContinue:
         assert sessions[0].user_turns == 2
 
     @patch("holmes.config.Config.create_toolcalling_llm")
+    def test_continue_attaches_files_to_the_new_question(
+        self, mock_create_toolcalling_llm, tmp_path, monkeypatch
+    ):
+        """--file must reach the LLM when continuing, not just print a message."""
+        monkeypatch.setattr("holmes.utils.sessions.config_path_dir", str(tmp_path))
+        manager = SessionManager(sessions_dir=str(tmp_path / "sessions"))
+        _make_session(manager, "why is my pod crashing?")
+        log_file = tmp_path / "error.log"
+        log_file.write_text("OOMKilled at 03:14")
+
+        mock_ai = MagicMock()
+        mock_ai.llm.model = "gpt-4o"
+        mock_ai.call.return_value = LLMResult(result="ok", tool_calls=[], messages=[])
+        mock_create_toolcalling_llm.return_value = mock_ai
+
+        result = runner.invoke(
+            app,
+            [
+                "ask",
+                "-c",
+                "what does this say?",
+                "-f",
+                str(log_file),
+                "--no-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+        last_message = mock_ai.call.call_args[0][0][-1]
+        assert "OOMKilled at 03:14" in last_message["content"]
+
+    @patch("holmes.config.Config.create_toolcalling_llm")
     def test_continue_without_any_session_fails(
         self, mock_create_toolcalling_llm, tmp_path, monkeypatch
     ):

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -1,0 +1,215 @@
+"""Tests for the --continue wiring in the ask CLI and the session save/load helpers."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from holmes.core.tool_calling_llm import LLMResult
+from holmes.interactive import deserialize_tool_calls, persist_session
+from holmes.main import app
+from holmes.utils.sessions import ChatSession, SessionManager, derive_title
+
+runner = CliRunner()
+
+
+def _tool_call_dict(tool_call_id="call_1", tool_name="kubectl_get"):
+    """A serialized ToolCallResult as it would appear in a saved session."""
+    return {
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "description": f"{tool_name} pods",
+        "result": {"status": "success", "data": "pod1 Running", "error": None},
+    }
+
+
+def _make_session(manager: SessionManager, prompt: str) -> ChatSession:
+    session = ChatSession(
+        session_id=manager.new_session_id(),
+        title=derive_title([{"role": "user", "content": prompt}]),
+        working_directory=os.getcwd(),
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "prior answer"},
+        ],
+    )
+    manager.save(session)
+    return session
+
+
+class TestAskContinue:
+    """End-to-end coverage of `holmes ask --continue` in non-interactive mode."""
+
+    @patch("holmes.config.Config.create_toolcalling_llm")
+    def test_continue_reuses_latest_session_history(
+        self, mock_create_toolcalling_llm, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("holmes.utils.sessions.config_path_dir", str(tmp_path))
+        manager = SessionManager(sessions_dir=str(tmp_path / "sessions"))
+        prior = _make_session(manager, "why is my pod crashing?")
+
+        mock_ai = MagicMock()
+        mock_ai.llm.model = "gpt-4o"
+        mock_ai.call.return_value = LLMResult(
+            result="it recovered",
+            tool_calls=[],
+            messages=prior.messages
+            + [
+                {"role": "user", "content": "did the fix work?"},
+                {"role": "assistant", "content": "it recovered"},
+            ],
+        )
+        mock_create_toolcalling_llm.return_value = mock_ai
+
+        result = runner.invoke(
+            app, ["ask", "--continue", "did the fix work?", "--no-interactive"]
+        )
+
+        assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+        # The LLM got the prior conversation plus the new question, not a fresh
+        # system prompt.
+        sent_messages = mock_ai.call.call_args[0][0]
+        assert sent_messages[0] == {"role": "system", "content": "sys"}
+        assert sent_messages[-1] == {"role": "user", "content": "did the fix work?"}
+
+        # The same session file was updated in place.
+        sessions = manager.list_sessions()
+        assert len(sessions) == 1
+        assert sessions[0].session_id == prior.session_id
+        assert sessions[0].user_turns == 2
+
+    @patch("holmes.config.Config.create_toolcalling_llm")
+    def test_continue_without_any_session_fails(
+        self, mock_create_toolcalling_llm, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("holmes.utils.sessions.config_path_dir", str(tmp_path))
+
+        result = runner.invoke(app, ["ask", "-c", "anything", "--no-interactive"])
+
+        assert result.exit_code != 0
+        assert "No previous sessions found" in result.output
+        mock_create_toolcalling_llm.assert_not_called()
+
+    @patch("holmes.config.Config.create_toolcalling_llm")
+    def test_ask_without_continue_starts_a_new_session(
+        self, mock_create_toolcalling_llm, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("holmes.utils.sessions.config_path_dir", str(tmp_path))
+        manager = SessionManager(sessions_dir=str(tmp_path / "sessions"))
+        prior = _make_session(manager, "an old question")
+
+        mock_ai = MagicMock()
+        mock_ai.llm.model = "gpt-4o"
+        mock_ai.call.return_value = LLMResult(
+            result="answer",
+            tool_calls=[],
+            messages=[
+                {"role": "system", "content": "fresh sys"},
+                {"role": "user", "content": "a new question"},
+                {"role": "assistant", "content": "answer"},
+            ],
+        )
+        mock_create_toolcalling_llm.return_value = mock_ai
+
+        result = runner.invoke(app, ["ask", "a new question", "--no-interactive"])
+
+        assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+        session_ids = {s.session_id for s in manager.list_sessions()}
+        assert len(session_ids) == 2
+        assert prior.session_id in session_ids
+
+
+class TestPersistSession:
+    def test_round_trip_with_tool_calls(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        session_id = SessionManager.new_session_id()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "why is the db slow?"},
+            {"role": "assistant", "content": "checking"},
+        ]
+
+        class _ToolCall:
+            def model_dump(self, mode=None):
+                return {"tool_name": "kubectl_logs", "result": "ok"}
+
+        persist_session(
+            manager,
+            session_id,
+            messages,
+            [_ToolCall()],
+            "anthropic/claude-sonnet-4-5-20250929",
+        )
+
+        loaded = manager.latest()
+        assert loaded is not None
+        assert loaded.session_id == session_id
+        assert loaded.title == "why is the db slow?"
+        assert loaded.model == "anthropic/claude-sonnet-4-5-20250929"
+        assert loaded.messages == messages
+        assert loaded.tool_calls == [{"tool_name": "kubectl_logs", "result": "ok"}]
+        assert loaded.working_directory == os.getcwd()
+        assert loaded.metadata == {"session_type": "interactive"}
+
+    def test_unserializable_tool_call_only_drops_itself(self, tmp_path):
+        """A single bad tool call is skipped without discarding the good ones."""
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        session_id = SessionManager.new_session_id()
+
+        class _GoodToolCall:
+            def model_dump(self, mode=None):
+                return {"tool_name": "good"}
+
+        class _BadToolCall:
+            def model_dump(self, mode=None):
+                raise RuntimeError("cannot serialize")
+
+        persist_session(
+            manager,
+            session_id,
+            [{"role": "user", "content": "hi"}],
+            [_GoodToolCall(), _BadToolCall(), _GoodToolCall()],
+            None,
+        )
+
+        loaded = manager.latest()
+        assert loaded is not None
+        assert loaded.tool_calls == [{"tool_name": "good"}, {"tool_name": "good"}]
+        assert loaded.messages == [{"role": "user", "content": "hi"}]
+
+    def test_persistence_can_be_disabled_via_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOLMES_DISABLE_SESSION_PERSISTENCE", "true")
+        manager = SessionManager(sessions_dir=str(tmp_path))
+
+        persist_session(
+            manager,
+            SessionManager.new_session_id(),
+            [{"role": "user", "content": "secret tool output"}],
+            [],
+            None,
+        )
+
+        # Nothing was written to disk.
+        assert manager.list_sessions() == []
+
+
+class TestDeserializeToolCalls:
+    def test_round_trips_saved_tool_calls(self):
+        restored = deserialize_tool_calls([_tool_call_dict("a"), _tool_call_dict("b")])
+        assert [tc.tool_call_id for tc in restored] == ["a", "b"]
+        assert restored[0].result.data == "pod1 Running"
+        # Restored objects must be real ToolCallResult instances usable by the UI
+        # (e.g. they expose .description and can be re-serialized).
+        assert restored[0].description == "kubectl_get pods"
+        assert restored[0].model_dump(mode="json")["tool_call_id"] == "a"
+
+    def test_skips_malformed_entries(self):
+        restored = deserialize_tool_calls(
+            [_tool_call_dict("ok"), {"garbage": True}, None]
+        )
+        assert [tc.tool_call_id for tc in restored] == ["ok"]
+
+    def test_empty_input(self):
+        assert deserialize_tool_calls([]) == []
+        assert deserialize_tool_calls(None) == []  # type: ignore[arg-type]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -113,7 +113,7 @@ class TestSessionManager:
 class TestSessionPermissions:
     """Sessions contain tool output, so they must not be world readable."""
 
-    def _mode(self, path) -> int:
+    def _mode(self, path: str | os.PathLike[str]) -> int:
         return stat.S_IMODE(os.stat(path).st_mode)
 
     def test_dir_and_file_are_owner_only_under_a_permissive_umask(self, tmp_path):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,147 @@
+"""Unit tests for holmes.utils.sessions (local session storage for --continue)."""
+
+import os
+import time
+
+from holmes.utils.sessions import ChatSession, SessionManager, derive_title
+
+
+def _make_session(manager: SessionManager, prompt: str, **kwargs) -> ChatSession:
+    session = ChatSession(
+        session_id=manager.new_session_id(),
+        title=derive_title([{"role": "user", "content": prompt}]),
+        working_directory=os.getcwd(),
+        model="anthropic/claude-sonnet-4-5-20250929",
+        messages=[
+            {"role": "system", "content": "you are holmes"},
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "answer"},
+        ],
+        **kwargs,
+    )
+    manager.save(session)
+    return session
+
+
+class TestSessionManager:
+    def test_save_round_trip(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        saved = _make_session(manager, "why is my pod crashing?")
+
+        loaded = manager.latest()
+
+        assert loaded is not None
+        assert loaded.session_id == saved.session_id
+        assert loaded.title == "why is my pod crashing?"
+        assert loaded.model == "anthropic/claude-sonnet-4-5-20250929"
+        assert loaded.messages == saved.messages
+        assert loaded.user_turns == 1
+        assert loaded.message_count == 3
+
+    def test_list_sessions_ordered_most_recent_first(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        first = _make_session(manager, "first question")
+        time.sleep(0.01)
+        second = _make_session(manager, "second question")
+        time.sleep(0.01)
+        third = _make_session(manager, "third question")
+
+        listed = manager.list_sessions()
+
+        assert [s.session_id for s in listed] == [
+            third.session_id,
+            second.session_id,
+            first.session_id,
+        ]
+
+    def test_latest_returns_most_recently_updated(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        _make_session(manager, "old")
+        time.sleep(0.01)
+        newest = _make_session(manager, "new")
+
+        latest = manager.latest()
+
+        assert latest is not None
+        assert latest.session_id == newest.session_id
+
+    def test_latest_none_when_empty(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path / "empty"))
+        assert manager.latest() is None
+        assert manager.list_sessions() == []
+
+    def test_save_updates_updated_at_and_persists_in_place(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        session = _make_session(manager, "hello")
+        first_updated_at = session.updated_at
+
+        time.sleep(0.01)
+        session.messages.append({"role": "user", "content": "follow up"})
+        manager.save(session)
+
+        reloaded = manager.latest()
+        assert reloaded is not None
+        assert reloaded.updated_at > first_updated_at
+        assert reloaded.user_turns == 2
+        # Updating an existing session must not create a second file.
+        assert len(manager.list_sessions()) == 1
+
+    def test_atomic_save_leaves_no_temp_files(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        _make_session(manager, "tidy up")
+        leftovers = [n for n in os.listdir(tmp_path) if not n.endswith(".json")]
+        assert leftovers == []
+
+    def test_list_skips_corrupt_files(self, tmp_path):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        good = _make_session(manager, "valid session")
+        (tmp_path / "broken.json").write_text("{not valid json")
+
+        listed = manager.list_sessions()
+
+        assert [s.session_id for s in listed] == [good.session_id]
+
+    def test_new_session_ids_are_unique(self):
+        ids = {SessionManager.new_session_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestDeriveTitle:
+    def test_uses_first_user_message(self):
+        title = derive_title(
+            [
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "what is broken?"},
+                {"role": "assistant", "content": "let me check"},
+            ]
+        )
+        assert title == "what is broken?"
+
+    def test_collapses_whitespace(self):
+        assert derive_title([{"role": "user", "content": "  a\n\n  b\tc "}]) == "a b c"
+
+    def test_truncates_long_titles(self):
+        long_prompt = "word " * 50
+        title = derive_title([{"role": "user", "content": long_prompt}])
+        assert len(title) <= 80
+        assert title.endswith("…")
+
+    def test_handles_multimodal_content(self):
+        title = derive_title(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "look at this image"},
+                        {"type": "image_url", "image_url": {"url": "data:..."}},
+                    ],
+                }
+            ]
+        )
+        assert title == "look at this image"
+
+    def test_falls_back_when_no_user_message(self):
+        assert (
+            derive_title([{"role": "system", "content": "sys"}]) == "(untitled session)"
+        )
+        assert derive_title([]) == "(untitled session)"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,7 +1,10 @@
 """Unit tests for holmes.utils.sessions (local session storage for --continue)."""
 
 import os
+import stat
 import time
+
+import pytest
 
 from holmes.utils.sessions import ChatSession, SessionManager, derive_title
 
@@ -104,6 +107,53 @@ class TestSessionManager:
     def test_new_session_ids_are_unique(self):
         ids = {SessionManager.new_session_id() for _ in range(100)}
         assert len(ids) == 100
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes")
+class TestSessionPermissions:
+    """Sessions contain tool output, so they must not be world readable."""
+
+    def _mode(self, path) -> int:
+        return stat.S_IMODE(os.stat(path).st_mode)
+
+    def test_dir_and_file_are_owner_only_under_a_permissive_umask(self, tmp_path):
+        original_umask = os.umask(0o000)
+        try:
+            manager = SessionManager(sessions_dir=str(tmp_path / "sessions"))
+            session = _make_session(manager, "keep this private")
+        finally:
+            os.umask(original_umask)
+
+        session_file = os.path.join(manager.sessions_dir, f"{session.session_id}.json")
+        assert self._mode(manager.sessions_dir) == 0o700
+        assert self._mode(session_file) == 0o600
+
+    def test_temp_file_is_owner_only_before_the_rename(self, tmp_path, monkeypatch):
+        manager = SessionManager(sessions_dir=str(tmp_path))
+        real_replace = os.replace
+        captured = {}
+
+        def _capture_then_replace(src, dst):
+            captured["mode"] = self._mode(src)
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("holmes.utils.sessions.os.replace", _capture_then_replace)
+        original_umask = os.umask(0o000)
+        try:
+            _make_session(manager, "keep this private")
+        finally:
+            os.umask(original_umask)
+
+        assert captured["mode"] == 0o600
+
+    def test_existing_world_readable_dir_is_tightened(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(mode=0o755)
+        manager = SessionManager(sessions_dir=str(sessions_dir))
+
+        _make_session(manager, "keep this private")
+
+        assert self._mode(sessions_dir) == 0o700
 
 
 class TestDeriveTitle:


### PR DESCRIPTION
## What

`holmes ask --continue` (`-c`) reopens the most recent conversation with its full history and tool calls, so you can pick up an investigation instead of re-asking:

```bash
holmes ask -c
holmes ask -c "did the fix work?"
```

Every `holmes ask` conversation is saved to `~/.holmes/sessions/` (honoring `HOLMES_CONFIGPATH_DIR`) as one JSON file per session. Opt out with `HOLMES_DISABLE_SESSION_PERSISTENCE=true`, existing sessions can still be continued.

Part 1 of 2 for #2363. Part 2 adds the `--resume` picker and `--session-id`. This replaces #2110, which was the whole feature in one ~1000 line PR.

The two open design questions (persistence default on vs opt in, global vs per directory scoping) are in #2363. Both are one line changes here if you want them the other way.

## How it works

1. `holmes/utils/sessions.py`: `ChatSession` + `SessionManager` (atomic save, list, latest). The payload reuses the `messages` + `tool_calls` shape that `save_conversation_to_file` / `LLMResult` already produce, so the on disk format matches the rest of HolmesGPT.
2. The interactive loop saves after each AI response, seeds `messages` and the tool call history from the session when continuing, and starts a fresh session on `/clear`.
3. Non-interactive `ask` saves and continues too, so `--continue` works with `--no-interactive`.
4. Files passed with `--file` are attached to the first question of a continued session, since `build_initial_ask_messages` (which normally attaches them) is skipped when the history comes from disk.
5. The sessions directory is created `0700` and each session file `0600`, independent of the umask, since sessions hold tool output.
6. A continued conversation reuses the original session's system prompt as is, with the toolsets and skills from that run. Re-rendering a fresh system prompt onto old history is out of scope here.

## Size

~1075 added lines, ~645 of them tests.

## Tests

`poetry run pytest tests -m "not llm"` on Python 3.12: 2758 passed, 94 skipped. The 3 failures I get locally are the `test_prometheus.py` mimir health checks that need a Prometheus on `localhost:9000`, and they fail identically on unmodified master.

New coverage:

1. `tests/test_sessions.py`: save round trip, list ordering, `latest()`, in place update without creating a second file, atomic write leaving no temp files, corrupt file skipping, title derivation including multimodal content, and `0700`/`0600` permissions on the directory, the final file and the temp file under a `0o000` umask.
2. `tests/test_session_cli.py`: `holmes ask --continue` end to end via `CliRunner` (prior history reaches the LLM, same session file updated), `--continue` with no sessions failing cleanly, a normal `ask` starting a new session, `-c` plus `-f` actually sending the file contents, `persist_session` round trip, tool call (de)serialization, and the persistence opt out.
3. `tests/test_interactive.py`: continuing inside the interactive loop passes the prior history through unchanged as a prefix, appends the new turn, saves back to the same file, and keeps the previously persisted tool calls instead of overwriting them. Plus `/clear` in a continued session not re-attaching `--file` to later questions.

## Docs

1. `docs/walkthrough/interactive-mode.md`: "Continuing a Session"
2. `docs/reference/environment-variables.md`: `HOLMES_DISABLE_SESSION_PERSISTENCE`

One mechanical note: I'm a first time contributor here, so the workflows on this PR need a maintainer to click "Approve and run workflows" before `build-and-test-gate` can run. That is what kept #2110 permanently red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversation persistence for `holmes ask`, including message history and tool-call details.
  * Added `--continue`/`-c` to resume the latest session and submit follow-up questions.
  * Interactive sessions can now be resumed or cleared while retaining appropriate context.
  * Added `HOLMES_DISABLE_SESSION_PERSISTENCE` to disable saving new sessions while preserving access to existing ones.

* **Documentation**
  * Documented session continuation, persistence, clearing conversations, and the new environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->