### PR TITLE
ROB-795: retry the startup Robusta models fetch

### DIFF
--- a/holmes/clients/robusta_client.py
+++ b/holmes/clients/robusta_client.py
@@ -4,11 +4,27 @@ from typing import Any, Dict, Optional
 
 import requests  # type: ignore
 from pydantic import BaseModel, ConfigDict
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
-from holmes.common.env_vars import ROBUSTA_API_ENDPOINT
+from holmes.common.env_vars import (
+    FETCH_ROBUSTA_MODELS_ATTEMPTS,
+    ROBUSTA_API_ENDPOINT,
+)
 
 HOLMES_GET_INFO_URL = f"{ROBUSTA_API_ENDPOINT}/api/holmes/get_info"
 TIMEOUT = 0.5
+
+# 429/5xx (gateway blips, overload) heal on retry; 4xx (bad token, unknown
+# account) doesn't, and retrying it would only delay startup.
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+logger = logging.getLogger(__name__)
 
 
 class HolmesInfo(BaseModel):
@@ -27,19 +43,44 @@ class RobustaModelsResponse(BaseModel):
     models: Dict[str, RobustaModel]
 
 
+def _is_retryable_fetch_error(exc: BaseException) -> bool:
+    if isinstance(exc, requests.exceptions.HTTPError):
+        return (
+            exc.response is not None
+            and exc.response.status_code in _RETRYABLE_STATUS_CODES
+        )
+    return isinstance(
+        exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+    )
+
+
+# The model list is fetched once, at startup: losing that single request to a
+# transient relay/gateway blip degrades the agent to the legacy single-model
+# fallback for the pod's whole life (ROB-795). Retries stay bounded because
+# they block boot — the liveness probe kills the pod after ~130s without a
+# served /healthz.
+@retry(
+    retry=retry_if_exception(_is_retryable_fetch_error),
+    stop=stop_after_attempt(FETCH_ROBUSTA_MODELS_ATTEMPTS),
+    wait=wait_exponential(min=2, max=10),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
+def _request_robusta_models(account_id: str, token: str) -> RobustaModelsResponse:
+    resp = requests.post(
+        f"{ROBUSTA_API_ENDPOINT}/api/llm/models/v2",
+        json={"session_token": token, "account_id": account_id},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return RobustaModelsResponse(models=resp.json())
+
+
 def fetch_robusta_models(
     account_id: str, token: str
 ) -> Optional[RobustaModelsResponse]:
     try:
-        session_request = {"session_token": token, "account_id": account_id}
-        resp = requests.post(
-            f"{ROBUSTA_API_ENDPOINT}/api/llm/models/v2",
-            json=session_request,
-            timeout=10,
-        )
-        resp.raise_for_status()
-        response_json = resp.json()
-        return RobustaModelsResponse(**{"models": response_json})
+        return _request_robusta_models(account_id, token)
     except Exception:
         logging.exception("Failed to fetch robusta models for account")
         return None

--- a/holmes/clients/robusta_client.py
+++ b/holmes/clients/robusta_client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import requests  # type: ignore
 from pydantic import BaseModel, ConfigDict
 from tenacity import (
-    before_sleep_log,
+    RetryCallState,
     retry,
     retry_if_exception,
     stop_after_attempt,
@@ -52,6 +52,21 @@ def _is_retryable_fetch_error(exc: BaseException) -> bool:
     )
 
 
+def _log_fetch_retry(retry_state: RetryCallState) -> None:
+    # Only the first attempt's failure is loud - repeating the same warning
+    # for every attempt in a 5-attempt burst adds noise without new
+    # information (review feedback on ROB-795).
+    level = logging.WARNING if retry_state.attempt_number == 1 else logging.DEBUG
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    logger.log(
+        level,
+        "Fetching Robusta models failed (attempt %d/%d): %s; retrying",
+        retry_state.attempt_number,
+        FETCH_MODELS_ATTEMPTS,
+        exc,
+    )
+
+
 # The model list is fetched once, at startup: losing that single request to a
 # transient relay/gateway blip degrades the agent to the legacy single-model
 # fallback for the pod's whole life (ROB-795). Retries stay bounded because
@@ -60,8 +75,8 @@ def _is_retryable_fetch_error(exc: BaseException) -> bool:
 @retry(
     retry=retry_if_exception(_is_retryable_fetch_error),
     stop=stop_after_attempt(FETCH_MODELS_ATTEMPTS),
-    wait=wait_exponential(min=2, max=10),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
+    wait=wait_exponential(multiplier=2, min=2, max=10),
+    before_sleep=_log_fetch_retry,
     reraise=True,
 )
 def _request_robusta_models(account_id: str, token: str) -> RobustaModelsResponse:
@@ -75,12 +90,13 @@ def _request_robusta_models(account_id: str, token: str) -> RobustaModelsRespons
 
 
 def fetch_robusta_models(
-    account_id: str, token: str
+    account_id: str, token: str, log_failure: bool = True
 ) -> Optional[RobustaModelsResponse]:
     try:
         return _request_robusta_models(account_id, token)
     except Exception:
-        logging.exception("Failed to fetch robusta models for account")
+        if log_failure:
+            logging.exception("Failed to fetch robusta models for account")
         return None
 
 

--- a/holmes/clients/robusta_client.py
+++ b/holmes/clients/robusta_client.py
@@ -12,10 +12,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from holmes.common.env_vars import (
-    FETCH_ROBUSTA_MODELS_ATTEMPTS,
-    ROBUSTA_API_ENDPOINT,
-)
+from holmes.common.env_vars import ROBUSTA_API_ENDPOINT
 
 HOLMES_GET_INFO_URL = f"{ROBUSTA_API_ENDPOINT}/api/holmes/get_info"
 TIMEOUT = 0.5
@@ -23,6 +20,7 @@ TIMEOUT = 0.5
 # 429/5xx (gateway blips, overload) heal on retry; 4xx (bad token, unknown
 # account) doesn't, and retrying it would only delay startup.
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+FETCH_MODELS_ATTEMPTS = 5
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +59,7 @@ def _is_retryable_fetch_error(exc: BaseException) -> bool:
 # served /healthz.
 @retry(
     retry=retry_if_exception(_is_retryable_fetch_error),
-    stop=stop_after_attempt(FETCH_ROBUSTA_MODELS_ATTEMPTS),
+    stop=stop_after_attempt(FETCH_MODELS_ATTEMPTS),
     wait=wait_exponential(min=2, max=10),
     before_sleep=before_sleep_log(logger, logging.WARNING),
     reraise=True,

--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -49,7 +49,6 @@ STORE_PASSWORD = os.environ.get("STORE_PASSWORD", "")
 ROBUSTA_AI = load_bool("ROBUSTA_AI", None)
 LOAD_ALL_ROBUSTA_MODELS = load_bool("LOAD_ALL_ROBUSTA_MODELS", True)
 ROBUSTA_API_ENDPOINT = os.environ.get("ROBUSTA_API_ENDPOINT", "https://api.robusta.dev")
-FETCH_ROBUSTA_MODELS_ATTEMPTS = int(os.environ.get("FETCH_ROBUSTA_MODELS_ATTEMPTS", 5))
 
 LOG_PERFORMANCE = os.environ.get("LOG_PERFORMANCE", None)
 

--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -49,6 +49,7 @@ STORE_PASSWORD = os.environ.get("STORE_PASSWORD", "")
 ROBUSTA_AI = load_bool("ROBUSTA_AI", None)
 LOAD_ALL_ROBUSTA_MODELS = load_bool("LOAD_ALL_ROBUSTA_MODELS", True)
 ROBUSTA_API_ENDPOINT = os.environ.get("ROBUSTA_API_ENDPOINT", "https://api.robusta.dev")
+FETCH_ROBUSTA_MODELS_ATTEMPTS = int(os.environ.get("FETCH_ROBUSTA_MODELS_ATTEMPTS", 5))
 
 LOG_PERFORMANCE = os.environ.get("LOG_PERFORMANCE", None)
 

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -161,6 +161,12 @@ def get_context_window_compaction_threshold_pct() -> int:
 
 ROBUSTA_AI_MODEL_NAME = "Robusta"
 
+# Refreshes run every TOOLSET_STATUS_REFRESH_INTERVAL_SECONDS (default 300s); an
+# extended relay outage would otherwise log a failure every cycle. Only the
+# first failure and every Nth one after it get a full log line (review
+# feedback on ROB-795).
+ROBUSTA_REFRESH_FAILURE_LOG_EVERY = 5
+
 
 def _is_gemini_route(litellm_model_name: str) -> bool:
     """True if the model goes through Google's Gemini GenerateContent API.
@@ -824,6 +830,7 @@ class LLMModelRegistry:
         self._default_robusta_model: Optional[str] = None
         self.dal = dal
         self._lock = threading.RLock()
+        self._robusta_refresh_failures = 0
 
         self._init_models()
 
@@ -966,6 +973,11 @@ class LLMModelRegistry:
         (ROB-795, ROB-707). A failed or empty fetch leaves the registry alone:
         downgrading a healthy catalog on every relay blip would be worse than
         briefly serving a stale list. Returns True when the registry changed.
+
+        Failures are logged on the first occurrence and every
+        `ROBUSTA_REFRESH_FAILURE_LOG_EVERY`th one after that - an outage that
+        outlives several refresh cycles would otherwise log the same failure
+        every cycle.
         """
         with self._lock:
             # Robusta AI is in play iff something Robusta-hosted is loaded -
@@ -984,25 +996,44 @@ class LLMModelRegistry:
         ):
             return False
 
+        log_this_failure = (
+            self._robusta_refresh_failures == 0
+            or self._robusta_refresh_failures % ROBUSTA_REFRESH_FAILURE_LOG_EVERY == 0
+        )
+
         try:
-            robusta_models = fetch_robusta_models(*self.dal.get_ai_credentials())
+            robusta_models = fetch_robusta_models(
+                *self.dal.get_ai_credentials(), log_failure=log_this_failure
+            )
         except Exception:
-            logging.exception("Failed to refresh Robusta AI models")
+            self._robusta_refresh_failures += 1
+            if log_this_failure:
+                logging.exception("Failed to refresh Robusta AI models")
             return False
 
         if not robusta_models or not robusta_models.models:
-            logging.warning("Keeping the loaded models: the catalog came back empty.")
+            self._robusta_refresh_failures += 1
+            if log_this_failure:
+                logging.warning(
+                    "Keeping the loaded models: the catalog came back empty."
+                )
             return False
 
+        self._robusta_refresh_failures = 0
+
         with self._lock:
+            previous_default = self._default_robusta_model
             added, removed = self._install_robusta_models(robusta_models)
             self._register_pricing_for_loaded_models()
 
-        if added or removed:
+        changed = bool(added or removed) or (
+            self._default_robusta_model != previous_default
+        )
+        if changed:
             logging.info(
                 f"Refreshed Robusta AI models. added: {added}, removed: {removed}"
             )
-        return bool(added or removed)
+        return changed
 
     def _install_robusta_models(
         self, robusta_models: RobustaModelsResponse

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -821,7 +821,7 @@ class LLMModelRegistry:
     def __init__(self, config: "Config", dal: SupabaseDal) -> None:
         self.config = config
         self._llms: dict[str, ModelEntry] = {}
-        self._default_robusta_model = None
+        self._default_robusta_model: Optional[str] = None
         self.dal = dal
         self._lock = threading.RLock()
 
@@ -950,23 +950,99 @@ class LLMModelRegistry:
                 self._load_default_robusta_config()
                 return
 
-            default_model = None
-            for model_name, model_data in robusta_models.models.items():
-                logging.info(f"Loading Robusta AI model: {model_name}")
-                self._llms[model_name] = self._create_robusta_model_entry(
-                    model_name=model_name, model_data=model_data
-                )
-                if model_data.is_default:
-                    default_model = model_name
-
-            if default_model:
-                logging.info(f"Setting default Robusta AI model to: {default_model}")
-                self._default_robusta_model: str = default_model  # type: ignore
+            logging.info(f"Loading Robusta AI models: {list(robusta_models.models)}")
+            self._install_robusta_models(robusta_models)
 
         except Exception:
             logging.exception("Failed to get all robusta models")
             # fallback to default behavior
             self._load_default_robusta_config()
+
+    def refresh_robusta_models(self) -> bool:
+        """Re-read the Robusta-hosted catalog into the running registry.
+
+        Startup is otherwise the only read, so an agent that lost that fetch
+        stays on the legacy fallback and later catalog edits never reach it
+        (ROB-795, ROB-707). A failed or empty fetch leaves the registry alone:
+        downgrading a healthy catalog on every relay blip would be worse than
+        briefly serving a stale list. Returns True when the registry changed.
+        """
+        with self._lock:
+            # Robusta AI is in play iff something Robusta-hosted is loaded -
+            # startup leaves either the catalog or the legacy fallback behind.
+            serves_robusta_models = any(
+                entry.is_robusta_model for entry in self._llms.values()
+            )
+
+        # cluster_name and LOAD_ALL_ROBUSTA_MODELS are what put an agent in
+        # legacy single-model mode at boot; refreshing must not promote it.
+        if not (
+            serves_robusta_models
+            and self.config.cluster_name
+            and LOAD_ALL_ROBUSTA_MODELS
+            and self.dal.enabled
+        ):
+            return False
+
+        try:
+            robusta_models = fetch_robusta_models(*self.dal.get_ai_credentials())
+        except Exception:
+            logging.exception("Failed to refresh Robusta AI models")
+            return False
+
+        if not robusta_models or not robusta_models.models:
+            logging.warning("Keeping the loaded models: the catalog came back empty.")
+            return False
+
+        with self._lock:
+            added, removed = self._install_robusta_models(robusta_models)
+            self._register_pricing_for_loaded_models()
+
+        if added or removed:
+            logging.info(
+                f"Refreshed Robusta AI models. added: {added}, removed: {removed}"
+            )
+        return bool(added or removed)
+
+    def _install_robusta_models(
+        self, robusta_models: RobustaModelsResponse
+    ) -> tuple[list[str], list[str]]:
+        """Make the Robusta-hosted entries exactly `robusta_models`, and point
+        the default at whichever one relay flagged. Returns (added, removed).
+
+        Only Robusta-hosted entries are replaced - models the user defined in
+        model_list.yaml or via MODEL aren't ours to touch. Callers holding
+        `_lock` (the refresh path) keep it; startup runs single-threaded before
+        the registry is shared.
+        """
+        incoming = set(robusta_models.models)
+        current = {n for n, entry in self._llms.items() if entry.is_robusta_model}
+
+        # Rebuilt rather than patched: whatever the catalog dropped is simply
+        # not carried over - the legacy `Robusta` entry among it, which is what
+        # heals an agent that booted without a catalog.
+        user_defined = {
+            name: entry
+            for name, entry in self._llms.items()
+            if not entry.is_robusta_model
+        }
+        hosted = {
+            name: self._create_robusta_model_entry(model_name=name, model_data=data)
+            for name, data in robusta_models.models.items()
+        }
+        self._llms = user_defined | hosted
+
+        # Relay flags exactly one model as the account's default.
+        defaults = [
+            name for name, data in robusta_models.models.items() if data.is_default
+        ]
+        if defaults:
+            self._default_robusta_model = defaults[0]
+        elif self._default_robusta_model not in self._llms:
+            # Nothing flagged and the previous default just left the catalog.
+            self._default_robusta_model = None
+
+        return sorted(incoming - current), sorted(current - incoming)
 
     def _load_default_robusta_config(self):
         if self._should_load_robusta_ai():

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -1090,9 +1090,14 @@ class LLMModelRegistry:
                     display_logger.info(f"Using selected model: {model_key}")
                     return model_params.model_copy()
 
-                if model_key.startswith("Robusta/"):
-                    logging.warning("Resyncing Registry and Robusta models.")
-                    self._init_models()
+                # The catalog may have gained this model since it was last read.
+                # Any name is worth a look: a customer's models carry their own
+                # prefix, so keying on `Robusta/` left exactly those unable to
+                # recover. Unlike _init_models, refreshing never rebuilds from
+                # the model file and never falls back to the legacy entry, so a
+                # fetch that fails here cannot cost us the models we do have.
+                logging.warning(f"Model {model_key} is not loaded; refreshing.")
+                if self.refresh_robusta_models():
                     model_params = self._llms.get(model_key)
                     if model_params:
                         display_logger.info(f"Using selected model: {model_key}")

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -167,13 +167,6 @@ ROBUSTA_AI_MODEL_NAME = "Robusta"
 # feedback on ROB-795).
 ROBUSTA_REFRESH_FAILURE_LOG_EVERY = 5
 
-_NO_MODELS_ERROR = (
-    "No LLM models were loaded. Configure a model using one of: "
-    "--model '<provider/model>', export MODEL='<provider/model>', "
-    "or MODEL_LIST_FILE_LOCATION/config model list. "
-    "Setting only an API key (for example OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_API_KEY) is not enough without a model."
-)
-
 
 def _is_gemini_route(litellm_model_name: str) -> bool:
     """True if the model goes through Google's Gemini GenerateContent API.
@@ -1133,10 +1126,6 @@ class LLMModelRegistry:
         return True
 
     def get_model_params(self, model_key: Optional[str] = None) -> ModelEntry:
-        with self._lock:
-            if not self._llms:
-                raise Exception(_NO_MODELS_ERROR)
-
         if model_key:
             model_params = self._loaded_model(model_key)
             if model_params is not None:
@@ -1182,7 +1171,12 @@ class LLMModelRegistry:
         requested one couldn't be found even after a refresh."""
         with self._lock:
             if not self._llms:
-                raise Exception(_NO_MODELS_ERROR)
+                raise Exception(
+                    "No LLM models were loaded. Configure a model using one of: "
+                    "--model '<provider/model>', export MODEL='<provider/model>', "
+                    "or MODEL_LIST_FILE_LOCATION/config model list. "
+                    "Setting only an API key (for example OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_API_KEY) is not enough without a model."
+                )
 
             if self._default_robusta_model:
                 model_params = self._llms.get(self._default_robusta_model)

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -831,6 +831,12 @@ class LLMModelRegistry:
         self.dal = dal
         self._lock = threading.RLock()
         self._robusta_refresh_failures = 0
+        # Not an RLock: refresh_robusta_models() only ever tries to acquire
+        # this non-blockingly, so a second overlapping refresh (the periodic
+        # loop and a get_model_params() resync can race) backs off instead of
+        # installing a response that may be older than the one already in
+        # flight (CodeRabbit review on ROB-795).
+        self._robusta_refresh_lock = threading.Lock()
 
         self._init_models()
 
@@ -978,6 +984,14 @@ class LLMModelRegistry:
         `ROBUSTA_REFRESH_FAILURE_LOG_EVERY`th one after that - an outage that
         outlives several refresh cycles would otherwise log the same failure
         every cycle.
+
+        At most one refresh actually fetches+installs at a time: the periodic
+        refresh loop and a get_model_params() resync can overlap, and the
+        fetch runs outside `_lock` (it's a network call), so a naive
+        implementation could let an older response install after a newer one
+        and silently revert the catalog. An overlapping call backs off
+        (returns False) rather than waiting, so it can never block behind
+        someone else's network fetch.
         """
         with self._lock:
             # Robusta AI is in play iff something Robusta-hosted is loaded -
@@ -996,44 +1010,50 @@ class LLMModelRegistry:
         ):
             return False
 
-        log_this_failure = (
-            self._robusta_refresh_failures == 0
-            or self._robusta_refresh_failures % ROBUSTA_REFRESH_FAILURE_LOG_EVERY == 0
-        )
-
+        if not self._robusta_refresh_lock.acquire(blocking=False):
+            return False
         try:
-            robusta_models = fetch_robusta_models(
-                *self.dal.get_ai_credentials(), log_failure=log_this_failure
+            log_this_failure = (
+                self._robusta_refresh_failures == 0
+                or self._robusta_refresh_failures % ROBUSTA_REFRESH_FAILURE_LOG_EVERY
+                == 0
             )
-        except Exception:
-            self._robusta_refresh_failures += 1
-            if log_this_failure:
-                logging.exception("Failed to refresh Robusta AI models")
-            return False
 
-        if not robusta_models or not robusta_models.models:
-            self._robusta_refresh_failures += 1
-            if log_this_failure:
-                logging.warning(
-                    "Keeping the loaded models: the catalog came back empty."
+            try:
+                robusta_models = fetch_robusta_models(
+                    *self.dal.get_ai_credentials(), log_failure=log_this_failure
                 )
-            return False
+            except Exception:
+                self._robusta_refresh_failures += 1
+                if log_this_failure:
+                    logging.exception("Failed to refresh Robusta AI models")
+                return False
 
-        self._robusta_refresh_failures = 0
+            if not robusta_models or not robusta_models.models:
+                self._robusta_refresh_failures += 1
+                if log_this_failure:
+                    logging.warning(
+                        "Keeping the loaded models: the catalog came back empty."
+                    )
+                return False
 
-        with self._lock:
-            previous_default = self._default_robusta_model
-            added, removed = self._install_robusta_models(robusta_models)
-            self._register_pricing_for_loaded_models()
+            self._robusta_refresh_failures = 0
 
-        changed = bool(added or removed) or (
-            self._default_robusta_model != previous_default
-        )
-        if changed:
-            logging.info(
-                f"Refreshed Robusta AI models. added: {added}, removed: {removed}"
+            with self._lock:
+                previous_default = self._default_robusta_model
+                added, removed = self._install_robusta_models(robusta_models)
+                self._register_pricing_for_loaded_models()
+
+            changed = bool(added or removed) or (
+                self._default_robusta_model != previous_default
             )
-        return changed
+            if changed:
+                logging.info(
+                    f"Refreshed Robusta AI models. added: {added}, removed: {removed}"
+                )
+            return changed
+        finally:
+            self._robusta_refresh_lock.release()
 
     def _install_robusta_models(
         self, robusta_models: RobustaModelsResponse

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -167,6 +167,13 @@ ROBUSTA_AI_MODEL_NAME = "Robusta"
 # feedback on ROB-795).
 ROBUSTA_REFRESH_FAILURE_LOG_EVERY = 5
 
+_NO_MODELS_ERROR = (
+    "No LLM models were loaded. Configure a model using one of: "
+    "--model '<provider/model>', export MODEL='<provider/model>', "
+    "or MODEL_LIST_FILE_LOCATION/config model list. "
+    "Setting only an API key (for example OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_API_KEY) is not enough without a model."
+)
+
 
 def _is_gemini_route(litellm_model_name: str) -> bool:
     """True if the model goes through Google's Gemini GenerateContent API.
@@ -1128,33 +1135,54 @@ class LLMModelRegistry:
     def get_model_params(self, model_key: Optional[str] = None) -> ModelEntry:
         with self._lock:
             if not self._llms:
-                raise Exception(
-                    "No LLM models were loaded. Configure a model using one of: "
-                    "--model '<provider/model>', export MODEL='<provider/model>', "
-                    "or MODEL_LIST_FILE_LOCATION/config model list. "
-                    "Setting only an API key (for example OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_API_KEY) is not enough without a model."
-                )
+                raise Exception(_NO_MODELS_ERROR)
 
-            if model_key:
-                model_params = self._llms.get(model_key)
-                if model_params:
-                    display_logger.info(f"Using selected model: {model_key}")
-                    return model_params.model_copy()
+        if model_key:
+            model_params = self._loaded_model(model_key)
+            if model_params is not None:
+                display_logger.info(f"Using selected model: {model_key}")
+                return model_params
 
-                # The catalog may have gained this model since it was last read.
-                # Any name is worth a look: a customer's models carry their own
-                # prefix, so keying on `Robusta/` left exactly those unable to
-                # recover. Unlike _init_models, refreshing never rebuilds from
-                # the model file and never falls back to the legacy entry, so a
-                # fetch that fails here cannot cost us the models we do have.
-                logging.warning(f"Model {model_key} is not loaded; refreshing.")
-                if self.refresh_robusta_models():
-                    model_params = self._llms.get(model_key)
-                    if model_params:
-                        display_logger.info(f"Using selected model: {model_key}")
-                        return model_params.model_copy()
+            # The catalog may have gained this model since it was last read.
+            # Any name is worth a look: a customer's models carry their own
+            # prefix, so keying on `Robusta/` left exactly those unable to
+            # recover. Unlike _init_models, refreshing never rebuilds from
+            # the model file and never falls back to the legacy entry, so a
+            # fetch that fails here cannot cost us the models we do have.
+            #
+            # Deliberately NOT under `_lock`: this is a network call that can
+            # run ~74s against an unreachable relay (5 attempts x 10s timeout
+            # plus 24s of backoff). `_lock` is reentrant, so holding it across
+            # the refresh silently serialized every other reader behind that
+            # whole window - including ones asking for non-Robusta models
+            # (ROB-795 review).
+            logging.warning(f"Model {model_key} is not loaded; refreshing.")
+            self.refresh_robusta_models()
 
-                logging.error(f"Couldn't find model: {model_key} in model list")
+            # Re-read regardless of what the refresh returned: a refresh
+            # already in flight on another thread makes this one back off
+            # (returning False) yet may have installed exactly what we want.
+            model_params = self._loaded_model(model_key)
+            if model_params is not None:
+                display_logger.info(f"Using selected model: {model_key}")
+                return model_params
+
+            logging.error(f"Couldn't find model: {model_key} in model list")
+
+        return self._fallback_model()
+
+    def _loaded_model(self, model_key: str) -> Optional[ModelEntry]:
+        """Point lookup against the loaded registry; None when it isn't there."""
+        with self._lock:
+            model_params = self._llms.get(model_key)
+            return model_params.model_copy() if model_params is not None else None
+
+    def _fallback_model(self) -> ModelEntry:
+        """The entry to serve when no specific model was asked for, or the
+        requested one couldn't be found even after a refresh."""
+        with self._lock:
+            if not self._llms:
+                raise Exception(_NO_MODELS_ERROR)
 
             if self._default_robusta_model:
                 model_params = self._llms.get(self._default_robusta_model)

--- a/server.py
+++ b/server.py
@@ -281,6 +281,15 @@ def _toolset_status_refresh_loop():
 
             time.sleep(sleep_time)
             try:
+                # Re-read the Robusta model catalog before publishing status, so
+                # the heartbeat advertises what the agent can serve right now:
+                # catalog changes reach a running agent, and an agent that
+                # booted without a catalog heals, without a pod restart.
+                if dal.enabled:
+                    config.llm_model_registry.refresh_robusta_models()
+            except Exception:
+                logging.error("Failed to refresh robusta models", exc_info=True)
+            try:
                 # Heartbeat: re-upsert HolmesStatus so updated_at signals
                 # liveness (platform-mcp filters remote-tool clusters on it),
                 # preserving the verified realtime flag. Skip when the DAL is

--- a/tests/core/test_llm_model_registry_get_model_params.py
+++ b/tests/core/test_llm_model_registry_get_model_params.py
@@ -1,9 +1,10 @@
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
 
+from holmes.clients.robusta_client import RobustaModel, RobustaModelsResponse
 from holmes.config import Config
 from holmes.core.llm import LLMModelRegistry, ModelEntry
 
@@ -99,54 +100,78 @@ class TestLLMModelRegistryGetModelParams:
         assert model_params.model == "gpt-4o"
         assert model_params.name == "gpt4o"
 
+    def _robusta_registry(self, mock_config, mock_dal, monkeypatch, gpt4o, boot_catalog):
+        """A registry booted with `gpt4o` plus whatever `boot_catalog` carries,
+        wired so refresh_robusta_models() (the ROB-707 resync path) is able to
+        actually run a fetch."""
+        mock_config.should_try_robusta_ai = True
+        mock_config.cluster_name = "test-cluster"
+        mock_dal.enabled = True
+        mock_dal.account_id = "account-id"
+        mock_dal.get_ai_credentials.return_value = ("account-id", "token")
+
+        # ROBUSTA_AI=True bypasses _should_load_robusta_ai's "user already
+        # provided a model list" skip, so `gpt4o` and the Robusta catalog can
+        # coexist the way a real model_list.yaml + Robusta AI deployment does.
+        monkeypatch.setattr(
+            "holmes.core.llm.LLMModelRegistry._parse_models_file",
+            lambda self, path: {"gpt4o": gpt4o},
+        )
+        with (
+            patch("holmes.core.llm.ROBUSTA_AI", True),
+            patch("holmes.core.llm.fetch_robusta_models", return_value=boot_catalog),
+        ):
+            return LLMModelRegistry(mock_config, mock_dal)
+
     def test_get_model_params_robusta_resync_behavior(
-        self, mock_config, mock_dal, monkeypatch, gpt4o, gpt5, caplog
+        self, mock_config, mock_dal, monkeypatch, gpt4o
     ):
+        """get_model_params refreshes the Robusta catalog when the requested
+        model isn't loaded, and serves it once the refresh finds it (ROB-707).
         """
-        Test get_model_params resyncs when Robusta model not found.
-        """
-        # Setup initial models without the requested Robusta model
-        monkeypatch.setattr(
-            "holmes.core.llm.LLMModelRegistry._parse_models_file",
-            lambda self, path: {"gpt5": gpt5, "gpt4o": gpt4o},
+        registry = self._robusta_registry(
+            mock_config,
+            mock_dal,
+            monkeypatch,
+            gpt4o,
+            boot_catalog=RobustaModelsResponse(models={}),
         )
-        registry = LLMModelRegistry(mock_config, mock_dal)
-        monkeypatch.setattr(
-            "holmes.core.llm.LLMModelRegistry._parse_models_file",
-            lambda self, path: {
-                "Robusta/test": ModelEntry(
-                    model="sonnet-4",
-                    name="Robusta/test",
-                    api_key=SecretStr("test-key"),
-                ),
-                "gpt4o": gpt4o,
-            },
-        )
-        model_params = registry.get_model_params("Robusta/test")
+
+        with patch(
+            "holmes.core.llm.fetch_robusta_models",
+            return_value=RobustaModelsResponse(
+                models={"Robusta/test": RobustaModel(model="sonnet-4")}
+            ),
+        ):
+            model_params = registry.get_model_params("Robusta/test")
 
         assert model_params.model == "sonnet-4"
         assert model_params.name == "Robusta/test"
 
     def test_get_model_params_robusta_resync_still_not_found(
-        self, mock_config, mock_dal, caplog, monkeypatch, gpt5, gpt4o
+        self, mock_config, mock_dal, caplog, monkeypatch, gpt4o
     ):
-        """
-        Test get_model_params when Robusta model not found after resync.
-        """
-        monkeypatch.setattr(
-            "holmes.core.llm.LLMModelRegistry._parse_models_file",
-            lambda self, path: {"gpt5": gpt5, "gpt4o": gpt4o},
+        """get_model_params falls back to a loaded model when a refresh still
+        can't find the requested one (ROB-707)."""
+        boot_catalog = RobustaModelsResponse(
+            models={"Robusta/opus-4-6": RobustaModel(model="bedrock/opus")}
         )
-        registry = LLMModelRegistry(mock_config, mock_dal)
-        with caplog.at_level(logging.WARNING):
-            model_params = registry.get_model_params("Robusta/non-existent")
+        registry = self._robusta_registry(
+            mock_config, mock_dal, monkeypatch, gpt4o, boot_catalog
+        )
 
-        assert "Resyncing Registry and Robusta models" in caplog.text
+        with caplog.at_level(logging.WARNING):
+            with patch(
+                "holmes.core.llm.fetch_robusta_models", return_value=boot_catalog
+            ):
+                model_params = registry.get_model_params("Robusta/non-existent")
+
+        assert "Model Robusta/non-existent is not loaded; refreshing." in caplog.text
         error_msg = "Couldn't find model: Robusta/non-existent in model list"
         assert error_msg in caplog.text
 
-        assert model_params.model == "gpt-5o"
-        assert model_params.name == "gpt5"
+        assert model_params.model == "gpt-4o"
+        assert model_params.name == "gpt4o"
 
     def test_get_model_params_with_no_models_raises_helpful_error(
         self, mock_config, mock_dal, monkeypatch

--- a/tests/test_llm_registry_refresh.py
+++ b/tests/test_llm_registry_refresh.py
@@ -146,6 +146,44 @@ def test_keeps_user_defined_models(build_registry):
     assert set(registry.models) == {"my-azure-gpt4", "Robusta/gpt-5"}
 
 
+def test_unknown_model_lookup_keeps_the_catalog_when_the_fetch_fails(build_registry):
+    """Asking for a model the agent doesn't have must not cost it the ones it does.
+
+    `get_model_params` re-syncs on an unknown `Robusta/` name, and that re-sync
+    used to rebuild the registry from scratch: if the fetch failed mid-request,
+    the whole catalog was replaced by the legacy fallback - ROB-795, triggered
+    by a single click.
+    """
+    registry = build_registry(
+        _catalog("Robusta/opus-4-6", "Robusta/gpt-5", default="Robusta/opus-4-6")
+    )
+
+    with patch("holmes.core.llm.fetch_robusta_models", return_value=None):
+        registry.get_model_params("Robusta/retired-model")
+
+    assert set(registry.models) == {"Robusta/opus-4-6", "Robusta/gpt-5"}
+    assert registry.default_robusta_model == "Robusta/opus-4-6"
+
+
+def test_unknown_custom_named_model_is_found_after_a_resync(build_registry):
+    """A model added to the catalog after boot must become usable without a
+    pod restart - including one whose name carries no `Robusta/` prefix, which
+    is every model on a customer with a private catalog (ROB-707)."""
+    registry = build_registry(
+        _catalog("Playtika-sonnet-4-5", default="Playtika-sonnet-4-5")
+    )
+
+    with patch(
+        "holmes.core.llm.fetch_robusta_models",
+        return_value=_catalog(
+            "Playtika-sonnet-4-5", "Playtika-sonnet-5", default="Playtika-sonnet-4-5"
+        ),
+    ):
+        entry = registry.get_model_params("Playtika-sonnet-5")
+
+    assert entry.name == "Playtika-sonnet-5"
+
+
 def test_unchanged_catalog_reports_no_change(build_registry):
     registry = build_registry(_catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"))
 

--- a/tests/test_llm_registry_refresh.py
+++ b/tests/test_llm_registry_refresh.py
@@ -195,6 +195,39 @@ def test_unchanged_catalog_reports_no_change(build_registry):
     assert set(registry.models) == {"Robusta/opus-4-6"}
 
 
+def test_default_only_change_is_reported_as_a_change(build_registry):
+    """Same model names, new default: the registry did change (CodeRabbit ROB-795)."""
+    registry = build_registry(
+        _catalog("Robusta/opus-4-6", "Robusta/gpt-5", default="Robusta/opus-4-6")
+    )
+
+    changed = _refresh_with(
+        registry, _catalog("Robusta/opus-4-6", "Robusta/gpt-5", default="Robusta/gpt-5")
+    )
+
+    assert changed
+    assert registry.default_robusta_model == "Robusta/gpt-5"
+
+
+def test_repeated_failures_log_only_the_first_and_every_nth(build_registry):
+    """An outage that outlives several 300s refresh cycles must not log the
+    same failure every cycle (review feedback on ROB-795)."""
+    registry = build_registry(_catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"))
+
+    log_failure_calls = []
+    with patch(
+        "holmes.core.llm.fetch_robusta_models",
+        side_effect=lambda *a, **kw: log_failure_calls.append(kw["log_failure"])
+        or None,
+    ):
+        for _ in range(6):
+            assert not registry.refresh_robusta_models()
+
+    # 1st failure logs; 2nd-5th are suppressed; the 6th (one full interval
+    # later) logs again.
+    assert log_failure_calls == [True, False, False, False, False, True]
+
+
 def test_skipped_when_robusta_ai_is_disabled(build_registry):
     registry = build_registry(
         None,

--- a/tests/test_llm_registry_refresh.py
+++ b/tests/test_llm_registry_refresh.py
@@ -272,6 +272,61 @@ def test_concurrent_refreshes_do_not_race(build_registry):
     assert set(registry.models) == {"Robusta/first"}
 
 
+def test_unknown_model_lookup_does_not_block_other_readers(build_registry):
+    """The refresh get_model_params triggers on a miss is a network call that
+    can run ~74s against an unreachable relay. It must not happen under the
+    registry lock: every other read path takes that same (reentrant) lock, so
+    one lookup of a stale name would otherwise stall every concurrent caller -
+    including ones asking for non-Robusta models (ROB-795 review)."""
+    registry = build_registry(
+        _catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"),
+        file_models={
+            "my-azure-gpt4": ModelEntry(model="azure/gpt-4", name="my-azure-gpt4")
+        },
+    )
+
+    fetch_started = threading.Event()
+    release_fetch = threading.Event()
+
+    def slow_fetch(*args, **kwargs):
+        fetch_started.set()
+        # Generously longer than the reader's wait below, so that when this
+        # test does fail it fails on the reader's assertion - the one that
+        # explains why - rather than on this timeout firing first.
+        release_fetch.wait(timeout=30)
+        return _catalog("Robusta/opus-4-6", default="Robusta/opus-4-6")
+
+    def lookup_missing_model():
+        with patch("holmes.core.llm.fetch_robusta_models", side_effect=slow_fetch):
+            registry.get_model_params("Robusta/does-not-exist")
+
+    refresher = threading.Thread(target=lookup_missing_model, daemon=True)
+    refresher.start()
+    try:
+        assert fetch_started.wait(timeout=5)
+
+        # The refresh is now parked mid-fetch. A reader after an unrelated,
+        # user-defined model must still be served immediately.
+        served = {}
+        reader_done = threading.Event()
+
+        def unrelated_reader():
+            served["entry"] = registry.get_model_params("my-azure-gpt4")
+            reader_done.set()
+
+        reader = threading.Thread(target=unrelated_reader, daemon=True)
+        reader.start()
+
+        assert reader_done.wait(timeout=5), (
+            "a reader of an unrelated model blocked behind the in-flight refresh"
+        )
+        assert served["entry"].model == "azure/gpt-4"
+        reader.join(timeout=5)
+    finally:
+        release_fetch.set()
+        refresher.join(timeout=10)
+
+
 def test_skipped_when_robusta_ai_is_disabled(build_registry):
     registry = build_registry(
         None,

--- a/tests/test_llm_registry_refresh.py
+++ b/tests/test_llm_registry_refresh.py
@@ -7,6 +7,7 @@ downgrading a healthy registry when a refresh fails.
 """
 
 import json
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -226,6 +227,49 @@ def test_repeated_failures_log_only_the_first_and_every_nth(build_registry):
     # 1st failure logs; 2nd-5th are suppressed; the 6th (one full interval
     # later) logs again.
     assert log_failure_calls == [True, False, False, False, False, True]
+
+
+def test_concurrent_refreshes_do_not_race(build_registry):
+    """The periodic refresh loop and a get_model_params() resync can overlap.
+    The fetch runs outside any lock (it's a network call), so a second
+    refresh that starts while the first is still fetching must back off
+    instead of racing to install - otherwise a slower, older response could
+    install after a newer one and silently revert the catalog (CodeRabbit
+    review on ROB-795)."""
+    registry = build_registry(_catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"))
+
+    first_fetch_started = threading.Event()
+    release_first_fetch = threading.Event()
+
+    def slow_fetch(*args, **kwargs):
+        first_fetch_started.set()
+        assert release_first_fetch.wait(timeout=2)
+        return _catalog("Robusta/first", default="Robusta/first")
+
+    results = {}
+
+    def run_first():
+        with patch("holmes.core.llm.fetch_robusta_models", side_effect=slow_fetch):
+            results["first"] = registry.refresh_robusta_models()
+
+    thread = threading.Thread(target=run_first)
+    thread.start()
+    assert first_fetch_started.wait(timeout=2)
+
+    # The first refresh is still mid-fetch (blocked on release_first_fetch);
+    # a second refresh attempted right now must not run concurrently.
+    with patch(
+        "holmes.core.llm.fetch_robusta_models",
+        return_value=_catalog("Robusta/second", default="Robusta/second"),
+    ):
+        results["second"] = registry.refresh_robusta_models()
+
+    release_first_fetch.set()
+    thread.join(timeout=2)
+
+    assert results["second"] is False
+    assert results["first"] is True
+    assert set(registry.models) == {"Robusta/first"}
 
 
 def test_skipped_when_robusta_ai_is_disabled(build_registry):

--- a/tests/test_llm_registry_refresh.py
+++ b/tests/test_llm_registry_refresh.py
@@ -1,0 +1,203 @@
+"""LLMModelRegistry.refresh_robusta_models (ROB-795, ROB-707).
+
+The Robusta catalog used to be read once, at startup: an agent that lost that
+fetch served the legacy fallback until its pod restarted, and catalog changes
+never reached a running agent. Refreshing must pick both up - without ever
+downgrading a healthy registry when a refresh fails.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from holmes.clients.robusta_client import RobustaModel, RobustaModelsResponse
+from holmes.config import Config
+from holmes.core.llm import ROBUSTA_AI_MODEL_NAME, LLMModelRegistry, ModelEntry
+from holmes.utils.holmes_status import update_holmes_status_in_db
+
+
+def _catalog(*model_names: str, default: str = "") -> RobustaModelsResponse:
+    return RobustaModelsResponse(
+        models={
+            name: RobustaModel(
+                model=f"azure/{name}", holmes_args={}, is_default=name == default
+            )
+            for name in model_names
+        }
+    )
+
+
+def _config() -> MagicMock:
+    config = MagicMock()
+    config.cluster_name = "test-cluster"
+    config.should_try_robusta_ai = True
+    # Not a Mock: an unset model must not look like a configured one.
+    config.model = None
+    config.api_base = None
+    config.api_key = None
+    config.api_version = None
+    return config
+
+
+def _dal() -> MagicMock:
+    dal = MagicMock()
+    dal.account_id = "account-id"
+    dal.enabled = True
+    dal.get_ai_credentials.return_value = ("account-id", "token")
+    return dal
+
+
+@pytest.fixture
+def build_registry(monkeypatch):
+    """A registry booted against `boot_catalog` (None = the fetch failed)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MODEL", raising=False)
+
+    def factory(boot_catalog, file_models=None, robusta_ai=True):
+        monkeypatch.setattr(
+            LLMModelRegistry,
+            "_parse_models_file",
+            lambda self, path: dict(file_models or {}),
+        )
+        with (
+            patch("holmes.core.llm.ROBUSTA_AI", robusta_ai),
+            patch("holmes.core.llm.fetch_robusta_models", return_value=boot_catalog),
+        ):
+            return LLMModelRegistry(_config(), _dal())
+
+    return factory
+
+
+def _refresh_with(registry: LLMModelRegistry, catalog) -> bool:
+    with patch("holmes.core.llm.fetch_robusta_models", return_value=catalog):
+        return registry.refresh_robusta_models()
+
+
+def test_adds_new_models_and_drops_deleted_ones(build_registry):
+    registry = build_registry(
+        _catalog("Robusta/sonnet-4-5", default="Robusta/sonnet-4-5")
+    )
+
+    changed = _refresh_with(
+        registry, _catalog("Robusta/sonnet-5", default="Robusta/sonnet-5")
+    )
+
+    assert changed
+    assert set(registry.models) == {"Robusta/sonnet-5"}
+    assert registry.default_robusta_model == "Robusta/sonnet-5"
+
+
+def test_drops_deleted_models_that_are_not_robusta_prefixed(build_registry):
+    """Custom-named hosted models are catalog models too (ROB-707)."""
+    registry = build_registry(
+        _catalog("Playtika-sonnet-4-5", default="Playtika-sonnet-4-5")
+    )
+
+    _refresh_with(registry, _catalog("Playtika-sonnet-5", default="Playtika-sonnet-5"))
+
+    assert set(registry.models) == {"Playtika-sonnet-5"}
+
+
+def test_failed_refresh_keeps_the_loaded_models(build_registry):
+    registry = build_registry(_catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"))
+
+    changed = _refresh_with(registry, None)
+
+    assert not changed
+    assert set(registry.models) == {"Robusta/opus-4-6"}
+    assert registry.default_robusta_model == "Robusta/opus-4-6"
+
+
+def test_empty_response_keeps_the_loaded_models(build_registry):
+    registry = build_registry(_catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"))
+
+    changed = _refresh_with(registry, _catalog())
+
+    assert not changed
+    assert set(registry.models) == {"Robusta/opus-4-6"}
+
+
+def test_heals_an_agent_that_booted_without_a_catalog(build_registry):
+    """The ROB-795 recovery: the legacy entry gives way to the real catalog."""
+    registry = build_registry(None)
+    assert set(registry.models) == {ROBUSTA_AI_MODEL_NAME}
+
+    changed = _refresh_with(
+        registry,
+        _catalog("Robusta/opus-4-6", "Robusta/gpt-5", default="Robusta/opus-4-6"),
+    )
+
+    assert changed
+    assert set(registry.models) == {"Robusta/opus-4-6", "Robusta/gpt-5"}
+    assert registry.default_robusta_model == "Robusta/opus-4-6"
+
+
+def test_keeps_user_defined_models(build_registry):
+    registry = build_registry(
+        _catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"),
+        file_models={
+            "my-azure-gpt4": ModelEntry(model="azure/gpt-4", name="my-azure-gpt4")
+        },
+    )
+
+    _refresh_with(registry, _catalog("Robusta/gpt-5", default="Robusta/gpt-5"))
+
+    assert set(registry.models) == {"my-azure-gpt4", "Robusta/gpt-5"}
+
+
+def test_unchanged_catalog_reports_no_change(build_registry):
+    registry = build_registry(_catalog("Robusta/opus-4-6", default="Robusta/opus-4-6"))
+
+    changed = _refresh_with(
+        registry, _catalog("Robusta/opus-4-6", default="Robusta/opus-4-6")
+    )
+
+    assert not changed
+    assert set(registry.models) == {"Robusta/opus-4-6"}
+
+
+def test_skipped_when_robusta_ai_is_disabled(build_registry):
+    registry = build_registry(
+        None,
+        file_models={"my-model": ModelEntry(model="azure/gpt-4", name="my-model")},
+        robusta_ai=False,
+    )
+    assert set(registry.models) == {"my-model"}
+
+    with patch("holmes.core.llm.ROBUSTA_AI", False):
+        changed = _refresh_with(registry, _catalog("Robusta/gpt-5"))
+
+    assert not changed
+    assert set(registry.models) == {"my-model"}
+
+
+@patch("holmes.core.llm.ROBUSTA_AI", True)
+@patch("holmes.config.Config._Config__get_cluster_name", return_value="test-cluster")
+def test_heartbeat_advertises_the_refreshed_catalog(mock_cluster, monkeypatch):
+    """The ROB-707 acceptance criterion: what a refresh loads is what the next
+    HolmesStatus upsert advertises, without a pod restart."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MODEL", raising=False)
+    monkeypatch.setattr(LLMModelRegistry, "_parse_models_file", lambda self, path: {})
+
+    dal = _dal()
+    with patch(
+        "holmes.core.llm.fetch_robusta_models",
+        return_value=_catalog("Playtika-sonnet-4-5", default="Playtika-sonnet-4-5"),
+    ):
+        config = Config.load_from_env()
+        config._dal = dal
+        assert config.llm_model_registry.models  # boot loaded the old catalog
+
+    # Ops edit the catalog in the relay: 4-5 deleted, 5 added.
+    with patch(
+        "holmes.core.llm.fetch_robusta_models",
+        return_value=_catalog("Playtika-sonnet-5", default="Playtika-sonnet-5"),
+    ):
+        assert config.llm_model_registry.refresh_robusta_models()
+
+    update_holmes_status_in_db(dal, config)
+
+    advertised = json.loads(dal.upsert_holmes_status.call_args[0][0]["model"])
+    assert advertised == ["Playtika-sonnet-5"]

--- a/tests/test_robusta_client.py
+++ b/tests/test_robusta_client.py
@@ -1,0 +1,85 @@
+"""fetch_robusta_models retry behavior (ROB-795): a transient relay/gateway
+failure during the single startup fetch must not permanently degrade the
+agent to the legacy single-model fallback."""
+
+import pytest
+import requests
+import responses
+from tenacity import wait_none
+
+import holmes.clients.robusta_client as robusta_client
+from holmes.clients.robusta_client import fetch_robusta_models
+from holmes.common.env_vars import (
+    FETCH_ROBUSTA_MODELS_ATTEMPTS,
+    ROBUSTA_API_ENDPOINT,
+)
+
+MODELS_URL = f"{ROBUSTA_API_ENDPOINT}/api/llm/models/v2"
+MODELS_PAYLOAD = {
+    "Robusta/gpt-5": {"model": "azure/gpt-5", "holmes_args": {}, "is_default": True}
+}
+
+
+@pytest.fixture(autouse=True)
+def instant_retries(monkeypatch):
+    monkeypatch.setattr(
+        robusta_client._request_robusta_models.retry, "wait", wait_none()
+    )
+
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+
+def test_returns_models_on_first_success(mocked_responses):
+    mocked_responses.post(MODELS_URL, json=MODELS_PAYLOAD, status=200)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is not None
+    assert set(result.models) == {"Robusta/gpt-5"}
+    assert result.models["Robusta/gpt-5"].is_default
+    assert len(mocked_responses.calls) == 1
+
+
+def test_recovers_from_transient_gateway_errors(mocked_responses):
+    mocked_responses.post(MODELS_URL, status=502)
+    mocked_responses.post(MODELS_URL, status=502)
+    mocked_responses.post(MODELS_URL, json=MODELS_PAYLOAD, status=200)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is not None
+    assert set(result.models) == {"Robusta/gpt-5"}
+    assert len(mocked_responses.calls) == 3
+
+
+def test_gives_up_after_max_attempts(mocked_responses):
+    for _ in range(FETCH_ROBUSTA_MODELS_ATTEMPTS):
+        mocked_responses.post(MODELS_URL, status=502)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is None
+    assert len(mocked_responses.calls) == FETCH_ROBUSTA_MODELS_ATTEMPTS
+
+
+def test_does_not_retry_client_errors(mocked_responses):
+    mocked_responses.post(MODELS_URL, status=401)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is None
+    assert len(mocked_responses.calls) == 1
+
+
+def test_retries_connection_errors(mocked_responses):
+    mocked_responses.post(MODELS_URL, body=requests.exceptions.ConnectionError())
+    mocked_responses.post(MODELS_URL, json=MODELS_PAYLOAD, status=200)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is not None
+    assert len(mocked_responses.calls) == 2

--- a/tests/test_robusta_client.py
+++ b/tests/test_robusta_client.py
@@ -8,11 +8,8 @@ import responses
 from tenacity import wait_none
 
 import holmes.clients.robusta_client as robusta_client
-from holmes.clients.robusta_client import fetch_robusta_models
-from holmes.common.env_vars import (
-    FETCH_ROBUSTA_MODELS_ATTEMPTS,
-    ROBUSTA_API_ENDPOINT,
-)
+from holmes.clients.robusta_client import FETCH_MODELS_ATTEMPTS, fetch_robusta_models
+from holmes.common.env_vars import ROBUSTA_API_ENDPOINT
 
 MODELS_URL = f"{ROBUSTA_API_ENDPOINT}/api/llm/models/v2"
 MODELS_PAYLOAD = {
@@ -57,13 +54,13 @@ def test_recovers_from_transient_gateway_errors(mocked_responses):
 
 
 def test_gives_up_after_max_attempts(mocked_responses):
-    for _ in range(FETCH_ROBUSTA_MODELS_ATTEMPTS):
+    for _ in range(FETCH_MODELS_ATTEMPTS):
         mocked_responses.post(MODELS_URL, status=502)
 
     result = fetch_robusta_models("account-id", "token")
 
     assert result is None
-    assert len(mocked_responses.calls) == FETCH_ROBUSTA_MODELS_ATTEMPTS
+    assert len(mocked_responses.calls) == FETCH_MODELS_ATTEMPTS
 
 
 def test_does_not_retry_client_errors(mocked_responses):

--- a/tests/test_robusta_client.py
+++ b/tests/test_robusta_client.py
@@ -80,3 +80,13 @@ def test_retries_connection_errors(mocked_responses):
 
     assert result is not None
     assert len(mocked_responses.calls) == 2
+
+
+def test_retries_timeouts(mocked_responses):
+    mocked_responses.post(MODELS_URL, body=requests.exceptions.Timeout())
+    mocked_responses.post(MODELS_URL, json=MODELS_PAYLOAD, status=200)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is not None
+    assert len(mocked_responses.calls) == 2

--- a/tests/test_robusta_client.py
+++ b/tests/test_robusta_client.py
@@ -90,3 +90,13 @@ def test_retries_timeouts(mocked_responses):
 
     assert result is not None
     assert len(mocked_responses.calls) == 2
+
+
+def test_retries_rate_limiting(mocked_responses):
+    mocked_responses.post(MODELS_URL, status=429)
+    mocked_responses.post(MODELS_URL, json=MODELS_PAYLOAD, status=200)
+
+    result = fetch_robusta_models("account-id", "token")
+
+    assert result is not None
+    assert len(mocked_responses.calls) == 2


### PR DESCRIPTION
A transient relay/gateway blip (e.g. a 502 during a relay deploy) at pod startup used to permanently degrade the agent: the model-list fetch was a single attempt whose failure was swallowed, leaving only the legacy "Robusta" fallback until the next restart.

Retry failures that can heal - connection errors, timeouts, 429/5xx - up to FETCH_ROBUSTA_MODELS_ATTEMPTS times (default 5, env-tunable) with capped exponential backoff (2/4/8/10s). 4xx is never retried: a bad token cannot heal, and boot is blocked while retrying (the liveness probe kills the pod after ~130s, which caps how patient startup may be).


Claude-Session: https://claude.ai/code/session_01GJGQ6tq865vm94GdkUCfge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Robusta model catalogs now refresh automatically during periodic status updates.
  * Refreshes detect added, removed, and default-model changes while preserving custom models.
* **Bug Fixes**
  * Improved reliability when fetching Robusta models by retrying transient network and server errors with exponential backoff.
  * Preserved fallback behavior when refreshes fail.
  * Reduced repetitive error logging during repeated refresh failures.
* **Tests**
  * Added coverage for model refresh scenarios and retry behavior, including recovery and non-retryable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->