### PR TITLE
ROB-900: wire kubernetes-remediation MCP bearer-token auth in Helm chart

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -40,6 +40,12 @@ spec:
         {{- end }}
         # checksum annotation triggering pod reload when .Values.toolsets changes by helm upgrade
         checksum/toolset-config: {{ list .Values.toolsets .Values.modelList .Values.mcp_servers .Values.customSkillPaths .Values.customSkills | toYaml | sha256sum }}
+        {{- if and .Values.mcpAddons.kubernetesRemediation.enabled .Values.mcpAddons.kubernetesRemediation.auth.enabled }}
+        # Roll this pod when the remediation MCP auth token rotates — the token
+        # is read from a Secret into env, so a content change alone would not
+        # restart anything.
+        checksum/k8s-remediation-auth-token: {{ include "holmes.kubernetesRemediationMcp.authTokenChecksum" . }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "holmes.serviceAccountName" . }}
       {{- if .Values.imagePullSecrets }}
@@ -203,6 +209,16 @@ spec:
               secretKeyRef:
                 name: {{ required "mcpAddons.github.auth.secretName is required for PAT auth" .Values.mcpAddons.github.auth.secretName }}
                 key: {{ .Values.mcpAddons.github.auth.secretKey | default "token" }}
+          {{- end }}
+          {{- if and .Values.mcpAddons.kubernetesRemediation.enabled .Values.mcpAddons.kubernetesRemediation.auth.enabled }}
+          # The remediation MCP server requires a bearer token on every HTTP
+          # request. toolset-config.yaml renders {{ "{{" }} env.K8S_REMEDIATION_MCP_TOKEN {{ "}}" }}
+          # into the Authorization header, so the token must live in this pod's env.
+          - name: K8S_REMEDIATION_MCP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "holmes.kubernetesRemediationMcp.authSecretName" . }}
+                key: token
           {{- end }}
         {{- if or .Values.additional_env_froms .Values.extraEnvVarsSecrets }}
         envFrom:

--- a/helm/holmes/templates/mcp-servers/kubernetes-remediation/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/kubernetes-remediation/_helpers.tpl
@@ -12,21 +12,20 @@ server (MCP_AUTH_TOKEN) and the Holmes pod (K8S_REMEDIATION_MCP_TOKEN).
 
 {{/*
 Resolve the HTTP bearer token shared by the remediation server and Holmes.
-Precedence: explicit auth.token > existing in-cluster Secret > freshly generated.
+Precedence: existing in-cluster Secret > freshly generated. (There is no
+plaintext value knob — the token only ever lives in a Secret, so it never lands
+in values or a pod-template annotation.)
 The generated value is memoized on .Values so every caller in a single render
 (the Secret's data and both pods' checksum annotations) sees the SAME token —
 otherwise the enabling upgrade would write a random token in the Secret while a
 pod-checksum lookup still saw the not-yet-created Secret as empty, and the next
 upgrade would roll that pod spuriously. lookup returns nothing under
-`helm template`/ArgoCD, so set auth.token or auth.existingSecret there.
+`helm template`/ArgoCD, so set auth.existingSecret for clusterless rendering.
 When auth.existingSecret is set but not yet present at render time, this emits
 nothing; the pods still read the token via secretKeyRef at runtime.
 */}}
 {{- define "holmes.kubernetesRemediationMcp.authToken" -}}
 {{- $auth := .Values.mcpAddons.kubernetesRemediation.auth -}}
-{{- if $auth.token -}}
-{{- $auth.token -}}
-{{- else -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "holmes.kubernetesRemediationMcp.authSecretName" .) -}}
 {{- if and $existing $existing.data (hasKey $existing.data "token") -}}
 {{- index $existing.data "token" | b64dec -}}
