### PR TITLE
fix: filter Azure-incompatible dynamic MCP tool schemas

### DIFF
--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -195,6 +195,14 @@ class MCPConfig(ToolsetConfig):
         "connection is fully functional (e.g., API token is valid). Example: 'get_me' for GitHub MCP.",
         examples=["get_me", "get_current_user"],
     )
+    excluded_tools: Optional[List[str]] = Field(
+        default=None,
+        title="Excluded Tools",
+        description="List of tool names to exclude from this MCP server. "
+        "Useful for filtering out tools with Azure-incompatible schemas "
+        "(e.g., dynamic object arguments in 'required' but not in 'properties').",
+        examples=[["tools_call", "dynamic_args_tool"]],
+    )
 
     @model_validator(mode="after")
     def default_oauth_resource(self) -> "MCPConfig":
@@ -250,6 +258,14 @@ class StdioMCPConfig(ToolsetConfig):
         "If set, this tool will be called with empty arguments after loading tools to ensure the "
         "connection is fully functional (e.g., API token is valid). Example: 'get_me' for GitHub MCP.",
         examples=["get_me", "get_current_user"],
+    )
+    excluded_tools: Optional[List[str]] = Field(
+        default=None,
+        title="Excluded Tools",
+        description="List of tool names to exclude from this MCP server. "
+        "Useful for filtering out tools with Azure-incompatible schemas "
+        "(e.g., dynamic object arguments in 'required' but not in 'properties').",
+        examples=[["tools_call", "dynamic_args_tool"]],
     )
 
     def get_lock_string(self) -> str:
@@ -905,6 +921,33 @@ class RemoteMCPTool(Tool):
         return f"{self.toolset.name}: {self.name} {params}"
 
 
