### PR TITLE
fix(mcp): block credential-bearing cross-origin redirects

### DIFF
--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -11,8 +11,6 @@ from contextlib import asynccontextmanager
 from datetime import timedelta
 from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional, TextIO, Tuple, Type, Union
-from urllib.parse import urlparse
-
 import httpx
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
@@ -78,6 +76,42 @@ def _extract_root_error_message(exc: Exception) -> str:
     return str(current)
 
 
+class MCPRedirectError(httpx.HTTPError):
+    """Raised when an MCP endpoint redirects to a different origin."""
+
+
+def _url_origin(url: httpx.URL) -> tuple[str, str, int | None]:
+    """Return the effective HTTP origin for a URL.
+
+    ``httpx.URL.port`` is ``None`` for the default port, so normalize it before
+    comparing origins. This prevents a redirect from ``https://host`` to
+    ``https://host:8443`` from being treated as same-origin.
+    """
+    default_ports = {"http": 80, "https": 443}
+    return url.scheme, url.host, url.port or default_ports.get(url.scheme)
+
+
+async def _reject_cross_origin_redirect(response: httpx.Response) -> None:
+    """Reject an MCP redirect before HTTPX sends the next request.
+
+    MCP headers can contain OAuth tokens or arbitrary API keys. HTTPX removes
+    ``Authorization`` on a cross-origin redirect, but preserves custom headers;
+    fail closed for the whole origin so no configured credential can reach an
+    unexpected server.
+    """
+    if not response.has_redirect_location:
+        return
+
+    target = response.request.url.join(response.headers["location"])
+    source_origin = _url_origin(response.request.url)
+    target_origin = _url_origin(target)
+    if source_origin != target_origin:
+        raise MCPRedirectError(
+            "Refusing to follow cross-origin MCP redirect: "
+            f"{source_origin!r} -> {target_origin!r}"
+        )
+
+
 # Lock per MCP server URL to serialize calls to the same server
 _server_locks: Dict[str, threading.Lock] = {}
 _locks_lock = threading.Lock()
@@ -94,6 +128,7 @@ def create_mcp_http_client_factory(verify_ssl: bool = True):
         kwargs: Dict[str, Any] = {
             "follow_redirects": True,
             "verify": verify_ssl,
+            "event_hooks": {"response": [_reject_cross_origin_redirect]},
         }
         if timeout is None:
             kwargs["timeout"] = httpx.Timeout(SSE_READ_TIMEOUT)

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from mcp.types import (
     BlobResourceContents,
@@ -31,10 +32,12 @@ from holmes.core.tools import (
 )
 from holmes.plugins.toolsets.mcp.toolset_mcp import (
     MCPConfig,
+    MCPRedirectError,
     MCPMode,
     RemoteMCPTool,
     RemoteMCPToolset,
     StdioMCPConfig,
+    create_mcp_http_client_factory,
     _extract_root_error_message,
     get_initialized_mcp_session,
 )
@@ -47,6 +50,84 @@ def suppress_migration_warnings():
     logger.setLevel(logging.ERROR)
     yield
     logger.setLevel(original_level)
+
+
+class TestMCPRedirects:
+    @pytest.mark.parametrize(
+        "redirect_url",
+        [
+            "http://trusted.example/collect",
+            "https://trusted.example:8443/collect",
+        ],
+    )
+    async def test_cross_origin_redirect_is_blocked_before_next_request(
+        self, monkeypatch, redirect_url
+    ):
+        seen_requests = []
+
+        def handler(request):
+            seen_requests.append(request)
+            return httpx.Response(
+                302,
+                headers={"Location": redirect_url},
+                request=request,
+            )
+
+        transport = httpx.MockTransport(handler)
+        real_async_client = httpx.AsyncClient
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(transport=transport, **kwargs),
+        )
+
+        factory = create_mcp_http_client_factory()
+        async with factory(
+            headers={
+                "Authorization": "Bearer secret",
+                "X-Api-Key": "secret2",
+            }
+        ) as client:
+            with pytest.raises(MCPRedirectError, match="cross-origin"):
+                await client.get("https://trusted.example/start")
+
+        assert len(seen_requests) == 1
+        assert seen_requests[0].headers["Authorization"] == "Bearer secret"
+        assert seen_requests[0].headers["X-Api-Key"] == "secret2"
+
+    async def test_same_origin_redirect_is_followed_with_headers(
+        self, monkeypatch
+    ):
+        seen_requests = []
+
+        def handler(request):
+            seen_requests.append(request)
+            if len(seen_requests) == 1:
+                return httpx.Response(
+                    302,
+                    headers={"Location": "/next"},
+                    request=request,
+                )
+            return httpx.Response(200, text="ok", request=request)
+
+        transport = httpx.MockTransport(handler)
+        real_async_client = httpx.AsyncClient
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(transport=transport, **kwargs),
+        )
+
+        factory = create_mcp_http_client_factory()
+        async with factory(
+            headers={"Authorization": "Bearer secret", "X-Api-Key": "secret2"}
+        ) as client:
+            response = await client.get("https://trusted.example/start")
+
+        assert response.status_code == 200
+        assert len(seen_requests) == 2
+        assert seen_requests[1].headers["Authorization"] == "Bearer secret"
+        assert seen_requests[1].headers["X-Api-Key"] == "secret2"
 
 
 class TestToolParameter:


### PR DESCRIPTION
## Summary

MCP HTTP clients currently set `follow_redirects=True` for both SSE and Streamable HTTP transports. HTTPX 0.28.1 strips `Authorization` on a cross-origin redirect, but preserves arbitrary configured headers. MCP configurations support static and rendered headers such as `X-Api-Key`, tenant tokens, and other credentials.

This patch rejects a cross-origin redirect before HTTPX sends the next request. Same-origin redirects remain supported.

## Changes

- Add an HTTPX response hook to the shared MCP client factory.
- Compare scheme, host, and effective port for every redirect.
- Raise a clear `MCPRedirectError` for cross-origin targets.
- Keep same-origin path redirects compatible.
- Cover cross-scheme, cross-port, and same-origin behavior with MockTransport tests, including custom credential headers.

## Verification

- `pytest -q --no-cov -n 0 tests/test_mcp_toolset.py`
- Result: 101 passed

The regression reproduces with HTTPX 0.28.1: `Authorization` is removed across origins while `X-Api-Key` is retained. The guard prevents the second request entirely, so no configured MCP credential reaches the redirected origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked MCP HTTP requests from following redirects to a different origin.
  * Continued to support redirects within the same origin.
  * Preserved request headers during permitted redirects.
  * Added clear errors when cross-origin redirects are blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->