@@ -35,7 +34,6 @@ nothing; the pods still read the token via secretKeyRef at runtime.
 {{- $_ := set .Values "_k8sRemediationAuthToken" (randAlphaNum 48) -}}
 {{- end -}}
 {{- index .Values "_k8sRemediationAuthToken" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/holmes/templates/mcp-servers/kubernetes-remediation/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/kubernetes-remediation/_helpers.tpl
@@ -1,4 +1,55 @@
 {{/*
+Name of the Secret holding the HTTP bearer token shared by the remediation
+server (MCP_AUTH_TOKEN) and the Holmes pod (K8S_REMEDIATION_MCP_TOKEN).
+*/}}
+{{- define "holmes.kubernetesRemediationMcp.authSecretName" -}}
+{{- if .Values.mcpAddons.kubernetesRemediation.auth.existingSecret -}}
+{{- .Values.mcpAddons.kubernetesRemediation.auth.existingSecret -}}
+{{- else -}}
+{{- .Release.Name -}}-k8s-remediation-mcp-auth
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the HTTP bearer token shared by the remediation server and Holmes.
+Precedence: explicit auth.token > existing in-cluster Secret > freshly generated.
+The generated value is memoized on .Values so every caller in a single render
+(the Secret's data and both pods' checksum annotations) sees the SAME token —
+otherwise the enabling upgrade would write a random token in the Secret while a
+pod-checksum lookup still saw the not-yet-created Secret as empty, and the next
+upgrade would roll that pod spuriously. lookup returns nothing under
+`helm template`/ArgoCD, so set auth.token or auth.existingSecret there.
+When auth.existingSecret is set but not yet present at render time, this emits
+nothing; the pods still read the token via secretKeyRef at runtime.
+*/}}
+{{- define "holmes.kubernetesRemediationMcp.authToken" -}}
+{{- $auth := .Values.mcpAddons.kubernetesRemediation.auth -}}
+{{- if $auth.token -}}
+{{- $auth.token -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "holmes.kubernetesRemediationMcp.authSecretName" .) -}}
+{{- if and $existing $existing.data (hasKey $existing.data "token") -}}
+{{- index $existing.data "token" | b64dec -}}
+{{- else if not $auth.existingSecret -}}
+{{- if not (hasKey .Values "_k8sRemediationAuthToken") -}}
+{{- $_ := set .Values "_k8sRemediationAuthToken" (randAlphaNum 48) -}}
+{{- end -}}
+{{- index .Values "_k8sRemediationAuthToken" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Checksum of the auth token for pod-template annotations: rolls the pods when
+the token rotates (env comes from a Secret via secretKeyRef, which does not
+restart pods on its own). Same source as the Secret data, so a stable token
+produces a stable checksum and no needless restarts.
+*/}}
+{{- define "holmes.kubernetesRemediationMcp.authTokenChecksum" -}}
+{{- include "holmes.kubernetesRemediationMcp.authToken" . | sha256sum -}}
+{{- end -}}
+
+{{/*
 Define the LLM instructions for Kubernetes Remediation MCP
 */}}
 {{- define "holmes.kubernetesRemediationMcp.llmInstructions" -}}

--- a/helm/holmes/templates/mcp-servers/kubernetes-remediation/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/kubernetes-remediation/deployment.yaml
@@ -1,4 +1,27 @@
 {{- if .Values.mcpAddons.kubernetesRemediation.enabled }}
