### PR TITLE
Implement fail-closed API authentication (CWE-306)

### DIFF
--- a/docs/installation/kubernetes-installation.md
+++ b/docs/installation/kubernetes-installation.md
@@ -138,6 +138,10 @@ Deploy HolmesGPT as a service in your Kubernetes cluster with an HTTP API.
 After installation, test the service with a simple API call:
 
 ```bash
+# Fetch the API key the chart generated on install
+# (all endpoints except /healthz and /readyz require it)
+HOLMES_API_KEY=$(kubectl get secret holmesgpt-holmes-api-key -o jsonpath='{.data.apiKey}' | base64 -d)
+
 # Port forward to access the service locally
 # Note: Service name is {release-name}-holmes
 kubectl port-forward svc/holmesgpt-holmes 8080:80
@@ -148,13 +152,17 @@ kubectl port-forward svc/holmesgpt-holmes 8080:80
 # Test with a basic question using a model name from your modelList
 curl -X POST http://localhost:8080/api/chat \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $HOLMES_API_KEY" \
   -d '{"ask": "list pods in namespace default?", "model": "gpt-4.1"}'
 
 # Using a different model from your modelList
 curl -X POST http://localhost:8080/api/chat \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $HOLMES_API_KEY" \
   -d '{"ask": "list pods in namespace default?", "model": "claude-sonnet"}'
 ```
+
+The chart generates the API key automatically and reuses it across `helm upgrade`. To supply your own key set `auth.apiKey` (or `auth.existingApiKeySecret` to reference a pre-existing Secret with an `apiKey` key — required for GitOps tools like ArgoCD that render with `helm template` and would otherwise regenerate the key on every sync).
 
 > **Note**: Responses may take some time when HolmesGPT needs to gather large amounts of data to answer your question. Streaming APIs are coming soon to stream results.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -59,7 +59,7 @@ export TOOL_SCHEMA_NO_PARAM_OBJECT_IF_NO_PARAMS=true
 ## Server Security
 
 ### HOLMES_API_KEY
-**Default:** not set (authentication disabled)
+**Default:** not set
 
 When set, all API requests must include this key via either:
 
@@ -67,6 +67,12 @@ When set, all API requests must include this key via either:
 - `Authorization: Bearer <key>` header
 
 Health check endpoints (`/healthz`, `/readyz`) are always exempt.
