### PR TITLE
fix(prometheus): handle explicit null timeout in instant and range query invoke

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1611,7 +1611,7 @@ class ExecuteInstantQuery(BasePrometheusTool):
             # Get timeout parameter and enforce limits
             default_timeout = self.toolset.config.query_timeout_seconds_default
             max_timeout = self.toolset.config.query_timeout_seconds_hard_max
-            timeout = params.get("timeout", default_timeout)
+            timeout = params.get("timeout") or default_timeout
             if timeout > max_timeout:
                 timeout = max_timeout
                 logging.warning(
@@ -1865,7 +1865,7 @@ class ExecuteRangeQuery(BasePrometheusTool):
             # Get timeout parameter and enforce limits
             default_timeout = self.toolset.config.query_timeout_seconds_default
             max_timeout = self.toolset.config.query_timeout_seconds_hard_max
-            timeout = params.get("timeout", default_timeout)
+            timeout = params.get("timeout") or default_timeout
             if timeout > max_timeout:
                 timeout = max_timeout
                 logging.warning(

--- a/tests/plugins/toolsets/test_prometheus_unit.py
+++ b/tests/plugins/toolsets/test_prometheus_unit.py
@@ -1,9 +1,13 @@
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 
 from holmes.plugins.toolsets.prometheus.prometheus import (
+    DEFAULT_QUERY_TIMEOUT_SECONDS,
     AzurePrometheusConfig,
+    ExecuteInstantQuery,
+    ExecuteRangeQuery,
     PrometheusConfig,
     PrometheusToolset,
     adjust_step_for_max_points,
@@ -329,3 +333,74 @@ class TestIsAzureConfig:
             )
         assert cls is PrometheusConfig
         assert "Partial Azure" in caplog.text
+
+
+class TestNullTimeout:
+    """Regression: explicit null timeout from the LLM must not raise TypeError."""
+
+    def _make_toolset(self) -> PrometheusToolset:
+        toolset = PrometheusToolset()
+        toolset.config = PrometheusConfig(
+            prometheus_url="http://prometheus.example:9090"
+        )
+        return toolset
+
+    def _fake_response(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "status": "success",
+            "data": {"resultType": "vector", "result": []},
+        }
+        return resp
+
+    def test_instant_query_null_timeout_falls_back_to_default(self, monkeypatch):
+        toolset = self._make_toolset()
+        tool = ExecuteInstantQuery(toolset)
+
+        captured: dict = {}
+
+        def fake_do_request(*args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            return self._fake_response()
+
+        monkeypatch.setattr(
+            "holmes.plugins.toolsets.prometheus.prometheus.do_request",
+            fake_do_request,
+        )
+
+        result = tool._invoke(
+            {"query": "up", "description": "test", "timeout": None},
+            context=MagicMock(),
+        )
+
+        assert "timeout" in captured
+        assert captured["timeout"] == DEFAULT_QUERY_TIMEOUT_SECONDS
+
+    def test_range_query_null_timeout_falls_back_to_default(self, monkeypatch):
+        toolset = self._make_toolset()
+        tool = ExecuteRangeQuery(toolset)
+
+        captured: dict = {}
+
+        def fake_do_request(*args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            return self._fake_response()
+
+        monkeypatch.setattr(
+            "holmes.plugins.toolsets.prometheus.prometheus.do_request",
+            fake_do_request,
+        )
+
+        result = tool._invoke(
+            {
+                "query": "up",
+                "description": "test",
+                "output_type": "Plain",
+                "timeout": None,
+            },
+            context=MagicMock(),
+        )
+
+        assert "timeout" in captured
+        assert captured["timeout"] == DEFAULT_QUERY_TIMEOUT_SECONDS


### PR DESCRIPTION

## What's wrong

When the LLM emits `"timeout": null` in the tool arguments, `params.get("timeout", default_timeout)` still returns `None` the key exists so the default is never applied. The comparison `None > max_timeout` then raises:
TypeError: '>' not supported between instances of 'NoneType' and 'int'


This surfaces to the operator as `Failed to connect to Prometheus`, which is misleading since Prometheus connectivity is fine. The bug is present in both the instant query (`ExecuteInstantQuery._invoke`, line 1614) and range query (`ExecuteRangeQuery._invoke`, line 1868) paths.

## Fix

Changed `params.get("timeout", default_timeout)` to `params.get("timeout") or default_timeout` in both paths so an explicit `null` falls through to the configured default.

## Tests

Added `TestNullTimeout` in `tests/plugins/toolsets/test_prometheus_unit.py` with two cases — one for instant query and one for range query — that patch `do_request` and assert the timeout passed downstream equals `DEFAULT_QUERY_TIMEOUT_SECONDS` when `"timeout": null` is in the params.

Fixes #2376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus instant and range queries now consistently use the configured default timeout when no effective timeout is provided, including `0` or `None`.
  * Existing maximum and minimum timeout limits remain unchanged.

* **Tests**
  * Added regression coverage for default timeout behavior in instant and range queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->