### PR TITLE
ROB-855 pulling skills with github app credentials

### DIFF
--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -32,7 +32,7 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
       --from-literal=token='<PAT>'
     ```
 
-    For a public repo, omit the Secret and drop the `oauth2:${GIT_PAT}@` segment from the clone URL below.
+    For a public repo, omit the Secret, delete the `GIT_PAT` entry from the `env:` block, and drop the `oauth2:${GIT_PAT}@` segment from the clone URL below.
 
     **2. Add the init container, volume, and skill path to your Helm values:**
 
@@ -64,7 +64,7 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
         args:
           - |
             set -e
-            rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
+            rm -rf /skills-repo/* /skills-repo/.[!.]* /skills-repo/..?* 2>/dev/null || true
             git clone --depth 1 --branch "$GIT_BRANCH" \
               "https://oauth2:${GIT_PAT}@${GIT_REPO}" \
               /skills-repo
@@ -100,7 +100,7 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
       --from-literal=token='<PAT>'
     ```
 
-    For a public repo, omit the Secret and drop the `oauth2:${GIT_PAT}@` segment from the clone URL below.
+    For a public repo, omit the Secret, delete the `GIT_PAT` entry from the `env:` block, and drop the `oauth2:${GIT_PAT}@` segment from the clone URL below.
 
     **2. Add the init container, volume, and skill path to your `generated_values.yaml`:**
 
@@ -134,7 +134,7 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
           args:
             - |
               set -e
-              rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
+              rm -rf /skills-repo/* /skills-repo/.[!.]* /skills-repo/..?* 2>/dev/null || true
               git clone --depth 1 --branch "$GIT_BRANCH" \
                 "https://oauth2:${GIT_PAT}@${GIT_REPO}" \
                 /skills-repo
@@ -171,7 +171,7 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
 
 #### Using a GitHub App
 
-Instead of a Personal Access Token, authenticate with a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps). The init container generates a JWT from the App's private key, exchanges it for a short-lived installation token (valid 1 hour), and clones with it — no long-lived credential ever reaches the pod.
+Instead of a Personal Access Token, authenticate with a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps). The init container generates a JWT from the App's private key, exchanges it for a short-lived installation token (valid 1 hour), and clones with it. The App's private key is still mounted into the init container, but the credential used to reach your repo is the installation token, which expires after an hour — so a leaked clone URL or `.git/config` goes stale on its own, unlike a Personal Access Token.
 
 Create the App, generate a private key, and install it on your skills repo by following steps 1–4 in [GitHub MCP — Using a GitHub App](../data-sources/builtin-toolsets/github-mcp.md#using-a-github-app). For skills the App only needs the **Contents: Read-only** repository permission (plus Metadata, which GitHub adds automatically).
 
@@ -241,7 +241,7 @@ Create the App, generate a private key, and install it on your skills repo by fo
               exit 1
             fi
 
-            rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
+            rm -rf /skills-repo/* /skills-repo/.[!.]* /skills-repo/..?* 2>/dev/null || true
             git clone --depth 1 --branch "$GIT_BRANCH" \
               "https://x-access-token:${TOKEN}@${GIT_REPO}" \
               /skills-repo
@@ -335,7 +335,7 @@ Create the App, generate a private key, and install it on your skills repo by fo
                 exit 1
               fi
 
-              rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
+              rm -rf /skills-repo/* /skills-repo/.[!.]* /skills-repo/..?* 2>/dev/null || true
               git clone --depth 1 --branch "$GIT_BRANCH" \
                 "https://x-access-token:${TOKEN}@${GIT_REPO}" \
                 /skills-repo
@@ -366,9 +366,13 @@ Create the App, generate a private key, and install it on your skills repo by fo
     Mint a short-lived installation token from the App credentials and clone with it:
 
     ```bash
+    set -eu
+
     APP_ID=<YOUR_APP_ID>
     INSTALLATION_ID=<YOUR_INSTALLATION_ID>
     KEY_FILE=/path/to/private-key.pem
+    GIT_REPO=github.com/<org>/<repo>.git
+    GIT_BRANCH=main
 
     b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
 
@@ -383,7 +387,13 @@ Create the App, generate a private key, and install it on your skills repo by fo
       "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens" \
       | sed -n 's/.*"token" *: *"\([^"]*\)".*/\1/p')
 