+def _is_azure_incompatible_schema(input_schema: dict) -> bool:
+    """Detect MCP tool schemas that Azure OpenAI rejects.
+
+    Azure OpenAI requires that if a property is in ``required``, it must also
+    appear in ``properties``.  Some MCP tools define dynamic object arguments
+    (e.g. ``args``) where ``required`` lists the key but ``properties`` is
+    absent or doesn't include it.  This causes Azure to reject the entire
+    schema, which disables all tools from that MCP server.
+
+    Returns True if the schema is Azure-incompatible.
+    """
+    if not isinstance(input_schema, dict):
+        return False
+
+    required = input_schema.get("required", [])
+    properties = input_schema.get("properties", {})
+
+    if not required or not isinstance(required, list):
+        return False
+
+    for key in required:
+        if key not in properties:
+            return True
+
+    return False
+
+
 class RemoteMCPToolset(Toolset):
     config_classes: ClassVar[list[Type[Union[MCPConfig, StdioMCPConfig]]]] = [
         MCPConfig,
@@ -930,17 +973,39 @@ class RemoteMCPToolset(Toolset):
         return self._mcp_config.oauth.model_dump(exclude_none=True)
 
     def _load_remote_tools(self, request_context: Optional[Dict[str, Any]] = None) -> List["RemoteMCPTool"]:
-        """Load tools from the MCP server and return as RemoteMCPTool instances."""
+        """Load tools from the MCP server and return as RemoteMCPTool instances.
+
+        Filters out tools listed in ``excluded_tools`` and tools with
+        Azure-incompatible schemas (dynamic object arguments in 'required'
+        but not in 'properties').
+        """
         if request_context:
             tools_result = asyncio.run(self._get_server_tools_with_context(request_context))
         else:
             tools_result = asyncio.run(self._get_server_tools())
-        return [
-            RemoteMCPTool.create(
-                tool, self, is_remote=tool.name.startswith(REMOTE_TOOL_NAME_PREFIX)
+
+        excluded = set(self._mcp_config.excluded_tools or [])
+        loaded = []
+        for tool in tools_result.tools:
+            if tool.name in excluded:
+                logger.info(
+                    "MCP server %s: excluding tool '%s' (listed in excluded_tools)",
+                    self.name, tool.name,
+                )
+                continue
+            if _is_azure_incompatible_schema(tool.inputSchema):
+                logger.warning(
+                    "MCP server %s: excluding tool '%s' (Azure-incompatible schema: "
+                    "dynamic object in 'required' but not in 'properties')",
+                    self.name, tool.name,
+                )
+                continue
+            loaded.append(
+                RemoteMCPTool.create(
+                    tool, self, is_remote=tool.name.startswith(REMOTE_TOOL_NAME_PREFIX)
+                )
             )
-            for tool in tools_result.tools
-        ]
+        return loaded
 
     def _render_headers(
         self, request_context: Optional[Dict[str, Any]] = None

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -941,6 +941,9 @@ def _is_azure_incompatible_schema(input_schema: dict) -> bool:
     if not required or not isinstance(required, list):
         return False
 
+    if not isinstance(properties, dict):
+        return True
+
     for key in required:
         if key not in properties:
             return True

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -865,6 +865,18 @@ class TestAzureIncompatibleSchema:
         }
         assert _is_azure_incompatible_schema(schema) is False
 
+    def test_null_properties_flagged(self):
+        """Test that schema with null properties is flagged as Azure-incompatible."""
+        from holmes.plugins.toolsets.mcp.toolset_mcp import _is_azure_incompatible_schema
+
+        # properties is null - should be treated as incompatible
+        schema = {
+            "type": "object",
+            "properties": None,
+            "required": ["args"],
+        }
+        assert _is_azure_incompatible_schema(schema) is True
+
     def test_azure_incompatible_tool_excluded_from_loading(self, monkeypatch, suppress_migration_warnings):
         """Test that Azure-incompatible tools are automatically excluded when loading."""
         mcp_toolset = RemoteMCPToolset(

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -809,6 +809,208 @@ class TestMCPSchemaPreservation:
         assert tool.parameters["name"].json_schema_extra is None
 
 
+class TestAzureIncompatibleSchema:
+    """Tests for Azure-incompatible schema detection and exclusion."""
+
+    def test_azure_incompatible_schema_detected(self):
+        """Test that schema with dynamic object in required but not properties is detected."""
+        from holmes.plugins.toolsets.mcp.toolset_mcp import _is_azure_incompatible_schema
+
+        # This is the problematic pattern: 'args' is in required but not in properties
+        schema = {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+            },
+            "required": ["command", "args"],  # 'args' not in properties
+        }
+        assert _is_azure_incompatible_schema(schema) is True
+
+    def test_azure_compatible_schema_not_flagged(self):
+        """Test that normal schema is not flagged as Azure-incompatible."""
+        from holmes.plugins.toolsets.mcp.toolset_mcp import _is_azure_incompatible_schema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "args": {"type": "object"},
+            },
+            "required": ["command", "args"],
+        }
+        assert _is_azure_incompatible_schema(schema) is False
+
+    def test_empty_required_not_flagged(self):
+        """Test that schema with empty required list is not flagged."""
+        from holmes.plugins.toolsets.mcp.toolset_mcp import _is_azure_incompatible_schema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+            },
+            "required": [],
+        }
+        assert _is_azure_incompatible_schema(schema) is False
+
+    def test_no_required_not_flagged(self):
+        """Test that schema without required field is not flagged."""
+        from holmes.plugins.toolsets.mcp.toolset_mcp import _is_azure_incompatible_schema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+            },
+        }
+        assert _is_azure_incompatible_schema(schema) is False
+
+    def test_azure_incompatible_tool_excluded_from_loading(self, monkeypatch, suppress_migration_warnings):
+        """Test that Azure-incompatible tools are automatically excluded when loading."""
+        mcp_toolset = RemoteMCPToolset(
+            name="test_mcp",
+            description="Test toolset",
+            config={"url": "http://localhost:1234"},
+        )
+
+        # One compatible tool, one Azure-incompatible tool
+        compatible_tool = Tool(
+            name="run_command",
+            inputSchema={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+            description="Run a command",
+        )
+        incompatible_tool = Tool(
+            name="tools_call",
+            inputSchema={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command", "args"],  # 'args' not in properties
+            },
+            description="Call tools",
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(tools=[compatible_tool, incompatible_tool])
+
+        monkeypatch.setattr(mcp_toolset, "_get_server_tools", mock_get_server_tools)
+        mcp_toolset.prerequisites_callable(config=mcp_toolset.config)
+
+        # Only the compatible tool should be loaded
+        assert len(mcp_toolset.tools) == 1
+        assert mcp_toolset.tools[0].name == "run_command"
+
+    def test_excluded_tools_config_filters_tools(self, monkeypatch, suppress_migration_warnings):
+        """Test that excluded_tools config option filters out specified tools."""
+        mcp_toolset = RemoteMCPToolset(
+            name="test_mcp",
+            description="Test toolset",
+            config={
+                "url": "http://localhost:1234",
+                "excluded_tools": ["unwanted_tool"],
+            },
+        )
+
+        tool1 = Tool(
+            name="useful_tool",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="Useful tool",
+        )
+        tool2 = Tool(
+            name="unwanted_tool",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="Unwanted tool",
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(tools=[tool1, tool2])
+
+        monkeypatch.setattr(mcp_toolset, "_get_server_tools", mock_get_server_tools)
+        mcp_toolset.prerequisites_callable(config=mcp_toolset.config)
+
+        # Only the non-excluded tool should be loaded
+        assert len(mcp_toolset.tools) == 1
+        assert mcp_toolset.tools[0].name == "useful_tool"
+
+    def test_excluded_tools_and_azure_incompatible_combined(self, monkeypatch, suppress_migration_warnings):
+        """Test that both excluded_tools and Azure-incompatible detection work together."""
+        mcp_toolset = RemoteMCPToolset(
+            name="test_mcp",
+            description="Test toolset",
+            config={
+                "url": "http://localhost:1234",
+                "excluded_tools": ["manual_exclude"],
+            },
+        )
+
+        compatible_tool = Tool(
+            name="good_tool",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="Good tool",
+        )
+        manually_excluded = Tool(
+            name="manual_exclude",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="Manually excluded tool",
+        )
+        azure_incompatible = Tool(
+            name="azure_bad",
+            inputSchema={
+                "type": "object",
+                "properties": {"cmd": {"type": "string"}},
+                "required": ["cmd", "args"],  # 'args' not in properties
+            },
+            description="Azure-incompatible tool",
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(tools=[compatible_tool, manually_excluded, azure_incompatible])
+
+        monkeypatch.setattr(mcp_toolset, "_get_server_tools", mock_get_server_tools)
+        mcp_toolset.prerequisites_callable(config=mcp_toolset.config)
+
+        # Only the compatible, non-excluded tool should be loaded
+        assert len(mcp_toolset.tools) == 1
+        assert mcp_toolset.tools[0].name == "good_tool"
+
+    def test_excluded_tools_config_works_for_stdio(self, monkeypatch, suppress_migration_warnings):
+        """Test that excluded_tools works for StdioMCPConfig."""
+        mcp_toolset = RemoteMCPToolset(
+            name="test_mcp",
+            description="Test toolset",
+            config={
+                "mode": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-everything"],
+                "excluded_tools": ["echo"],
+            },
+        )
+
+        tool1 = Tool(
+            name="add",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="Add tool",
+        )
+        tool2 = Tool(
+            name="echo",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+            description="Echo tool",
+        )
+
+        async def mock_get_server_tools():
+            return ListToolsResult(tools=[tool1, tool2])
+
+        monkeypatch.setattr(mcp_toolset, "_get_server_tools", mock_get_server_tools)
+        mcp_toolset.prerequisites_callable(config=mcp_toolset.config)
+
+        # Only the non-excluded tool should be loaded
+        assert len(mcp_toolset.tools) == 1
+        assert mcp_toolset.tools[0].name == "add"
+
+
 class TestExceptionGroupUnwrapping:
     def test_extract_root_error_from_exception_group(self):
         root_cause = ConnectionRefusedError("Connection refused")


### PR DESCRIPTION
## Summary

This PR adds automatic detection and filtering of MCP tool schemas that Azure OpenAI rejects.

### Problem
Azure OpenAI requires that all keys in `required` must also appear in `properties`. Some MCP tools define dynamic object arguments (e.g., `args`) where `required` lists the key but `properties` is absent. This causes Azure to reject the entire schema, **disabling all tools from that MCP server**.

### Solution
Two complementary features:

1. **Auto-detection**: `_is_azure_incompatible_schema()` detects problematic schemas and logs a warning while excluding the tool automatically
2. **Manual exclusion**: `excluded_tools` config option for fine-grained control over which tools to load

### Changes
- `holmes/plugins/toolsets/mcp/toolset_mcp.py`: 
  - Added `_is_azure_incompatible_schema()` helper function
  - Added `excluded_tools` field to both `MCPConfig` and `StdioMCPConfig`
  - Modified `_load_remote_tools()` to filter tools automatically
- `tests/test_mcp_toolset.py`:
  - Added `TestAzureIncompatibleSchema` class with 8 comprehensive tests

### Example Config

```yaml
# MCP server with excluded tools
mcp_servers:
  everything:
    url: "http://localhost:3001"
    excluded_tools:
      - "tools_call"
      - "dynamic_args_tool"
```

### Test Coverage
- Schema detection (compatible/incompatible)
- Auto-exclusion of incompatible tools
- Manual exclusion via config
- Combined exclusion scenarios
- Stdio config support

Closes #2297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options to exclude specific MCP tools from loading.
  * Added support for applying exclusions to HTTP/SSE and standard-input MCP connections.
  * Added automatic detection of schemas incompatible with Azure.

* **Bug Fixes**
  * Prevented unsupported or incomplete tools from being loaded, improving MCP compatibility and reliability.
  * Improved remote tool loading by skipping tools with missing required schema properties.
  * Ensured remote approval metadata is applied only to remote tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->