### PR TITLE
fix(bash): require approval for shell redirections (ROB-895)

### DIFF
--- a/holmes/plugins/toolsets/bash/validation.py
+++ b/holmes/plugins/toolsets/bash/validation.py
@@ -28,6 +28,17 @@ from holmes.plugins.toolsets.bash.common.default_lists import (
 
 logger = logging.getLogger(__name__)
 
+# Redirect targets that touch no real file, so they never require approval.
+# These keep common, benign LLM idioms auto-allowed (e.g. `2>/dev/null`).
+_SAFE_REDIRECT_TARGETS = {
+    "/dev/null",
+    "/dev/stdout",
+    "/dev/stderr",
+    "/dev/stdin",
+}
+# Heredoc / here-string redirect operators feed inline text, not a file.
+_HEREDOC_REDIRECT_TYPES = {"<<", "<<-", "<<<"}
+
 
 class ValidationStatus(Enum):
     """Result status for command validation."""
@@ -120,14 +131,34 @@ class CommandSegmentExtractor(ast.nodevisitor):
         self.contains_compound_command = True
 
     def visitredirect(self, node, *args, **kwargs):
-        """Flag shell redirections (>, >>, 2>, &>, <, heredocs, etc.).
+        """Flag redirections whose target is a real filesystem path.
 
         Prefix matching only inspects the START of a command segment, so a
         redirect target appended to an allowed command (e.g. `echo x > /file`)
-        would otherwise be silently auto-allowed. Flagging redirects forces
-        approval, closing an arbitrary file write (output redirects) and an
-        arbitrary file read (input redirects) bypass of the allow list.
+        would otherwise be silently auto-allowed. Flagging such redirects forces
+        approval, closing an arbitrary file write (`>`, `>>`, `&>`) and an
+        arbitrary file read (`<`) bypass of the allow list.
+
+        Redirections that touch no real file are intentionally NOT flagged, so
+        the common, benign shell idioms the LLM relies on stay auto-allowed:
+        - file-descriptor duplication/close (`2>&1`, `>&2`, `2>&-`): the target
+          is an fd number or '-', not a WordNode.
+        - harmless device sinks (`2>/dev/null`, `>/dev/stdout`, ...).
+        - heredocs / here-strings (`<<EOF`, `<<<`): inline text, not a file.
         """
+        redirect_type = getattr(node, "type", "")
+        if redirect_type in _HEREDOC_REDIRECT_TYPES:
+            return
+
+        output = getattr(node, "output", None)
+        # fd duplication/close — output is an int fd or '-', never a WordNode.
+        if not isinstance(output, ast.node):
+            return
+
+        target = (getattr(output, "word", "") or "").strip()
+        if target in _SAFE_REDIRECT_TARGETS:
+            return
+
         self.contains_redirect = True
 
 
@@ -386,14 +417,15 @@ def validate_command(
             prefixes_needing_approval=[],
         )
 
-    # Shell redirections bypass prefix matching (which only checks the start of a
-    # segment), so an allowed command plus `> target` / `< target` would otherwise
-    # be auto-allowed as an arbitrary file write or read. Require one-time approval;
-    # never save these to the allow list.
+    # A redirect to/from a real file bypasses prefix matching (which only checks
+    # the start of a segment), so an allowed command plus `> file` / `< file`
+    # would otherwise be auto-allowed as an arbitrary file write or read. Require
+    # one-time approval; never save these to the allow list. (Benign redirects
+    # like `2>/dev/null` and `2>&1` are not flagged — see visitredirect.)
     if contains_redirect:
         return ValidationResult(
             status=ValidationStatus.APPROVAL_REQUIRED,
-            message="Contains a shell redirection (>, >>, 2>, &>, <, etc.) which requires approval.",
+            message="Redirects to or from a file (>, >>, &>, <) which requires approval.",
             prefixes_needing_approval=[],
         )
 

--- a/holmes/plugins/toolsets/bash/validation.py
+++ b/holmes/plugins/toolsets/bash/validation.py
@@ -108,6 +108,7 @@ class CommandSegmentExtractor(ast.nodevisitor):
         self.command = command
         self.segments: List[str] = []
         self.contains_compound_command: bool = False
+        self.contains_redirect: bool = False
 
     def visitcommand(self, node, *args, **kwargs):
         """Extract the command text for simple commands."""
@@ -118,17 +119,29 @@ class CommandSegmentExtractor(ast.nodevisitor):
         """Flag compound statements but continue traversal to extract inner segments."""
         self.contains_compound_command = True
 
+    def visitredirect(self, node, *args, **kwargs):
+        """Flag shell redirections (>, >>, 2>, &>, <, heredocs, etc.).
 
-def parse_command_segments(command: str) -> Tuple[List[str], bool]:
+        Prefix matching only inspects the START of a command segment, so a
+        redirect target appended to an allowed command (e.g. `echo x > /file`)
+        would otherwise be silently auto-allowed. Flagging redirects forces
+        approval, closing an arbitrary file write (output redirects) and an
+        arbitrary file read (input redirects) bypass of the allow list.
+        """
+        self.contains_redirect = True
+
+
+def parse_command_segments(command: str) -> Tuple[List[str], bool, bool]:
     """
     Parse a command into segments separated by |, &&, ||, ;, &.
 
     Uses bashlex AST visitor for proper shell parsing.
 
     Returns:
-        Tuple of (segments, contains_compound_command):
+        Tuple of (segments, contains_compound_command, contains_redirect):
         - segments: List of command segments extracted from the command
         - contains_compound_command: True if compound statements (for, while, if, etc.) were detected
+        - contains_redirect: True if any shell redirection (>, >>, 2>, &>, <, heredoc) was detected
 
     Raises:
         bashlex.errors.ParsingError: If bashlex cannot parse the command
@@ -138,7 +151,11 @@ def parse_command_segments(command: str) -> Tuple[List[str], bool]:
     extractor = CommandSegmentExtractor(command)
     for part in parts:
         extractor.visit(part)
-    return (extractor.segments, extractor.contains_compound_command)
+    return (
+        extractor.segments,
+        extractor.contains_compound_command,
+        extractor.contains_redirect,
+    )
 
 
 def check_hardcoded_blocks(segment: str) -> Optional[str]:
@@ -321,7 +338,9 @@ def validate_command(
 
     # Parse command into segments and detect compound statements
     try:
-        segments, contains_compound_command = parse_command_segments(command)
+        segments, contains_compound_command, contains_redirect = (
+            parse_command_segments(command)
+        )
     except (bashlex.errors.ParsingError, NotImplementedError):
         # Can't parse — do safety checks on raw string, then ask user to approve
         blocked = check_blocked_in_raw_command(command, HARDCODED_BLOCKS)
@@ -364,6 +383,17 @@ def validate_command(
         return ValidationResult(
             status=ValidationStatus.APPROVAL_REQUIRED,
             message="Contains compound statements (for/while/if/etc).",
+            prefixes_needing_approval=[],
+        )
+
+    # Shell redirections bypass prefix matching (which only checks the start of a
+    # segment), so an allowed command plus `> target` / `< target` would otherwise
+    # be auto-allowed as an arbitrary file write or read. Require one-time approval;
+    # never save these to the allow list.
+    if contains_redirect:
+        return ValidationResult(
+            status=ValidationStatus.APPROVAL_REQUIRED,
+            message="Contains a shell redirection (>, >>, 2>, &>, <, etc.) which requires approval.",
             prefixes_needing_approval=[],
         )
 

--- a/tests/test_bash_toolset_validation.py
+++ b/tests/test_bash_toolset_validation.py
@@ -132,43 +132,43 @@ class TestParseCommandSegments:
 
     def test_simple_command(self):
         """Test parsing a simple command."""
-        segments, has_compound = parse_command_segments("kubectl get pods")
+        segments, has_compound, _ = parse_command_segments("kubectl get pods")
         assert segments == ["kubectl get pods"]
         assert not has_compound
 
     def test_piped_command(self):
         """Test parsing a piped command."""
-        segments, has_compound = parse_command_segments("kubectl get pods | grep error")
+        segments, has_compound, _ = parse_command_segments("kubectl get pods | grep error")
         assert segments == ["kubectl get pods", "grep error"]
         assert not has_compound
 
     def test_multiple_pipes(self):
         """Test parsing multiple pipes."""
-        segments, has_compound = parse_command_segments("kubectl get pods | grep error | head -10")
+        segments, has_compound, _ = parse_command_segments("kubectl get pods | grep error | head -10")
         assert segments == ["kubectl get pods", "grep error", "head -10"]
         assert not has_compound
 
     def test_and_operator(self):
         """Test parsing && operator."""
-        segments, has_compound = parse_command_segments("mkdir test && cd test")
+        segments, has_compound, _ = parse_command_segments("mkdir test && cd test")
         assert segments == ["mkdir test", "cd test"]
         assert not has_compound
 
     def test_or_operator(self):
         """Test parsing || operator."""
-        segments, has_compound = parse_command_segments("test -f file.txt || touch file.txt")
+        segments, has_compound, _ = parse_command_segments("test -f file.txt || touch file.txt")
         assert segments == ["test -f file.txt", "touch file.txt"]
         assert not has_compound
 
     def test_semicolon_operator(self):
         """Test parsing ; operator."""
-        segments, has_compound = parse_command_segments("echo hello; echo world")
+        segments, has_compound, _ = parse_command_segments("echo hello; echo world")
         assert segments == ["echo hello", "echo world"]
         assert not has_compound
 
     def test_background_operator(self):
         """Test parsing & operator."""
-        segments, has_compound = parse_command_segments("sleep 10 & echo done")
+        segments, has_compound, _ = parse_command_segments("sleep 10 & echo done")
         assert segments == ["sleep 10", "echo done"]
         assert not has_compound
 
@@ -181,14 +181,14 @@ class TestParseCommandSegments:
 
     def test_for_loop_extracts_inner_segments(self):
         """For loop returns inner command segments with compound flag."""
-        segments, has_compound = parse_command_segments('for i in 1 2 3; do echo "$i"; done')
+        segments, has_compound, _ = parse_command_segments('for i in 1 2 3; do echo "$i"; done')
         assert has_compound
         assert len(segments) > 0
         assert any("echo" in s for s in segments)
 
     def test_if_statement_extracts_inner_segments(self):
         """If statement returns inner command segments with compound flag."""
-        segments, has_compound = parse_command_segments("if [ -f file ]; then cat file; fi")
+        segments, has_compound, _ = parse_command_segments("if [ -f file ]; then cat file; fi")
         assert has_compound
         assert len(segments) > 0
 
@@ -196,6 +196,32 @@ class TestParseCommandSegments:
         """Case statement (unsupported by bashlex) raises NotImplementedError."""
         with pytest.raises(NotImplementedError):
             parse_command_segments("case $x in 1) echo one;; 2) echo two;; esac")
+
+    def test_no_redirect_flag_for_plain_command(self):
+        """Commands without redirects have contains_redirect False."""
+        _, _, has_redirect = parse_command_segments("echo hello")
+        assert not has_redirect
+
+    def test_no_redirect_flag_for_pipe(self):
+        """A pipe is not a redirect (tool-result read flow uses pipes, not redirects)."""
+        _, _, has_redirect = parse_command_segments("cat /tmp/.holmes/x | jq '.field'")
+        assert not has_redirect
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo pwned > /root/authorized_keys",
+            "echo hi >> /tmp/x",
+            "echo hi 2> /tmp/z",
+            "echo hi &> /tmp/z",
+            "grep '' < /etc/shadow",
+            "kubectl get pods | grep err > /tmp/out",
+        ],
+    )
+    def test_redirect_flagged(self, command):
+        """Output and input redirections set contains_redirect."""
+        _, _, has_redirect = parse_command_segments(command)
+        assert has_redirect
 
 
 class TestCheckHardcodedBlocks:
@@ -572,6 +598,76 @@ class TestValidateCommand:
         assert result.status == ValidationStatus.APPROVAL_REQUIRED
         # Should only appear once in prefixes_needing_approval
         assert result.prefixes_needing_approval == ["custom-tool"]
+
+
+class TestRedirectValidation:
+    """Redirections must never be silently auto-allowed (ROB-895).
+
+    An allowed command plus a redirect target (e.g. `echo x > /file`) is an
+    arbitrary file write; an input redirect (e.g. `grep '' < /etc/shadow`) is an
+    arbitrary file read of the core allow list. Both must require approval and
+    must not be saved to the allow list.
+    """
+
+    @pytest.mark.parametrize(
+        "command,prefix",
+        [
+            ("echo pwned > /root/authorized_keys", "echo"),
+            ("echo pwned >> /root/.bashrc", "echo"),
+            ("echo hi 2> /tmp/z", "echo"),
+            ("echo hi &> /tmp/z", "echo"),
+            ("grep '' < /etc/shadow", "grep"),
+        ],
+    )
+    def test_redirect_with_allowed_command_requires_approval(self, command, prefix):
+        """A redirect on an otherwise-allowed command must require approval, not ALLOW."""
+        # core allowlist: echo and grep are both allowed prefixes
+        config = BashExecutorConfig(builtin_allowlist="core")
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(command, [prefix], allow_list, deny_list)
+        assert result.status == ValidationStatus.APPROVAL_REQUIRED
+        # One-time approval only — never persisted to the allow list.
+        assert result.prefixes_needing_approval == []
+
+    def test_redirect_in_pipe_requires_approval(self):
+        """A redirect anywhere in a pipeline forces approval."""
+        config = BashExecutorConfig(builtin_allowlist="core")
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(
+            "kubectl get pods | grep err > /tmp/out",
+            ["kubectl get", "grep"],
+            allow_list,
+            deny_list,
+        )
+        assert result.status == ValidationStatus.APPROVAL_REQUIRED
+        assert result.prefixes_needing_approval == []
+
+    def test_denied_command_with_redirect_still_denied(self):
+        """A hardcoded block wins over the redirect approval path."""
+        config = BashExecutorConfig(builtin_allowlist="core")
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(
+            "sudo tee /etc/passwd > /tmp/x",
+            ["sudo"],
+            allow_list,
+            deny_list,
+        )
+        assert result.status == ValidationStatus.DENIED
+        assert result.deny_reason == DenyReason.HARDCODED_BLOCK
+
+    def test_piped_read_without_redirect_still_allowed(self):
+        """The tool-result read flow (cat | jq / cat | grep) uses pipes, not
+        redirects, and must remain auto-allowed after the redirect fix."""
+        config = BashExecutorConfig(
+            allow=["cat /tmp/.holmes"], builtin_allowlist="core"
+        )
+        allow_list, deny_list = get_effective_lists(config)
+        for command, prefixes in [
+            ("cat /tmp/.holmes/uuid/file.json | jq '.field'", ["cat /tmp/.holmes", "jq"]),
+            ("cat /tmp/.holmes/uuid/file.json | grep -oP 'pattern'", ["cat /tmp/.holmes", "grep"]),
+        ]:
+            result = validate_command(command, prefixes, allow_list, deny_list)
+            assert result.status == ValidationStatus.ALLOWED, command
 
 
 class TestValidationOrder:

--- a/tests/test_bash_toolset_validation.py
+++ b/tests/test_bash_toolset_validation.py
@@ -218,10 +218,34 @@ class TestParseCommandSegments:
             "kubectl get pods | grep err > /tmp/out",
         ],
     )