-    git clone "https://x-access-token:${TOKEN}@github.com/<org>/<repo>.git"
+    if [ -z "$TOKEN" ]; then
+      echo "Failed to obtain a GitHub App installation token" >&2
+      exit 1
+    fi
+
+    git clone --depth 1 --branch "$GIT_BRANCH" \
+      "https://x-access-token:${TOKEN}@${GIT_REPO}"
     ```
 
     Then point `custom_skill_paths` at the clone in `~/.holmes/config.yaml`:

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -56,13 +56,17 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
               secretKeyRef:
                 name: holmes-skills-git-credentials
                 key: token
+          - name: GIT_REPO
+            value: github.com/<org>/<repo>.git
+          - name: GIT_BRANCH
+            value: main
         command: ["/bin/sh", "-c"]
         args:
           - |
             set -e
             rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
-            git clone --depth 1 --branch main \
-              "https://oauth2:${GIT_PAT}@github.com/<org>/<repo>.git" \
+            git clone --depth 1 --branch "$GIT_BRANCH" \
+              "https://oauth2:${GIT_PAT}@${GIT_REPO}" \
               /skills-repo
         volumeMounts:
           - name: skills-repo
@@ -72,10 +76,10 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
       - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
     ```
 
-    Adjust:
+    Adjust — everything install-specific lives in the `env:` block, so the script body can be copied verbatim:
 
-    - `--branch main` — branch you push skills to.
-    - `https://github.com/<org>/<repo>.git` — your repo URL.
+    - `GIT_REPO` — your repo, without the scheme (for example `github.com/acme/holmes-skills.git`).
+    - `GIT_BRANCH` — branch you push skills to. Check your repo's actual default: GitHub creates new repos with `main`, but older repos are often still `master`, and the clone fails outright on a wrong branch name.
     - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
 
     **3. Refresh after changes.** The clone runs only on pod startup. After pushing skill changes to the tracked branch, roll the Holmes Deployment:
@@ -122,13 +126,17 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
                 secretKeyRef:
                   name: holmes-skills-git-credentials
                   key: token
+            - name: GIT_REPO
+              value: github.com/<org>/<repo>.git
+            - name: GIT_BRANCH
+              value: main
           command: ["/bin/sh", "-c"]
           args:
             - |
               set -e
               rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
-              git clone --depth 1 --branch main \
-                "https://oauth2:${GIT_PAT}@github.com/<org>/<repo>.git" \
+              git clone --depth 1 --branch "$GIT_BRANCH" \
+                "https://oauth2:${GIT_PAT}@${GIT_REPO}" \
                 /skills-repo
           volumeMounts:
             - name: skills-repo
