### PR TITLE
Add flyio/core built-in toolset for Fly.io investigation

### DIFF
--- a/holmes/plugins/toolsets/flyio.yaml
+++ b/holmes/plugins/toolsets/flyio.yaml
@@ -13,8 +13,8 @@ toolsets:
         command: "fly status -a {{ app }}"
 
       - name: "fly_logs_recent"
-        description: "Fetch recent logs for a Fly app without tailing (bounded, safe for investigation)"
-        command: "fly logs -a {{ app }} --no-tail"
+        description: "Fetch recent logs for a Fly app without tailing, capped to the last 500 lines to avoid unbounded output during a noisy incident"
+        command: "fly logs -a {{ app }} --no-tail | tail -n 500"
 
       - name: "fly_machine_list"
         description: "List all machines for a Fly app, including state and restart counts"

--- a/holmes/plugins/toolsets/flyio.yaml
+++ b/holmes/plugins/toolsets/flyio.yaml
@@ -1,0 +1,41 @@
+toolsets:
+  flyio/core:
+    description: "Read access to Fly.io apps, machines, logs, and releases — for investigating a service that runs on Fly rather than Kubernetes"
+    docs_url: "https://holmesgpt.dev/data-sources/builtin-toolsets/flyio/"
+    tags:
+      - cli
+    prerequisites:
+      - command: "fly version"
+
+    tools:
+      - name: "fly_status"
+        description: "Show the current status of a Fly app — machines, regions, health"
+        command: "fly status -a {{ app }}"
+
+      - name: "fly_logs_recent"
+        description: "Fetch recent logs for a Fly app without tailing (bounded, safe for investigation)"
+        command: "fly logs -a {{ app }} --no-tail"
+
+      - name: "fly_machine_list"
+        description: "List all machines for a Fly app, including state and restart counts"
+        command: "fly machine list -a {{ app }}"
+
+      - name: "fly_machine_status"
+        description: "Show detailed status for one Fly machine, including recent events (crashes, restarts, OOM kills)"
+        command: "fly machine status {{ machine_id }} -a {{ app }}"
+
+      - name: "fly_checks_list"
+        description: "List health check results for a Fly app"
+        command: "fly checks list -a {{ app }}"
+
+      - name: "fly_releases"
+        description: "Show recent deploy/release history for a Fly app — useful for correlating an incident with a recent deploy"
+        command: "fly releases -a {{ app }}"
+
+      - name: "fly_scale_show"
+        description: "Show current VM size/count configuration for a Fly app"
+        command: "fly scale show -a {{ app }}"
+
+      - name: "fly_secrets_list"
+        description: "List secret NAMES configured for a Fly app (values are never exposed) — useful for checking whether expected integrations (e.g. an API key) are actually wired"
+        command: "fly secrets list -a {{ app }}"

--- a/tests/plugins/toolsets/test_flyio_toolset.py
+++ b/tests/plugins/toolsets/test_flyio_toolset.py
@@ -60,6 +60,15 @@ def test_flyio_toolset_prerequisite_is_fly_version():
     assert toolset.prerequisites[0].command == "fly version"
 
 