-    def test_redirect_flagged(self, command):
-        """Output and input redirections set contains_redirect."""
+    def test_redirect_to_real_file_flagged(self, command):
+        """Output and input redirections to a real file set contains_redirect."""
         _, _, has_redirect = parse_command_segments(command)
         assert has_redirect
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # fd duplication / merge / close — no file target
+            "echo hi 2>&1",
+            "echo hi >&2",
+            "echo hi 1>&2",
+            "echo hi 2>&-",
+            "kubectl get pods | grep err 2>&1",
+            # harmless device sinks the LLM uses constantly
+            "kubectl get pods 2>/dev/null",
+            "ls >/dev/null 2>&1",
+            "echo hi > /dev/null",
+            "tee /dev/stderr",
+            # here-string / heredoc feed inline text, not a file
+            "grep x <<< 'inline text'",
+        ],
+    )
+    def test_benign_redirect_not_flagged(self, command):
+        """fd-duplication, /dev/null-family sinks, and heredocs must NOT be flagged,
+        so common benign shell idioms stay auto-allowed."""
+        _, _, has_redirect = parse_command_segments(command)
+        assert not has_redirect
 
 
 class TestCheckHardcodedBlocks:
@@ -668,6 +692,23 @@ class TestRedirectValidation:
         ]:
             result = validate_command(command, prefixes, allow_list, deny_list)
             assert result.status == ValidationStatus.ALLOWED, command
