### PR TITLE
fix(helm): scope chart resources to the release for multi-release namespaces

### DIFF
--- a/helm/holmes/templates/_helpers.tpl
+++ b/helm/holmes/templates/_helpers.tpl
@@ -54,6 +54,20 @@ Usage: {{- include "holmes.commonAnnotations" . | nindent 4 }}
 {{- end }}
 
 {{/*
+Selector labels for the Holmes Deployment/Service.
+Adds a release-scoped instance label when releaseScopedSelectors is enabled,
+so multiple Holmes releases can coexist in one namespace without their
+Services selecting each other's pods (see issue #2337).
+Usage: {{- include "holmes.selectorLabels" . | nindent 8 }}
+*/}}
+{{- define "holmes.selectorLabels" -}}
+app: holmes
+{{- if .Values.releaseScopedSelectors }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels to apply to all objects created by this chart.
 Reserved keys used in selector.matchLabels are rejected to prevent
 Deployment reconciliation failures caused by label divergence.

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ .Release.Name }}-holmes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: holmes
+    {{- include "holmes.selectorLabels" . | nindent 4 }}
     {{- include "holmes.commonLabels" . | nindent 4 }}
   {{- with (include "holmes.commonAnnotations" .) }}
   annotations:
@@ -25,11 +25,11 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: holmes
+      {{- include "holmes.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: holmes
+        {{- include "holmes.selectorLabels" . | nindent 8 }}
         {{- include "holmes.commonLabels" . | nindent 8 }}
       annotations:
         {{- with (include "holmes.commonAnnotations" .) }}
@@ -274,7 +274,7 @@ spec:
             optional: true
         - name: custom-toolsets-configmap
           configMap:
-            name: custom-toolsets-configmap
+            name: {{ .Release.Name }}-toolsets
             optional: true
         {{- if .Values.customSkills }}
         - name: holmes-skills
@@ -304,7 +304,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: holmes
+    {{- include "holmes.selectorLabels" . | nindent 4 }}
   ports:
     - name: http
       protocol: TCP

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -296,7 +296,7 @@ metadata:
   name: {{ .Release.Name }}-holmes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: holmes
+    {{- include "holmes.selectorLabels" . | nindent 4 }}
     {{- include "holmes.commonLabels" . | nindent 4 }}
   {{- with (include "holmes.commonAnnotations" .) }}
   annotations:

--- a/helm/holmes/templates/hpa.yaml
+++ b/helm/holmes/templates/hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-holmes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: holmes
+    {{- include "holmes.selectorLabels" . | nindent 4 }}
     {{- include "holmes.commonLabels" . | nindent 4 }}
   {{- with (include "holmes.commonAnnotations" .) }}
   annotations:

--- a/helm/holmes/templates/mcp-servers/aws/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/aws/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/mcp-servers/confluence-mcp/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/confluence-mcp/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/mcp-servers/github/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/github/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/mcp-servers/gitlab-mcp/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/gitlab-mcp/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/mcp-servers/kubernetes-remediation/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/kubernetes-remediation/networkpolicy.yaml
@@ -29,7 +29,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
       namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: {{ .Release.Namespace }}

--- a/helm/holmes/templates/mcp-servers/kubernetes/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/kubernetes/networkpolicy.yaml
@@ -23,7 +23,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/mcp-servers/prefect/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/prefect/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/mcp-servers/sentry/networkpolicy.yaml
+++ b/helm/holmes/templates/mcp-servers/sentry/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: holmes
+          {{- include "holmes.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8000

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: custom-toolsets-configmap
+  name: {{ .Release.Name }}-toolsets
   namespace: {{ .Release.Namespace }}
   {{- with (include "holmes.commonLabels" .) }}
   labels:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -38,6 +38,16 @@ podAnnotations: {}
 commonLabels: {}
 commonAnnotations: {}
 
+# Scope the Holmes Deployment/Service selectors and MCP-server NetworkPolicy
+# podSelectors to this Helm release by adding
+# app.kubernetes.io/instance: <release-name> alongside app: holmes.
+# Enable when running multiple Holmes releases in one namespace, so each
+# Service only selects its own release's pods (issue #2337).
+# NOTE: the Deployment selector is immutable. Existing releases that upgrade
+# with this flag enabled must delete and reinstall the Deployment (or use
+# --force), because the selector cannot be changed in place.
+releaseScopedSelectors: false
+
 replicas: 1
 imagePullPolicy: IfNotPresent
 

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -43,6 +43,9 @@ commonAnnotations: {}
 # app.kubernetes.io/instance: <release-name> alongside app: holmes.
 # Enable when running multiple Holmes releases in one namespace, so each
 # Service only selects its own release's pods (issue #2337).
+# NOTE: the toolsets ConfigMap is always named <release-name>-toolsets. This
+# changes the old fixed ConfigMap name during upgrade; update any external
+# references to custom-toolsets-configmap before relying on the new name.
 # NOTE: the Deployment selector is immutable. Existing releases that upgrade
 # with this flag enabled must delete and reinstall the Deployment (or use
 # --force), because the selector cannot be changed in place.


### PR DESCRIPTION
## Summary

Fixes #2337 — two chart resources were release-agnostic, breaking multiple Holmes releases in one namespace (e.g. one release per Prometheus/Mimir tenant):

1. **`templates/toolset-config.yaml`**: the toolsets ConfigMap name was hardcoded as `custom-toolsets-configmap`, so a second release with `toolsets` set failed to install over the shared ConfigMap. Renamed to `{{ .Release.Name }}-toolsets` (consistent with the existing `{{ .Release.Name }}-holmes-skills` pattern), with the Deployment volume reference updated to match.

2. **`templates/holmes.yaml`**: the Deployment `matchLabels`, pod template labels and Service selector were the literal `app: holmes`, so every release load-balanced across all releases pods. Added a `holmes.selectorLabels` helper that appends `app.kubernetes.io/instance: {{ .Release.Name }}` when the new `releaseScopedSelectors` value is enabled, applied to the Deployment, Service, HPA and MCP-server NetworkPolicies.

Also applied the same helper to the MCP-server NetworkPolicy ingress `podSelector`s, which had the same cross-release allowlisting issue (release A could reach release B MCP servers).

## Backwards compatibility

- The toolsets ConfigMap name changes from `custom-toolsets-configmap` to `{{ .Release.Name }}-toolsets` for all releases. Update any external references to the old fixed name before upgrading.
- `releaseScopedSelectors` defaults to `false`, so selector behavior remains unchanged unless the new option is enabled. The ConfigMap name migration is independent of this selector option.
- The Deployment selector is immutable, so existing releases enabling `releaseScopedSelectors` need to delete/reinstall the Deployment (or use `--force`); this is documented in the values file.

## Testing

- `helm lint ./helm/holmes` — passes
- `helm template` with two different release names, flag off — selectors render as before (the ConfigMap name intentionally migrates to the release-scoped name)
- `helm template --set releaseScopedSelectors=true [--set mcpAddons.aws.enabled=true]` — Deployment/Service/pod selectors and the NetworkPolicy `podSelector` all gain `app.kubernetes.io/instance: <release>`, and the toolsets ConfigMap renders per-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to scope resource selectors to the Helm release, helping support multiple installations in the same cluster.
  * Toolset configuration names are now generated per release.

* **Bug Fixes**
  * Improved consistency between workload labels, services, autoscaling, and network policies so resources target the correct Holmes deployment.
  * Added guidance for replacing existing deployments when enabling release-scoped selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->