### PR TITLE
docs: multi-agent investigations now default to on

### DIFF
--- a/docs/data-sources/cross-cluster-tools.md
+++ b/docs/data-sources/cross-cluster-tools.md
@@ -8,12 +8,14 @@ The mechanism is opt-in per toolset via the `expose_remotely` flag, and gated pe
 
 ## Two ways to use it
 
-Once a toolset is exposed remotely, its tools can be reached in two ways. Each is controlled by its **own, independent** account setting (both off by default):
+Once a toolset is exposed remotely, its tools can be reached in two ways. Each is controlled by its **own, independent** account setting:
 
-| Use case | Who calls the tools | Account setting | Enable in the UI |
-|---|---|---|---|
-| **Multi-agent investigations** | Another Holmes agent, during an investigation | `multi_agent_investigation_enabled` | **Settings → Enable Multi Agent Investigations** |
-| **External MCP clients** | Any MCP client (Claude Code, Claude Desktop, …) via an API key | `expose_remote_tool_calls_externally` | **Settings → Robusta MCP Server** |
+| Use case | Who calls the tools | Account setting | Default | Enable in the UI |
+|---|---|---|---|---|
+| **Multi-agent investigations** | Another Holmes agent, during an investigation | `multi_agent_investigation_enabled` | On | **Settings → Enable Multi Agent Investigations** |
+| **External MCP clients** | Any MCP client (Claude Code, Claude Desktop, …) via an API key | `expose_remote_tool_calls_externally` | Off | **Settings → Robusta MCP Server** |
+
+Multi-agent investigations are on for new accounts and can be turned off from the same setting. Accounts created before this default changed keep their existing (off) value until an admin turns it on.
 
 The two switches are independent — turning one on does not turn on the other.
 


### PR DESCRIPTION
@sheeproid

`docs/data-sources/cross-cluster-tools.md` said the two cross-cluster account settings were "both off by default". `multi_agent_investigation_enabled` is being flipped to an opt-out (a missing value now means enabled), so that line is no longer accurate.

Companion PRs: robusta-dev/relay#714 (server-side flip), robusta-dev/robusta-storage#286 (backfill for existing accounts), robusta-dev/robusta-frontend#3496 (UI reader).

## Changes

- Replaced the "both off by default" claim with a **Default** column: `multi_agent_investigation_enabled` = On, `expose_remote_tool_calls_externally` = Off (unchanged — it stays opt-in).
- Added a note that accounts created before the flip keep their existing (off) value until an admin turns it on, since those are backfilled with an explicit `false`.

Docs only — no code, no toolset changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk7SmqRVHZY1gHPEXCCoUG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified account settings for multi-agent investigations and external MCP clients.
  * Documented default values and where to manage these settings in the interface.
  * Noted that multi-agent investigations are enabled for new accounts, while existing accounts retain their current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->