+def test_flyio_logs_recent_output_is_bounded():
+    """fly logs --no-tail has no built-in line limit -- a noisy incident
+    could return unbounded output. Pin that the command caps it, per
+    CodeRabbit review feedback on this PR."""
+    toolset = _find_flyio_toolset()
+    tool = next(t for t in toolset.tools if t.name == "fly_logs_recent")
+    assert "tail -n" in tool.command
+
+
 def test_flyio_secrets_list_never_exposes_values():
     """fly_secrets_list must only ever be able to list secret NAMES -- `fly
     secrets list` never prints values, unlike e.g. `fly secrets unset` or a

--- a/tests/plugins/toolsets/test_flyio_toolset.py
+++ b/tests/plugins/toolsets/test_flyio_toolset.py
@@ -1,0 +1,70 @@
+"""
+Integration test for the flyio/core built-in toolset.
+
+HolmesGPT's built-in toolsets are overwhelmingly Kubernetes/cloud-native
+specific despite the "works with any infrastructure" claim — there was no
+adapter for a PaaS like Fly.io. This wraps `flyctl` the same way the
+existing docker.yaml wraps the Docker CLI.
+
+See https://github.com/tsushanth/holmesgpt-toolset-flyio for real
+production proof runs (two apps, two languages) validating this toolset's
+diagnostic output, not just that it loads.
+"""
+
+from holmes.plugins.toolsets import load_builtin_toolsets
+
+
+def _find_flyio_toolset():
+    toolsets = load_builtin_toolsets()
+    matches = [t for t in toolsets if t.name == "flyio/core"]
+    assert (
+        len(matches) == 1
+    ), "flyio/core should be loaded exactly once as a built-in toolset"
+    return matches[0]
+
+
+def test_flyio_toolset_loads():
+    toolset = _find_flyio_toolset()
+    assert toolset.description
+    assert "cli" in toolset.tags
+
+
+def test_flyio_toolset_has_expected_tools():
+    toolset = _find_flyio_toolset()
+    tool_names = {tool.name for tool in toolset.tools}
+    assert tool_names == {
+        "fly_status",
+        "fly_logs_recent",
+        "fly_machine_list",
+        "fly_machine_status",
+        "fly_checks_list",
+        "fly_releases",
+        "fly_scale_show",
+        "fly_secrets_list",
+    }
+
+
+def test_flyio_toolset_commands_use_app_placeholder():
+    toolset = _find_flyio_toolset()
+    for tool in toolset.tools:
+        # every tool scopes to one Fly app, and none write/mutate state --
+        # this is a read-only investigation toolset
+        assert "{{ app }}" in tool.command
+        for destructive in ("destroy", "delete", "secrets set", "scale set", "deploy"):
+            assert destructive not in tool.command
+
+
+def test_flyio_toolset_prerequisite_is_fly_version():
+    toolset = _find_flyio_toolset()
+    assert len(toolset.prerequisites) == 1
+    assert toolset.prerequisites[0].command == "fly version"
+
+
+def test_flyio_secrets_list_never_exposes_values():
+    """fly_secrets_list must only ever be able to list secret NAMES -- `fly
+    secrets list` never prints values, unlike e.g. `fly secrets unset` or a
+    hypothetical `--reveal` flag. Pin the exact command so a future edit
+    can't silently swap in something that leaks values."""
+    toolset = _find_flyio_toolset()
+    tool = next(t for t in toolset.tools if t.name == "fly_secrets_list")
+    assert tool.command == "fly secrets list -a {{ app }}"


### PR DESCRIPTION
## What

Adds a `flyio/core` built-in toolset wrapping `flyctl`, the same pattern
`docker.yaml` uses for the Docker CLI: app status, recent logs (bounded,
not tailing), machine list/status, health checks, release history, scale
config, and secret *names* (never values).

## Why

The docs say "no Kubernetes required — works with any infrastructure,"
which is true of the CLI itself but not of the built-in toolsets: of the
~25 shipped today, all but a handful (`internet`, `bash`,
`core_investigation`, `skills`, `connectivity_check`) are
Kubernetes/cloud-native-specific (`kubernetes/*`, `openshift/*`, `aks/*`,
`cilium`, `argocd`, `kubevela`, ...). There's currently no adapter for a
PaaS like Fly.io, Render, or Railway — a team running a plain VM/PaaS
stack has almost nothing to plug into out of the box. This fills that gap
for Fly.io specifically.

## Validation

Beyond the unit tests in this PR (toolset loads, exact tool set, no
destructive commands, prerequisite check, secret-values-never-exposed
pinned), this was validated against two real, live, actually-failing
production apps in different languages — not staged demos:

- **Node/Express app**: correctly diagnosed a TTS backend timeout as root
  cause, and surfaced two problems that weren't part of the original ask
  (a machine stopped since the prior day halving capacity, and an
  unrelated third-party API 403).
- **Python/aiohttp app**: correctly parsed multi-line stack traces
  (structurally different from the Node app's single-line errors),
  correctly distinguished a SIGABRT crash (exit code 134) from a requested
  stop (exit code -1), and again correctly identified the external
  WebSocket timeout as root cause.

Full transcripts, unedited:
https://github.com/tsushanth/holmesgpt-toolset-flyio/tree/main/docs

## Notes for reviewers

- All tools are read-only investigation commands; the test suite
  explicitly asserts no destructive substrings (`destroy`, `delete`,
  `secrets set`, `scale set`, `deploy`) appear in any command template.
- `docs_url` points at the `holmesgpt.dev/data-sources/builtin-toolsets/`
  convention used by other built-in toolsets — happy to also add the docs
  page itself if that's expected as part of this PR rather than a
  follow-up.
- Ran into the Python 3.14/prometrix incompatibility mentioned in
  CONTRIBUTING.md during local setup (unrelated to this change) — pinned
  to 3.12 via poetry to develop and test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Fly.io toolset with read-only access to app status, logs, machines, health checks, releases, scaling settings, and secret names.
  * Added Fly CLI availability checks before running Fly.io tools.

* **Tests**
  * Added coverage for toolset loading, app scoping, read-only restrictions, prerequisites, bounded log output, and secret-safe command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->