+
+The server **fails closed**: if `HOLMES_API_KEY` is not set and `HOLMES_HOST`
+is not a loopback address, the server refuses to start (see
+[HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED](#holmes_unsafe_allow_unauthenticated)
+for the explicit opt-out). The official Helm chart generates and injects a
+key automatically — see the `auth` section in the chart's `values.yaml`.
 
 **Generating a key:**
 ```bash
@@ -87,6 +93,32 @@ export HOLMES_API_KEY=my-secret-key-here
 docker run -d \
   -e HOLMES_API_KEY=your-generated-key \
   ...
+```
+
+### HOLMES_HOST
+**Default:** `0.0.0.0`
+
+Address the API server binds to. Binding to a loopback address
+(`127.0.0.1`, `::1`, or `localhost`) allows running without `HOLMES_API_KEY`,
+since only local processes can reach the server.
+
+**Example:**
+```bash
+export HOLMES_HOST=127.0.0.1
+```
+
+### HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED
+**Default:** `false`
+
+Explicit opt-out from the fail-closed startup check. When `true`, the server
+starts without `HOLMES_API_KEY` even on a non-loopback address. Anyone who can
+reach the server can then invoke chat and check endpoints, which execute
+Holmes's infrastructure tools — only set this when the network already
+restricts access to trusted callers.
+
+**Example:**
+```bash
+export HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED=true
 ```
 
 ### HOLMES_APPROVAL_SIGNING_KEY

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -5,7 +5,13 @@ The HolmesGPT API provides endpoints for conversational troubleshooting. This do
 
 ## Authentication
 
-API authentication is optional. When the `HOLMES_API_KEY` environment variable is set, all endpoints (except `/healthz` and `/readyz`) require authentication.
+API authentication is required by default: the server refuses to start on a non-loopback address unless the `HOLMES_API_KEY` environment variable is set (or `HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED=true` explicitly opts out). When `HOLMES_API_KEY` is set, all endpoints (except `/healthz` and `/readyz`) require authentication.
+
+When deployed with the official Helm chart, a key is generated automatically on first install and stored in the `<release>-holmes-api-key` Secret:
+
+```bash
+kubectl get secret <release>-holmes-api-key -o jsonpath='{.data.apiKey}' | base64 -d
+```
 
 **Generating a key:**
 ```bash

--- a/helm/holmes/templates/_helpers.tpl
+++ b/helm/holmes/templates/_helpers.tpl
@@ -44,6 +44,41 @@ false
 {{- end -}}
 
 {{/*
+Whether API-key authentication is enabled ("true"/"false"). Defaults to true.
+Uses hasKey rather than `default` because `false | default true` yields true.
+*/}}
+{{- define "holmes.authEnabled" -}}
+{{- $auth := .Values.auth | default dict -}}
+{{- if hasKey $auth "enabled" -}}
+{{- $auth.enabled -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the Secret holding the Holmes API key (HOLMES_API_KEY).
+Honors auth.existingApiKeySecret, else the chart-managed secret.
+*/}}
+{{- define "holmes.apiKeySecretName" -}}
+{{- $auth := .Values.auth | default dict -}}
+{{- $auth.existingApiKeySecret | default (printf "%s-holmes-api-key" .Release.Name) -}}
+{{- end -}}
+
+{{/*
+Checksum of the stable API-key inputs, used as a pod annotation so every
+consumer (holmes, operator, robusta-runner) rolls together when the key
+configuration changes. The generated random key can't be hashed here (each
+template invocation of randAlphaNum yields a new value); it only changes on
+first install (pods are new anyway) or under `helm template` without an
+explicit key — a mode where users must set auth.apiKey/existingApiKeySecret.
+*/}}
+{{- define "holmes.apiKeyChecksum" -}}
+{{- $auth := .Values.auth | default dict -}}
+{{- list (include "holmes.authEnabled" .) ($auth.apiKey | default "") ($auth.existingApiKeySecret | default "") | toYaml | sha256sum -}}
+{{- end -}}
+
+{{/*
 Common annotations to apply to all objects created by this chart.
 Usage: {{- include "holmes.commonAnnotations" . | nindent 4 }}
 */}}

--- a/helm/holmes/templates/api-key-secret.yaml
+++ b/helm/holmes/templates/api-key-secret.yaml
@@ -1,0 +1,25 @@
+{{- $auth := .Values.auth | default dict }}
+{{- if and (eq (include "holmes.authEnabled" .) "true") (not $auth.existingApiKeySecret) }}
+{{- $secretName := printf "%s-holmes-api-key" .Release.Name }}
+{{- /* Reuse the key from a previous install so helm upgrades don't rotate it.
+       lookup returns nothing under `helm template` (ArgoCD and friends) — those
+       renderers regenerate a random key every time, so GitOps users must set
+       auth.apiKey or auth.existingApiKeySecret instead. */}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $apiKey := $auth.apiKey | default (dig "data" "apiKey" "" ($existing | default dict) | b64dec) | default (randAlphaNum 32) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: holmes
+    {{- include "holmes.commonLabels" . | nindent 4 }}
+  {{- with (include "holmes.commonAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  apiKey: {{ $apiKey | b64enc | quote }}
+{{- end }}

--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -40,6 +40,8 @@ spec:
         {{- end }}
         # checksum annotation triggering pod reload when .Values.toolsets changes by helm upgrade
         checksum/toolset-config: {{ list .Values.toolsets .Values.modelList .Values.mcp_servers .Values.customSkillPaths .Values.customSkills | toYaml | sha256sum }}
+        # rolls all API-key consumers together when the auth configuration changes
+        checksum/holmes-api-key: {{ include "holmes.apiKeyChecksum" . }}
     spec:
       serviceAccountName: {{ include "holmes.serviceAccountName" . }}
       {{- if .Values.imagePullSecrets }}
@@ -147,6 +149,18 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
         env:
+          {{- if eq (include "holmes.authEnabled" .) "true" }}
+          - name: HOLMES_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "holmes.apiKeySecretName" . }}
+                key: apiKey
+          {{- else }}
+          # auth.enabled=false: the server refuses to start unauthenticated on a
+          # non-loopback address unless this explicit opt-out is set.
+          - name: HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED
+            value: "true"
+          {{- end }}
           - name: LOG_LEVEL
             value: {{ .Values.logLevel }}
           - name: ENABLE_JSON_LOGS_FORMAT

--- a/helm/holmes/templates/operator-deployment.yaml
+++ b/helm/holmes/templates/operator-deployment.yaml
@@ -28,10 +28,12 @@ spec:
         app.kubernetes.io/name: holmes-operator
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- include "holmes.commonLabels" . | nindent 8 }}
-      {{- with (include "holmes.commonAnnotations" .) }}
       annotations:
+        {{- with (include "holmes.commonAnnotations" .) }}
         {{- . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        # rolls all API-key consumers together when the auth configuration changes
+        checksum/holmes-api-key: {{ include "holmes.apiKeyChecksum" . }}
     spec:
       serviceAccountName: {{ .Release.Name }}-operator
       securityContext:
@@ -49,6 +51,13 @@ spec:
         env:
         - name: HOLMES_API_URL
           value: {{ .Values.operator.holmesApiUrl | default (printf "http://%s-holmes:80" .Release.Name) }}
+        {{- if eq (include "holmes.authEnabled" .) "true" }}
+        - name: HOLMES_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "holmes.apiKeySecretName" . }}
+              key: apiKey
+        {{- end }}
         - name: HOLMES_API_TIMEOUT
           value: {{ .Values.operator.holmesApiTimeout | default 300 | quote }}
         - name: LOG_LEVEL

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -10,6 +10,25 @@ enableJsonLogsFormat: false
 # safely reference .Values.global.* when Holmes is installed standalone.
 global: {}
 
+# API-key authentication for the Holmes HTTP API (all endpoints except
+# /healthz and /readyz). Callers must send the key as an X-API-Key header or
+# Authorization Bearer token.
+auth:
+  # When true (default), HOLMES_API_KEY is injected into the Holmes server and
+  # the operator from a Secret named <release>-holmes-api-key. When false, the
+  # server runs with HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED=true — anyone who can
+  # reach the Service can execute Holmes's infrastructure tools; only disable
+  # auth if the network already restricts access to trusted callers.
+  enabled: true
+  # Explicit API key. Leave empty to auto-generate one on first install (the
+  # generated key is reused on helm upgrades via lookup). NOTE: `helm template`
+  # based tooling (e.g. ArgoCD) cannot use lookup and would regenerate the key
+  # on every render — such setups must set apiKey or existingApiKeySecret.
+  apiKey: ""
+  # Name of a pre-existing Secret containing the API key under the key
+  # "apiKey". When set, the chart does not create its own Secret.
+  existingApiKeySecret: ""
+
 # Serve the Holmes API over HTTPS directly from the pod (in-app TLS, no ingress/proxy).
 # When enabled you must provide your own TLS secret via secretName (e.g. issued by
 # cert-manager or created manually); the chart does not generate a self-signed cert.

--- a/holmes/common/env_vars.py
+++ b/holmes/common/env_vars.py
@@ -31,6 +31,13 @@ ENABLED_BY_DEFAULT_TOOLSETS = os.environ.get(
 )
 HOLMES_HOST = os.environ.get("HOLMES_HOST", "0.0.0.0")
 HOLMES_PORT = int(os.environ.get("HOLMES_PORT", 5050))
+# Escape hatch for the fail-closed server default: serving on a non-loopback
+# address without HOLMES_API_KEY exposes privileged, tool-executing endpoints
+# to anyone who can reach the socket, so the server refuses to start unless
+# this is explicitly set to true.
+HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED = load_bool(
+    "HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED", False
+)
 # TLS: when both certfile and keyfile are set, the API server serves HTTPS instead
 # of HTTP. HOLMES_SSL_CA_CERTS additionally enables mTLS (client-cert verification).
 HOLMES_SSL_CERTFILE = os.environ.get("HOLMES_SSL_CERTFILE", "")

--- a/holmes/utils/auth.py
+++ b/holmes/utils/auth.py
@@ -2,6 +2,8 @@ from fastapi import Request
 
 AUTH_EXEMPT_PATHS = {"/healthz", "/readyz"}
 
+LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
 
 def extract_api_key(request: Request) -> str:
     """Extract API key from X-API-Key header or Authorization Bearer token.
@@ -16,3 +18,32 @@ def extract_api_key(request: Request) -> str:
     if auth.lower().startswith("bearer "):
         return auth[7:].strip()
     return ""
+
+
+def validate_auth_config(
+    api_key: str,
+    host: str,
+    unsafe_allow_unauthenticated: bool,
+) -> None:
+    """Fail closed: refuse to serve a privileged, unauthenticated API beyond loopback.
+
+    Non-health endpoints execute LLM-driven infrastructure tools, so binding
+    them to a non-loopback address without an API key is an open privileged
+    API (CWE-306). Raises ValueError unless at least one of these holds:
+    HOLMES_API_KEY is set, the bind address is loopback, or the operator
+    explicitly opted out via HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED=true.
+    """
+    if api_key or unsafe_allow_unauthenticated:
+        return
+    if host.strip().lower() in LOOPBACK_HOSTS:
+        return
+    raise ValueError(
+        f"Refusing to start: HOLMES_API_KEY is not set and HOLMES_HOST={host!r} is not "
+        "a loopback address, which would expose privileged API endpoints (chat, checks, "
+        "investigations) to unauthenticated callers. Fix one of the following: "
+        "(1) set HOLMES_API_KEY to a secret value and send it as an X-API-Key header "
+        "(the official Helm chart does this automatically), "
+        "(2) set HOLMES_HOST=127.0.0.1 to serve on loopback only, or "
+        "(3) set HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED=true if the network already "
+        "restricts access to trusted callers."
+    )

--- a/holmes_operator/client/holmes_api_client.py
+++ b/holmes_operator/client/holmes_api_client.py
@@ -22,19 +22,21 @@ class HolmesAPIClient:
     - Error handling and logging
     """
 
-    def __init__(self, base_url: str, timeout: int = 300):
+    def __init__(self, base_url: str, timeout: int = 300, api_key: str = ""):
         """
         Initialize the Holmes API client.
 
         Args:
             base_url: Base URL of the Holmes API server (e.g., "http://holmes-api:80")
             timeout: Default timeout for requests in seconds
+            api_key: HOLMES_API_KEY value, sent as X-API-Key on every request
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.client = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout=timeout, connect=10.0),
             limits=httpx.Limits(max_keepalive_connections=10, max_connections=20),
+            headers={"X-API-Key": api_key} if api_key else None,
         )
         logger.info(f"Initialized Holmes API client for {self.base_url}")
 

--- a/holmes_operator/config.py
+++ b/holmes_operator/config.py
@@ -15,6 +15,7 @@ def load_bool(env_var, default: Optional[bool]) -> Optional[bool]:
 
 
 HOLMES_API_URL = os.getenv("HOLMES_API_URL", "http://holmes-api:80")
+HOLMES_API_KEY = os.getenv("HOLMES_API_KEY", "").strip()
 HOLMES_API_TIMEOUT = int(os.getenv("HOLMES_API_TIMEOUT", "300"))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 MAX_HISTORY_ITEMS = int(os.getenv("MAX_HISTORY_ITEMS", "10"))
@@ -39,11 +40,15 @@ class OperatorConfig:
     cleanup_completed_checks: bool
     completed_check_ttl_hours: int
 
+    # Sent as X-API-Key on every Holmes API request (empty = no auth header)
+    holmes_api_key: str = ""
+
     @classmethod
     def load(cls) -> "OperatorConfig":
         """Load configuration from environment variables."""
         return cls(
             holmes_api_url=HOLMES_API_URL,
+            holmes_api_key=HOLMES_API_KEY,
             holmes_api_timeout=HOLMES_API_TIMEOUT,
             log_level=LOG_LEVEL,
             max_history_items=MAX_HISTORY_ITEMS,

--- a/holmes_operator/context.py
+++ b/holmes_operator/context.py
@@ -61,6 +61,7 @@ async def initialize() -> OperatorConfig:
     api_client = HolmesAPIClient(
         base_url=config.holmes_api_url,
         timeout=config.holmes_api_timeout,
+        api_key=config.holmes_api_key,
     )
 
     # Initialize and start scheduler manager

--- a/server.py
+++ b/server.py
@@ -44,6 +44,7 @@ from holmes.common.env_vars import (
     HOLMES_SSL_CERTFILE,
     HOLMES_SSL_KEYFILE,
     HOLMES_SSL_KEYFILE_PASSWORD,
+    HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED,
     LOG_PERFORMANCE,
     MCP_RETRY_BACKOFF_SCHEDULE,
     SENTRY_DSN,
@@ -75,7 +76,7 @@ from holmes.utils.holmes_status import (
     update_holmes_status_in_db,
 )
 from holmes.utils.holmes_sync_toolsets import holmes_sync_toolsets_status
-from holmes.utils.auth import AUTH_EXEMPT_PATHS, extract_api_key
+from holmes.utils.auth import AUTH_EXEMPT_PATHS, extract_api_key, validate_auth_config
 from holmes.utils.log import (
     EndpointFilter,
     JSON_LOG_DATEFMT,
@@ -948,6 +949,18 @@ def build_ssl_kwargs() -> dict:
 
 def main():
     """Holmes AI Server entry point"""
+    # Fail closed (CWE-306): serving privileged endpoints beyond loopback
+    # requires an API key or an explicit unsafe opt-out.
+    try:
+        validate_auth_config(
+            api_key=HOLMES_API_KEY,
+            host=HOLMES_HOST,
+            unsafe_allow_unauthenticated=HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED,
+        )
+    except ValueError as e:
+        logging.error(str(e))
+        sys.exit(1)
+
     # Resolve TLS config up front so a misconfiguration fails fast, before the
     # (potentially slow) pre-start sync below.
     ssl_kwargs = build_ssl_kwargs()

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,9 +1,10 @@
+import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from starlette.datastructures import URL
 
-from holmes.utils.auth import AUTH_EXEMPT_PATHS, extract_api_key
+from holmes.utils.auth import AUTH_EXEMPT_PATHS, extract_api_key, validate_auth_config
 
 TEST_API_KEY = "test-secret-key-12345"
 
@@ -107,6 +108,54 @@ class TestAuthEnabled:
     def test_get_endpoint_with_key(self):
         response = self.client.get("/api/model", headers={"X-API-Key": TEST_API_KEY})
         assert response.status_code == 200
+
+
+class TestFailClosedStartup:
+    """Regression for ROB-989 (CWE-306): the server must refuse to serve a
+    privileged, unauthenticated API on a non-loopback address.
+
+    Starting the server without HOLMES_API_KEY either refuses to bind
+    non-loopback or requires an explicit unsafe opt-out; loopback binds and
+    keyed configurations remain allowed.
+    """
+
+    def test_no_key_non_loopback_refuses(self):
+        with pytest.raises(ValueError, match="Refusing to start"):
+            validate_auth_config(
+                api_key="", host="0.0.0.0", unsafe_allow_unauthenticated=False
+            )
+
+    def test_no_key_public_ip_refuses(self):
+        with pytest.raises(ValueError, match="Refusing to start"):
+            validate_auth_config(
+                api_key="", host="10.0.0.7", unsafe_allow_unauthenticated=False
+            )
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost", "LOCALHOST"])
+    def test_no_key_loopback_allowed(self, host):
+        validate_auth_config(
+            api_key="", host=host, unsafe_allow_unauthenticated=False
+        )
+
+    def test_no_key_unsafe_flag_allowed(self):
+        validate_auth_config(
+            api_key="", host="0.0.0.0", unsafe_allow_unauthenticated=True
+        )
+
+    def test_key_set_non_loopback_allowed(self):
+        validate_auth_config(
+            api_key=TEST_API_KEY, host="0.0.0.0", unsafe_allow_unauthenticated=False
+        )
+
+    def test_error_message_lists_remediations(self):
+        with pytest.raises(ValueError) as excinfo:
+            validate_auth_config(
+                api_key="", host="0.0.0.0", unsafe_allow_unauthenticated=False
+            )
+        message = str(excinfo.value)
+        assert "HOLMES_API_KEY" in message
+        assert "HOLMES_HOST=127.0.0.1" in message
+        assert "HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED" in message
 
 
 class TestAuthBypassRegression:


### PR DESCRIPTION
## Summary

Implements fail-closed security for the Holmes API server to prevent exposing privileged endpoints to unauthenticated callers on non-loopback addresses. The server now refuses to start unless one of these conditions is met: an API key is configured, the bind address is loopback-only, or the operator explicitly opts out via `HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED=true`.

## Key Changes

**Core Authentication Logic**
- Added `validate_auth_config()` function in `holmes/utils/auth.py` that enforces the fail-closed policy
- Defined `LOOPBACK_HOSTS` constant for loopback address detection (127.0.0.1, ::1, localhost)
- Server startup now calls `validate_auth_config()` and exits with error if validation fails
- Added `HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED` environment variable as explicit escape hatch

**Operator Integration**
- Updated `holmes_operator/config.py` to load `HOLMES_API_KEY` from environment
- Modified `HolmesAPIClient` to accept and send API key as `X-API-Key` header on all requests
- Operator now passes the API key when initializing the client

**Helm Chart Enhancements**
- Created new `api-key-secret.yaml` template that auto-generates API keys on first install
- Keys are persisted and reused across `helm upgrade` via `lookup` function
- Added `auth` section to `values.yaml` with options for:
  - `enabled`: Toggle authentication (default: true)
  - `apiKey`: Explicit key value (auto-generated if empty)
  - `existingApiKeySecret`: Reference to pre-existing Secret
- Added helper templates: `holmes.authEnabled`, `holmes.apiKeySecretName`, `holmes.apiKeyChecksum`
- Updated Holmes and operator deployments to inject API key from Secret
- Pod annotations include checksum of auth config to trigger rolling updates when key changes

**Documentation**
- Updated environment variables reference with new `HOLMES_HOST` and `HOLMES_UNSAFE_ALLOW_UNAUTHENTICATED` docs
- Updated HTTP API documentation to reflect required authentication by default
- Updated Kubernetes installation guide with examples of fetching and using the auto-generated key
- Error messages include specific remediation steps (set key, use loopback, or opt-out)

**Testing**
- Added comprehensive test suite `TestFailClosedStartup` covering:
  - Rejection of non-loopback addresses without key
  - Acceptance of loopback addresses without key
  - Acceptance with explicit unsafe flag
  - Acceptance with API key set
  - Verification that error messages list all remediation options

## Implementation Details

- Loopback detection is case-insensitive to handle variations like "LOCALHOST"
- Helm chart uses `lookup` to preserve keys across upgrades; GitOps tools (ArgoCD) must set `auth.apiKey` or `auth.existingApiKeySecret` since they use `helm template` without cluster access
- Error messages are detailed and actionable, guiding operators to one of three solutions
- The checksum annotation ensures all API-key consumers (Holmes, operator, robusta-runner) roll together when auth config changes

https://claude.ai/code/session_01PyF5xkXFDAk9jXTewu9z5w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API-key authentication for non-loopback Holmes servers by default.
  - Added Helm configuration for explicit, generated, or existing Kubernetes Secret API keys.
  - Helm deployments now inject API keys into Holmes and operator components.
  - Operator requests now support authenticated API access.
  - Health and readiness endpoints remain available without authentication.
  - Added an explicit opt-out for unauthenticated operation.

- **Bug Fixes**
  - Prevented insecure non-loopback startup without authentication unless explicitly overridden.

- **Documentation**
  - Updated Kubernetes installation, environment-variable, and HTTP API authentication guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->