### PR TITLE
Update GitLab MCP to v2.1.46 and use whoami health check

### DIFF
--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -125,13 +125,16 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.mcpAddons.gitlabMcp.enabled }}
+    {{- /* health_check_tool: @zereight/mcp-gitlab's identity tool is `whoami`
+           (present in all versions 2.1.11-2.1.47, including read-only mode).
+           It must exist in the mcpGitlabVersion pinned in values.yaml. */}}
     {{- $gitlabMcpServers := dict "gitlab" (dict
         "description" "GitLab MCP Server - access projects, merge requests, issues, pipelines, and code. Debug CI failures, search code, and create MRs."
         "config" (dict
           "url" (printf "http://%s-gitlab-mcp-server.%s.svc.cluster.local:8000/sse" .Release.Name .Release.Namespace)
           "mode" "sse"
           "icon_url" "https://raw.githubusercontent.com/gilbarbara/logos/de2c1f96ff6e74ea7ea979b43202e8d4b863c655/logos/gitlab.svg"
-          "health_check_tool" "get_current_user"
+          "health_check_tool" "whoami"
         )
         "llm_instructions" (include "holmes.gitlabMcp.llmInstructions" . | trim)
       )

--- a/helm/holmes/templates/toolset-config.yaml
+++ b/helm/holmes/templates/toolset-config.yaml
@@ -125,9 +125,6 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.mcpAddons.gitlabMcp.enabled }}
-    {{- /* health_check_tool: @zereight/mcp-gitlab's identity tool is `whoami`
-           (present in all versions 2.1.11-2.1.47, including read-only mode).
-           It must exist in the mcpGitlabVersion pinned in values.yaml. */}}
     {{- $gitlabMcpServers := dict "gitlab" (dict
         "description" "GitLab MCP Server - access projects, merge requests, issues, pipelines, and code. Debug CI failures, search code, and create MRs."
         "config" (dict

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -554,9 +554,6 @@ mcpAddons:
     imagePullPolicy: IfNotPresent
 
     # Pinned version of the @zereight/mcp-gitlab npm package executed via npx.
-    # If you override this, make sure the pinned version still exposes the
-    # health-check tool configured in toolset-config.yaml (currently `whoami`),
-    # or the Holmes health check will fail with "tool not found".
     mcpGitlabVersion: "2.1.46"
 
     auth:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -554,7 +554,10 @@ mcpAddons:
     imagePullPolicy: IfNotPresent
 
     # Pinned version of the @zereight/mcp-gitlab npm package executed via npx.
-    mcpGitlabVersion: "2.1.11"
+    # If you override this, make sure the pinned version still exposes the
+    # health-check tool configured in toolset-config.yaml (currently `whoami`),
+    # or the Holmes health check will fail with "tool not found".
+    mcpGitlabVersion: "2.1.46"
 
     auth:
       # K8s secret holding the GitLab Personal Access Token.

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -125,7 +125,7 @@ class MCPMode(str, Enum):
 # Well-known, read-only "who am I" tools used to verify MCP authentication when
 # no health_check_tool is explicitly configured. MCP servers commonly expose an
 # authenticated-identity endpoint (e.g. GitHub's get_me, GitLab's
-# get_current_user). Calling one with empty arguments is a side-effect-free way
+# whoami). Calling one with empty arguments is a side-effect-free way
 # to confirm credentials (such as an API token) are actually valid, since
 # list_tools succeeds even with a bad token. Order reflects matching priority.
 DEFAULT_HEALTH_CHECK_TOOLS: List[str] = [


### PR DESCRIPTION
## Summary
Updates the GitLab MCP (Model Context Protocol) server integration to use the latest version and switches the health check tool from `get_current_user` to `whoami` for better compatibility.

## Changes
- **Helm Chart**: Updated `mcpGitlabVersion` from `2.1.11` to `2.1.46` in `values.yaml`
- **Toolset Config**: Changed GitLab MCP health check tool from `get_current_user` to `whoami` in `toolset-config.yaml`
- **Documentation**: Updated code comments in `toolset_mcp.py` to reflect that GitLab uses `whoami` as its authenticated-identity endpoint (instead of `get_current_user`)

## Implementation Details
The health check tool is used to verify MCP authentication by calling a side-effect-free endpoint with empty arguments. This confirms that credentials (such as API tokens) are actually valid, since `list_tools` succeeds even with invalid tokens. The `whoami` endpoint is the standard authenticated-identity tool exposed by the GitLab MCP server.

https://claude.ai/code/session_01KXVSc71TUptkPT7voRq6DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitLab integration health check to use the current identity endpoint, improving compatibility and reliability.

* **Maintenance**
  * Updated the bundled GitLab integration to a newer version, bringing compatibility improvements and the latest available fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->