### PR TITLE
Improve shell injection security in GitHub Actions workflows

### DIFF
--- a/.github/actions/post-eval-comment/action.yml
+++ b/.github/actions/post-eval-comment/action.yml
@@ -23,6 +23,13 @@ runs:
   steps:
     - name: Post or update PR comment
       uses: actions/github-script@v7
+      env:
+        # Read action inputs via env (not inline ${{ }}) so a caller passing a
+        # value containing a quote or backtick cannot break out of the JS
+        # string literal it would otherwise be pasted into.
+        REPORT_FILE: ${{ inputs.report-file }}
+        COMMENT_IDENTIFIER: ${{ inputs.comment-identifier }}
+        DELETE_PREVIOUS: ${{ inputs.delete-previous }}
       with:
         retries: 3
         github-token: ${{ inputs.github-token }}
@@ -37,7 +44,7 @@ runs:
             }
 
             // Read the report file
-            const reportPath = '${{ inputs.report-file }}';
+            const reportPath = process.env.REPORT_FILE;
             if (!fs.existsSync(reportPath)) {
               console.log(`Report file not found: ${reportPath}`);
               return;
@@ -56,7 +63,7 @@ runs:
               }
             );
 
-            const commentIdentifier = '${{ inputs.comment-identifier }}';
+            const commentIdentifier = process.env.COMMENT_IDENTIFIER;
             const botComments = allComments.filter(comment =>
               comment.user.type === 'Bot' &&
               comment.body.includes(commentIdentifier)
@@ -71,7 +78,7 @@ runs:
             });
 
             // Delete old comments if requested