+
+    @pytest.mark.parametrize(
+        "command,prefixes",
+        [
+            # stderr suppression / stream merge — the LLM uses these constantly
+            ("kubectl get pods 2>/dev/null", ["kubectl get"]),
+            ("kubectl get pods 2>&1 | grep error", ["kubectl get", "grep"]),
+            ("kubectl get pods 2>/dev/null | grep error", ["kubectl get", "grep"]),
+            ("echo done > /dev/null", ["echo"]),
+        ],
+    )
+    def test_benign_stream_redirects_still_allowed(self, command, prefixes):
+        """fd-duplication and /dev/null sinks must not force approval."""
+        config = BashExecutorConfig(builtin_allowlist="core")
+        allow_list, deny_list = get_effective_lists(config)
+        result = validate_command(command, prefixes, allow_list, deny_list)
+        assert result.status == ValidationStatus.ALLOWED, command
 
 
 class TestValidationOrder:

--- a/tests/toolsets/bash/test_bash_approval_flow.py
+++ b/tests/toolsets/bash/test_bash_approval_flow.py
@@ -253,6 +253,84 @@ class TestBashApprovalInCompoundCommands:
         assert result is None
 
 
+class TestBashApprovalWithRedirects:
+    """Redirections must go through the approval flow (ROB-895), not auto-run."""
+
+    def test_output_redirect_requires_approval(self, bash_tool):
+        """`echo x > file` (arbitrary write) must require approval even though
+        'echo' is in the core allow list."""
+        context = _ctx()
+        result = bash_tool.requires_approval(
+            params={
+                "command": "echo pwned > /root/.ssh/authorized_keys",
+                "suggested_prefixes": ["echo"],
+            },
+            context=context,
+        )
+        assert result is not None, "Output redirect must require approval"
+        assert result.needs_approval is True
+        # One-time approval only — a redirect must never be persisted to the allow list.
+        assert result.prefixes_to_save == []
+
+    def test_input_redirect_requires_approval(self, bash_tool):
+        """`grep '' < /etc/shadow` (arbitrary read) must require approval."""
+        context = _ctx()
+        result = bash_tool.requires_approval(
+            params={
+                "command": "grep '' < /etc/shadow",
+                "suggested_prefixes": ["grep"],
+            },
+            context=context,
+        )
+        assert result is not None, "Input redirect must require approval"
+        assert result.needs_approval is True
+        assert result.prefixes_to_save == []
+
+    def test_redirect_executes_after_approval(self, bash_tool, monkeypatch):
+        """Once the user approves, the redirect command runs (validation skipped)."""
+        mock_execute = MagicMock()
+        mock_execute.return_value = MagicMock(
+            timed_out=False, stdout="", return_code=0, stderr=""
+        )
+        monkeypatch.setattr(
+            "holmes.plugins.toolsets.bash.bash_toolset.execute_bash_command",
+            mock_execute,
+        )
+        context = _ctx(user_approved=True)
+        result = bash_tool._invoke(
+            params={
+                "command": "echo hi > /tmp/holmes-test",
+                "suggested_prefixes": ["echo"],
+            },
+            context=context,
+        )
+        assert result.status in (
+            StructuredToolResultStatus.SUCCESS,
+            StructuredToolResultStatus.NO_DATA,
+        )
+        mock_execute.assert_called_once()
+
+    def test_piped_read_flow_not_treated_as_redirect(self, bash_tool):
+        """The tool-result read flow (`cat <file> | grep`) uses a pipe, not a
+        redirect, and must not be forced into the approval flow."""
+        toolset = BashExecutorToolset()
+        toolset.config = BashExecutorConfig(
+            allow=["cat /tmp/.holmes"],
+            deny=[],
+            builtin_allowlist="core",
+        )
+        tool = toolset.tools[0]
+        context = _ctx()
+        result = tool.requires_approval(
+            params={
+                "command": "cat /tmp/.holmes/uuid/file.json | grep -oP 'x'",
+                "suggested_prefixes": ["cat /tmp/.holmes", "grep"],
+            },
+            context=context,
+        )
+        assert result is None, "Piped reads must remain auto-allowed"
+
+
 class TestBashApprovalErrorCases:
     """Test error handling in bash approval flow."""
 

