### PR TITLE
fix: remove accidental 'from json import tool' import; align abstract completion() default

### DIFF
--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -341,7 +341,7 @@ class LLM:
     def completion(
         self,
         messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = [],
+        tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[str, dict]] = None,
         response_format: Optional[Union[dict, Type[BaseModel]]] = None,
         temperature: Optional[float] = None,

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import json
-from json import tool
 import logging
 import re
 import threading


### PR DESCRIPTION
## Summary

1. **`holmes/core/tool_calling_llm.py`** — line 3 has `from json import tool`, which imports Python's `json.tool` **CLI module** (the thing behind `python -m json.tool`). It looks like an IDE auto-import accident: the name is never used as that module — every use of `tool` in this file is a local variable (`tool = self.tool_executor.get_tool_by_name(...)`) that shadows it, which is why ruff reports F811 twice. Removed the import.

2. **`holmes/core/llm.py`** — the abstract `completion()` declares `tools: Optional[List[Dict[str, Any]]] = []` (mutable default, ruff B006), while the concrete implementation of the same method in this same file already uses `= None`. Aligned the abstract signature to `= None`.

## Testing
`python -m py_compile` passes on both files; `ruff check --select F811,B006` goes from 3 errors to clean. No behavior change: the removed import was shadowed everywhere, and the abstract method's default is never executed (implementations define their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of language model completion requests by preventing unintended reuse of tool configuration between calls.

* **Chores**
  * Removed an unused internal import without changing user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->