### PR TITLE
fix(tools): bound script/command tool subprocesses with a timeout

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -249,6 +249,17 @@ See [Tool Execution Safety](../data-sources/tool-execution-safety.md) for the fu
 export TOOL_MEMORY_LIMIT_MB=2000
 ```
 
+### TOOL_SUBPROCESS_TIMEOUT_SECONDS
+**Default:** `300`
+
+Wall-clock timeout (in seconds) for every `command:`/`script:` toolset tool Holmes runs as a subprocess (e.g. `kubectl`, `jq`). If the command has not finished by the deadline, Holmes kills the entire process group it spawned — not just the immediate shell — so a stalled grandchild process (for example a `kubectl` call stuck on a hung apiserver connection) cannot be left running forever. On timeout, the tool returns exit code `124` (matching GNU `timeout`) with any output produced so far plus a note that the command was killed.
+
+**Example:**
+```bash
+# Allow long-running tool commands up to 10 minutes before Holmes kills them
+export TOOL_SUBPROCESS_TIMEOUT_SECONDS=600
+```
+
 ## HolmesGPT Configuration
 
 ### MODEL_LIST_FILE_LOCATION

--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -98,6 +98,15 @@ TOOL_MEMORY_LIMIT_MB = int(
     os.environ.get("TOOL_MEMORY_LIMIT_MB", _default_memory_limit)
 )
 
+# Wall-clock timeout (seconds) for `command:`/`script:` toolset tools run via
+# subprocess (e.g. kubectl, jq). Without this, a stalled child process (e.g. an
+# apiserver connection that accepts the TCP handshake but never responds) blocks
+# the calling thread and leaks a process forever. On timeout the entire process
+# group spawned for the command is killed, not just the immediate shell child.
+TOOL_SUBPROCESS_TIMEOUT_SECONDS = int(
+    os.environ.get("TOOL_SUBPROCESS_TIMEOUT_SECONDS", 300)
+)
+
 STREAM_CHUNKS_PER_PARSE = int(
     os.environ.get("STREAM_CHUNKS_PER_PARSE", 80)
 )  # Empirical value with 6~ parsing calls. Consider using larger value if LLM response is long as to reduce markdown to section calls.

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shlex
+import signal
 import subprocess
 import tempfile
 import threading
@@ -40,6 +41,7 @@ from pydantic import (
 from rich.console import Console
 from rich.table import Table
 
+from holmes.common.env_vars import TOOL_SUBPROCESS_TIMEOUT_SECONDS
 from holmes.core.llm import LLM
 from holmes.core.openai_formatting import format_tool_to_open_ai_standard
 from holmes.core.transformers import (
@@ -658,20 +660,42 @@ class YAMLTool(Tool, BaseModel):
             logger.debug(f"Running `{cmd}`")
             protected_cmd = get_ulimit_prefix() + cmd
 
-            result = subprocess.run(
+            # start_new_session=True puts the shell (and everything it spawns,
+            # e.g. `kubectl`) in its own process group so a timeout can kill the
+            # whole tree with os.killpg() instead of leaving orphaned
+            # grandchildren running forever if the shell's direct child exits
+            # but a subprocess it started does not.
+            process = subprocess.Popen(
                 protected_cmd,
                 shell=True,
                 executable="/bin/bash",
                 text=True,
-                check=False,  # do not throw error, we just return the error code
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                start_new_session=True,
             )
+            try:
+                stdout, _ = process.communicate(timeout=TOOL_SUBPROCESS_TIMEOUT_SECONDS)
+                return_code = process.returncode
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    f"Command `{cmd}` did not complete within "
+                    f"{TOOL_SUBPROCESS_TIMEOUT_SECONDS}s, killing it"
+                )
+                stdout = self.__kill_process_group_and_collect_output(process)
+                # 124 is the conventional timeout exit code (matches GNU `timeout`)
+                return_code = 124
+                timeout_notice = (
+                    f"Command timed out after {TOOL_SUBPROCESS_TIMEOUT_SECONDS} "
+                    "seconds and was killed."
+                )
+                output = f"{stdout}\n{timeout_notice}" if stdout else timeout_notice
+                return output, return_code
 
-            output = result.stdout.strip()
-            output = check_oom_and_append_hint(output, result.returncode)
-            return output, result.returncode
+            output = (stdout or "").strip()
+            output = check_oom_and_append_hint(output, return_code)
+            return output, return_code
         except Exception as e:
             logger.error(
                 f"An unexpected error occurred while running '{cmd}': {e}",
@@ -679,6 +703,25 @@ class YAMLTool(Tool, BaseModel):
             )
             output = f"Command execution failed with error: {e}"
             return output, 1
+
+    @staticmethod
+    def __kill_process_group_and_collect_output(
+        process: "subprocess.Popen[str]",
+    ) -> str:
+        """Kill a timed-out process's entire process group and return whatever
+        output it had produced. Best-effort: the process group may already be
+        gone (race with natural exit), which is not an error."""
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass  # process (group) already exited on its own
+
+        try:
+            stdout, _ = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            # Extremely unlikely after SIGKILL, but never block forever here.
+            stdout = ""
+        return (stdout or "").strip()
 
 
 class StaticPrerequisite(BaseModel):

--- a/tests/core/test_tool_subprocess_timeout.py
+++ b/tests/core/test_tool_subprocess_timeout.py
@@ -106,7 +106,20 @@ class TestExecuteSubprocessTimeout:
         tool = _make_tool("sleep 30")
         context = create_mock_tool_invoke_context()
 
-        with patch("os.killpg", side_effect=ProcessLookupError()):
+        # Perform the real kill so the spawned `sleep 30` process group is
+        # actually reaped (avoiding an orphaned process), then raise
+        # ProcessLookupError to simulate the race where the process had
+        # already exited by the time killpg was called.
+        real_killpg = os.killpg
+
+        def killpg_then_raise(pgid, sig):
+            try:
+                real_killpg(pgid, sig)
+            except ProcessLookupError:
+                pass
+            raise ProcessLookupError()
+
+        with patch("os.killpg", side_effect=killpg_then_raise):
             result = tool._invoke(params={}, context=context)
 
         assert result.return_code == 124

--- a/tests/core/test_tool_subprocess_timeout.py
+++ b/tests/core/test_tool_subprocess_timeout.py
@@ -1,0 +1,123 @@
+"""
+Tests for the subprocess timeout added to Tool.__execute_subprocess().
+
+Regression coverage for: a script/command tool (e.g. kubernetes/core's
+kubectl-based tools) whose underlying subprocess stalls forever (for example
+an apiserver connection that accepts the TCP handshake but never responds)
+used to block the calling thread indefinitely and leak the child process.
+`__execute_subprocess()` now bounds every run with `TOOL_SUBPROCESS_TIMEOUT_SECONDS`
+and kills the whole process group on timeout, not just the immediate shell
+child, so any grandchild process (e.g. `kubectl`) spawned by the command is
+also reaped.
+"""
+
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from holmes.common.env_vars import TOOL_SUBPROCESS_TIMEOUT_SECONDS
+from holmes.core.tools import StructuredToolResultStatus, YAMLTool
+from tests.conftest import create_mock_tool_invoke_context
+
+
+def _make_tool(command: str) -> YAMLTool:
+    return YAMLTool(name="test-tool", description="test tool", command=command)
+
+
+class TestSubprocessTimeoutConfig:
+    def test_default_timeout_is_positive(self):
+        assert TOOL_SUBPROCESS_TIMEOUT_SECONDS > 0
+
+
+class TestExecuteSubprocessTimeout:
+    def test_fast_command_completes_normally(self):
+        tool = _make_tool("echo hello")
+        context = create_mock_tool_invoke_context()
+
+        result = tool._invoke(params={}, context=context)
+
+        assert result.return_code == 0
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert "hello" in result.data
+
+    def test_slow_command_is_killed_after_timeout(self, monkeypatch):
+        monkeypatch.setattr("holmes.core.tools.TOOL_SUBPROCESS_TIMEOUT_SECONDS", 0.5)
+        tool = _make_tool("sleep 30")
+        context = create_mock_tool_invoke_context()
+
+        start = time.time()
+        result = tool._invoke(params={}, context=context)
+        elapsed = time.time() - start
+
+        # Must not have blocked anywhere near the full 30s sleep.
+        assert elapsed < 10
+        assert result.return_code == 124
+        assert result.status == StructuredToolResultStatus.ERROR
+        assert "timed out" in result.data.lower()
+
+    def test_partial_output_before_timeout_is_preserved(self, monkeypatch):
+        monkeypatch.setattr("holmes.core.tools.TOOL_SUBPROCESS_TIMEOUT_SECONDS", 0.5)
+        tool = _make_tool("echo partial-output; sleep 30")
+        context = create_mock_tool_invoke_context()
+
+        result = tool._invoke(params={}, context=context)
+
+        assert result.return_code == 124
+        assert "partial-output" in result.data
+        assert "timed out" in result.data.lower()
+
+    def test_grandchild_process_is_also_killed(self, tmp_path, monkeypatch):
+        """Regression test for the reported bug: killing only the direct shell
+        child (as plain subprocess.run(timeout=...) + .kill() would do) leaves
+        a backgrounded grandchild (e.g. a stalled kubectl call) running
+        forever. The whole process group must be killed."""
+        monkeypatch.setattr("holmes.core.tools.TOOL_SUBPROCESS_TIMEOUT_SECONDS", 0.5)
+        pid_file = tmp_path / "grandchild.pid"
+        command = f"sleep 30 & echo $! > {pid_file}; wait"
+        tool = _make_tool(command)
+        context = create_mock_tool_invoke_context()
+
+        result = tool._invoke(params={}, context=context)
+        assert result.return_code == 124
+
+        # Give the kernel a brief moment to finish delivering SIGKILL.
+        deadline = time.time() + 2
+        grandchild_pid = int(pid_file.read_text().strip())
+        alive = True
+        while time.time() < deadline:
+            try:
+                os.kill(grandchild_pid, 0)
+                alive = True
+            except ProcessLookupError:
+                alive = False
+                break
+            time.sleep(0.1)
+        assert (
+            not alive
+        ), f"grandchild process {grandchild_pid} survived the timeout kill"
+
+    def test_kill_race_condition_does_not_raise(self, monkeypatch):
+        """If the process happens to exit on its own right before we signal
+        it, os.killpg raises ProcessLookupError — this must be swallowed, not
+        propagated as an unhandled exception."""
+        monkeypatch.setattr("holmes.core.tools.TOOL_SUBPROCESS_TIMEOUT_SECONDS", 0.3)
+        tool = _make_tool("sleep 30")
+        context = create_mock_tool_invoke_context()
+
+        with patch("os.killpg", side_effect=ProcessLookupError()):
+            result = tool._invoke(params={}, context=context)
+
+        assert result.return_code == 124
+        assert "timed out" in result.data.lower()
+
+    @pytest.mark.parametrize("command", ["sleep 30"])
+    def test_timeout_does_not_raise_unexpected_exception(self, monkeypatch, command):
+        monkeypatch.setattr("holmes.core.tools.TOOL_SUBPROCESS_TIMEOUT_SECONDS", 0.3)
+        tool = _make_tool(command)
+        context = create_mock_tool_invoke_context()
+
+        # Should never raise — the caller always gets back a StructuredToolResult.
+        result = tool._invoke(params={}, context=context)
+        assert result.return_code == 124


### PR DESCRIPTION
## Problem

`Tool.__execute_subprocess()` (`holmes/core/tools.py`) is the shared execution path for every `command:`/`script:` toolset tool, including the built-in `kubernetes/core` tools (`kubernetes_jq_query`, `kubernetes_tabular_query`, `kubernetes_count`, all of which shell out to `kubectl`). It ran the command via `subprocess.run()` with no `timeout=`.

If the underlying process stalls — e.g. `kubectl` hits an apiserver connection that accepts the TCP handshake but never responds — `subprocess.run()` blocks the calling thread forever and the child process is never reaped. This doesn't require a pod restart to snowball: a single long-lived Holmes pod accumulates one permanently-blocked worker (and orphaned `kubectl` process) per stuck call, and each pins significant CPU.

This is not specific to `kubernetes/core` — `__execute_subprocess()` is shared by every `script:`-defined tool across every toolset (e.g. `kubevela.yaml` too).

Fixes #2365.

## Fix

- `__execute_subprocess()` now runs the command via `subprocess.Popen(..., start_new_session=True)` + `process.communicate(timeout=TOOL_SUBPROCESS_TIMEOUT_SECONDS)` (new env var, default `300`s) instead of an unbounded `subprocess.run()`.
- On timeout, the **entire process group** is killed with `os.killpg(..., SIGKILL)`, not just the immediate `bash` child. This matters because the direct child of `Popen` is `bash <script>`, and the actual offending command (`kubectl`, etc.) runs as *its* child — killing only the direct child (what plain `subprocess.run(timeout=...)` + `.kill()` does) leaves that grandchild running independently, which is exactly the failure mode described in the issue. `start_new_session=True` puts the whole tree in its own process group so `killpg` reaps it all.
- The race where the process exits on its own right as we're about to signal it (`os.killpg` raising `ProcessLookupError`) is handled explicitly and does not propagate.
- On timeout the tool returns exit code `124` (matching GNU `timeout`) plus any output produced before the deadline, so the LLM sees a clear, actionable error instead of the call silently vanishing.
- Added `TOOL_SUBPROCESS_TIMEOUT_SECONDS` (default `300`) to `holmes/common/env_vars.py`, following the existing `TOOL_MEMORY_LIMIT_MB` pattern, and documented it in `docs/reference/environment-variables.md`.

## Changes

- `holmes/common/env_vars.py`: new `TOOL_SUBPROCESS_TIMEOUT_SECONDS` env var (default 300s).
- `holmes/core/tools.py`: `Tool.__execute_subprocess()` rewritten around `Popen` + `communicate(timeout=...)`; new `Tool.__kill_process_group_and_collect_output()` helper that kills the process group and returns whatever output was buffered.
- `docs/reference/environment-variables.md`: reference entry for the new env var.
- `tests/core/test_tool_subprocess_timeout.py`: new tests (see below).

## Test plan

Added `tests/core/test_tool_subprocess_timeout.py`, covering:
- Fast commands still complete normally and return exit code 0.
- A command exceeding the timeout is killed and returns exit code 124 without blocking anywhere near the original duration.
- Output produced before the timeout is preserved alongside the timeout notice.
- **The specific bug scenario**: a command that backgrounds a child process (simulating a stalled `kubectl` grandchild) — the regression test confirms that process is actually killed, not left orphaned.
- The `os.killpg` race (process exits right as we try to signal it) is swallowed rather than raised.

Validation performed in this environment:
- `ast.parse` on all changed Python files (syntax-valid).
- `ruff check` and `ruff format --diff` with the pinned versions from `.pre-commit-config.yaml` (`ruff==0.7.2`) — clean on all lines touched by this change.
- `isort --profile black --check-only --diff` (`isort==6.1.0`, closest available to the pinned `7.0.0` for this environment's Python) — the new import is correctly positioned; no changes requested to lines touched by this PR.
- `mypy` against `holmes/core/tools.py` / `holmes/common/env_vars.py` — no new errors introduced by this change (pre-existing unrelated errors elsewhere in the file/codebase are untouched by this diff).
- This sandbox only has Python 3.9 available and the project requires 3.10+ (`litellm`/`aiohttp` enforce this at install time), so I could not run `pytest`/`make test-without-llm` directly here. To compensate, I extracted the exact `Popen`/`communicate`/`killpg` logic added in this PR into a standalone script (no holmes imports) and exercised it directly — confirmed: fast commands return normally, slow commands are killed at the timeout without blocking, partial output is preserved, and critically, the backgrounded "grandchild" process is killed with the new process-group approach while a side-by-side run of the *old* `subprocess.run(timeout=...)` pattern left that same grandchild process alive, reproducing the exact bug from the issue. CI will run the full suite including the new test file on a proper Python 3.10+ environment.

## Example

```bash
export TOOL_SUBPROCESS_TIMEOUT_SECONDS=600  # default is 300
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for subprocess-based commands and scripts, defaulting to 300 seconds.
  * Timed-out processes now stop cleanly, including child processes, and return exit code 124.
  * Partial output is preserved and accompanied by a timeout notice.

* **Documentation**
  * Added configuration guidance, default behavior, timeout handling, and examples for the new setting.

* **Bug Fixes**
  * Improved handling of subprocess termination races and timeout results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->