--- a/tests/toolsets/bash/test_bash_approval_flow.py
+++ b/tests/toolsets/bash/test_bash_approval_flow.py
@@ -310,6 +310,20 @@ class TestBashApprovalWithRedirects:
         )
         mock_execute.assert_called_once()
 
+    def test_stderr_suppression_not_treated_as_redirect(self, bash_tool):
+        """`2>/dev/null` and `2>&1` are benign stream plumbing the LLM uses
+        constantly — they must not be forced into the approval flow."""
+        context = _ctx()
+        for command, prefixes in [
+            ("kubectl get pods 2>/dev/null", ["kubectl get"]),
+            ("kubectl get pods 2>&1", ["kubectl get"]),
+        ]:
+            result = bash_tool.requires_approval(
+                params={"command": command, "suggested_prefixes": prefixes},
+                context=context,
+            )
+            assert result is None, f"{command} should stay auto-allowed"
+
     def test_piped_read_flow_not_treated_as_redirect(self, bash_tool):
         """The tool-result read flow (`cat <file> | grep`) uses a pipe, not a
         redirect, and must not be forced into the approval flow."""


### PR DESCRIPTION
## Summary

The bash toolset validator only checked that a command **segment starts with** an allowed prefix. `bashlex` includes the redirect target inside the command node's position span, so the redirect was invisible to validation. Under the default (`core`) allowlist:

```
echo pwned > /root/.ssh/authorized_keys   # suggested_prefixes=["echo"]  -> auto-ALLOWED
```

was executed with no approval — an **arbitrary file write** that breaks the toolset's "read-only by design" guarantee. The same blind spot let an input redirect bypass the core allowlist's deliberate exclusion of file-reading commands:

```
grep '' < /etc/shadow                     # arbitrary file READ -> auto-ALLOWED
```

This is an **integrity** issue (overwrite/truncate kubeconfig, mounted secrets, Holmes's own runbooks/config, tool-result storage; or read arbitrary files), not remote code execution — nothing in Holmes executes what gets written.

## Fix

Flag a redirect **only when its target is a real filesystem path**, and treat that like a compound statement: downgrade to **one-time `APPROVAL_REQUIRED`**, never persisted to the allow list. Hardcoded blocks (`sudo`/`su`) and the deny list still take precedence.

Crucially, redirects that touch **no real file are not flagged**, so the benign shell idioms the LLM emits constantly stay auto-allowed:

- **fd duplication / merge / close** — `2>&1`, `>&2`, `1>&2`, `2>&-` (the target is an fd number or `-`, not a file).
- **harmless device sinks** — `2>/dev/null`, `>/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/stdin`.
- **heredocs / here-strings** — `<<EOF`, `<<<` (inline text, not a file).

**Pipes are untouched** (distinct AST node), so the tool-result storage read flow (`cat <file> | jq`, `cat <file> | grep`) — which Holmes generates itself — keeps working with no approval prompt. (Holmes writes those files in Python via `save_large_result`, never via shell `>`.)

## What is blocked vs. still allowed

**Now requires one-time approval (was auto-allowed):** redirect to/from a real file —

- `echo pwned > /root/.ssh/authorized_keys`, `echo x >> ~/.bashrc`, `echo x &> f`, `echo x 2> /tmp/evil`, `echo x >| f`
- `grep '' < /etc/shadow` and other input redirects to a file
- a file redirect anywhere in a pipeline: `kubectl get pods | grep err > /tmp/out`

**Still auto-allowed (unchanged):**

- plain allowlisted commands and pipes: `echo hello`, `kubectl get pods | grep err`
- **stderr plumbing:** `kubectl get pods 2>/dev/null`, `ls >/dev/null 2>&1`, `... 2>&1 | grep error`, `echo x > /dev/null`
- heredocs / here-strings: `grep x <<< 'inline text'`
- the tool-result read flow: `cat /tmp/.holmes/<id>/file.json | jq '.field'`, `... | grep -oP 'pat'`

**Still denied (unchanged):** `sudo`/`su` and deny-list matches, even combined with a redirect.

## Tests

- `tests/test_bash_toolset_validation.py`
  - `TestParseCommandSegments`: redirect-to-real-file sets the flag for `>`/`>>`/`2>`/`&>`/`<` and in pipelines; fd-dup (`2>&1`, `>&2`, `2>&-`), `/dev/null`-family sinks, and heredocs are **not** flagged.
  - `TestRedirectValidation`: redirect-to-file → `APPROVAL_REQUIRED` (empty `prefixes_needing_approval`); redirect in a pipe → approval; hardcoded block still wins; piped read flow and benign `2>/dev/null`/`2>&1` stay `ALLOWED`.
- `tests/toolsets/bash/test_bash_approval_flow.py::TestBashApprovalWithRedirects`: end-to-end through `requires_approval()`/`_invoke()` — file redirects require approval (`prefixes_to_save == []`), an approved redirect executes, and stderr plumbing / piped reads stay auto-allowed.

Full bash suite green (`test_bash_toolset_validation.py`, `test_bash_toolset.py`, `test_bash_command_execution.py`, `test_bash_session_prefix_flow.py`, `test_bash_prefix_cluster_scoping.py`, `tests/toolsets/bash/`, `tests/plugins/toolsets/bash/`).

## Known limitation (not a regression)

Write-side process substitution `>(cmd)` is not a `RedirectNode`, but its inner writing command becomes a validated segment — so `tee`/`dd`/`cp` inside it still hit the allowlist and require approval. No silent write path remains via that route under the default lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bash command validation now distinguishes file-affecting redirections from benign stream operations.
  - Real file input and output redirections require one-time approval and cannot be saved as allowed command prefixes.
  - Safe operations, including `/dev/null`, file-descriptor redirects, heredocs, and benign pipelines, remain automatically approved.

- **Bug Fixes**
  - Preserved hardcoded command-blocking precedence and automatic approval for allowed tool-result reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->