+{{- $auth := .Values.mcpAddons.kubernetesRemediation.auth }}
+{{- if and $auth.enabled (not $auth.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "holmes.kubernetesRemediationMcp.authSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-k8s-remediation-mcp
+    app.kubernetes.io/name: k8s-remediation-mcp-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: mcp-server
+    app.kubernetes.io/part-of: holmes
+    {{- include "holmes.commonLabels" . | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  token: {{ include "holmes.kubernetesRemediationMcp.authToken" . | b64enc }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -64,6 +87,11 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
         checksum/config: {{ .Values.mcpAddons.kubernetesRemediation | toYaml | sha256sum }}
+        {{- if .Values.mcpAddons.kubernetesRemediation.auth.enabled }}
+        # Roll the pod when the auth token is rotated (env comes from a Secret,
+        # so a content change alone would not restart anything).
+        checksum/auth-token: {{ include "holmes.kubernetesRemediationMcp.authTokenChecksum" . }}
+        {{- end }}
     spec:
       {{- if .Values.mcpAddons.kubernetesRemediation.serviceAccount.create }}
       serviceAccountName: {{ .Values.mcpAddons.kubernetesRemediation.serviceAccount.name }}
@@ -134,6 +162,15 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-k8s-remediation-mcp-config
               key: LOG_LEVEL
+        {{- if .Values.mcpAddons.kubernetesRemediation.auth.enabled }}
+        # Bearer token required on every HTTP request (server image >= 1.2.0).
+        # Holmes sends it via the toolset's extra_headers (toolset-config.yaml).
+        - name: MCP_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "holmes.kubernetesRemediationMcp.authSecretName" . }}
+              key: token
+        {{- end }}
         resources:
           {{- toYaml .Values.mcpAddons.kubernetesRemediation.resources | nindent 10 }}
         readinessProbe:

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -165,13 +165,23 @@ data:
     {{- $mcpServers = merge $mcpServers $prefectMcpServers }}
     {{- end }}
     {{- if .Values.mcpAddons.kubernetesRemediation.enabled }}
+    {{- $k8sRemediationConfig := dict
+        "url" (printf "http://%s-k8s-remediation-mcp-server.%s.svc.cluster.local:8000/mcp" .Release.Name .Release.Namespace)
+        "mode" "streamable-http"
+        "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/kubernetes.svg"
+    }}
+    {{- if .Values.mcpAddons.kubernetesRemediation.auth.enabled }}
+    {{- /* The server rejects requests without this bearer token (image >= 1.2.0).
+           The token is mounted as env on the Holmes pod from the auth Secret
+           (see holmes.yaml) and rendered into the header via Jinja. */}}
+    {{- $_ := set $k8sRemediationConfig "extra_headers" (dict
+          "Authorization" "Bearer {{ env.K8S_REMEDIATION_MCP_TOKEN }}"
+        )
+    }}
+    {{- end }}
     {{- $k8sRemediationMcpServers := dict "kubernetes_remediation" (dict
         "description" "Kubernetes remediation & deep diagnostics - execute kubectl and run diagnostic pods"
-        "config" (dict
-          "url" (printf "http://%s-k8s-remediation-mcp-server.%s.svc.cluster.local:8000/mcp" .Release.Name .Release.Namespace)
-          "mode" "streamable-http"
-          "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/kubernetes.svg"
-        )
+        "config" $k8sRemediationConfig
         "llm_instructions" (include "holmes.kubernetesRemediationMcp.llmInstructions" . | trim)
         "approval_required_tools" .Values.mcpAddons.kubernetesRemediation.approvalRequiredTools
       )

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -710,12 +710,13 @@ mcpAddons:
     # extra env/header are ignored and behavior is unchanged (unauthenticated).
     auth:
       enabled: true
-      # Explicit token value. Set this (or existingSecret) when rendering
-      # without cluster access (`helm template`, ArgoCD), where the generated
-      # token cannot be looked up and would change on every render.
-      token: ""
-      # Name of a pre-existing Secret with the token under the key "token".
+      # Name of a pre-existing Secret holding the token under the key "token".
       # When set, the chart creates no Secret and uses this one on both sides.
+      # Required for clusterless rendering (`helm template`, ArgoCD), where the
+      # auto-generated token cannot be looked up and would otherwise change on
+      # every render. Create it once with, e.g.:
+      #   kubectl create secret generic my-remediation-auth \
+      #     --from-literal=token="$(openssl rand -hex 32)"
       existingSecret: ""
 
     serviceAccount:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -695,9 +695,28 @@ mcpAddons:
   kubernetesRemediation:
     enabled: false          # opt-in; defaults work once enabled (plug-and-play)
 
-    image: "kubernetes-remediation-mcp:1.1.0"
+    image: "kubernetes-remediation-mcp:1.2.0"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
     imagePullPolicy: IfNotPresent
+
+    # Bearer-token authentication for the server's HTTP endpoint. Without it,
+    # any pod that can reach the port gets the full tool surface (including
+    # cluster mutations) with the remediation ServiceAccount's RBAC, bypassing
+    # Holmes's human-approval gate. The chart generates a random per-release
+    # token Secret and wires both the server and Holmes automatically; the
+    # token is preserved across `helm upgrade` (rotate by deleting the Secret
+    # and upgrading again).
+    # Requires server image >= 1.2.0; when running an older pinned image, the
+    # extra env/header are ignored and behavior is unchanged (unauthenticated).
+    auth:
+      enabled: true
+      # Explicit token value. Set this (or existingSecret) when rendering
+      # without cluster access (`helm template`, ArgoCD), where the generated
+      # token cannot be looked up and would change on every render.
+      token: ""
+      # Name of a pre-existing Secret with the token under the key "token".
+      # When set, the chart creates no Secret and uses this one on both sides.
+      existingSecret: ""
 
     serviceAccount:
       create: true


### PR DESCRIPTION
## Problem

The kubernetes-remediation MCP server exposes its full tool surface (including cluster mutations via the pod's elevated ServiceAccount) over an unauthenticated HTTP endpoint. The `run_kubectl_command` human-approval gate lives in the Holmes client, so any actor reaching the socket directly bypasses it. NetworkPolicy is the only existing control and is silently inert on non-enforcing CNIs. This is ROB-900.

The server-side token check is added in the companion PR (`robusta-dev/holmes-mcp-integrations`, image 1.2.0). This PR wires it up in the chart so it's on by default with no user action.

## Fix

- Generate a per-release bearer-token **Secret** for the remediation server.
- Mount it as `MCP_AUTH_TOKEN` on the server pod.
- Render the same token into the Holmes toolset config via `extra_headers`:
  `Authorization: "Bearer {{ env.K8S_REMEDIATION_MCP_TOKEN }}"` — the identical mechanism the GitHub PAT addon already uses, so **no Holmes code changes**. The token is mounted as env on the Holmes pod (like `GITHUB_PERSONAL_ACCESS_TOKEN`).

The token is resolved once per render through a shared, memoized helper (`holmes.kubernetesRemediationMcp.authToken`) with precedence: explicit `auth.token` > existing in-cluster Secret > freshly generated. Using one source for the Secret data **and** both pods' checksum annotations guarantees they always agree within a render, and reusing the existing Secret across `helm upgrade` means no-op upgrades don't rotate the token or restart pods. Rotate by deleting the Secret and running `helm upgrade`; both pods roll in lockstep via a `checksum/auth-token` annotation (env from `secretKeyRef` does not restart pods on its own).

## Values

```yaml
mcpAddons:
  kubernetesRemediation:
    image: "kubernetes-remediation-mcp:1.2.0"   # requires >= 1.2.0 for enforcement
    auth:
      enabled: true          # default on
      token: ""              # set for helm template / ArgoCD (lookup unavailable there)
      existingSecret: ""     # bring-your-own Secret (key: token)
```

- `auth.enabled: true` (default) requires server image ≥ 1.2.0. On an older pinned image the extra env/header are simply ignored (unauthenticated, unchanged behavior).
- `auth.enabled: false` renders exactly as before (verified byte-identical to master aside from the image tag).

## Changes

- `templates/mcp-servers/kubernetes-remediation/deployment.yaml`: token Secret + `MCP_AUTH_TOKEN` env + `checksum/auth-token` annotation.
- `templates/mcp-servers/kubernetes-remediation/_helpers.tpl`: `authSecretName`, memoized `authToken`, `authTokenChecksum` helpers.
- `templates/holmes.yaml`: `K8S_REMEDIATION_MCP_TOKEN` env from the Secret + token checksum annotation on the Holmes pod.
- `templates/toolset-config.yaml`: `extra_headers` Authorization on the remediation MCP entry (gated on `auth.enabled`).
- `values.yaml`: `mcpAddons.kubernetesRemediation.auth` block; image → 1.2.0.

## Testing

`helm lint` + render assertions for all four value combinations (default, `auth.enabled=false`, explicit token, existingSecret), plus internal consistency of the auto-generated token across Secret and both checksums.

End-to-end on a real k3s cluster with the actual old→new upgrade flow:

- **Finding reproduced**: old chart + 1.1.0 image, NetworkPolicy removed → attacker pod completes an unauthenticated MCP `initialize` (200).
- **Fix confirmed**: after `helm upgrade` to this chart + 1.2.0 → attacker with no/wrong token → 401, correct token → 200. Verified through Holmes's own MCP streamable-http client + `render_header_templates` (connects and lists all 5 tools with the token, rejected without).
- **No-op upgrade**: token unchanged, neither pod restarts.
- **Rotation** (delete Secret + upgrade): token changes, both pods roll in lockstep, Holmes reconnects with the new token.
- **Manual deployer** (raw manifests + 1.2.0 image, no token env): still serves unauthenticated with a startup warning — image-only upgrades don't break.

## Notes

- The companion `robusta-dev/holmes-mcp-integrations` PR must ship (and its 1.2.0 image be pushed to the registry) alongside this change.
- The existing NetworkPolicy is retained as defense-in-depth. The audit's "default bind 127.0.0.1" suggestion does not apply here — in-cluster servers must bind 0.0.0.0 for the Service to reach them, so token auth is the meaningful control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012r1KLMxodhi8apHF3qKRqa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for the Kubernetes remediation integration.
  * Supports existing Kubernetes Secrets or automatically generated credentials.
  * Automatically refreshes deployed pods when authentication credentials change.
  * Upgraded the Kubernetes remediation integration to version 1.2.0.
  * Added configurable diagnostic target policies for safer network probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->