@@ -138,10 +146,10 @@ For private repos there are two ways to authenticate: a fine-grained [Personal A
         - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
     ```
 
-    Adjust:
+    Adjust — everything install-specific lives in the `env:` block, so the script body can be copied verbatim:
 
-    - `--branch main` — branch you push skills to.
-    - `https://github.com/<org>/<repo>.git` — your repo URL.
+    - `GIT_REPO` — your repo, without the scheme (for example `github.com/acme/holmes-skills.git`).
+    - `GIT_BRANCH` — branch you push skills to. Check your repo's actual default: GitHub creates new repos with `main`, but older repos are often still `master`, and the clone fails outright on a wrong branch name.
     - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
 
     **3. Refresh after changes.** The clone runs only on pod startup. After pushing skill changes to the tracked branch, roll the Holmes Deployment:
@@ -200,6 +208,11 @@ Create the App, generate a private key, and install it on your skills repo by fo
         envFrom:
           - secretRef:
               name: holmes-github-app
+        env:
+          - name: GIT_REPO
+            value: github.com/<org>/<repo>.git
+          - name: GIT_BRANCH
+            value: main
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -229,8 +242,8 @@ Create the App, generate a private key, and install it on your skills repo by fo
             fi
 
             rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
-            git clone --depth 1 --branch main \
-              "https://x-access-token:${TOKEN}@github.com/<org>/<repo>.git" \
+            git clone --depth 1 --branch "$GIT_BRANCH" \
+              "https://x-access-token:${TOKEN}@${GIT_REPO}" \
               /skills-repo
         volumeMounts:
           - name: skills-repo
@@ -240,10 +253,10 @@ Create the App, generate a private key, and install it on your skills repo by fo
       - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
     ```
 
-    Adjust:
+    Adjust — everything install-specific lives in the `env:` block, so the script body can be copied verbatim:
 
-    - `--branch main` — branch you push skills to.
-    - `https://github.com/<org>/<repo>.git` — your repo URL.
+    - `GIT_REPO` — your repo, without the scheme (for example `github.com/acme/holmes-skills.git`).
+    - `GIT_BRANCH` — branch you push skills to. Check your repo's actual default: GitHub creates new repos with `main`, but older repos are often still `master`, and the clone fails outright on a wrong branch name.
     - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
 
     The init container installs `git`, `openssl`, and `curl` at startup, which requires egress to the Alpine package CDN. If your cluster restricts egress, build a small image with those packages preinstalled and drop the `apk add` line.
@@ -289,6 +302,11 @@ Create the App, generate a private key, and install it on your skills repo by fo
           envFrom:
             - secretRef:
                 name: holmes-github-app
+          env:
+            - name: GIT_REPO
+              value: github.com/<org>/<repo>.git
+            - name: GIT_BRANCH
+              value: main
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -318,8 +336,8 @@ Create the App, generate a private key, and install it on your skills repo by fo
               fi
 
               rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
-              git clone --depth 1 --branch main \
-                "https://x-access-token:${TOKEN}@github.com/<org>/<repo>.git" \
+              git clone --depth 1 --branch "$GIT_BRANCH" \
+                "https://x-access-token:${TOKEN}@${GIT_REPO}" \
                 /skills-repo
           volumeMounts:
             - name: skills-repo
@@ -329,10 +347,10 @@ Create the App, generate a private key, and install it on your skills repo by fo
         - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
     ```
 
-    Adjust:
+    Adjust — everything install-specific lives in the `env:` block, so the script body can be copied verbatim:
 
-    - `--branch main` — branch you push skills to.
-    - `https://github.com/<org>/<repo>.git` — your repo URL.
+    - `GIT_REPO` — your repo, without the scheme (for example `github.com/acme/holmes-skills.git`).
+    - `GIT_BRANCH` — branch you push skills to. Check your repo's actual default: GitHub creates new repos with `main`, but older repos are often still `master`, and the clone fails outright on a wrong branch name.
     - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
 
     The init container installs `git`, `openssl`, and `curl` at startup, which requires egress to the Alpine package CDN. If your cluster restricts egress, build a small image with those packages preinstalled and drop the `apk add` line.

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -16,6 +16,10 @@ There are three ways to load custom skills, covered below. Within each, pick you
 
 Keep skills version-controlled in a Git repo so they can be reviewed, versioned, and shared across a team.
 
+For private repos there are two ways to authenticate: a fine-grained [Personal Access Token](#using-a-personal-access-token) (simplest) or a [GitHub App](#using-a-github-app) (short-lived auto-expiring tokens, not tied to a personal account).
+
+#### Using a Personal Access Token
+
 === "Holmes Helm Chart"
 
     Have Holmes re-clone the repo on every pod restart. An init container pulls the repo into an `emptyDir` shared with the main Holmes container, and a `customSkillPaths` entry registers the directory.
@@ -156,6 +160,222 @@ Keep skills version-controlled in a Git repo so they can be reviewed, versioned,
     ```
 
     Run `git pull` in the clone whenever you want to pick up new or updated skills.
+
+#### Using a GitHub App
+
+Instead of a Personal Access Token, authenticate with a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps). The init container generates a JWT from the App's private key, exchanges it for a short-lived installation token (valid 1 hour), and clones with it — no long-lived credential ever reaches the pod.
+
+Create the App, generate a private key, and install it on your skills repo by following steps 1–4 in [GitHub MCP — Using a GitHub App](../data-sources/builtin-toolsets/github-mcp.md#using-a-github-app). For skills the App only needs the **Contents: Read-only** repository permission (plus Metadata, which GitHub adds automatically).
+
+=== "Holmes Helm Chart"
+
+    Have Holmes re-clone the repo on every pod restart. An init container exchanges the GitHub App credentials for an installation token, pulls the repo into an `emptyDir` shared with the main Holmes container, and a `customSkillPaths` entry registers the directory.
+
+    **1. Create a Secret with the GitHub App credentials:**
+
+    ```bash
+    kubectl create secret generic holmes-github-app \
+      -n <holmes-namespace> \
+      --from-literal=GITHUB_APP_ID=<YOUR_APP_ID> \
+      --from-literal=GITHUB_APP_INSTALLATION_ID=<YOUR_INSTALLATION_ID> \
+      --from-file=GITHUB_APP_PRIVATE_KEY=/path/to/private-key.pem
+    ```
+
+    **2. Add the init container, volume, and skill path to your Helm values:**
+
+    ```yaml
+    additionalVolumes:
+      - name: skills-repo
+        emptyDir:
+          sizeLimit: 64Mi
+
+    additionalVolumeMounts:
+      - name: skills-repo
+        mountPath: /etc/holmes/skills-git
+        readOnly: true
+
+    initContainers:
+      - name: clone-skills
+        image: alpine:3.22
+        envFrom:
+          - secretRef:
+              name: holmes-github-app
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            apk add --no-cache git openssl curl >/dev/null
+
+            b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+            KEY_FILE=$(mktemp)
+            printf '%s' "$GITHUB_APP_PRIVATE_KEY" > "$KEY_FILE"
+
+            NOW=$(date +%s)
+            HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+            PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 540))" "$GITHUB_APP_ID" | b64url)
+            SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign "$KEY_FILE" -binary | b64url)
+            rm -f "$KEY_FILE"
+
+            TOKEN=$(curl -sf -X POST \
+              -H "Authorization: Bearer ${HEADER}.${PAYLOAD}.${SIGNATURE}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+              | sed -n 's/.*"token" *: *"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Failed to obtain a GitHub App installation token" >&2
+              exit 1
+            fi
+
+            rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
+            git clone --depth 1 --branch main \
+              "https://x-access-token:${TOKEN}@github.com/<org>/<repo>.git" \
+              /skills-repo
+        volumeMounts:
+          - name: skills-repo
+            mountPath: /skills-repo
+
+    customSkillPaths:
+      - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
+    ```
+
+    Adjust:
+
+    - `--branch main` — branch you push skills to.
+    - `https://github.com/<org>/<repo>.git` — your repo URL.
+    - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
+
+    The init container installs `git`, `openssl`, and `curl` at startup, which requires egress to the Alpine package CDN. If your cluster restricts egress, build a small image with those packages preinstalled and drop the `apk add` line.
+
+    **3. Refresh after changes.** The clone runs only on pod startup. After pushing skill changes to the tracked branch, roll the Holmes Deployment:
+
+    ```bash
+    kubectl rollout restart deploy/<release>-holmes -n <holmes-namespace>
+    ```
+
+=== "Robusta Helm Chart"
+
+    Have Holmes re-clone the repo on every pod restart. An init container exchanges the GitHub App credentials for an installation token, pulls the repo into an `emptyDir` shared with the main Holmes container, and a `customSkillPaths` entry registers the directory.
+
+    **1. Create a Secret with the GitHub App credentials:**
+
+    ```bash
+    kubectl create secret generic holmes-github-app \
+      -n <robusta-namespace> \
+      --from-literal=GITHUB_APP_ID=<YOUR_APP_ID> \
+      --from-literal=GITHUB_APP_INSTALLATION_ID=<YOUR_INSTALLATION_ID> \
+      --from-file=GITHUB_APP_PRIVATE_KEY=/path/to/private-key.pem
+    ```
+
+    **2. Add the init container, volume, and skill path to your `generated_values.yaml`:**
+
+    ```yaml
+    enableHolmesGPT: true
+    holmes:
+      additionalVolumes:
+        - name: skills-repo
+          emptyDir:
+            sizeLimit: 64Mi
+
+      additionalVolumeMounts:
+        - name: skills-repo
+          mountPath: /etc/holmes/skills-git
+          readOnly: true
+
+      initContainers:
+        - name: clone-skills
+          image: alpine:3.22
+          envFrom:
+            - secretRef:
+                name: holmes-github-app
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              apk add --no-cache git openssl curl >/dev/null
+
+              b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+              KEY_FILE=$(mktemp)
+              printf '%s' "$GITHUB_APP_PRIVATE_KEY" > "$KEY_FILE"
+
+              NOW=$(date +%s)
+              HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+              PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 540))" "$GITHUB_APP_ID" | b64url)
+              SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign "$KEY_FILE" -binary | b64url)
+              rm -f "$KEY_FILE"
+
+              TOKEN=$(curl -sf -X POST \
+                -H "Authorization: Bearer ${HEADER}.${PAYLOAD}.${SIGNATURE}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+                | sed -n 's/.*"token" *: *"\([^"]*\)".*/\1/p')
+
+              if [ -z "$TOKEN" ]; then
+                echo "Failed to obtain a GitHub App installation token" >&2
+                exit 1
+              fi
+
+              rm -rf /skills-repo/.git /skills-repo/* 2>/dev/null || true
+              git clone --depth 1 --branch main \
+                "https://x-access-token:${TOKEN}@github.com/<org>/<repo>.git" \
+                /skills-repo
+          volumeMounts:
+            - name: skills-repo
+              mountPath: /skills-repo
+
+      customSkillPaths:
+        - /etc/holmes/skills-git/skills   # subdirectory inside the repo where SKILL.md files live
+    ```
+
+    Adjust:
+
+    - `--branch main` — branch you push skills to.
+    - `https://github.com/<org>/<repo>.git` — your repo URL.
+    - `customSkillPaths` — point at the subdirectory inside the repo that contains skill folders. If skills are in the repo root, use `/etc/holmes/skills-git`.
+
+    The init container installs `git`, `openssl`, and `curl` at startup, which requires egress to the Alpine package CDN. If your cluster restricts egress, build a small image with those packages preinstalled and drop the `apk add` line.
+
+    **3. Refresh after changes.** The clone runs only on pod startup. After pushing skill changes to the tracked branch, roll the Holmes Deployment:
+
+    ```bash
+    kubectl rollout restart deploy/robusta-holmes -n <robusta-namespace>
+    ```
+
+=== "Holmes CLI"
+
+    Mint a short-lived installation token from the App credentials and clone with it:
+
+    ```bash
+    APP_ID=<YOUR_APP_ID>
+    INSTALLATION_ID=<YOUR_INSTALLATION_ID>
+    KEY_FILE=/path/to/private-key.pem
+
+    b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+    NOW=$(date +%s)
+    HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+    PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 540))" "$APP_ID" | b64url)
+    SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign "$KEY_FILE" -binary | b64url)
+
+    TOKEN=$(curl -sf -X POST \
+      -H "Authorization: Bearer ${HEADER}.${PAYLOAD}.${SIGNATURE}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens" \
+      | sed -n 's/.*"token" *: *"\([^"]*\)".*/\1/p')
+
+    git clone "https://x-access-token:${TOKEN}@github.com/<org>/<repo>.git"
+    ```
+
+    Then point `custom_skill_paths` at the clone in `~/.holmes/config.yaml`:
+
+    ```yaml
+    custom_skill_paths:
+      - /path/to/your-skills-clone/
+    ```
+
+    Installation tokens expire after 1 hour — re-run the token snippet and `git pull` with a fresh token whenever you want to pick up new or updated skills.
 
 ### From a Bitbucket Repository
 


### PR DESCRIPTION
## What

Documents how to load skills from a private GitHub repo using **GitHub App credentials** instead of a Personal Access Token. The init container mints a JWT from the App's private key, exchanges it for a short-lived installation token (1 hour), and clones with that — no long-lived credential ever reaches the pod.

Covers the Holmes Helm Chart, Robusta Helm Chart, and Holmes CLI.

## Verified against a live cluster

This was tested end-to-end, not just written:

- The documented JWT generation (`openssl` RS256 + base64url) and installation-token exchange were run verbatim — GitHub accepted the JWT and returned a real `ghs_` token.
- The init container recipe was applied to a running Holmes deployment, which cloned a **private** repo successfully and came up healthy.
- Holmes registered all 4 skills from the repo as `source=user`. Confirmed via `load_skill_catalog()` inside the pod, and visible in the UI.

The test repo's skills are a completely different set from the ones previously mounted from Bitbucket, so this can't be a stale-mount false positive.

## Two fixes that came out of testing

- **Repo and branch are now env vars** (`GIT_REPO`, `GIT_BRANCH`). They were previously buried inside the shell script, so adopting the recipe meant hand-editing the script body. Now everything install-specific lives in one `env:` block and the script can be copied verbatim.
- **`--branch main` is a silent trap.** The clone fails outright when a repo still defaults to `master` — which is exactly what happened on the repo used for testing. Now called out explicitly in the adjust notes.

Both were applied to the Personal Access Token tabs too, which had the same hardcoded values and the same branch-name trap.

## Note for reviewers

The docs state the App needs only **Contents: Read-only**. The App used for testing (`holmes-mcp-integration`) carries considerably more — `contents: write`, `issues: write`, `pull_requests: write`, `statuses: write`. It works, but anyone copying this setup should scope a skills-only App down to read-only rather than reusing that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added configuration guidance for customizing Git repository and branch settings in Helm deployments.
  - Documented GitHub App authentication using short-lived installation tokens, including required permissions, secrets, egress, and CLI usage.
  - Added instructions for token generation, validation, and repository cloning.
  - Clarified public-repository setup by removing the unnecessary personal access token configuration.
  - Applied the same guidance across supported Helm deployment variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->