### PR TITLE
fix(investigator): render failed TodoWrite tasks

### DIFF
--- a/holmes/core/todo_tasks_formatter.py
+++ b/holmes/core/todo_tasks_formatter.py
@@ -15,6 +15,7 @@ def format_tasks(tasks: List[Task]) -> str:
         TaskStatus.PENDING: 0,
         TaskStatus.IN_PROGRESS: 1,
         TaskStatus.COMPLETED: 2,
+        TaskStatus.FAILED: 3,
     }
 
     sorted_tasks = sorted(
@@ -28,10 +29,15 @@ def format_tasks(tasks: List[Task]) -> str:
     pending_count = sum(1 for t in tasks if t.status == TaskStatus.PENDING)
     progress_count = sum(1 for t in tasks if t.status == TaskStatus.IN_PROGRESS)
     completed_count = sum(1 for t in tasks if t.status == TaskStatus.COMPLETED)
+    failed_count = sum(1 for t in tasks if t.status == TaskStatus.FAILED)
 
-    lines.append(
-        f"**Task Status**: {completed_count} completed, {progress_count} in progress, {pending_count} pending"
+    status_summary = (
+        f"**Task Status**: {completed_count} completed, {progress_count} in progress, "
+        f"{pending_count} pending"
     )
+    if failed_count:
+        status_summary += f", {failed_count} failed"
+    lines.append(status_summary)
     lines.append("")
 
     for task in sorted_tasks:
@@ -39,13 +45,16 @@ def format_tasks(tasks: List[Task]) -> str:
             TaskStatus.PENDING: "[ ]",
             TaskStatus.IN_PROGRESS: "[~]",
             TaskStatus.COMPLETED: "[✓]",
+            TaskStatus.FAILED: "[✗]",
         }.get(task.status, "[?]")
 
         lines.append(f"{status_indicator} [{task.id}] {task.content}")
 
     lines.append("")
     lines.append(
-        "**Instructions**: Use TodoWrite tool to update task status as you work. Mark tasks as 'in_progress' when starting, 'completed' when finished."
+        "**Instructions**: Use TodoWrite tool to update task status as you work. "
+        "Mark tasks as 'in_progress' when starting, 'completed' when finished, "
+        "or 'failed' when they cannot be completed."
     )
 
     return "\n".join(lines)

--- a/holmes/plugins/toolsets/investigator/investigator_instructions.jinja2
+++ b/holmes/plugins/toolsets/investigator/investigator_instructions.jinja2
@@ -1,7 +1,7 @@
 # TodoWrite
 You MUST use the TodoWrite tool to plan and track any investigation requiring 3+ distinct steps or multiple user-provided tasks — always create the task list BEFORE gathering data; the updated list always appears in the prompt, giving the user visibility. Skip it only for single trivial tasks or purely informational questions.
 
-Task states: `pending`, `in_progress` (mark BEFORE starting work), `completed`. Update in real time — mark tasks completed immediately when fully done, never in batches; independent tasks may be in_progress simultaneously and worked in parallel. If you hit a blocker, keep the task in_progress and add a new task for what must be resolved. Create specific, actionable items and add follow-ups you discover.
+Task states: `pending`, `in_progress` (mark BEFORE starting work), `completed`, `failed`. Update in real time — mark tasks completed immediately when fully done, never in batches; mark a task failed only after it was attempted and cannot be completed. Independent tasks may be in_progress simultaneously and worked in parallel. If you hit a recoverable blocker, keep the task in_progress and add a new task for what must be resolved. Create specific, actionable items and add follow-ups you discover.
 
 When the investigation is complete, validate that your analysis is supported by the evidence collected.
 
@@ -11,7 +11,7 @@ Tool results and user messages may include <system-reminder> tags with useful re
 {
   todos: {
     content: string;
-    status: "pending" | "in_progress" | "completed";
+    status: "pending" | "in_progress" | "completed" | "failed";
     priority: "high" | "medium" | "low";
     id: string;
   }[];

--- a/tests/core/test_todo_write_tool.py
+++ b/tests/core/test_todo_write_tool.py
@@ -66,6 +66,27 @@ class TestTodoWriteTool:
         # Should include pretty printed TodoList
         assert "Test task" in result.data
 
+    def test_todo_write_tool_formats_failed_tasks(self):
+        """Failed tasks are counted and rendered as a known terminal state."""
+        tool = TodoWriteTool()
+        params = {
+            "todos": [
+                {"id": "1", "content": "Check pod status", "status": "completed"},
+                {"id": "2", "content": "Query metrics", "status": "failed"},
+                {"id": "3", "content": "Analyze logs", "status": "pending"},
+            ]
+        }
+
+        result = tool._invoke(params, context=create_mock_tool_invoke_context())
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert (
+            "**Task Status**: 1 completed, 0 in progress, 1 pending, 1 failed"
+            in result.data
+        )
+        assert "[✗] [2] Query metrics" in result.data
+        assert "[?] [2] Query metrics" not in result.data
+
     def test_todo_write_tool_invalid_enum_values(self):
         """Test TodoWriteTool handles invalid enum values gracefully."""
         tool = TodoWriteTool()
@@ -102,6 +123,7 @@ class TestTodoWriteTool:
         assert TaskStatus.PENDING == "pending"
         assert TaskStatus.IN_PROGRESS == "in_progress"
         assert TaskStatus.COMPLETED == "completed"
+        assert TaskStatus.FAILED == "failed"
 
     def test_openai_format(self):
         """Test that the tool generates correct OpenAI format."""


### PR DESCRIPTION
## Summary

- render `TaskStatus.FAILED` with the existing `[✗]` indicator in conversation task reminders
- include failed tasks in status totals without changing summaries that have no failures
- document `failed` in the investigator prompt and TodoWrite type example

## Why

PR #1152 added `failed` to the TodoWrite parser, schema, and terminal table, but the conversation reminder formatter and investigator instructions were left behind. A valid failed task was therefore shown to the model as unknown and omitted from the totals:

```text
**Task Status**: 0 completed, 0 in progress, 0 pending
[?] [7] Query failed
```

For an investigation agent, that can hide the fact that a planned check did not complete. This change keeps the supported status consistent across parsing, terminal output, prompt instructions, and subsequent conversation reminders.

## Tests

```text
python -m pytest -q -n 0 --no-cov tests/core/test_todo_write_tool.py tests/plugins/toolsets/test_core_investigation.py
12 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking tasks as **failed** after an attempted, unsuccessful completion.
  * Failed tasks now appear after completed tasks, include a failure indicator, and are counted in status summaries.
  * Updated task guidance to document the new failed state and distinguish recoverable blockers.

* **Tests**
  * Added coverage for failed-task counting and terminal-state display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->