### PR TITLE
ROB-878 remove stale Sonnet 4.0/4.5 model recommendations from docs

### DIFF
--- a/docs/ai-providers/aws-bedrock.md
+++ b/docs/ai-providers/aws-bedrock.md
@@ -2,9 +2,6 @@
 
 Configure HolmesGPT to use AWS Bedrock foundation models.
 
-!!! tip "Which Model to Use"
-    We highly recommend using Sonnet 4.0 or Sonnet 4.5 as they give the best results by far. See examples below for configuration.
-
 ## Setup
 
 ### Prerequisites

--- a/docs/ai-providers/openai-compatible.md
+++ b/docs/ai-providers/openai-compatible.md
@@ -88,7 +88,7 @@ Point HolmesGPT at your OpenAI-compatible endpoint:
 
 ## Known Limitations
 
-- **Some models**: May hallucinate responses instead of reporting function calling limitations. See [benchmark results](../development/evaluations/index.md) for recommended models.
+- **Some models**: May hallucinate responses instead of reporting function calling limitations. See [benchmark results](../development/evaluations/latest-results.md) for recommended models.
 
 ## Additional Resources
 

--- a/docs/installation/cli-installation.md
+++ b/docs/installation/cli-installation.md
@@ -89,7 +89,7 @@ Run HolmesGPT from your terminal as a standalone CLI tool.
 Choose your AI provider (see [all providers](../ai-providers/index.md) for more options).
 
 !!! tip "Which Model to Use"
-    Model choice has a large impact on results. [View Benchmarks.](../development/evaluations/index.md)
+    Model choice has a large impact on results. [View Benchmarks.](../development/evaluations/latest-results.md)
 
 !!! info "No Kubernetes Required"
     The examples below use a Kubernetes pod for a quick guided demo, but HolmesGPT works with any infrastructure. If you don't use Kubernetes, skip the `kubectl apply` step and ask about your own systems instead:

--- a/docs/installation/cli-installation.md
+++ b/docs/installation/cli-installation.md
@@ -186,6 +186,9 @@ Choose your AI provider (see [all providers](../ai-providers/index.md) for more 
 
     4. **Ask your first question**:
         ```bash
+        holmes ask "what is wrong with the user-profile-import pod?" --model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+        # Or use another model
         holmes ask "what is wrong with the user-profile-import pod?" --model="bedrock/<your-model-name>"
         ```
 

--- a/docs/installation/cli-installation.md
+++ b/docs/installation/cli-installation.md
@@ -89,7 +89,7 @@ Run HolmesGPT from your terminal as a standalone CLI tool.
 Choose your AI provider (see [all providers](../ai-providers/index.md) for more options).
 
 !!! tip "Which Model to Use"
-    We highly recommend using Sonnet 4.0 or Sonnet 4.5 as they give the best results by far. These models are available from Anthropic, AWS Bedrock, and Google Vertex. [View Benchmarks.](../development/evaluations/index.md)
+    Model choice has a large impact on results. [View Benchmarks.](../development/evaluations/index.md)
 
 !!! info "No Kubernetes Required"
     The examples below use a Kubernetes pod for a quick guided demo, but HolmesGPT works with any infrastructure. If you don't use Kubernetes, skip the `kubectl apply` step and ask about your own systems instead:
@@ -186,10 +186,6 @@ Choose your AI provider (see [all providers](../ai-providers/index.md) for more 
 
     4. **Ask your first question**:
         ```bash
-        # Recommended: Use Sonnet 4.0 or Sonnet 4.5 for best results
-        holmes ask "what is wrong with the user-profile-import pod?" --model="bedrock/anthropic.claude-sonnet-4-20250514-v1:0"
-
-        # Or use another model
         holmes ask "what is wrong with the user-profile-import pod?" --model="bedrock/<your-model-name>"
         ```
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -42,16 +42,10 @@ Older LLM models lack reasoning capability for complex problems.
 **Solution:**
 ```yaml
 config:
-  model: "gpt-4.1"  # or anthropic/claude-sonnet-4-20250514
+  model: "<your-model-name>"
   temperature: 0.1
   maxTokens: 2000
 ```
-
-**Recommended Models:**
-
-- `anthropic/claude-opus-4-1-20250805` - Most powerful for complex investigations (recommended)
-- `anthropic/claude-sonnet-4-20250514` - Superior reasoning with faster performance
-- `gpt-4.1` - Good balance of speed/capability
 
 See [benchmark results](../development/evaluations/latest-results.md) for detailed model performance comparisons.
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -42,7 +42,7 @@ Older LLM models lack reasoning capability for complex problems.
 **Solution:**
 ```yaml
 config:
-  model: "<your-model-name>"
+  model: "anthropic/claude-sonnet-4-5-20250929"
   temperature: 0.1
   maxTokens: 2000
 ```


### PR DESCRIPTION
## What

The docs told readers to use "Sonnet 4.0 or Sonnet 4.5" because they "give the best results by far". That is no longer accurate, so the claim is removed everywhere it appears and readers are pointed at the benchmark results instead — guidance that stays current on its own.

| File | Change |
|---|---|
| `docs/ai-providers/aws-bedrock.md` | Removed the `Which Model to Use` tip admonition entirely. |
| `docs/installation/cli-installation.md` | Quick Start tip now reads "Model choice has a large impact on results. View Benchmarks." — the benchmarks link carries the recommendation instead of a named model. |
| `docs/installation/cli-installation.md` | AWS Bedrock tab: dropped the `# Recommended: Use Sonnet 4.0 or Sonnet 4.5…` comment. The example itself stays concrete and runnable, updated to the current `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0`. |
| `docs/reference/troubleshooting.md` | "5. Model Issues": removed the `Recommended Models` list pinned to dated model IDs. The config snippet stays runnable, updated to `anthropic/claude-sonnet-4-5-20250929`. The benchmark-results link already present now carries the guidance. |
| `docs/installation/cli-installation.md`, `docs/ai-providers/openai-compatible.md` | Benchmark links repointed from the `evaluations/` section index to `evaluations/latest-results.md`, so they land on the actual numbers — matching what `troubleshooting.md` and `openai.md` already did. |

The distinction throughout: what goes away is the **claim** that a specific model gives the best results. Concrete model IDs remain in examples so they stay copy-pasteable, per the repo guideline that docs examples use the latest Claude models.

## Notes

- Docs only, and only the docs built in this repo. No changes to relay, robusta-frontend, or robusta-storage.
- No heading was renamed, so no anchors changed; verified there are no inbound references to the removed `Recommended Models` block.
- The two homepage "View Benchmarks" links in `docs/index.md` are intentionally left pointing at the `evaluations/` index — they read as navigation into the Benchmarks section rather than a "see the numbers" reference.
- The red `License Compliance` check is a pre-existing failure on `master`, unrelated to this diff (same 13 issues appear on #2370, which touches no dependency files).

Ticket: [ROB-878](https://linear.app/robusta/issue/ROB-878/remove-outdated-which-model-to-use-section-from-aws-bedrock-docs-page)

<sub>Note: the first commit references the original Jira key ROB-4129, which has since been closed in favour of the Linear ticket above.</sub>