### PR TITLE
Add diagnostic-pod target policy to prevent SSRF/exfiltration (ROB-910)

### DIFF
--- a/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
@@ -19,7 +19,7 @@ It runs **alongside** your existing [built-in Kubernetes toolset](kubernetes.md)
 |------|----------|----------|--------------|
 | `read_file_from_container` | No | Auto | Read a single file from inside a running container. Secret/token mounts are always refused. |
 | `run_preapproved_kubectl_command` | No | Auto | Run a read-only diagnostic command from the allowlist (`ps`/`top`/`df`/`ls`/`netstat`/`ss` via exec). |
-| `run_preapproved_diagnostic_image` | No | Auto | Launch a short-lived pod from a pre-approved troubleshooting image (netshoot/busybox/curl), capture output, auto-delete. |
+| `run_preapproved_diagnostic_image` | No | Auto | Launch a short-lived pod from a pre-approved troubleshooting image (netshoot/busybox/curl), capture output, auto-delete. Probe targets are restricted to in-cluster destinations; cloud metadata is always refused ([details](#diagnostic-pod-target-policy)). |
 | `get_remediation_mcp_config` | No | Auto | Return the live effective policy for debugging. |
 | `run_kubectl_command` | Yes | **Human approval** | Catch-all for everything not pre-approved: all mutations, arbitrary exec, non-allowlisted images. |
 
@@ -124,7 +124,7 @@ For CLI deployments, you'll need to create the RBAC resources manually. For Helm
           serviceAccountName: k8s-remediation-mcp-sa
           containers:
           - name: k8s-remediation-mcp
-            image: us-central1-docker.pkg.dev/genuine-flight-317411/mcp/kubernetes-remediation-mcp:1.1.0
+            image: us-central1-docker.pkg.dev/genuine-flight-317411/mcp/kubernetes-remediation-mcp:1.2.0
             imagePullPolicy: IfNotPresent
             ports:
             - containerPort: 8000
@@ -135,6 +135,13 @@ For CLI deployments, you'll need to create the RBAC resources manually. For Helm
               value: "edit,patch,delete,scale,rollout,cordon,uncordon,drain,taint,label,annotate,run,exec"
             - name: KUBECTL_TIMEOUT
               value: "60"
+            # Diagnostic-pod target policy (see "Diagnostic-pod target policy"
+            # below). These are the defaults; both are shown because they are
+            # the two you are most likely to need to change.
+            - name: KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS
+              value: "false"
+            - name: KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES
+              value: ".svc,.svc.cluster.local,.cluster.local"
             resources:
               requests:
                 memory: "64Mi"
@@ -240,6 +247,7 @@ All policy lives in the MCP server; Holmes only maps tool name → approval.
 | **Path policy** | `read_file_from_container` resolves symlinks in-container and re-checks them; secret/token mounts (`/var/run/secrets/`, `/run/secrets/`) and the `/proc`, `/sys`, `/dev` pseudo-filesystems are always denied |
 | **Command allowlist** | `run_preapproved_kubectl_command` only runs the read-only diagnostics allowlist |
 | **Image allowlist** | `run_preapproved_diagnostic_image` only launches pre-approved, pinned troubleshooting images |
+| **Diagnostic target policy** | `run_preapproved_diagnostic_image` probes are restricted to in-cluster targets, and cloud-metadata/link-local addresses are always refused — see [Diagnostic-pod target policy](#diagnostic-pod-target-policy) |
 | **Verb allowlist** | `run_kubectl_command` only accepts an allowlisted set of verbs |
 | **Flag blocklist** | Flags like `--kubeconfig`, `--context`, `--token`, `--as` are always blocked |
 | **Shell injection protection** | Shell metacharacters are rejected; `shell=False` |
@@ -247,6 +255,79 @@ All policy lives in the MCP server; Holmes only maps tool name → approval.
 | **Scoped RBAC** | Least-privilege ClusterRole — no `cluster-admin`, no `secrets` |
 | **NetworkPolicy** | Ingress-only, locked to Holmes pods |
 | **Command timeout** | Commands are killed after a configurable timeout (default: 60s) |
+
+## Diagnostic-pod target policy
+
+!!! warning "Requires MCP server image 1.2.0 or newer"
+
+    The `config` keys in this section are read by the MCP server, not by Holmes.
+    On an older image they are passed through and ignored, and probe targets are
+    unrestricted. The Helm chart pins 1.2.0 by default.
+
+`run_preapproved_diagnostic_image` is auto-approved, and the images it launches
+are network-probing tools (`curl`, `dig`, `wget`, `tcpdump`). The image allowlist
+controls *what runs* but not *where the probe points* — so without a target
+policy, prompt-injected content in your cluster (a pod log, an annotation, an
+alert description) could steer an auto-approved probe at the cloud metadata
+service and have the response handed back to Holmes, or POST cluster data to an
+external collector. No approval prompt would appear, because this tool
+legitimately never asks for one.
+
+Two layers constrain the target:
+
+**1. Target validation in the server**, before any pod is created:
+
+- **Always refused, and not configurable:** cloud metadata and
+  link-local/loopback destinations — `169.254.0.0/16` (AWS/Azure/OpenStack IMDS
+  and ECS task metadata), `127.0.0.0/8`, `0.0.0.0/8`, `100.100.100.200`
+  (Alibaba), `192.0.0.192` (Oracle), `::1`, `fe80::/10`, `fd00:ec2::254`, plus
+  metadata hostnames like `metadata.google.internal`. Recognised in every IPv4
+  spelling (decimal, hex, octal, short forms) and as IPv4-mapped IPv6.
+- **Refused unless you opt in:** targets outside the cluster
+  (`diagnosticAllowExternalTargets`).
+- **Always refused:** redirect-following (`curl -L`), which would let the
+  responding server choose the real target.
+
+**2. An egress NetworkPolicy** on the diagnostic pod, which is the CNI-enforced
+backstop for anything validation cannot see — a DNS name that only resolves to a
+metadata address inside the pod, or `wget` following a redirect it was never told
+to follow. The server labels every diagnostic pod `robusta.dev/diagnostic-pod: "true"`
+and pins `hostNetwork: false` so the policy applies.
+
+!!! important "The NetworkPolicy is not installed by this chart"
+
+    Apply
+    [`diagnostic-pod-networkpolicy.yaml`](https://github.com/robusta-dev/holmes-mcp-integrations/blob/master/servers/kubernetes-remediation/diagnostic-pod-networkpolicy.yaml)
+    to **every namespace** Holmes may run diagnostics in — NetworkPolicy is
+    namespaced, and the namespace comes from the caller. Namespaces without it
+    fall back to target validation alone. It is also inert on a CNI that does not
+    enforce NetworkPolicy.
+
+### If a legitimate probe is refused
+
+Refusals name the rule and the fix, and Holmes will usually correct itself. The
+most common case is a namespace-qualified short name: `kubernetes.default` is
+refused because by shape it is indistinguishable from an external domain — use
+the FQDN `kubernetes.default.svc.cluster.local`.
+
+Otherwise, in order of preference:
+
+1. **Custom cluster domain** → set `diagnosticInternalDnsSuffixes`.
+2. **Legitimate external probing** (egress checks, reaching a known external API)
+   → set `diagnosticAllowExternalTargets: true`. Metadata and link-local stay refused.
+3. **A one-off that genuinely needs a restricted target** → use
+   `run_kubectl_command`, which asks a human first.
+4. **Last resort** → `diagnosticTargetPolicyEnabled: false`.
+
+!!! danger "`diagnosticTargetPolicyEnabled: false` disables all target checks"
+
+    This includes the cloud-metadata ranges that are otherwise not configurable,
+    and restores the pre-1.2.0 behaviour: an auto-approved probe can be pointed
+    at the metadata service and its response returned to Holmes. The server logs
+    a warning at startup and on every call while it is off. Apply the egress
+    NetworkPolicy first if you set this, since it becomes your only remaining
+    control. The image allowlist, shell-metacharacter rejection and
+    flag-injection guard are unaffected.
 
 ## Configuration Reference
 
@@ -256,6 +337,9 @@ All policy lives in the MCP server; Holmes only maps tool name → approval.
 | `dangerousFlags` | `--kubeconfig,--context,--cluster,--user,--token,--as,--as-group,--as-uid` | Blocked flags |
 | `preapprovedCommands` | `exec * -- ps*,...,exec * -- ss*` | `run_preapproved_kubectl_command` allowlist |
 | `diagnosticImages` | `nicolaka/netshoot:v0.13,busybox:1.37.0,curlimages/curl:8.11.1` | `run_preapproved_diagnostic_image` allowlist |
+| `diagnosticTargetPolicyEnabled` | `true` | master switch for the [target policy](#diagnostic-pod-target-policy); `false` disables **all** target checks |
+| `diagnosticAllowExternalTargets` | `false` | allow diagnostic probes to reach hosts outside the cluster |
+| `diagnosticInternalDnsSuffixes` | `.svc,.svc.cluster.local,.cluster.local` | DNS suffixes counted as cluster-internal (set for a custom cluster domain) |
 | `fileReadAllowedPaths` | `/` | `read_file_from_container` allow roots |
 | `fileReadDeniedPaths` | `/var/run/secrets/,/run/secrets/,...` | secret-mount denylist |
 | `allowArbitraryKubectlCommands` | `true` | enable the approval-gated fallback |

--- a/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
@@ -328,10 +328,17 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # Cluster DNS, so service names still resolve. Port-only rule: kube-dns sits
-    # in kube-system, which a namespaceSelector cannot match without a label that
-    # is not guaranteed to be present.
-    - ports:
+    # Cluster DNS, so service names still resolve. Scoped with `to:` — a rule
+    # carrying only `ports` would match ALL destinations on port 53, turning DNS
+    # into an exfiltration channel out of the cluster.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
@@ -341,6 +348,8 @@ spec:
     # does not allow, so cloud metadata (169.254.0.0/16), loopback (127.0.0.0/8),
     # 0.0.0.0/8, 100.100.100.200 (Alibaba), 192.0.0.192 (Oracle) and the public
     # internet are all denied by omission — none of them fall inside these blocks.
+    # Also covers DNS sent to the kube-dns Service ClusterIP on CNIs that evaluate
+    # policy before kube-proxy's DNAT.
     - to:
         - ipBlock:
             cidr: 10.0.0.0/8
@@ -349,6 +358,12 @@ spec:
         - ipBlock:
             cidr: 192.168.0.0/16
 ```
+
+Two things to check against your cluster: `kubernetes.io/metadata.name` is set on
+every namespace automatically from Kubernetes 1.21, and CoreDNS carries
+`k8s-app: kube-dns` on both kubeadm and k3s — adjust the selector if your DNS
+provider differs. And if your **Service CIDR is outside RFC1918**, add it as an
+`ipBlock` or in-cluster resolution will break.
 
 If you set `diagnosticAllowExternalTargets: true`, widen the `ipBlock` to
 `0.0.0.0/0` but add the denied ranges back as `except` entries — this policy

--- a/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md
@@ -19,7 +19,7 @@ It runs **alongside** your existing [built-in Kubernetes toolset](kubernetes.md)
 |------|----------|----------|--------------|
 | `read_file_from_container` | No | Auto | Read a single file from inside a running container. Secret/token mounts are always refused. |
 | `run_preapproved_kubectl_command` | No | Auto | Run a read-only diagnostic command from the allowlist (`ps`/`top`/`df`/`ls`/`netstat`/`ss` via exec). |
-| `run_preapproved_diagnostic_image` | No | Auto | Launch a short-lived pod from a pre-approved troubleshooting image (netshoot/busybox/curl), capture output, auto-delete. Probe targets are restricted to in-cluster destinations; cloud metadata is always refused ([details](#diagnostic-pod-target-policy)). |
+| `run_preapproved_diagnostic_image` | No | Auto | Launch a short-lived pod from a pre-approved troubleshooting image (netshoot/busybox/curl), capture output, auto-delete. By default probe targets are restricted to in-cluster destinations, and cloud metadata is refused for as long as the target policy is enabled ([details](#diagnostic-pod-target-policy)). |
 | `get_remediation_mcp_config` | No | Auto | Return the live effective policy for debugging. |
 | `run_kubectl_command` | Yes | **Human approval** | Catch-all for everything not pre-approved: all mutations, arbitrary exec, non-allowlisted images. |
 
@@ -247,7 +247,7 @@ All policy lives in the MCP server; Holmes only maps tool name → approval.
 | **Path policy** | `read_file_from_container` resolves symlinks in-container and re-checks them; secret/token mounts (`/var/run/secrets/`, `/run/secrets/`) and the `/proc`, `/sys`, `/dev` pseudo-filesystems are always denied |
 | **Command allowlist** | `run_preapproved_kubectl_command` only runs the read-only diagnostics allowlist |
 | **Image allowlist** | `run_preapproved_diagnostic_image` only launches pre-approved, pinned troubleshooting images |
-| **Diagnostic target policy** | `run_preapproved_diagnostic_image` probes are restricted to in-cluster targets, and cloud-metadata/link-local addresses are always refused — see [Diagnostic-pod target policy](#diagnostic-pod-target-policy) |
+| **Diagnostic target policy** | With the defaults, `run_preapproved_diagnostic_image` probes are restricted to in-cluster targets; cloud-metadata/link-local addresses are refused and cannot be re-enabled by config while the policy is on. `diagnosticAllowExternalTargets: true` permits external targets, and `diagnosticTargetPolicyEnabled: false` removes the whole layer — see [Diagnostic-pod target policy](#diagnostic-pod-target-policy) |
 | **Verb allowlist** | `run_kubectl_command` only accepts an allowlisted set of verbs |
 | **Flag blocklist** | Flags like `--kubeconfig`, `--context`, `--token`, `--as` are always blocked |
 | **Shell injection protection** | Shell metacharacters are rejected; `shell=False` |
@@ -296,12 +296,72 @@ and pins `hostNetwork: false` so the policy applies.
 
 !!! important "The NetworkPolicy is not installed by this chart"
 
-    Apply
-    [`diagnostic-pod-networkpolicy.yaml`](https://github.com/robusta-dev/holmes-mcp-integrations/blob/master/servers/kubernetes-remediation/diagnostic-pod-networkpolicy.yaml)
-    to **every namespace** Holmes may run diagnostics in — NetworkPolicy is
-    namespaced, and the namespace comes from the caller. Namespaces without it
-    fall back to target validation alone. It is also inert on a CNI that does not
-    enforce NetworkPolicy.
+    Apply it yourself to **every namespace** Holmes may run diagnostics in —
+    NetworkPolicy is namespaced, and the namespace comes from the caller.
+    Namespaces without it fall back to target validation alone. It is also inert
+    on a CNI that does not enforce NetworkPolicy.
+
+    Note this is a *different* policy from the ingress-only one the chart already
+    renders for the MCP server itself: that one selects the server pod
+    (`app: kubernetes-remediation-mcp`) and restricts inbound traffic, whereas
+    this one selects the short-lived diagnostic pods and restricts their egress.
+
+Save this as `diagnostic-pod-networkpolicy.yaml` and apply it with
+`kubectl apply -f diagnostic-pod-networkpolicy.yaml -n <namespace>`. It ships
+alongside the MCP server, at
+[`servers/kubernetes-remediation/`](https://github.com/robusta-dev/holmes-mcp-integrations/tree/master/servers/kubernetes-remediation)
+in `holmes-mcp-integrations`, which is the canonical copy if the two ever drift.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubernetes-remediation-diagnostic-pod-egress
+  labels:
+    app: kubernetes-remediation-mcp
+spec:
+  # The MCP server stamps this label on every diagnostic pod it creates, and
+  # pins hostNetwork:false (a host-networked pod is exempt from NetworkPolicy).
+  podSelector:
+    matchLabels:
+      robusta.dev/diagnostic-pod: "true"
+  policyTypes:
+    - Egress
+  egress:
+    # Cluster DNS, so service names still resolve. Port-only rule: kube-dns sits
+    # in kube-system, which a namespaceSelector cannot match without a label that
+    # is not guaranteed to be present.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # In-cluster (RFC1918) destinations only. An egress policy denies whatever it
+    # does not allow, so cloud metadata (169.254.0.0/16), loopback (127.0.0.0/8),
+    # 0.0.0.0/8, 100.100.100.200 (Alibaba), 192.0.0.192 (Oracle) and the public
+    # internet are all denied by omission — none of them fall inside these blocks.
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+        - ipBlock:
+            cidr: 172.16.0.0/12
+        - ipBlock:
+            cidr: 192.168.0.0/16
+```
+
+If you set `diagnosticAllowExternalTargets: true`, widen the `ipBlock` to
+`0.0.0.0/0` but add the denied ranges back as `except` entries — this policy
+should never be looser than the server-side checks it backs up.
+
+Verify your CNI actually enforces it before relying on it:
+
+```bash
+kubectl run np-test --rm -i --restart=Never -n <namespace> \
+  --image=curlimages/curl:8.11.1 \
+  --overrides='{"metadata":{"labels":{"robusta.dev/diagnostic-pod":"true"}}}' \
+  -- curl -s -m 5 http://169.254.169.254/    # must time out, not answer
+```
 
 ### If a legitimate probe is refused
 

--- a/helm/holmes/templates/mcp-servers/kubernetes-remediation/deployment.yaml
+++ b/helm/holmes/templates/mcp-servers/kubernetes-remediation/deployment.yaml
@@ -21,6 +21,9 @@ data:
   KUBECTL_DANGEROUS_FLAGS: {{ .Values.mcpAddons.kubernetesRemediation.config.dangerousFlags | quote }}
   KUBECTL_PREAPPROVED_COMMANDS: {{ .Values.mcpAddons.kubernetesRemediation.config.preapprovedCommands | quote }}
   KUBECTL_DIAGNOSTIC_IMAGES: {{ .Values.mcpAddons.kubernetesRemediation.config.diagnosticImages | quote }}
+  KUBECTL_DIAGNOSTIC_TARGET_POLICY_ENABLED: {{ .Values.mcpAddons.kubernetesRemediation.config.diagnosticTargetPolicyEnabled | quote }}
+  KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS: {{ .Values.mcpAddons.kubernetesRemediation.config.diagnosticAllowExternalTargets | quote }}
+  KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES: {{ .Values.mcpAddons.kubernetesRemediation.config.diagnosticInternalDnsSuffixes | quote }}
   KUBECTL_FILE_READ_ALLOWED_PATHS: {{ .Values.mcpAddons.kubernetesRemediation.config.fileReadAllowedPaths | quote }}
   KUBECTL_FILE_READ_DENIED_PATHS: {{ .Values.mcpAddons.kubernetesRemediation.config.fileReadDeniedPaths | quote }}
   KUBECTL_ALLOW_ARBITRARY_COMMANDS: {{ .Values.mcpAddons.kubernetesRemediation.config.allowArbitraryKubectlCommands | quote }}
@@ -114,6 +117,21 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-k8s-remediation-mcp-config
               key: KUBECTL_DIAGNOSTIC_IMAGES
+        - name: KUBECTL_DIAGNOSTIC_TARGET_POLICY_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-k8s-remediation-mcp-config
+              key: KUBECTL_DIAGNOSTIC_TARGET_POLICY_ENABLED
+        - name: KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-k8s-remediation-mcp-config
+              key: KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS
+        - name: KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-k8s-remediation-mcp-config
+              key: KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES
         - name: KUBECTL_FILE_READ_ALLOWED_PATHS
           valueFrom:
             configMapKeyRef:

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -695,7 +695,7 @@ mcpAddons:
   kubernetesRemediation:
     enabled: false          # opt-in; defaults work once enabled (plug-and-play)
 
-    image: "kubernetes-remediation-mcp:1.1.0"
+    image: "kubernetes-remediation-mcp:1.2.0"
     registry: "us-central1-docker.pkg.dev/genuine-flight-317411/mcp"
     imagePullPolicy: IfNotPresent
 
@@ -715,6 +715,25 @@ mcpAddons:
       preapprovedCommands: "exec * -- ps*,exec * -- top*,exec * -- df*,exec * -- ls*,exec * -- netstat*,exec * -- ss*"
       # Pre-approved troubleshooting images for run_preapproved_diagnostic_image (auto-approved)
       diagnosticImages: "nicolaka/netshoot:v0.13,busybox:1.37.0,curlimages/curl:8.11.1"
+
+      # ---- Diagnostic-pod target policy (server >= 1.2.0) ----
+      # run_preapproved_diagnostic_image is auto-approved and its images are
+      # network-probing tools, so the probe TARGET is the security boundary.
+      # Without this policy, prompt-injected agent output could point curl at the
+      # cloud metadata service and read instance credentials back, or POST cluster
+      # data to an external collector, with no human in the loop.
+      #
+      # Master switch. false disables ALL target checks, including the
+      # cloud-metadata/link-local ranges, and restores that behaviour. Prefer the
+      # two narrower knobs below; only disable if neither fits your environment.
+      diagnosticTargetPolicyEnabled: true
+      # Allow probes to reach hosts outside the cluster. false keeps probes
+      # in-cluster so an auto-approved probe cannot ship data to an external host.
+      # Cloud-metadata and link-local stay denied either way.
+      diagnosticAllowExternalTargets: false
+      # DNS suffixes counted as cluster-internal. Set this if you run a custom
+      # cluster domain (e.g. ".svc,.svc.mycorp.internal").
+      diagnosticInternalDnsSuffixes: ".svc,.svc.cluster.local,.cluster.local"
       # read_file_from_container path policy (allow roots minus secret/token mounts)
       fileReadAllowedPaths: "/"
       fileReadDeniedPaths: "/var/run/secrets/,/run/secrets/,/var/run/secrets/kubernetes.io/serviceaccount/"

--- a/specs/kubernetes-remediation-mcp.md
+++ b/specs/kubernetes-remediation-mcp.md
@@ -240,9 +240,23 @@ Two layers now constrain the target.
 - **Always denied:** explicit redirect-following (`curl -L`, bundled `-fsSL`), which
   hands target selection to the responding server.
 
-**Layer 2 — an egress NetworkPolicy** on the diagnostic pod
-(`diagnostic-pod-networkpolicy.yaml` in the server repo, selecting the label from §6.3),
+**Layer 2 — an egress NetworkPolicy** on the diagnostic pod:
+`diagnostic-pod-networkpolicy.yaml`, added by holmes-mcp-integrations#39 next to the
+server manifests, selecting the `robusta.dev/diagnostic-pod` label from §6.3 and
 allowing cluster DNS + RFC1918 only.
+
+This is **not** the same object as the pre-existing `networkpolicy.yaml` in that
+directory (also rendered by the chart as
+`templates/mcp-servers/kubernetes-remediation/networkpolicy.yaml`). That one is
+`policyTypes: [Ingress]` and selects the *server* pod
+(`app: kubernetes-remediation-mcp`) to restrict who may call the MCP server; it says
+nothing about diagnostic-pod egress and cannot substitute for this layer. Two policies,
+two different pod selectors, opposite directions.
+
+Neither is installed by the Helm chart for diagnostic pods — NetworkPolicy is
+namespaced and `run_preapproved_diagnostic_image` takes the namespace from the caller,
+so the operator applies the egress policy per namespace. The docs page carries the
+manifest inline for that reason.
 
 **Neither layer is sufficient alone.** Layer 1 cannot see a DNS name that only resolves
 to a metadata address *inside* the pod (wildcard DNS such as `169.254.169.254.nip.io`),

--- a/specs/kubernetes-remediation-mcp.md
+++ b/specs/kubernetes-remediation-mcp.md
@@ -103,13 +103,18 @@ of HolmesGPT approval):
 | `KUBECTL_DANGEROUS_FLAGS` | see above | Blocked flags |
 | `KUBECTL_PREAPPROVED_COMMANDS` | 6 read-only exec patterns | Auto-approved command allowlist |
 | `KUBECTL_DIAGNOSTIC_IMAGES` | 3 pinned images | Auto-approved image allowlist |
+| `KUBECTL_DIAGNOSTIC_TARGET_POLICY_ENABLED` | `true` | Master switch for the diagnostic target policy (§6.4) |
+| `KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS` | `false` | Permit probes to non-cluster targets |
+| `KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES` | `.svc,.svc.cluster.local,.cluster.local` | Suffixes counted as cluster-internal |
 | `KUBECTL_FILE_READ_ALLOWED_PATHS` | `/` | Read allow roots |
 | `KUBECTL_FILE_READ_DENIED_PATHS` | secret/token mounts | Configurable read denylist |
 | `KUBECTL_ALLOW_ARBITRARY_COMMANDS` | `true` | Enable the gated fallback |
 | `KUBECTL_TIMEOUT` | `60` | Per-command timeout (s) |
 
 In addition, `/proc`, `/sys`, `/dev` are **hard-denied in code** (not operator-removable) —
-see §6.2.
+see §6.2. The cloud-metadata/link-local ranges are hard-denied for diagnostic-pod
+targets on the same basis, overridable only by turning the whole target policy off —
+see §6.4.
 
 ### 3.4 RBAC & NetworkPolicy
 
@@ -146,7 +151,7 @@ Net core change is a deletion plus config plumbing.
 ## 5. Helm chart (`helm/holmes/.../kubernetes-remediation/`)
 
 `mcpAddons.kubernetesRemediation`: opt-in (`enabled: false`) but plug-and-play once
-enabled. Image `1.1.0`. Chart renders the scoped ClusterRole when
+enabled. Image `1.2.0`. Chart renders the scoped ClusterRole when
 `serviceAccount.clusterRole` is empty (bring-your-own otherwise), the ingress-only
 NetworkPolicy (on by default), the ConfigMap/env wiring for all the new config keys,
 and `approval_required_tools: ["run_kubectl_command"]` in `toolset-config.yaml`. The
@@ -198,7 +203,66 @@ memory limit + requests. It deliberately does **not** drop capabilities, force
 non-root, or set a CPU limit — so `tcpdump`/`ping` keep their caps and `iperf` isn't
 throttled.
 
-### 6.4 Residual risks (accepted, documented)
+The overrides also pin `hostNetwork`/`hostPID`/`hostIPC` to `false` and stamp the pod
+with `robusta.dev/diagnostic-pod: "true"`. Both exist for §6.4: a host-networked pod is
+exempt from NetworkPolicy, and the label is what the egress policy selects on.
+
+### 6.4 Diagnostic-pod targets were unrestricted (fixed — ROB-910)
+
+The image allowlist constrains *what runs*; it said nothing about *where the probe
+points*. Since the allowlisted images are network-probing tools (`curl`/`dig`/`wget`)
+and the tool is **auto-approved**, the probe target was the real security boundary and
+it was wide open. Shell-char rejection does not help: `:` `/` `.` `?` `=` are all legal,
+so a URL passes untouched.
+
+Prompt-injected content in the cluster (a pod log, an annotation, an alert body) could
+therefore steer an auto-approved probe at `169.254.169.254` and have the instance
+credentials returned to the agent, or POST cluster data to an external collector — with
+no approval prompt, because this tool legitimately never asks for one.
+`automountServiceAccountToken: false` (§6.3) does not cover it: IMDSv1, GCP and Azure
+metadata need no pod credential.
+
+Two layers now constrain the target.
+
+**Layer 1 — `validate_diagnostic_command`, before any pod is created:**
+
+- **Hard-denied, not operator-tunable** (same basis as `/proc` in §6.2):
+  `169.254.0.0/16` (IMDS + ECS task metadata), `127.0.0.0/8`, `0.0.0.0/8`,
+  `100.100.100.200` (Alibaba), `192.0.0.192` (Oracle), `::1`, `fe80::/10`,
+  `fd00:ec2::254`, and the metadata hostnames. Matched in **every IPv4 spelling
+  `inet_aton` accepts** (decimal `2852039166`, hex `0xA9FEA9FE`, octal, 2-/3-part) and
+  as IPv4-mapped IPv6, with URL userinfo stripped first so
+  `http://harmless.example.com@169.254.169.254/` is judged on the real host.
+- **Denied unless `KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS=true`:** non-cluster
+  targets. This is the half that closes exfiltration. *Every* token is inspected, not
+  just the URL, so `-x http://collector` / `--proxy=socks5://…` and `dig @server` are
+  covered — those change where the connection actually goes.
+- **Always denied:** explicit redirect-following (`curl -L`, bundled `-fsSL`), which
+  hands target selection to the responding server.
+
+**Layer 2 — an egress NetworkPolicy** on the diagnostic pod
+(`diagnostic-pod-networkpolicy.yaml` in the server repo, selecting the label from §6.3),
+allowing cluster DNS + RFC1918 only.
+
+**Neither layer is sufficient alone.** Layer 1 cannot see a DNS name that only resolves
+to a metadata address *inside* the pod (wildcard DNS such as `169.254.169.254.nip.io`),
+nor `wget`'s follow-redirects-by-default, which has no flag to key on — layer 2 contains
+those. Layer 2 is namespaced (so it must be applied to every namespace diagnostics run
+in), inert on a non-enforcing CNI, and cannot give the model a reason it can act on —
+layer 1 does that, and Holmes self-corrects from the refusal text.
+
+Cluster-internal means a bare service name, a configured suffix
+(`KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES`), or an RFC1918 address.
+Namespace-qualified shortcuts (`kubernetes.default`) are deliberately *not* internal —
+by shape they are indistinguishable from `evil.com` — and the refusal tells the caller
+to use the FQDN.
+
+`KUBECTL_DIAGNOSTIC_TARGET_POLICY_ENABLED=false` disables layer 1 entirely, including
+the hard denials, for environments the policy misjudges. It restores the pre-fix
+exposure and is logged loudly at startup and per call; the image allowlist, shell-char
+rejection and flag-injection guard are unaffected.
+
+### 6.5 Residual risks (accepted, documented)
 
 - **`pods/exec` is granted and reachable from an auto-approved path.** `pods/exec`
   cluster-wide is a known privilege-escalation verb; `read_file_from_container` and
@@ -218,7 +282,7 @@ throttled.
   in which case the approval boundary can be bypassed by anything that can reach the
   pod; enforce a NetworkPolicy-capable CNI (or add host/firewall-level restrictions)
   where this matters; (2) operators should monitor for direct calls to
-  `run_kubectl_command` that don't originate from HolmesGPT (see §6.6) as a
+  `run_kubectl_command` that don't originate from HolmesGPT (see §6.7) as a
   detection for both misconfiguration and bypass.
     - *Which CNIs enforce NetworkPolicy:* Calico, Cilium, Antrea, and Weave Net
       enforce `NetworkPolicy` out of the box; plain Flannel does **not** without an
@@ -240,14 +304,14 @@ throttled.
   `ResourceQuota`/`LimitRange` is an operator-side deployment control available
   today; the server-side concurrency cap is a follow-up enhancement.*
 
-### 6.5 Things that are correct by construction
+### 6.6 Things that are correct by construction
 
 - Path traversal: `posixpath.normpath` + residue check rejects `..` escapes.
 - Prefix matching: `_path_is_under` uses `root.rstrip("/") + "/"`, so
   `/var/run/secrets-public` doesn't match `/var/run/secrets`.
 - Deny-wins-ties: hard-denied → configured-deny → allow, in that order.
 
-### 6.6 Audit logging — current state and recommendations
+### 6.7 Audit logging — current state and recommendations
 
 For a tool that can mutate the cluster, an audit trail matters (incident
 investigation, compliance, anomaly detection). What exists today, and where the
@@ -271,7 +335,7 @@ gaps are:
   logging, enable Kubernetes API audit logging for the SA, retain per your
   compliance window, and alert on anomalous patterns (bursts of
   `run_preapproved_diagnostic_image`, repeated policy-deny `WARNING`s, or any direct
-  `run_kubectl_command` not correlated with a HolmesGPT approval — see §6.4).
+  `run_kubectl_command` not correlated with a HolmesGPT approval — see §6.5).
 
 ---
 

--- a/tests/test_kubernetes_remediation_helm.py
+++ b/tests/test_kubernetes_remediation_helm.py
@@ -112,6 +112,47 @@ def test_deployment_configmap_keys_all_reach_the_container():
     )
 
 
+def test_docs_inline_diagnostic_egress_policy_is_valid_and_restrictive():
+    """The docs page carries the diagnostic-pod egress NetworkPolicy inline, because
+    the chart does not install it (NetworkPolicy is namespaced and the namespace
+    comes from the caller). Operators copy-paste it, so assert it stays parseable
+    and actually restrictive: egress-only, selecting the label the server stamps,
+    and never widened to 0.0.0.0/0 without the denied ranges carved back out."""
+    import re
+
+    doc = (
+        Path(__file__).resolve().parents[1]
+        / "docs"
+        / "data-sources"
+        / "builtin-toolsets"
+        / "kubernetes-remediation-mcp.md"
+    ).read_text()
+
+    blocks = [
+        b
+        for b in re.findall(r"```yaml\n(.*?)```", doc, re.S)
+        if "kubernetes-remediation-diagnostic-pod-egress" in b
+    ]
+    assert len(blocks) == 1, f"expected exactly one inlined policy, found {len(blocks)}"
+
+    policy = yaml.safe_load(blocks[0])
+    assert policy["kind"] == "NetworkPolicy"
+    assert policy["spec"]["policyTypes"] == ["Egress"]
+    assert policy["spec"]["podSelector"]["matchLabels"] == {
+        "robusta.dev/diagnostic-pod": "true"
+    }
+
+    cidrs = [
+        block["ipBlock"]["cidr"]
+        for rule in policy["spec"]["egress"]
+        for block in rule.get("to", [])
+        if "ipBlock" in block
+    ]
+    assert cidrs, "egress policy allows no destinations at all"
+    # RFC1918 only. 169.254.0.0/16, 127.0.0.0/8 etc. must be denied by omission.
+    assert set(cidrs) == {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}, cidrs
+
+
 def test_networkpolicy_is_ingress_only_and_scoped():
     text = (TEMPLATE_DIR / "networkpolicy.yaml").read_text()
     assert "Ingress" in text

--- a/tests/test_kubernetes_remediation_helm.py
+++ b/tests/test_kubernetes_remediation_helm.py
@@ -28,7 +28,9 @@ def test_values_drop_restricted_tools_and_map_approval():
 def test_values_defaults_are_plug_and_play():
     v = _values()
     assert v["enabled"] is False  # opt-in
-    assert v["image"] == "kubernetes-remediation-mcp:1.1.0"
+    # 1.2.0 carries the diagnostic-pod target policy (ROB-910); the config keys
+    # asserted below only take effect on that version or newer.
+    assert v["image"] == "kubernetes-remediation-mcp:1.2.0"
     assert v["serviceAccount"]["clusterRole"] == ""  # chart creates scoped role
     assert v["networkPolicy"]["enabled"] is True
     assert v["config"]["allowArbitraryKubectlCommands"] is True
@@ -42,6 +44,15 @@ def test_values_defaults_are_plug_and_play():
         assert key in v["config"], key
     # Old run_image image allowlist is gone
     assert "allowedImages" not in v["config"]
+
+
+def test_values_default_to_the_restrictive_diagnostic_target_policy():
+    """The diagnostic target policy must ship on, and in-cluster-only, so a fresh
+    install is not exposed to the ROB-910 SSRF/exfiltration path."""
+    cfg = _values()["config"]
+    assert cfg["diagnosticTargetPolicyEnabled"] is True
+    assert cfg["diagnosticAllowExternalTargets"] is False
+    assert cfg["diagnosticInternalDnsSuffixes"] == ".svc,.svc.cluster.local,.cluster.local"
 
 
 def test_rbac_template_is_scoped_not_cluster_admin():
@@ -71,6 +82,34 @@ def test_deployment_binding_has_no_cluster_admin_default():
     ):
         assert key in text, key
     assert "KUBECTL_ALLOWED_IMAGES" not in text
+
+
+def test_deployment_wires_diagnostic_target_policy_env():
+    """Each target-policy key must appear twice: once in the ConfigMap data and
+    once as a container env entry. A key present only in the ConfigMap is
+    silently ignored by the server."""
+    text = (TEMPLATE_DIR / "deployment.yaml").read_text()
+    for key in (
+        "KUBECTL_DIAGNOSTIC_TARGET_POLICY_ENABLED",
+        "KUBECTL_DIAGNOSTIC_ALLOW_EXTERNAL_TARGETS",
+        "KUBECTL_DIAGNOSTIC_INTERNAL_DNS_SUFFIXES",
+    ):
+        assert text.count(key) >= 2, f"{key} not wired through both ConfigMap and env"
+
+
+def test_deployment_configmap_keys_all_reach_the_container():
+    """Every KUBECTL_* key defined in the ConfigMap block must also be referenced
+    as an env var, so a newly added value cannot be dropped on the floor."""
+    import re
+
+    text = (TEMPLATE_DIR / "deployment.yaml").read_text()
+    defined = set(re.findall(r"^  (KUBECTL_[A-Z_]+):", text, re.MULTILINE))
+    referenced = set(re.findall(r"key: (KUBECTL_[A-Z_]+)", text))
+    assert defined, "no ConfigMap keys found — did the template layout change?"
+    assert defined == referenced, (
+        f"ConfigMap/env mismatch: only in ConfigMap={defined - referenced}, "
+        f"only in env={referenced - defined}"
+    )
 
 
 def test_networkpolicy_is_ingress_only_and_scoped():

--- a/tests/test_kubernetes_remediation_helm.py
+++ b/tests/test_kubernetes_remediation_helm.py
@@ -6,6 +6,7 @@ the scoped ClusterRole (no cluster-admin) is rendered, the NetworkPolicy is on,
 the new config env vars are wired, and approval maps to run_kubectl_command.
 """
 
+import re
 from pathlib import Path
 
 import yaml
@@ -118,8 +119,6 @@ def test_docs_inline_diagnostic_egress_policy_is_valid_and_restrictive():
     comes from the caller). Operators copy-paste it, so assert it stays parseable
     and actually restrictive: egress-only, selecting the label the server stamps,
     and never widened to 0.0.0.0/0 without the denied ranges carved back out."""
-    import re
-
     doc = (
         Path(__file__).resolve().parents[1]
         / "docs"
@@ -142,15 +141,44 @@ def test_docs_inline_diagnostic_egress_policy_is_valid_and_restrictive():
         "robusta.dev/diagnostic-pod": "true"
     }
 
+    rules = policy["spec"]["egress"]
+    assert rules, "egress policy allows no destinations at all"
+
+    # EVERY rule must be scoped by `to`. A rule carrying only `ports` matches all
+    # destinations on those ports — that is how an "allow cluster DNS" rule
+    # silently becomes "allow exfiltration over port 53 to any resolver".
+    for i, rule in enumerate(rules):
+        assert rule.get("to"), (
+            f"egress rule {i} has no `to`, so it matches every destination on "
+            f"{rule.get('ports', 'all ports')}"
+        )
+
+    # Only approved peer kinds, and only approved CIDRs.
+    for i, rule in enumerate(rules):
+        for peer in rule["to"]:
+            assert set(peer) <= {"ipBlock", "namespaceSelector", "podSelector"}, (
+                f"egress rule {i} has an unexpected peer kind: {sorted(peer)}"
+            )
+
     cidrs = [
-        block["ipBlock"]["cidr"]
-        for rule in policy["spec"]["egress"]
-        for block in rule.get("to", [])
-        if "ipBlock" in block
+        peer["ipBlock"]["cidr"]
+        for rule in rules
+        for peer in rule["to"]
+        if "ipBlock" in peer
     ]
-    assert cidrs, "egress policy allows no destinations at all"
     # RFC1918 only. 169.254.0.0/16, 127.0.0.0/8 etc. must be denied by omission.
     assert set(cidrs) == {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}, cidrs
+
+    # The DNS rule must be pinned to kube-dns rather than left open.
+    dns_rules = [
+        r
+        for r in rules
+        if any(p.get("port") == 53 for p in r.get("ports", []))
+    ]
+    assert len(dns_rules) == 1, "expected exactly one port-53 egress rule"
+    assert any(
+        "podSelector" in peer or "ipBlock" in peer for peer in dns_rules[0]["to"]
+    ), "the DNS rule must name its destination"
 
 
 def test_networkpolicy_is_ingress_only_and_scoped():


### PR DESCRIPTION
## Summary

Chart, docs and spec side of the ROB-910 fix. The MCP server change itself lives in **[robusta-dev/holmes-mcp-integrations#39](https://github.com/robusta-dev/holmes-mcp-integrations/pull/39)** (server image `1.2.0`) — this PR bumps to that image and exposes/documents its new configuration. **Land #39 and publish 1.2.0 first**, or the chart pins an image that doesn't exist yet.

Raised by @Avi-Robusta on #39: add the docs to holmes, add the image (it was on 1.1.0), and make the new restriction disableable.

## Why

`run_preapproved_diagnostic_image` is auto-approved and the images it launches are network-probing tools (`curl`/`dig`/`wget`/`tcpdump`). The image allowlist controls *what runs*, not *where the probe points* — so prompt-injected cluster content (a pod log, an annotation, an alert body) could steer an auto-approved probe at the cloud metadata service and have instance credentials returned to Holmes, or POST cluster data to an external collector. No approval prompt would appear, because this tool legitimately never asks for one.

## What's in *this* PR (5 files)

**Chart**

- `mcpAddons.kubernetesRemediation.image` → `kubernetes-remediation-mcp:1.2.0`
- Three new `config` keys, wired through the ConfigMap **and** the container env:
  - `diagnosticTargetPolicyEnabled` (default `true`) — master switch
  - `diagnosticAllowExternalTargets` (default `false`) — opt-in for legitimate external probing
  - `diagnosticInternalDnsSuffixes` (default `.svc,.svc.cluster.local,.cluster.local`) — for custom cluster domains

  Defaults are the restrictive ones, so an existing install gets the protection without touching values.

**Docs** (`docs/data-sources/builtin-toolsets/kubernetes-remediation-mcp.md`)

- New "Diagnostic-pod target policy" section: the threat model, what the server refuses unconditionally vs. what you can opt into, and why the egress NetworkPolicy is needed *alongside* the argument checks rather than instead of them.
- **The NetworkPolicy is not installed by this chart** and is namespaced, so it needs applying to every namespace diagnostics may run in — called out explicitly, with a command to verify the CNI actually enforces it.
- A troubleshooting ladder for a refused probe. The most common case is a namespace-qualified short name (`kubernetes.default`), which is refused in favour of the FQDN because by shape it's indistinguishable from an external domain.
- Security Controls row, tool-table note, config reference entries, and the CLI manifest bumped to 1.2.0.

**Spec** — new §6.4 recording the vulnerability and both layers; following sections renumbered and their cross-references updated.

**Tests** — the restrictive defaults; that each new key reaches the container and not just the ConfigMap; and a general guard that every `KUBECTL_*` ConfigMap key has a matching env entry, so a future addition can't be silently dropped.

## Not in this PR

`validate_diagnostic_command`, `diagnostic-pod-networkpolicy.yaml`, and the pod hardening (`hostNetwork: false` + the `robusta.dev/diagnostic-pod` label) are all in #39. Don't look for them in this diff.

## Testing

`pytest tests/test_kubernetes_remediation_helm.py tests/test_approval_required_tools.py` → **14 passed**. `mkdocs build` clean. Verified with `helm template` that the defaults render into both the ConfigMap and the container env, and that `--set` overrides propagate.

The server-side behaviour was verified end-to-end against a live k3s cluster with Holmes driving it — including a prompt-injection test and confirmation that Holmes self-corrects from a refusal to the FQDN. Details, plus what that testing could **not** prove (the NetworkPolicy layer couldn't be verified — `ipset` is restricted in the test sandbox), are in #39's description.

## Backwards compatibility

On a server image older than 1.2.0 the three new keys are passed through and ignored, leaving probe targets unrestricted — which is why the chart pins 1.2.0.

`diagnosticTargetPolicyEnabled: false` disables **all** target checks, including the metadata ranges that are otherwise not operator-configurable, restoring the pre-1.2.0 exposure. It exists for environments the policy misjudges; the server logs a warning at startup and on every call while it's off, and the docs steer to the two narrower knobs first.

https://claude.ai/code/session_01HLLQDA2UVyQsZtCxwg3SsP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added restrictive diagnostic target validation by default.
  * Blocked metadata, link-local, and unsafe redirected destinations.
  * Added controls for external access, internal DNS suffixes, and diagnostic egress policies.

* **Configuration**
  * Exposed diagnostic target policy settings through deployment configuration.
  * Upgraded the Kubernetes Remediation MCP image to version 1.2.0.

* **Documentation**
  * Expanded guidance on validation, refusal handling, NetworkPolicy requirements, hardening, DNS access, and audit logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->