### PR TITLE
ROB-856 Add Atlassian Rovo MCP integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ HolmesGPT integrates with popular observability and cloud platforms. The followi
 | Data Source | Notes |
 |-------------|-------|
 | [<img src="images/integration_logos/aks-icon.png" alt="AKS" width="20" style="vertical-align: middle;"> **AKS**](https://holmesgpt.dev/data-sources/builtin-toolsets/aks/) | Azure Kubernetes Service cluster and node health diagnostics |
+| [<img src="images/integration_logos/jira-icon.png" alt="Atlassian Rovo" width="20" style="vertical-align: middle;"> **Atlassian Rovo**](https://holmesgpt.dev/data-sources/builtin-toolsets/atlassian-rovo-mcp/) | Jira issues and Confluence pages via Atlassian's hosted server (MCP) |
 | [<img src="images/integration_logos/argocd-icon.png" alt="ArgoCD" width="20" style="vertical-align: middle;"> **ArgoCD**](https://holmesgpt.dev/data-sources/builtin-toolsets/argocd/) | Get status, history and manifests and more of apps, projects and clusters |
 | [<img src="images/integration_logos/aws_logo.png" alt="AWS" width="20" style="vertical-align: middle;"> **AWS**](https://holmesgpt.dev/data-sources/builtin-toolsets/aws/) | RDS events, instances, slow query logs, and more (MCP) |
 | [<img src="images/integration_logos/azure.png" alt="Azure" width="20" style="vertical-align: middle;"> **Azure**](https://holmesgpt.dev/data-sources/builtin-toolsets/azure-mcp/) | Azure resources and diagnostics (MCP) |

--- a/docs/data-sources/builtin-toolsets/.nav.yml
+++ b/docs/data-sources/builtin-toolsets/.nav.yml
@@ -1,6 +1,7 @@
 nav:
   - index.md
   - AKS Node Health: aks-node-health.md
+  - Atlassian Rovo (MCP): atlassian-rovo-mcp.md
   - ArgoCD: argocd.md
   - AWS (MCP): aws.md
   - Azure (MCP): azure-mcp.md

--- a/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
+++ b/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
@@ -1,0 +1,250 @@
+# Atlassian Rovo (MCP)
+
+The [Atlassian Rovo MCP Server](https://support.atlassian.com/atlassian-rovo-mcp-server/) is hosted by Atlassian and gives Holmes access to Jira and Confluence Cloud. It lets Holmes search Jira issues for related incidents, read and comment on tickets, and pull runbooks out of Confluence during an investigation.
+
+Because Atlassian hosts the server, there is nothing to deploy in your cluster — Holmes connects directly to `https://mcp.atlassian.com/v1/mcp`.
+
+!!! note "Two ways to authenticate"
+    This page covers **API token** authentication, which is the right choice for Holmes running in Kubernetes or any other non-interactive environment: the credential is static and no browser login is involved.
+
+    If you want each user to authenticate with their own Atlassian account through a browser consent screen, use the OAuth 2.1 flow described in [OAuth MCP Servers](../oauth-mcp-servers.md) instead.
+
+## Prerequisites
+
+### 1. Your admin must enable API token authentication
+
+An Atlassian organization admin has to turn this on before any token will work:
+
+1. Go to [admin.atlassian.com](https://admin.atlassian.com/) and select your organization
+2. Navigate to **Rovo** → **Rovo MCP Server** → **Authentication**
+3. Enable authentication via API token
+
+### 2. Create a scoped API token
+
+!!! warning "Classic API tokens do not work"
+    The Rovo MCP Server requires an **API token with scopes**. A classic (unscoped) token authenticates successfully but exposes almost no tools — Jira and Confluence tools are granted per scope, so a token with no scopes gets none of them. See [Troubleshooting](#troubleshooting) for how this failure looks.
+
+1. Go to [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
+2. Click **Create API token with scopes** — *not* **Create API token**
+3. Give it a label (e.g. "HolmesGPT") and an expiry
+4. Select the apps and scopes you need (see the table below)
+5. **Copy the token immediately** — it won't be shown again
+
+Tools are granted per scope, so only pick the ones you actually want Holmes to have:
+
+| Scope | Unlocks |
+|-------|---------|
+| `read:jira-work` | Reading issues, projects, transitions, and issue metadata |
+| `search:jira-work` | JQL search |
+| `write:jira-work` | Creating and editing issues, comments, worklogs, transitions |
+| `read:page:confluence`, `read:space:confluence`, `read:hierarchical-content:confluence`, `read:comment:confluence` | Reading Confluence pages, spaces, and comments |
+| `search:confluence` | CQL search |
+| `write:page:confluence` | Creating and updating Confluence pages and comments |
+
+!!! tip "Read-only is a good default"
+    For investigations, the read and search scopes are enough. Only add the `write:` scopes if you want Holmes to open tickets or post comments.
+
+### 3. Build the Basic auth header value
+
+The Rovo MCP Server expects HTTP Basic authentication with your Atlassian account email and the API token:
+
+```bash
+printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_API_TOKEN>" | base64 -w0
+```
+
+Keep the resulting base64 string — it becomes the `Authorization: Basic <value>` header below.
+
+!!! note "Service accounts"
+    If your organization uses an Atlassian service account instead of a personal account, skip the base64 step and send the API key directly as `Authorization: Bearer <YOUR_API_KEY>`.
+
+## Configuration
+
+=== "Holmes CLI"
+
+    Export the base64 credential, then point Holmes at Atlassian's server:
+
+    ```bash
+    export ATLASSIAN_MCP_BASIC=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_API_TOKEN>" | base64 -w0)
+    ```
+
+    Add the MCP server to **~/.holmes/config.yaml**:
+
+    ```yaml
+    mcp_servers:
+      atlassian-rovo:
+        description: "Atlassian Jira and Confluence via the Rovo MCP server"
+        config:
+          mode: streamable-http
+          url: https://mcp.atlassian.com/v1/mcp
+          headers:
+            Authorization: "Basic {{ env.ATLASSIAN_MCP_BASIC }}"
+          icon_url: "https://cdn.simpleicons.org/jira/0052CC"
+        llm_instructions: |
+          Use the Atlassian Rovo MCP server to search Jira for tickets describing the same
+          symptoms before concluding an investigation, and to look up runbooks in Confluence.
+          Always pass the cloudId of the target site.
+    ```
+
+    --8<-- "snippets/toolset_refresh_warning.md"
+
+=== "Holmes Helm Chart"
+
+    Create a secret with the base64 credential:
+
+    ```bash
+    kubectl create secret generic atlassian-mcp-credentials \
+      --from-literal=basic-auth="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_API_TOKEN>' | base64 -w0)" \
+      -n <NAMESPACE>
+    ```
+
+    Then add the following to your `values.yaml`:
+
+    ```yaml
+    additionalEnvVars:
+      - name: ATLASSIAN_MCP_BASIC
+        valueFrom:
+          secretKeyRef:
+            name: atlassian-mcp-credentials
+            key: basic-auth
+
+    mcp_servers:
+      atlassian-rovo:
+        description: "Atlassian Jira and Confluence via the Rovo MCP server"
+        config:
+          mode: streamable-http
+          url: https://mcp.atlassian.com/v1/mcp
+          headers:
+            Authorization: "Basic {{ env.ATLASSIAN_MCP_BASIC }}"
+          icon_url: "https://cdn.simpleicons.org/jira/0052CC"
+        llm_instructions: |
+          Use the Atlassian Rovo MCP server to search Jira for tickets describing the same
+          symptoms before concluding an investigation, and to look up runbooks in Confluence.
+    ```
+
+    ```bash
+    helm upgrade --install holmes robusta/holmes -f values.yaml
+    ```
+
+=== "Robusta Helm Chart"
+
+    Create a secret with the base64 credential:
+
+    ```bash
+    kubectl create secret generic atlassian-mcp-credentials \
+      --from-literal=basic-auth="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_API_TOKEN>' | base64 -w0)" \
+      -n <NAMESPACE>
+    ```
+
+    Then add the following to your `generated_values.yaml`:
+
+    ```yaml
+    holmes:
+      additionalEnvVars:
+        - name: ATLASSIAN_MCP_BASIC
+          valueFrom:
+            secretKeyRef:
+              name: atlassian-mcp-credentials
+              key: basic-auth
+
+      mcp_servers:
+        atlassian-rovo:
+          description: "Atlassian Jira and Confluence via the Rovo MCP server"
+          config:
+            mode: streamable-http
+            url: https://mcp.atlassian.com/v1/mcp
+            headers:
+              Authorization: "Basic {{ env.ATLASSIAN_MCP_BASIC }}"
+            icon_url: "https://cdn.simpleicons.org/jira/0052CC"
+    ```
+
+    ```bash
+    helm upgrade robusta robusta/robusta --values=generated_values.yaml --set clusterName=<YOUR_CLUSTER_NAME>
+    ```
+
+`{{ env.ATLASSIAN_MCP_BASIC }}` is resolved when Holmes loads its configuration, so the token itself never has to appear in your values file or config file.
+
+## Available Tools
+
+The tools Atlassian exposes depend on the scopes attached to your token.
+
+| Tool | Description | Scope |
+|------|-------------|-------|
+| `getJiraIssue` | Get a Jira issue by key or ID | `read:jira-work` |
+| `getVisibleJiraProjects` | List projects the token can see | `read:jira-work` |
+| `getTransitionsForJiraIssue` | List available workflow transitions | `read:jira-work` |
+| `getJiraIssueRemoteIssueLinks` | List remote links on an issue | `read:jira-work` |
+| `getJiraProjectIssueTypesMetadata` | List issue types for a project | `read:jira-work` |
+| `lookupJiraAccountId` | Resolve a user to an account ID | `read:jira-work` |
+| `searchJiraIssuesUsingJql` | Search issues with JQL | `search:jira-work` |
+| `createJiraIssue` | Create an issue | `write:jira-work` |
+| `editJiraIssue` | Edit an existing issue | `write:jira-work` |
+| `addCommentToJiraIssue` | Comment on an issue | `write:jira-work` |
+| `transitionJiraIssue` | Move an issue through its workflow | `write:jira-work` |
+| `getConfluencePage` | Get a Confluence page and its body | `read:page:confluence` |
+| `getPagesInConfluenceSpace` | List pages in a space | `read:page:confluence` |
+| `getConfluenceSpaces` | List spaces | `read:space:confluence` |
+| `getConfluencePageFooterComments` | Read page comments | `read:comment:confluence` |
+| `searchConfluenceUsingCql` | Search Confluence with CQL | `search:confluence` |
+| `createConfluencePage` | Create a page | `write:page:confluence` |
+| `updateConfluencePage` | Update a page | `write:page:confluence` |
+
+See Atlassian's [supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/) reference for the complete list.
+
+!!! note "Most tools need a cloudId"
+    Rovo tools are site-scoped and take a `cloudId` argument. You can find yours at `https://<your-site>.atlassian.net/_edge/tenant_info`. Holmes will usually discover it via `getVisibleJiraProjects`, but putting it in `llm_instructions` saves a round trip.
+
+## Testing the Connection
+
+```bash
+holmes toolset list
+```
+
+`atlassian-rovo` should show as `enabled`. Then check that the tools actually work:
+
+```bash
+holmes ask "List the Jira projects I have access to"
+```
+
+## Common Use Cases
+
+```bash
+holmes ask "Search Jira for open issues mentioning the checkout-api pod crashing"
+```
+
+```bash
+holmes ask "Find the Confluence runbook for database failover and summarize the steps"
+```
+
+```bash
+holmes ask "Open a Jira ticket in PROJ describing the OOMKills on the payments deployment"
+```
+
+## Troubleshooting
+
+**Only three `TeamworkGraph` tools appear, and no Jira or Confluence tools**
+
+Your token is a classic API token without scopes. Holmes will show the toolset as `enabled` — Atlassian accepts the credential and serves its default tool set — but none of the Jira or Confluence tools are granted. Create a new token with **Create API token with scopes** and pick the scopes from the table above.
+
+**`403 Forbidden ... requires a modern API token (API token with scopes). Legacy API tokens without scopes are not supported.`**
+
+Same cause as above. The credential is valid, the token type is not.
+
+**`401 Unauthorized`**
+
+The email/token pair is wrong, the base64 encoding is malformed, or the token has been revoked. Re-run the `printf ... | base64 -w0` command and make sure there is no trailing newline (`-w0` on GNU coreutils; on macOS use `base64` with no flags).
+
+**The toolset fails to load entirely**
+
+Confirm the org-level setting is on (**Atlassian Administration** → **Rovo** → **Rovo MCP Server** → **Authentication**) and that outbound traffic to `mcp.atlassian.com` is allowed from wherever Holmes runs.
+
+**A tool returns "not found"**
+
+That tool's scope isn't on your token. Tools are filtered by scope, so the server reports them as missing rather than as permission errors.
+
+## Additional Resources
+
+- [Atlassian Rovo MCP Server documentation](https://support.atlassian.com/atlassian-rovo-mcp-server/)
+- [Configuring authentication via API token](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/configuring-authentication-via-api-token/)
+- [Supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/)
+- [Manage API tokens for your Atlassian account](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
+- [OAuth MCP Servers in Holmes](../oauth-mcp-servers.md)

--- a/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
+++ b/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
@@ -63,7 +63,7 @@ Tools are granted per scope, so only pick the ones you actually want Holmes to h
 The Rovo MCP Server expects HTTP Basic authentication with your Atlassian account email and the API token:
 
 ```bash
-printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_API_TOKEN>" | base64 -w0
+printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_API_TOKEN>" | base64 | tr -d '\n'
 ```
 
 Keep the resulting base64 string — it becomes the `Authorization: Basic <value>` header below. Run this once per token if you created both a Jira and a Confluence token.
@@ -80,8 +80,8 @@ Because a scoped token covers one app, register one `mcp_servers` entry per toke
     Export one base64 credential per token:
 
     ```bash
-    export ATLASSIAN_MCP_JIRA=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_JIRA_TOKEN>" | base64 -w0)
-    export ATLASSIAN_MCP_CONFLUENCE=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_CONFLUENCE_TOKEN>" | base64 -w0)
+    export ATLASSIAN_MCP_JIRA=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_JIRA_TOKEN>" | base64 | tr -d '\n')
+    export ATLASSIAN_MCP_CONFLUENCE=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_CONFLUENCE_TOKEN>" | base64 | tr -d '\n')
     ```
 
     Add the MCP servers to **~/.holmes/config.yaml**:
@@ -120,8 +120,8 @@ Because a scoped token covers one app, register one `mcp_servers` entry per toke
 
     ```bash
     kubectl create secret generic atlassian-mcp-credentials \
-      --from-literal=jira="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_JIRA_TOKEN>' | base64 -w0)" \
-      --from-literal=confluence="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_CONFLUENCE_TOKEN>' | base64 -w0)" \
+      --from-literal=jira="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_JIRA_TOKEN>' | base64 | tr -d '\n')" \
+      --from-literal=confluence="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_CONFLUENCE_TOKEN>' | base64 | tr -d '\n')" \
       -n <NAMESPACE>
     ```
 
@@ -175,8 +175,8 @@ Because a scoped token covers one app, register one `mcp_servers` entry per toke
 
     ```bash
     kubectl create secret generic atlassian-mcp-credentials \
-      --from-literal=jira="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_JIRA_TOKEN>' | base64 -w0)" \
-      --from-literal=confluence="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_CONFLUENCE_TOKEN>' | base64 -w0)" \
+      --from-literal=jira="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_JIRA_TOKEN>' | base64 | tr -d '\n')" \
+      --from-literal=confluence="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_CONFLUENCE_TOKEN>' | base64 | tr -d '\n')" \
       -n <NAMESPACE>
     ```
 
@@ -240,21 +240,31 @@ Everything else is scope-dependent:
 | `getTransitionsForJiraIssue` | List available workflow transitions | `read:jira-work` |
 | `getJiraIssueRemoteIssueLinks` | List remote links on an issue | `read:jira-work` |
 | `getJiraProjectIssueTypesMetadata` | List issue types for a project | `read:jira-work` |
+| `getJiraIssueTypeMetaWithFields` | Get create/edit field metadata for an issue type | `read:jira-work` |
+| `getIssueLinkTypes` | List the available issue link types | `read:jira-work` |
 | `lookupJiraAccountId` | Resolve a user to an account ID | `read:jira-work` |
 | `searchJiraIssuesUsingJql` | Search issues with JQL | `search:jira-work` |
 | `createJiraIssue` | Create an issue | `write:jira-work` |
 | `editJiraIssue` | Edit an existing issue | `write:jira-work` |
 | `addCommentToJiraIssue` | Comment on an issue | `write:jira-work` |
+| `addWorklogToJiraIssue` | Log work against an issue | `write:jira-work` |
 | `transitionJiraIssue` | Move an issue through its workflow | `write:jira-work` |
 | `getConfluencePage` | Get a Confluence page and its body | `read:page:confluence` |
 | `getPagesInConfluenceSpace` | List pages in a space | `read:page:confluence` |
+| `getConfluencePageDescendants` | Walk a page's child pages | `read:hierarchical-content:confluence` |
 | `getConfluenceSpaces` | List spaces | `read:space:confluence` |
-| `getConfluencePageFooterComments` | Read page comments | `read:comment:confluence` |
+| `getConfluencePageFooterComments` | Read footer comments on a page | `read:comment:confluence` |
+| `getConfluencePageInlineComments` | Read inline comments on a page | `read:comment:confluence` |
+| `getConfluenceCommentChildren` | Read replies to a comment | `read:comment:confluence` |
 | `searchConfluenceUsingCql` | Search Confluence with CQL | `search:confluence` |
 | `createConfluencePage` | Create a page | `write:page:confluence` |
 | `updateConfluencePage` | Update a page | `write:page:confluence` |
+| `createConfluenceFooterComment` | Add a footer comment to a page | `write:page:confluence` |
+| `createConfluenceInlineComment` | Add an inline comment to a page | `write:page:confluence` |
 
-See Atlassian's [supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/) reference for the complete list.
+Atlassian adds tools over time, so treat this as a snapshot rather than a contract — `holmes toolset list` and the server's own `tools/list` are the source of truth for what your token actually gets. See Atlassian's [supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/) reference for products beyond Jira and Confluence.
+
+Three `TeamworkGraph` tools (`getTeamworkGraphContext`, `getTeamworkGraphObject`, `addTeamworkGraphContext`) are also advertised to every client. They traverse relationships across Atlassian products and require their own scopes, so they will appear in your tool list even when they are not usable.
 
 !!! note "Most tools need a cloudId"
     Rovo tools are site-scoped and take a `cloudId` argument. Holmes can discover it by calling `getAccessibleAtlassianResources`, but putting it in `llm_instructions` saves a round trip. To look it up yourself, visit `https://<your-site>.atlassian.net/_edge/tenant_info`.
@@ -289,13 +299,13 @@ holmes ask "Open a Jira ticket in PROJ describing the OOMKills on the payments d
 
 ## Troubleshooting
 
-The tool count tells you what went wrong. Count what the server returns before debugging anything else:
+Which tools come back tells you what went wrong, so check the tool list before debugging anything else. The counts below were observed against Rovo at the time of writing and will drift as Atlassian ships tools — the pattern is what matters, not the exact number:
 
 | Tools returned | Meaning |
 |----------------|---------|
-| 3 (`TeamworkGraph` only) | Classic API token — no scopes at all |
-| 5 (`TeamworkGraph` + `atlassianUserInfo` + `getAccessibleAtlassianResources`) | Scoped token, but none of its scopes map to Rovo tools |
-| 14 | Scoped Jira token with `read:jira-work` and `search:jira-work` |
+| `TeamworkGraph` only (3) | Classic API token — no scopes at all |
+| `TeamworkGraph` plus `atlassianUserInfo` and `getAccessibleAtlassianResources` (5) | Scoped token, but none of its scopes map to Rovo tools |
+| The above plus a block of `*Jira*` or `*Confluence*` tools (14 for Jira read + search) | Working scoped token |
 
 **Only three `TeamworkGraph` tools appear**
 
@@ -321,9 +331,11 @@ curl -s -o /dev/null -w '%{http_code}\n' -u "<EMAIL>:<TOKEN>" \
   "https://api.atlassian.com/ex/confluence/$CLOUD_ID/wiki/api/v2/spaces?limit=1"
 ```
 
+Note that the Confluence probe hits `/wiki/api/v2/spaces`, which specifically requires `read:space:confluence`. If you scoped the token more narrowly — say `read:page:confluence` and `search:confluence` only — this probe returns `401` even though the token is valid and Rovo will serve the page and search tools. Probe `/wiki/api/v2/pages?limit=1` instead in that case. These probes must go through `api.atlassian.com`; scoped tokens are rejected against `<your-site>.atlassian.net`.
+
 **`401 Unauthorized`**
 
-The email/token pair is wrong, the base64 encoding is malformed, or the token has been revoked. Re-run the `printf ... | base64 -w0` command and make sure there is no trailing newline (`-w0` on GNU coreutils; on macOS use `base64` with no flags).
+The email/token pair is wrong, the base64 encoding is malformed, or the token has been revoked. Re-run the `printf ... | base64 | tr -d '\n'` command — the `tr` is what strips the line wrapping that `base64` adds by default, and a header containing a newline will be rejected.
 
 **The toolset fails to load entirely**
 

--- a/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
+++ b/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
@@ -38,14 +38,22 @@ An Atlassian organization admin has to turn this on before any token will work:
 
 Tools are granted per scope, so only pick the ones you actually want Holmes to have:
 
-| Scope | Unlocks |
-|-------|---------|
-| `read:jira-work` | Reading issues, projects, transitions, and issue metadata |
-| `search:jira-work` | JQL search |
-| `write:jira-work` | Creating and editing issues, comments, worklogs, transitions |
-| `read:page:confluence`, `read:space:confluence`, `read:hierarchical-content:confluence`, `read:comment:confluence` | Reading Confluence pages, spaces, and comments |
-| `search:confluence` | CQL search |
-| `write:page:confluence` | Creating and updating Confluence pages and comments |
+| App | Scope | Unlocks |
+|-----|-------|---------|
+| Jira | `read:jira-work` | Reading issues, projects, transitions, and issue metadata |
+| Jira | `search:jira-work` | JQL search |
+| Jira | `write:jira-work` | Creating and editing issues, comments, worklogs, transitions |
+| Confluence | `read:page:confluence` | Reading page bodies and listing pages in a space |
+| Confluence | `read:space:confluence` | Listing spaces |
+| Confluence | `read:comment:confluence` | Reading page comments |
+| Confluence | `read:hierarchical-content:confluence` | Walking page descendants |
+| Confluence | `search:confluence` | CQL search |
+| Confluence | `write:page:confluence` | Creating and updating pages and comments |
+
+!!! danger "Confluence: pick the granular scopes, not the classic ones"
+    The token creation screen offers Confluence scopes in two styles, and **Rovo only accepts the granular ones** — the `<action>:<resource>:confluence` names in the table above.
+
+    Selecting the classic `read:confluence-content.all`-style scopes produces a token that looks fine but grants no Confluence tools in Rovo. It still authenticates, and it still works against the legacy `/wiki/rest/api/content` REST endpoint, which makes it easy to conclude the token is good. Jira is not affected — its scopes (`read:jira-work` and friends) are the classic-style names and are what Rovo expects.
 
 !!! tip "Read-only is a good default"
     For investigations, the read and search scopes are enough. Only add the `write:` scopes if you want Holmes to open tickets or post comments.
@@ -216,7 +224,14 @@ The `{{ env.* }}` placeholders are resolved when Holmes loads its configuration,
 
 ## Available Tools
 
-The tools Atlassian exposes depend on the scopes attached to your token.
+The tools Atlassian exposes depend on the scopes attached to your token. Every scoped token also gets these two platform tools regardless of which app it targets, which is useful for confirming a token is live:
+
+| Tool | Description |
+|------|-------------|
+| `atlassianUserInfo` | Returns the authenticated account ID |
+| `getAccessibleAtlassianResources` | Lists the sites the token can reach, with their `cloudId` |
+
+Everything else is scope-dependent:
 
 | Tool | Description | Scope |
 |------|-------------|-------|
@@ -242,7 +257,7 @@ The tools Atlassian exposes depend on the scopes attached to your token.
 See Atlassian's [supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/) reference for the complete list.
 
 !!! note "Most tools need a cloudId"
-    Rovo tools are site-scoped and take a `cloudId` argument. You can find yours at `https://<your-site>.atlassian.net/_edge/tenant_info`. Holmes will usually discover it via `getVisibleJiraProjects`, but putting it in `llm_instructions` saves a round trip.
+    Rovo tools are site-scoped and take a `cloudId` argument. Holmes can discover it by calling `getAccessibleAtlassianResources`, but putting it in `llm_instructions` saves a round trip. To look it up yourself, visit `https://<your-site>.atlassian.net/_edge/tenant_info`.
 
 ## Testing the Connection
 
@@ -274,13 +289,37 @@ holmes ask "Open a Jira ticket in PROJ describing the OOMKills on the payments d
 
 ## Troubleshooting
 
-**Only three `TeamworkGraph` tools appear, and no Jira or Confluence tools**
+The tool count tells you what went wrong. Count what the server returns before debugging anything else:
 
-Your token is a classic API token without scopes. Holmes will show the toolset as `enabled` — Atlassian accepts the credential and serves its default tool set — but none of the Jira or Confluence tools are granted. Create a new token with **Create API token with scopes** and pick the scopes from the table above.
+| Tools returned | Meaning |
+|----------------|---------|
+| 3 (`TeamworkGraph` only) | Classic API token — no scopes at all |
+| 5 (`TeamworkGraph` + `atlassianUserInfo` + `getAccessibleAtlassianResources`) | Scoped token, but none of its scopes map to Rovo tools |
+| 14 | Scoped Jira token with `read:jira-work` and `search:jira-work` |
+
+**Only three `TeamworkGraph` tools appear**
+
+Your token is a classic API token without scopes. Holmes will show the toolset as `enabled` — Atlassian accepts the credential and serves its default tool set — but none of the Jira or Confluence tools are granted. Create a new token with **Create API token with scopes**.
 
 **`403 Forbidden ... requires a modern API token (API token with scopes). Legacy API tokens without scopes are not supported.`**
 
 Same cause as above. The credential is valid, the token type is not.
+
+**Five tools appear — the platform tools work, but no Jira or Confluence tools**
+
+The token is genuinely scoped (that is why `atlassianUserInfo` and `getAccessibleAtlassianResources` are there) but its scopes don't map to any Rovo tool. For Confluence this almost always means classic scopes were selected instead of the granular `read:page:confluence`-style ones. Scopes can't be edited after creation, so reissue the token.
+
+You can confirm which product a token is actually scoped for by calling the product gateway directly — a scope mismatch returns `401 Unauthorized; scope does not match`:
+
+```bash
+CLOUD_ID=<YOUR_CLOUD_ID>
+# Jira scopes
+curl -s -o /dev/null -w '%{http_code}\n' -u "<EMAIL>:<TOKEN>" \
+  "https://api.atlassian.com/ex/jira/$CLOUD_ID/rest/api/3/myself"
+# Confluence granular scopes
+curl -s -o /dev/null -w '%{http_code}\n' -u "<EMAIL>:<TOKEN>" \
+  "https://api.atlassian.com/ex/confluence/$CLOUD_ID/wiki/api/v2/spaces?limit=1"
+```
 
 **`401 Unauthorized`**
 

--- a/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
+++ b/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
@@ -26,9 +26,13 @@ An Atlassian organization admin has to turn this on before any token will work:
 
 1. Go to [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 2. Click **Create API token with scopes** — *not* **Create API token**
-3. Give it a label (e.g. "HolmesGPT") and an expiry
-4. Select the apps and scopes you need (see the table below)
-5. **Copy the token immediately** — it won't be shown again
+3. Give it a label (e.g. "HolmesGPT") and an expiry (1–365 days; scoped tokens cannot be non-expiring)
+4. Select the app — **Jira** or **Confluence**
+5. Select the scopes you need (see the table below)
+6. **Copy the token immediately** — it won't be shown again
+
+!!! warning "One token covers one app"
+    A scoped token targets a single app, so a Jira token grants no Confluence tools and vice versa. To give Holmes both, create two tokens and register two `mcp_servers` entries pointing at the same URL — see [Configuration](#configuration). Scopes also cannot be edited after creation; changing them means issuing a new token.
 
 Tools are granted per scope, so only pick the ones you actually want Holmes to have:
 
@@ -52,48 +56,62 @@ The Rovo MCP Server expects HTTP Basic authentication with your Atlassian accoun
 printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_API_TOKEN>" | base64 -w0
 ```
 
-Keep the resulting base64 string — it becomes the `Authorization: Basic <value>` header below.
+Keep the resulting base64 string — it becomes the `Authorization: Basic <value>` header below. Run this once per token if you created both a Jira and a Confluence token.
 
 !!! note "Service accounts"
     If your organization uses an Atlassian service account instead of a personal account, skip the base64 step and send the API key directly as `Authorization: Bearer <YOUR_API_KEY>`.
 
 ## Configuration
 
+Because a scoped token covers one app, register one `mcp_servers` entry per token. Both point at the same URL and differ only in the credential. If you only need Jira, drop the Confluence entry.
+
 === "Holmes CLI"
 
-    Export the base64 credential, then point Holmes at Atlassian's server:
+    Export one base64 credential per token:
 
     ```bash
-    export ATLASSIAN_MCP_BASIC=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_API_TOKEN>" | base64 -w0)
+    export ATLASSIAN_MCP_JIRA=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_JIRA_TOKEN>" | base64 -w0)
+    export ATLASSIAN_MCP_CONFLUENCE=$(printf '%s:%s' "<YOUR_ATLASSIAN_EMAIL>" "<YOUR_CONFLUENCE_TOKEN>" | base64 -w0)
     ```
 
-    Add the MCP server to **~/.holmes/config.yaml**:
+    Add the MCP servers to **~/.holmes/config.yaml**:
 
     ```yaml
     mcp_servers:
-      atlassian-rovo:
-        description: "Atlassian Jira and Confluence via the Rovo MCP server"
+      atlassian-jira:
+        description: "Jira issues via the Atlassian Rovo MCP server"
         config:
           mode: streamable-http
           url: https://mcp.atlassian.com/v1/mcp
           headers:
-            Authorization: "Basic {{ env.ATLASSIAN_MCP_BASIC }}"
+            Authorization: "Basic {{ env.ATLASSIAN_MCP_JIRA }}"
           icon_url: "https://cdn.simpleicons.org/jira/0052CC"
         llm_instructions: |
-          Use the Atlassian Rovo MCP server to search Jira for tickets describing the same
-          symptoms before concluding an investigation, and to look up runbooks in Confluence.
-          Always pass the cloudId of the target site.
+          Use this to search Jira for tickets describing the same symptoms before
+          concluding an investigation. Always pass the cloudId of the target site.
+
+      atlassian-confluence:
+        description: "Confluence pages via the Atlassian Rovo MCP server"
+        config:
+          mode: streamable-http
+          url: https://mcp.atlassian.com/v1/mcp
+          headers:
+            Authorization: "Basic {{ env.ATLASSIAN_MCP_CONFLUENCE }}"
+          icon_url: "https://cdn.simpleicons.org/confluence/172B4D"
+        llm_instructions: |
+          Use this to look up runbooks and architecture docs in Confluence.
     ```
 
     --8<-- "snippets/toolset_refresh_warning.md"
 
 === "Holmes Helm Chart"
 
-    Create a secret with the base64 credential:
+    Create a secret holding one base64 credential per token:
 
     ```bash
     kubectl create secret generic atlassian-mcp-credentials \
-      --from-literal=basic-auth="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_API_TOKEN>' | base64 -w0)" \
+      --from-literal=jira="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_JIRA_TOKEN>' | base64 -w0)" \
+      --from-literal=confluence="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_CONFLUENCE_TOKEN>' | base64 -w0)" \
       -n <NAMESPACE>
     ```
 
@@ -101,24 +119,40 @@ Keep the resulting base64 string — it becomes the `Authorization: Basic <value
 
     ```yaml
     additionalEnvVars:
-      - name: ATLASSIAN_MCP_BASIC
+      - name: ATLASSIAN_MCP_JIRA
         valueFrom:
           secretKeyRef:
             name: atlassian-mcp-credentials
-            key: basic-auth
+            key: jira
+      - name: ATLASSIAN_MCP_CONFLUENCE
+        valueFrom:
+          secretKeyRef:
+            name: atlassian-mcp-credentials
+            key: confluence
 
     mcp_servers:
-      atlassian-rovo:
-        description: "Atlassian Jira and Confluence via the Rovo MCP server"
+      atlassian-jira:
+        description: "Jira issues via the Atlassian Rovo MCP server"
         config:
           mode: streamable-http
           url: https://mcp.atlassian.com/v1/mcp
           headers:
-            Authorization: "Basic {{ env.ATLASSIAN_MCP_BASIC }}"
+            Authorization: "Basic {{ env.ATLASSIAN_MCP_JIRA }}"
           icon_url: "https://cdn.simpleicons.org/jira/0052CC"
         llm_instructions: |
-          Use the Atlassian Rovo MCP server to search Jira for tickets describing the same
-          symptoms before concluding an investigation, and to look up runbooks in Confluence.
+          Use this to search Jira for tickets describing the same symptoms before
+          concluding an investigation.
+
+      atlassian-confluence:
+        description: "Confluence pages via the Atlassian Rovo MCP server"
+        config:
+          mode: streamable-http
+          url: https://mcp.atlassian.com/v1/mcp
+          headers:
+            Authorization: "Basic {{ env.ATLASSIAN_MCP_CONFLUENCE }}"
+          icon_url: "https://cdn.simpleicons.org/confluence/172B4D"
+        llm_instructions: |
+          Use this to look up runbooks and architecture docs in Confluence.
     ```
 
     ```bash
@@ -127,11 +161,12 @@ Keep the resulting base64 string — it becomes the `Authorization: Basic <value
 
 === "Robusta Helm Chart"
 
-    Create a secret with the base64 credential:
+    Create a secret holding one base64 credential per token:
 
     ```bash
     kubectl create secret generic atlassian-mcp-credentials \
-      --from-literal=basic-auth="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_API_TOKEN>' | base64 -w0)" \
+      --from-literal=jira="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_JIRA_TOKEN>' | base64 -w0)" \
+      --from-literal=confluence="$(printf '%s:%s' '<YOUR_ATLASSIAN_EMAIL>' '<YOUR_CONFLUENCE_TOKEN>' | base64 -w0)" \
       -n <NAMESPACE>
     ```
 
@@ -140,28 +175,42 @@ Keep the resulting base64 string — it becomes the `Authorization: Basic <value
     ```yaml
     holmes:
       additionalEnvVars:
-        - name: ATLASSIAN_MCP_BASIC
+        - name: ATLASSIAN_MCP_JIRA
           valueFrom:
             secretKeyRef:
               name: atlassian-mcp-credentials
-              key: basic-auth
+              key: jira
+        - name: ATLASSIAN_MCP_CONFLUENCE
+          valueFrom:
+            secretKeyRef:
+              name: atlassian-mcp-credentials
+              key: confluence
 
       mcp_servers:
-        atlassian-rovo:
-          description: "Atlassian Jira and Confluence via the Rovo MCP server"
+        atlassian-jira:
+          description: "Jira issues via the Atlassian Rovo MCP server"
           config:
             mode: streamable-http
             url: https://mcp.atlassian.com/v1/mcp
             headers:
-              Authorization: "Basic {{ env.ATLASSIAN_MCP_BASIC }}"
+              Authorization: "Basic {{ env.ATLASSIAN_MCP_JIRA }}"
             icon_url: "https://cdn.simpleicons.org/jira/0052CC"
+
+        atlassian-confluence:
+          description: "Confluence pages via the Atlassian Rovo MCP server"
+          config:
+            mode: streamable-http
+            url: https://mcp.atlassian.com/v1/mcp
+            headers:
+              Authorization: "Basic {{ env.ATLASSIAN_MCP_CONFLUENCE }}"
+            icon_url: "https://cdn.simpleicons.org/confluence/172B4D"
     ```
 
     ```bash
     helm upgrade robusta robusta/robusta --values=generated_values.yaml --set clusterName=<YOUR_CLUSTER_NAME>
     ```
 
-`{{ env.ATLASSIAN_MCP_BASIC }}` is resolved when Holmes loads its configuration, so the token itself never has to appear in your values file or config file.
+The `{{ env.* }}` placeholders are resolved when Holmes loads its configuration, so the tokens themselves never have to appear in your values file or config file.
 
 ## Available Tools
 
@@ -239,7 +288,7 @@ Confirm the org-level setting is on (**Atlassian Administration** → **Rovo** �
 
 **A tool returns "not found"**
 
-That tool's scope isn't on your token. Tools are filtered by scope, so the server reports them as missing rather than as permission errors.
+That tool's scope isn't on your token. Tools are filtered by scope, so the server reports them as missing rather than as permission errors. If the missing tools are all from one product, you are probably hitting the one-app-per-token limit — check that you registered a second `mcp_servers` entry with that product's token.
 
 ## Additional Resources
 

--- a/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
+++ b/docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md
@@ -21,8 +21,10 @@ An Atlassian organization admin has to turn this on before any token will work:
 
 ### 2. Create a scoped API token
 
-!!! warning "Classic API tokens do not work"
-    The Rovo MCP Server requires an **API token with scopes**. A classic (unscoped) token authenticates successfully but exposes almost no tools — Jira and Confluence tools are granted per scope, so a token with no scopes gets none of them. See [Troubleshooting](#troubleshooting) for how this failure looks.
+!!! warning "A classic API token authenticates but grants no tools"
+    The Rovo MCP Server requires an **API token with scopes**. This failure is easy to misread as success: a classic (unscoped) token authenticates fine, the MCP session initializes, and `holmes toolset list` reports the toolset as `enabled`. But Jira and Confluence tools are granted per scope, so a token with no scopes gets none of them — you are left with three `TeamworkGraph` tools and every Jira or Confluence tool returning `not found`.
+
+    A classic token also still works against the Jira and Confluence REST APIs, so testing it with `curl` outside of Rovo will succeed and tell you nothing about whether Rovo will serve the tools. Check the tool list, not the connection status. See [Troubleshooting](#troubleshooting).
 
 1. Go to [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 2. Click **Create API token with scopes** — *not* **Create API token**
@@ -248,11 +250,13 @@ See Atlassian's [supported tools](https://support.atlassian.com/atlassian-rovo-m
 holmes toolset list
 ```
 
-`atlassian-rovo` should show as `enabled`. Then check that the tools actually work:
+The entries should show as `enabled` — but note that `enabled` only means Holmes reached the server and authenticated. It does **not** mean the Jira or Confluence tools were granted. Confirm that separately:
 
 ```bash
 holmes ask "List the Jira projects I have access to"
 ```
+
+If Holmes reports that it has no tool for this, or you see `Tool getVisibleJiraProjects not found`, your token is missing the scope — or is a classic token. Recheck the [prerequisites](#prerequisites).
 
 ## Common Use Cases
 

--- a/docs/data-sources/builtin-toolsets/index.md
+++ b/docs/data-sources/builtin-toolsets/index.md
@@ -63,6 +63,7 @@ HolmesGPT includes pre-built integrations for popular monitoring and observabili
 
 <div class="grid cards" markdown>
 
+-   [:simple-jira:{ .lg .middle } **Atlassian Rovo (MCP)**](atlassian-rovo-mcp.md)
 -   [:simple-confluence:{ .lg .middle } **Confluence**](confluence.md)
 -   [:simple-confluence:{ .lg .middle } **Confluence (MCP)**](confluence-mcp.md)
 -   [:material-github:{ .lg .middle } **GitHub (MCP)**](github-mcp.md)

--- a/docs/data-sources/oauth-mcp-servers.md
+++ b/docs/data-sources/oauth-mcp-servers.md
@@ -55,6 +55,9 @@ To add an OAuth MCP server, set `mode: streamable-http` and `oauth.enabled: true
 
 ## Example: Atlassian
 
+!!! tip "Running Holmes headlessly?"
+    OAuth requires a browser consent screen. To connect the same Atlassian Rovo MCP server with a static credential instead, see [Atlassian Rovo (MCP)](builtin-toolsets/atlassian-rovo-mcp.md).
+
 === "Robusta CLI"
 
     ```yaml

--- a/docs/why-holmesgpt.md
+++ b/docs/why-holmesgpt.md
@@ -71,7 +71,7 @@ See the [full list of built-in toolsets](data-sources/builtin-toolsets/index.md)
 
 ### Safe by Design
 
-Give SRE agents the data access they need, with the safety profile production demands. Built-in toolsets are read-only by default, respecting existing platform permissions (Kubernetes RBAC, Grafana roles, cloud IAM policies) with full audit logging of every tool call. The few integrations that can write — remediation and ticketing, for example — are opt-in and gated by the credentials you grant them.
+Give SRE agents the data access they need, with the safety profile production demands. Built-in toolsets are read-only by default, respecting existing platform permissions (Kubernetes RBAC, Grafana roles, cloud IAM policies). The few integrations that can write — remediation and ticketing, for example — are opt-in and gated by the credentials you grant them. For a full audit trail of every tool call, prompt, and answer, [export traces via OpenTelemetry](reference/opentelemetry.md).
 
 ### Controlled Access for Your Whole Team
 

--- a/docs/why-holmesgpt.md
+++ b/docs/why-holmesgpt.md
@@ -71,7 +71,7 @@ See the [full list of built-in toolsets](data-sources/builtin-toolsets/index.md)
 
 ### Safe by Design
 
-Give SRE agents the data access they need, with the safety profile production demands. All built-in toolsets are read-only, respecting existing platform permissions (Kubernetes RBAC, Grafana roles, cloud IAM policies) with full audit logging of every tool call.
+Give SRE agents the data access they need, with the safety profile production demands. Built-in toolsets are read-only by default, respecting existing platform permissions (Kubernetes RBAC, Grafana roles, cloud IAM policies) with full audit logging of every tool call. The few integrations that can write — remediation and ticketing, for example — are opt-in and gated by the credentials you grant them.
 
 ### Controlled Access for Your Whole Team
 

--- a/docs/why-holmesgpt.md
+++ b/docs/why-holmesgpt.md
@@ -65,7 +65,7 @@ HolmesGPT ships with read-only integrations for every major observability vendor
 - **Databases**: PostgreSQL, MySQL, ClickHouse, MariaDB, SQL Server, MongoDB Atlas
 - **ITSM**: ServiceNow
 - **Messaging**: Kafka, RabbitMQ
-- **Knowledge**: Confluence, Notion, Slab, Internet/web search
+- **Knowledge**: Atlassian Rovo (Jira + Confluence), Confluence, Notion, Slab, Internet/web search
 
 See the [full list of built-in toolsets](data-sources/builtin-toolsets/index.md).
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for integrating HolmesGPT with Atlassian's Rovo MCP Server, enabling Holmes to access Jira and Confluence Cloud for incident investigation and runbook lookup.

## Changes

- **New documentation**: `docs/data-sources/builtin-toolsets/atlassian-rovo-mcp.md`
  - Complete setup guide for API token authentication (the recommended approach for non-interactive environments)
  - Prerequisites including org-level admin setup and scoped API token creation
  - Detailed scope-to-tool mapping table for both Jira and Confluence
  - Configuration examples for Holmes CLI, Holmes Helm Chart, and Robusta Helm Chart
  - Comprehensive troubleshooting section addressing common issues (classic vs. scoped tokens, scope mismatches, etc.)
  - Available tools reference with scope requirements
  - Common use cases and testing instructions

- **Updated documentation**:
  - `docs/data-sources/oauth-mcp-servers.md`: Added tip linking to the new Atlassian Rovo guide for headless deployments
  - `docs/data-sources/builtin-toolsets/index.md`: Added Atlassian Rovo card to the integration grid
  - `docs/data-sources/builtin-toolsets/.nav.yml`: Added navigation entry for the new guide
  - `docs/why-holmesgpt.md`: Updated knowledge base section to include Atlassian Rovo
  - `README.md`: Added Atlassian Rovo to the integrations table

## Notable Details

- Documentation emphasizes the critical distinction between classic (unscoped) API tokens and scoped tokens, as classic tokens authenticate successfully but grant no tools—a common source of confusion
- Includes detailed troubleshooting by tool count to help users diagnose token configuration issues
- Covers the one-app-per-token limitation and how to register multiple `mcp_servers` entries for both Jira and Confluence access
- Provides curl commands for validating token scopes against the Atlassian API directly
- Distinguishes between Confluence's granular scopes (`read:page:confluence`) and legacy scopes, which Rovo does not support

https://claude.ai/code/session_01Mukzx1iZA2mkA7Nq66DnxG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atlassian Rovo as a built-in data source for accessing Jira and Confluence through Atlassian’s hosted MCP server.
  * Built-in toolsets are read-only by default; write access is available only when explicitly enabled with appropriate credentials.

* **Documentation**
  * Added setup guidance covering permissions, authentication, CLI and Helm configuration, available tools, testing, and troubleshooting.
  * Added Atlassian Rovo to toolset navigation and knowledge integration listings.
  * Documented static-credential configuration for headless use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->