-            if ('${{ inputs.delete-previous }}' === 'true' && botComments.length > 0) {
+            if (process.env.DELETE_PREVIOUS === 'true' && botComments.length > 0) {
               for (const comment of botComments) {
                 await github.rest.issues.deleteComment({
                   owner: context.repo.owner,

--- a/.github/actions/setup-kind-cluster/action.yml
+++ b/.github/actions/setup-kind-cluster/action.yml
@@ -24,6 +24,10 @@ runs:
 
     - name: Create KIND cluster
       shell: bash
+      env:
+        # Read action inputs via env (not inline ${{ }}) so a caller passing a
+        # crafted value cannot have it parsed as shell.
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
       run: |
         cat <<EOF > kind-config.yaml
         kind: Cluster
@@ -54,10 +58,10 @@ runs:
         EOF
 
         # Create cluster without waiting for full readiness (CNI needed first)
-        kind create cluster --name ${{ inputs.cluster-name }} --config kind-config.yaml
+        kind create cluster --name "$CLUSTER_NAME" --config kind-config.yaml
 
         # Configure kubectl
-        kubectl cluster-info --context kind-${{ inputs.cluster-name }}
+        kubectl cluster-info --context "kind-$CLUSTER_NAME"
 
     - name: Install Calico CNI
       shell: bash

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,6 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# No job here writes to the repository or reads a secret, so the whole
+# workflow runs with a read-only token.
+permissions:
+  contents: read
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest
@@ -15,12 +20,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for source changes
         id: changes
+        env:
+          # Read the branch name via env (not inline ${{ }}) so a crafted
+          # branch name cannot be interpreted as shell. A PR author picks
+          # this value, and git permits $, (, ) and {} in ref names.
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Skip tests for automated benchmark result branches
-          if [[ "${{ github.head_ref }}" == automated/benchmark-* ]]; then
+          if [[ "$HEAD_REF" == automated/benchmark-* ]]; then
             echo "Automated benchmark branch — skipping tests"
             echo "should_test=false" >> $GITHUB_OUTPUT
             exit 0
@@ -84,6 +95,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -157,6 +170,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/build-binaries-and-brew.yaml
+++ b/.github/workflows/build-binaries-and-brew.yaml
@@ -56,19 +56,25 @@ jobs:
 
     - name: Update package version (Linux)
       if: matrix.platform == 'linux'
-      run: sed -i 's/__version__ = .*/__version__ = "${{ github.ref_name }}"/g' holmes/__init__.py
+      env:
+        TAG: ${{ github.ref_name }}
+      run: sed -i "s/__version__ = .*/__version__ = \"$TAG\"/g" holmes/__init__.py
 
     # mac has BSD style sed command where you specify -i '' and not just -i
     - name: Update package version (macOS)
       if: matrix.platform == 'darwin'
-      run: sed -i '' 's/__version__ = .*/__version__ = "${{ github.ref_name }}"/g' holmes/__init__.py
+      env:
+        TAG: ${{ github.ref_name }}
+      run: sed -i '' "s/__version__ = .*/__version__ = \"$TAG\"/g" holmes/__init__.py
 
     # windows has no sed, so we use powershell
     - name: Update package version (Windows)
       if: matrix.platform == 'windows'
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
         $filePath = 'holmes/__init__.py'
-        (Get-Content $filePath) -replace '__version__ = .+', '__version__ = "${{ github.ref_name }}"' | Set-Content $filePath
+        (Get-Content $filePath) -replace '__version__ = .+', "__version__ = `"$env:TAG`"" | Set-Content $filePath
       shell: pwsh
 
     - name: Install unixODBC (macOS)
@@ -101,18 +107,22 @@ jobs:
 
     - name: Zip the application (Unix and Mac)
       if: matrix.platform != 'windows'
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
         cd dist
-        zip -r --symlinks holmes-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.ref_name }}.zip holmes
-        mv holmes-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.ref_name }}.zip ../
+        zip -r --symlinks "holmes-${{ matrix.platform }}-${{ matrix.arch }}-$TAG.zip" holmes
+        mv "holmes-${{ matrix.platform }}-${{ matrix.arch }}-$TAG.zip" ../
         cd ..
 
     - name: Zip the application (Windows)
       if: matrix.platform == 'windows'
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
         Set-Location -Path dist
-        Compress-Archive -Path holmes -DestinationPath holmes-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.ref_name }}.zip -Force
-        Move-Item -Path holmes-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.ref_name }}.zip -Destination ..\
+        Compress-Archive -Path holmes -DestinationPath "holmes-${{ matrix.platform }}-${{ matrix.arch }}-$($env:TAG).zip" -Force
+        Move-Item -Path "holmes-${{ matrix.platform }}-${{ matrix.arch }}-$($env:TAG).zip" -Destination ..\
         Set-Location -Path ..
 
     - name: Upload Release Asset
@@ -160,7 +170,9 @@ jobs:
           name: holmes-darwin-arm64-${{ github.ref_name }}
       - name: Calculate hash
         id: calc-hash
-        run: echo "MAC_ARM64_BUILD_HASH=$(sha256sum holmes-darwin-arm64-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
+        env:
+          TAG: ${{ github.ref_name }}
+        run: echo "MAC_ARM64_BUILD_HASH=$(sha256sum "holmes-darwin-arm64-$TAG.zip" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
   # Define Linux hash job
   linux-hash:
@@ -178,7 +190,9 @@ jobs:
           name: holmes-linux-amd64-${{ github.ref_name }}
       - name: Calculate hash
         id: calc-hash
-        run: echo "LINUX_BUILD_HASH=$(sha256sum holmes-linux-amd64-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
+        env:
+          TAG: ${{ github.ref_name }}
+        run: echo "LINUX_BUILD_HASH=$(sha256sum "holmes-linux-amd64-$TAG.zip" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
   # Update Homebrew formula with new binary URLs and hashes
   update-formula:
@@ -248,8 +262,10 @@ jobs:
           print(content)
           PYTHON_SCRIPT
       - name: Commit and push changes
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git commit -am "Update formula for release ${{ github.ref_name }}"
+          git commit -am "Update formula for release $TAG"
           git push

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -32,10 +32,12 @@ jobs:
 
 
     - name: Update package version
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
-        sed -i 's/__version__ = .*/__version__ = "${{github.ref_name}}"/g' holmes/__init__.py
-        sed -i 's/0.0.0/${{github.ref_name}}/g' helm/holmes/Chart.yaml helm/holmes/values.yaml
-        sed -i 's/0.0.1/${{github.ref_name}}/g' helm/holmes/Chart.yaml
+        sed -i "s/__version__ = .*/__version__ = \"$TAG\"/g" holmes/__init__.py
+        sed -i "s/0.0.0/$TAG/g" helm/holmes/Chart.yaml helm/holmes/values.yaml
+        sed -i "s/0.0.1/$TAG/g" helm/holmes/Chart.yaml
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -78,18 +80,20 @@ jobs:
     # for prereleases and drafts we don't tag latest
     - name: Tag and push Docker images as latest if applicable
       if: ${{ github.event.release.prerelease == false && github.event.release.draft == false }}
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
         # Tag Holmes as latest (preserves multi-arch manifest)
         docker buildx imagetools create \
           --tag us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes:latest \
           --tag robustadev/holmes:latest \
-          us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes:${{ github.ref_name }}
+          "us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes:$TAG"
 
         # Tag Holmes Operator as latest (preserves multi-arch manifest)
         docker buildx imagetools create \
           --tag us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes-operator:latest \
           --tag robustadev/holmes-operator:latest \
-          us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes-operator:${{ github.ref_name }}
+          "us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes-operator:$TAG"
 
     - name: Save artifact with helm chart
       uses: actions/upload-artifact@v4
@@ -108,6 +112,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}   
     - name: Push Helm chart to OCI registry
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
         helm package helm/holmes
-        helm push holmes-${{github.ref_name}}.tgz oci://ghcr.io/holmesgpt/charts
+        helm push "holmes-$TAG.tgz" oci://ghcr.io/holmesgpt/charts

--- a/.github/workflows/eval-benchmarks.yaml
+++ b/.github/workflows/eval-benchmarks.yaml
@@ -67,40 +67,53 @@ jobs:
 
       - name: Build benchmark command
         id: build-command
+        env:
+          # Read the dispatch inputs via env (not inline ${{ }}) so they are
+          # never parsed as shell. They are emitted below as a JSON argument
+          # array rather than a command string, so the run step can execute
+          # them without a second round of shell parsing either.
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BENCHMARK_TYPE: ${{ github.event.inputs.benchmark_type }}
+          INPUT_TEST_MARKERS: ${{ github.event.inputs.test_markers }}
+          INPUT_MODELS: ${{ github.event.inputs.models }}
+          INPUT_ITERATIONS: ${{ github.event.inputs.iterations }}
         run: |
-          # Start with base command
-          CMD="./run_benchmarks_local.py"
+          ARGS=()
 
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            BENCHMARK_TYPE="${{ github.event.inputs.benchmark_type }}"
-            CUSTOM_MARKERS="${{ github.event.inputs.test_markers }}"
-            MODELS="${{ github.event.inputs.models }}"
-            ITERATIONS="${{ github.event.inputs.iterations }}"
+          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
+            BENCHMARK_TYPE="$INPUT_BENCHMARK_TYPE"
 
             # Add benchmark type or custom markers (script validates they're mutually exclusive)
-            if [ -n "$CUSTOM_MARKERS" ]; then
-              CMD="$CMD --markers \"$CUSTOM_MARKERS\""
+            if [ -n "$INPUT_TEST_MARKERS" ]; then
+              ARGS+=(--markers "$INPUT_TEST_MARKERS")
             elif [ -n "$BENCHMARK_TYPE" ]; then
-              CMD="$CMD --benchmark-type $BENCHMARK_TYPE"
+              ARGS+=(--benchmark-type "$BENCHMARK_TYPE")
             fi
 
             # Add models only if specified (otherwise use script defaults)
-            if [ -n "$MODELS" ]; then
-              CMD="$CMD --models $MODELS"
+            if [ -n "$INPUT_MODELS" ]; then
+              ARGS+=(--models "$INPUT_MODELS")
             fi
 
             # Add iterations if specified
-            if [ -n "$ITERATIONS" ] && [ "$ITERATIONS" != "1" ]; then
-              CMD="$CMD --iterations $ITERATIONS"
+            if [ -n "$INPUT_ITERATIONS" ] && [ "$INPUT_ITERATIONS" != "1" ]; then
+              ARGS+=(--iterations "$INPUT_ITERATIONS")
             fi
           else
             # Scheduled run: use fast-benchmark with default models
             BENCHMARK_TYPE="fast-benchmark"
-            CMD="$CMD --benchmark-type fast-benchmark --models $DEFAULT_BENCHMARK_MODELS"
+            ARGS+=(--benchmark-type fast-benchmark --models "$DEFAULT_BENCHMARK_MODELS")
           fi
 
-          echo "command=$CMD" >> $GITHUB_OUTPUT
-          echo "benchmark_type=$BENCHMARK_TYPE" >> $GITHUB_OUTPUT
+          if [ ${#ARGS[@]} -gt 0 ]; then
+            ARGS_JSON=$(printf '%s\0' "${ARGS[@]}" | jq -Rsc 'split("\u0000")[:-1]')
+          else
+            ARGS_JSON='[]'
+          fi
+
+          echo "args_json=$ARGS_JSON" >> "$GITHUB_OUTPUT"
+          echo "benchmark_type=$BENCHMARK_TYPE" >> "$GITHUB_OUTPUT"
+          echo "command_display=./run_benchmarks_local.py ${ARGS[*]}" >> "$GITHUB_OUTPUT"
 
       - name: Create model list file
         run: |
@@ -128,9 +141,14 @@ jobs:
           ELASTICSEARCH_API_KEY: ${{ secrets.ELASTICSEARCH_API_KEY }}
           MODEL_LIST_FILE_LOCATION: /tmp/model_list.yaml
           EXPERIMENT_ID: "ci-benchmark-${{ github.run_id }}"
+          BENCHMARK_ARGS_JSON: ${{ steps.build-command.outputs.args_json }}
         run: |
-          echo "Running: ${{ steps.build-command.outputs.command }}"
-          ${{ steps.build-command.outputs.command }}
+          # Read the arguments back as an array. Executing "${ARGS[@]}" passes
+          # each element as one argv entry with no shell re-parsing, so a
+          # crafted dispatch input cannot reach the secrets in this step's env.
+          mapfile -t -d '' ARGS < <(jq -j '.[] | (., "\u0000")' <<< "$BENCHMARK_ARGS_JSON")
+          echo "Running: ./run_benchmarks_local.py ${ARGS[*]}"
+          ./run_benchmarks_local.py "${ARGS[@]}"
 
       - name: Upload eval results
         if: always()
@@ -148,6 +166,8 @@ jobs:
         if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_pr == 'true'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCHMARK_TYPE_OUT: ${{ steps.build-command.outputs.benchmark_type }}
+          COMMAND_DISPLAY: ${{ steps.build-command.outputs.command_display }}
         run: |
           # Configure git
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -167,7 +187,7 @@ jobs:
           fi
 
           # Commit and push
-          BENCHMARK_TYPE="${{ steps.build-command.outputs.benchmark_type }}"
+          BENCHMARK_TYPE="$BENCHMARK_TYPE_OUT"
           git commit -m "Update ${BENCHMARK_TYPE:-benchmark} results"
           git push origin "$BRANCH_NAME" --force
 
@@ -176,7 +196,7 @@ jobs:
           PR_BODY="Automated weekly benchmark results from CI.
 
           **Benchmark Type**: ${BENCHMARK_TYPE:-custom}
-          **Command**: ${{ steps.build-command.outputs.command }}"
+          **Command**: $COMMAND_DISPLAY"
 
           # Check if PR already exists
           EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -22,9 +22,11 @@ jobs:
         poetry config virtualenvs.create false
 
     - name: Update package version
+      env:
+        TAG: ${{ github.ref_name }}
       run: |
-        sed -i 's/__version__ = .*/__version__ = "${{ github.ref_name }}"/g' holmes/__init__.py
-        sed -i 's/version = "0.0.0"/version = "${{ github.ref_name }}"/g' pyproject.toml
+        sed -i "s/__version__ = .*/__version__ = \"$TAG\"/g" holmes/__init__.py
+        sed -i "s/version = \"0.0.0\"/version = \"$TAG\"/g" pyproject.toml
 
     - name: Install dependencies
       run: poetry install --no-root


### PR DESCRIPTION
## Summary

This PR hardens GitHub Actions workflows against shell injection vulnerabilities by moving user-controlled inputs and dynamic values into environment variables instead of inline shell substitutions. This prevents crafted inputs from being interpreted as shell commands or breaking out of string literals.

## Key Changes

### eval-benchmarks.yaml
- **Command building refactored**: Changed from building a shell command string to constructing a JSON array of arguments
  - Inputs are read into environment variables first, preventing shell parsing
  - Arguments are passed as an array to the Python script, avoiding a second round of shell parsing
  - Reduces attack surface for dispatch inputs (`benchmark_type`, `test_markers`, `models`, `iterations`)
- **Output handling**: Outputs now use environment variables in subsequent steps instead of inline substitutions
- **Execution safety**: The benchmark script is invoked with `"${ARGS[@]}"` to pass each argument atomically without re-parsing

### build-binaries-and-brew.yaml
- **Version tag handling**: `github.ref_name` moved to `TAG` environment variable in all sed/PowerShell commands
  - Prevents tag names containing special characters from breaking sed patterns or PowerShell strings
  - Applied consistently across Linux, macOS, and Windows build steps
- **File operations**: Zip and hash calculation commands now use environment variables for dynamic filenames

### build-docker-images.yaml
- **Version tag handling**: `github.ref_name` moved to `TAG` environment variable for sed commands and Docker image tagging
- **Helm chart operations**: Chart filename now uses environment variable instead of inline substitution

### build-and-test.yaml
- **Permissions hardening**: Added explicit `permissions: contents: read` to run the entire workflow with a read-only token
- **Credential isolation**: Added `persist-credentials: false` to all `actions/checkout@v4` calls to prevent credential leakage
- **Branch name safety**: `github.head_ref` moved to `HEAD_REF` environment variable in the branch name check, preventing crafted branch names (which can contain `$`, `(`, `)`, `{}`) from being interpreted as shell

### post-eval-comment/action.yml
- **Input sanitization**: Action inputs moved to environment variables before use in JavaScript
  - Prevents quote/backtick escaping in `report-file`, `comment-identifier`, and `delete-previous` inputs
  - Uses `process.env.*` to read values safely in the github-script context

### setup-kind-cluster/action.yml
- **Cluster name safety**: `inputs.cluster-name` moved to `CLUSTER_NAME` environment variable
  - Prevents crafted cluster names from being interpreted as shell arguments

### publish-pypi.yaml
- **Version tag handling**: `github.ref_name` moved to `TAG` environment variable for sed commands

## Implementation Details

The changes follow a consistent pattern:
1. Read potentially unsafe values into environment variables in the `env:` section
2. Reference environment variables instead of inline `${{ }}` substitutions
3. Quote all variable references to prevent word splitting and globbing
4. For complex data (like argument arrays), use JSON serialization and safe deserialization

This approach ensures that user-controlled inputs and dynamic values cannot break out of their intended context, even if they contain special shell characters or quotes.

https://claude.ai/code/session_01QCBS4ZhVcGUzibiHGxTGVc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI/CD workflow reliability when handling dynamic branch names, tags, paths, and command arguments.
  * Prevented special characters or unexpected input values from disrupting automated evaluations, builds, packaging, and deployments.
  * Preserved benchmark argument boundaries to ensure commands execute as intended.
  * Reduced credential persistence and limited workflow repository permissions for safer automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->