### PR TITLE
ROB-1177 Only inject __robusta_user_approved into relay-routed remote MCP calls

### DIFF
--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -569,7 +569,7 @@ class RemoteMCPTool(Tool):
     ) -> StructuredToolResult:
         is_remote = self.is_remote
         call_params = params
-        if user_approved:
+        if is_remote and user_approved:
             call_params = {**call_params, REMOTE_TOOL_APPROVED_PARAM: True}
         if is_remote and session_approved_prefixes:
             call_params = {

--- a/tests/toolsets/mcp/test_approval_response_parsing.py
+++ b/tests/toolsets/mcp/test_approval_response_parsing.py
@@ -208,6 +208,47 @@ async def test_invoke_forwards_user_approved_as_reserved_arg():
         assert REMOTE_TOOL_APPROVED_PARAM not in session.call_tool.call_args.args[1]
 
 
+@pytest.mark.asyncio
+async def test_invoke_never_sends_reserved_arg_to_local_mcp_server():
+    """Only relay pops the reserved approval arg. A local (non-remote) MCP
+    server gets the call verbatim, so an approved re-invocation must NOT
+    inject it — servers with strict signatures (e.g. kubernetes-remediation's
+    run_kubectl_command) reject unexpected keyword arguments."""
+    from holmes.plugins.toolsets.mcp.toolset_mcp import REMOTE_TOOL_APPROVED_PARAM
+
+    tool = RemoteMCPTool(
+        name="run_kubectl_command",
+        mcp_tool_name="run_kubectl_command",
+        description="Gated kubectl",
+        parameters={},
+        toolset=MagicMock(spec=RemoteMCPToolset),
+        is_remote=False,
+    )
+
+    ok = {"status": "success", "data": "ok"}
+    block = MagicMock(type="text", text=json.dumps(ok))
+    result_obj = MagicMock(content=[block], isError=False)
+
+    session = AsyncMock()
+    session.call_tool = AsyncMock(return_value=result_obj)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "holmes.plugins.toolsets.mcp.toolset_mcp.get_initialized_mcp_session"
+    ) as get_session:
+        get_session.return_value = session
+
+        await tool._invoke_async(
+            params={"args": ["scale", "deploy/x", "--replicas=2"]},
+            request_context=None,
+            user_approved=True,
+        )
+        sent_args = session.call_tool.call_args.args[1]
+        assert REMOTE_TOOL_APPROVED_PARAM not in sent_args
+        assert sent_args == {"args": ["scale", "deploy/x", "--replicas=2"]}
+
+
 def test_remote_one_liner_names_target_cluster():
     """The approval description surfaced to the UI must name the target cluster
     for remote tools (mirrors the Slack prompt), and must hide the routing/


### PR DESCRIPTION
## Summary

Approved re-invocations of MCP tools that require approval (e.g. the kubernetes-remediation server's `run_kubectl_command`) failed with:

```
1 validation error for call[run_kubectl_command]
__robusta_user_approved
  Unexpected keyword argument
```

`RemoteMCPTool._invoke_async` injected the reserved `__robusta_user_approved` arg into **every** approved re-invocation. Only relay knows to pop that arg (for relay-routed `remote_*` tools); a local MCP server receives the call verbatim, and strict tool signatures (fastmcp/pydantic) reject the unexpected kwarg — a regression from #2311.

## Fix

Gate the injection on `is_remote`, matching the existing gating of `__robusta_session_approved_prefixes` on the line below. Holmes versions before #2311 never sent the arg, so this restores the previous wire behavior for local MCP servers while keeping the cross-cluster approval flow intact.

## Tests

- New: `test_invoke_never_sends_reserved_arg_to_local_mcp_server` — an approved re-invocation of a non-remote tool sends the params verbatim, with no reserved args.
- Existing approval-flow suites pass (`test_approval_response_parsing.py`, `test_approval_required_tools.py`, `test_remote_bash_tool_approval_flow.py`, `test_tool_call_worker.py`, `test_mcp_toolset.py` — 144 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXaNfNrPH4WK7uetHMKMLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXaNfNrPH4WK7uetHMKMLg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP tool approvals so remote-only approval metadata is sent exclusively to remote tools.
  * Local MCP tool requests now preserve their original arguments without including reserved remote approval data.
  * Session approval prefixes continue to apply only to remote tool invocations.

* **Tests**
  * Added regression coverage to verify correct approval handling for local MCP tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->