### PR TITLE
Feature/investigation path completeness

### DIFF
--- a/.github/workflows/eval-regression.yaml
+++ b/.github/workflows/eval-regression.yaml
@@ -1342,6 +1342,38 @@ jobs:
             echo "duration=${DURATION}s" >> $GITHUB_OUTPUT
           fi
 
+      - name: Run investigation path benchmark
+        # Offline path-completeness benchmark for issue #2046. Deterministic, no
+        # LLM call, no cluster, a couple of seconds - it runs here so the
+        # retrieval policy accumulates a tracked history in the same place as
+        # the LLM evals before any user-facing behaviour depends on it.
+        #
+        # continue-on-error plus the exit-code guard below: this reports on a
+        # policy that nothing ships against yet, so it must never be the reason
+        # an eval run goes red or an eval report fails to post.
+        if: always() && steps.check-tests.outputs.should-run == 'true'
+        continue-on-error: true
+        working-directory: code
+        shell: bash
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          EXPERIMENT_ID: github-${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
+        run: |
+          set +e
+          poetry run python -m holmes.core.investigation_path.offline_eval \
+            --braintrust --markdown path_benchmark.md
+          BENCHMARK_EXIT=$?
+          set -e
+
+          if [[ $BENCHMARK_EXIT -ne 0 ]]; then
+            echo "⚠️ investigation path benchmark exited $BENCHMARK_EXIT; not posting a report"
+            exit 0
+          fi
+
+          # Appended rather than merged into the eval table: these rows are
+          # deterministic and would be misread next to model-scored ones.
+          { echo; echo "---"; echo; cat path_benchmark.md; } >> evals_report.md
+
       - name: Post evaluation results
         if: always() && steps.check-tests.outputs.should-run == 'true' && steps.eval-params.outputs.pr_number != ''
         uses: actions/github-script@v7

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -1,0 +1,188 @@
+# Investigation path completeness — schema, corpus and metrics
+
+Status: **offline only.** Nothing here is wired into an investigation. This is
+the benchmark groundwork for
+[issue #2046](https://github.com/HolmesGPT/holmesgpt/issues/2046), so that a
+retrieval policy can be measured before it is allowed to talk to a user.
+
+The idea in the issue is: after an investigation, compare what it checked
+against what similar resolved incidents checked, and point out anything it
+skipped. The risk is that a wrong suggestion during an incident costs a
+responder attention at the worst possible moment, and that borrowing one
+historical path teaches every future investigation to repeat it. So the first
+question is not "does it work" but "how would we know".
+
+Three artifacts answer that: a **path schema**, a **corpus**, and a **metrics
+definition** with a runnable offline eval.
+
+## 1. Canonical path event
+
+An investigation becomes an ordered list of `PathEvent` (see
+`holmes/core/investigation_path/schema.py`):
+
+| field | purpose |
+|---|---|
+| `ordinal` | position in the investigation, so order is preserved |
+| `tool` | tool as executed — provenance only, never matched on |
+| `intent` | why the check ran: `describe`, `logs`, `metrics`, `topology`, … |
+| `entity` | normalized kind / name / namespace of what was checked |
+| `time_window` | bucketed lookback, or a point-in-time marker |
+| `outcome` | `success` / `no_data` / `error`, plus a normalized `error_class` |
+| `evidence_ref` | opaque pointer to the output, never a copy of it |
+
+Two decisions carry most of the weight.
+
+**Matching is on intent, not tool.** `kubectl logs`, `fetch_pod_logs` and a Loki
+query are all `LOGS`. Matching on tool name would tell an investigation it
+skipped a check it actually ran through a different toolset.
+
+**The affected workload is stored as `<subject>`.** A reference path that names
+`payment-service` can only ever match `payment-service`. The token is
+substituted in when a live path is compared, and rendered back to the real name
+when a suggestion is shown.
+
+Signatures come at two granularities. `COARSE` is `intent:kind` and asks "did
+anyone look at the service topology at all". `FINE` adds the entity name and
+asks "did anyone look at `service/redis`". Both are scored, because they trade
+recall against precision differently.
+
+### What is deliberately not stored
+
+- **Tool output.** `StructuredToolResult.data` is never read.
+- **Raw error text.** It is read once to pick an `ErrorClass`, then dropped.
+- **Anything not on the parameter allow-list.** A new toolset cannot leak a
+  parameter into a stored path just by naming it something new.
+- **Credentials.** Parameter keys containing `token`, `secret`, `password`,
+  `auth` and similar are skipped even if allow-listed, and high-entropy words
+  inside shell commands are replaced with `<redacted>`.
+- **Unstable values.** Pod hashes are stripped, lookbacks are bucketed to
+  5m/15m/1h/6h/24h/7d, and absolute timestamps are reduced to a span.
+
+`tests/core/investigation_path/test_normalize.py` asserts each of these
+directly, including that a raw error string never survives into the record.
+
+## 2. Corpus
+
+`tests/fixtures/investigation_path/corpus/` holds twelve resolved incidents, one
+YAML file each — eight in the retrieval pool, four held out.
+
+Every record carries a `root_cause` label from a controlled vocabulary, a
+`reference_path` (what *should* have been checked, decided once the cause was
+known) with per-step weights and a written rationale, and `validated_by` /
+`validated_at`. Held-out records additionally carry an `observed_path`;
+`reference_path` minus `observed_path` is the ground-truth missing set.
+
+Records are human-reviewed by construction. Harvesting paths from production
+automatically would teach the validator whatever mistake each original
+investigation made, which is the exact failure this design is trying to avoid.
+
+**Twelve incidents is not evidence.** The corpus exists to make the schema
+concrete and the metrics runnable. It is far too small to justify shipping
+anything.
+
+### Similar symptoms vs. same root cause
+
+These are kept apart on purpose. Retrieval ranks by symptom overlap, because
+symptoms are all that is known while an incident is open. But the checks worth
+suggesting come from the *cause*. So candidates are collapsed to the single root
+cause most of them share, and everything that disagrees is dropped. If they do
+not agree, there is no defensible cause to borrow from.
+
+### Abstention
+
+Abstention is an outcome, not a failure. The policy declines when any of these
+hold, and records which one:
+
+| reason | condition |
+|---|---|
+| `no_candidates` | nothing in the corpus overlaps at all |
+| `low_similarity` | the closest incidents fall below the similarity floor |
+| `insufficient_support` | fewer than `min_matches` incidents share the cause |
+| `root_cause_disagreement` | candidates point at different causes |
+
+## 3. Metrics
+
+Defined in `holmes/core/investigation_path/metrics.py`. For a held-out incident
+with ground-truth missing set `M` (weighted) and suggestion set `S`:
+
+- **Weighted path recall** — share of `M`'s weight found in `S`, over *all*
+  cases. Abstentions contribute zero, so this is the coverage number.
+- **Weighted path recall when answering** — the same over answered cases only.
+  Reported alongside recall because the two move in opposite directions as the
+  abstention threshold changes, and neither means anything alone.
+- **Suggestion precision** — share of suggestions that were genuinely missing.
+  The weighted form credits a true positive by its weight and charges a false
+  positive a flat 1.0, so surfacing a trivial check cannot pay for a wrong one.
+- **False-positive burden** — mean wrong suggestions per answered incident.
+  Precision hides this: 80% over 25 suggestions is far worse than 80% over 4.
+- **Abstention rate** — with a breakdown by reason.
+- **Expected calibration error / Brier score** — whether the confidence attached
+  to a suggestion means anything. This is the check a raw top-k similarity score
+  cannot pass on its own.
+- **Latency** — p50/p95 per validation.
+- **Storage cost** — mean serialized bytes per stored record.
+- **LLM calls** — expected to be 0, tracked so a future model call shows up as a
+  cost regression rather than silently.
+
+### Running it
+
+```bash
+poetry run python -m holmes.core.investigation_path.offline_eval
+```
+
+## Current baseline
+
+```
+cases                       4
+answered                    2
+abstention rate             0.50
+weighted path recall        0.67
+  ... when answering        1.00
+suggestion precision        0.75
+  ... weighted              0.73
+false positives per answer  1.00
+expected calibration error  0.500
+brier score                 0.303
+latency p50 (ms)            0.03
+latency p95 (ms)            0.08
+bytes per incident          1450
+llm calls                   0
+```
+
+Read honestly, on four held-out cases:
+
+- When it answers, it finds everything that was skipped, and it is free —
+  microseconds, no tokens.
+- It is wrong once per answer. Both false positives are real: a check that
+  genuinely helped in one past incident but does not belong in the reference
+  path here. Support and confidence filtering did not remove them.
+- It stays quiet half the time, once because only one past incident shared the
+  root cause and once because nothing resembled the incident at all. Both are
+  the desired behaviour, and both cost recall — which is why coverage sits at
+  0.67 while accuracy-when-answering sits at 1.00.
+- **Confidence is badly calibrated.** ECE of 0.50 means the score is close to
+  meaningless: it multiplies three sub-1 terms, so it reads around 0.3 for
+  suggestions that turn out correct every time. It must not be shown to a user
+  as a percentage in this state.
+
+## What this does not answer
+
+- Whether any of it holds beyond twelve hand-written incidents.
+- Whether symptom keyword overlap is the right retrieval signal at all. It was
+  chosen because it is transparent and free, not because it was compared
+  against alternatives.
+- How incidents would be collected and reviewed at any real scale.
+- Whether a responder mid-incident finds the suggestions useful or noisy. No
+  metric here measures that.
+
+## Suggested next steps
+
+1. **Calibrate confidence**, then re-measure ECE. Until then no confidence
+   number should reach a user.
+2. **Grow the corpus** across more causes and more clusters, and re-run. Expect
+   precision to drop once near-miss causes appear.
+3. **Sweep the policy knobs** (`min_symptom_similarity`, `min_matches`,
+   `min_root_cause_agreement`, `min_support`) and publish the risk-coverage
+   curve rather than a single operating point.
+4. **Only then** consider a runtime surface, off by default, showing provenance
+   and rationale, and worded as advice rather than a checklist.

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -104,9 +104,22 @@ investigation made, which is the exact failure this design is trying to avoid.
 concrete and the metrics runnable. It is far too small to justify shipping
 anything.
 
-Each root cause has at least three pool members, which is a requirement of the
-calibration fit rather than a nicety: leave-one-out removes one incident and
-retrieval needs two remaining to answer at all.
+A root cause needs at least three pool members to be usable at all: leave-one-out
+removes one incident and retrieval needs two remaining to answer. Three of the
+five causes currently clear that bar:
+
+| root cause | pool incidents | usable |
+|---|---|---|
+| `dependency_unreachable` | 4 | yes |
+| `oom_kill` | 3 | yes |
+| `config_regression` | 3 | yes |
+| `image_pull_failure` | 1 | **no** |
+| `node_disk_pressure` | 1 | **no** |
+
+The last two are dead weight today. They can never be answered on, and they
+contribute nothing to the calibration fit. They are kept because the schema and
+the vocabulary should cover more than the three causes that happen to be
+populated — but no result in this document is evidence about them.
 
 ### Similar symptoms vs. same root cause
 

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -13,7 +13,9 @@ historical path teaches every future investigation to repeat it. So the first
 question is not "does it work" but "how would we know".
 
 Three artifacts answer that: a **path schema**, a **corpus**, and a **metrics
-definition** with a runnable offline eval.
+definition** with a runnable offline eval. The eval reports through the existing
+eval/Braintrust pipeline (section 5), so the policy builds a tracked history
+before anything user-facing depends on it.
 
 ## 1. Canonical path event
 
@@ -217,6 +219,45 @@ with ground-truth missing set `M` (weighted) and suggestion set `S`:
 ```bash
 poetry run python -m holmes.core.investigation_path.offline_eval
 ```
+
+## 5. Where the benchmark lives
+
+The review asked for this to be established in the existing eval/Braintrust
+pipeline rather than coupled to the product, so it is wired in at two points and
+neither of them is runtime code.
+
+**Every pull request.** The baseline below is asserted in
+`tests/core/investigation_path/test_corpus_and_offline_eval.py`, which carries no
+`llm` marker and so runs in `build-and-test.yaml` under `pytest -m "not llm"`. No
+API key, no cluster, about two seconds. A change to retrieval that moves recall
+or precision fails there.
+
+**Eval runs.** `.github/workflows/eval-regression.yaml` runs the benchmark after
+the LLM evals and appends its report to the `evals_report.md` comment, so a
+policy change is visible in the same place a model change is. The same step logs
+the run to Braintrust via `reporting.py`:
+
+```bash
+poetry run python -m holmes.core.investigation_path.offline_eval \
+  --braintrust --markdown path_benchmark.md
+```
+
+Three deliberate choices there:
+
+- **Its own experiment**, `{EXPERIMENT_ID}-investigation-path`. Sharing the
+  ask_holmes experiment would average deterministic scores into a model-scored
+  correctness number that is measuring something else.
+- **Costs are metadata, not scores.** Latency, bytes and LLM calls are logged as
+  metadata because Braintrust averages scores across rows, and a mean latency
+  reported as a score reads like a quality number.
+- **An abstention scores zero recall and is not scored for precision at all.** It
+  made no claim, so charging it a precision of 0 would be a lie about it. Each
+  row logs `answered` alongside, so the two cannot be read apart.
+
+Reporting cannot change a result and cannot fail a build: without
+`BRAINTRUST_API_KEY` the tracer is a no-op and the numbers are identical, and the
+CI step is `continue-on-error` because it reports on a policy nothing ships
+against yet.
 
 ## Current baseline
 

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -117,20 +117,30 @@ anything.
 
 A root cause needs at least three pool members to be usable at all: leave-one-out
 removes one incident and retrieval needs two remaining to answer. Three of the
-five causes currently clear that bar:
+six causes currently clear that bar:
 
 | root cause | pool incidents | usable |
 |---|---|---|
-| `dependency_unreachable` | 4 | yes |
+| `dependency_unreachable` | 3 | yes |
 | `oom_kill` | 3 | yes |
 | `config_regression` | 3 | yes |
+| `connection_pool_exhausted` | 1 | **no** |
 | `image_pull_failure` | 1 | **no** |
 | `node_disk_pressure` | 1 | **no** |
 
-The last two are dead weight today. They can never be answered on, and they
+The last three are dead weight today. They can never be answered on, and they
 contribute nothing to the calibration fit. They are kept because the schema and
 the vocabulary should cover more than the three causes that happen to be
 populated — but no result in this document is evidence about them.
+
+`connection_pool_exhausted` exists because INC-003 was originally labelled
+`dependency_unreachable` while its own summary said the database stayed
+reachable. Retrieval collapses candidates to one root cause and measures
+agreement on the label, so a saturation incident filed under a reachability
+label is a source of false agreement — it never surfaced here only because its
+symptoms are too far from anything held out to be retrieved at all. The
+usable-cause count is what pays for the correction: `dependency_unreachable`
+drops from four pool incidents to three, which is the minimum that still works.
 
 ### Similar symptoms vs. same root cause
 
@@ -335,7 +345,7 @@ expected calibration error  0.010
 brier score                 0.000
 latency p50 (ms)            0.05
 latency p95 (ms)            0.12
-bytes per incident          1483
+bytes per incident          1489
 llm calls                   0
 llm tokens                  0
 

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -268,7 +268,11 @@ Four properties are deliberate:
   they happened, so a responder can go and read them instead of trusting the
   tool.
 - **Rationale.** The human-written reason the check mattered in those incidents,
-  carried through from the corpus rather than generated.
+  carried through from the corpus rather than generated. One rationale is shown
+  against a support fraction covering several incidents, which is a known
+  rough edge: the same check can be run for different reasons. In the example
+  above INC-002 ran `endpoints/redis` to *eliminate* a selector problem, not as
+  the evidence the shown rationale describes.
 - **Support, shown as a fraction.** `3/3` is a different claim from `1/3`, and
   collapsing both into one confidence number hides that.
 - **Advisory wording, and a cap.** "not required steps — skip any that do not
@@ -331,12 +335,12 @@ expected calibration error  0.010
 brier score                 0.000
 latency p50 (ms)            0.05
 latency p95 (ms)            0.12
-bytes per incident          1451
+bytes per incident          1483
 llm calls                   0
 llm tokens                  0
 
-calibration: platt(slope=2.20, intercept=0.35, l2=0.01)
-             fitted on 80 leave-one-out samples, 44 positive
+calibration: platt(slope=2.30, intercept=-0.17, l2=0.01)
+             fitted on 93 leave-one-out samples, 44 positive
   calibration error before: 0.354   after: 0.010
   brier before:             0.136   after: 0.000
 ```
@@ -346,7 +350,10 @@ Read honestly, on five held-out cases:
 - **Nothing it says is wrong.** Precision 1.00, zero false positives per answer.
   Getting there took two fixes, both of which came out of the benchmark rather
   than out of review: the support-ratio filter, and refusing to name objects the
-  investigation has never seen.
+  investigation has never seen. A third filter, the confidence floor, turns out
+  to clear the same false positives independently — so precision 1.00 is held up
+  by more than one mechanism, and a test pins each in isolation rather than
+  letting whichever runs first take the credit.
 - **Confidence now means something.** Calibration error fell from 0.354 to 0.010
   out-of-sample.
 - **It is free.** Tens of microseconds, no tokens, ~1.4 KB per stored incident.

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -48,6 +48,15 @@ anyone look at the service topology at all". `FINE` adds the entity name and
 asks "did anyone look at `service/redis`". Both are scored, because they trade
 recall against precision differently.
 
+**One check has to parse to one entity however it was typed.** `deployment/x`
+and `deployment x` are the same check, and a sub-verb is not a kind:
+`kubectl rollout history deployment/x` targets `deployment/x`, not a resource
+of kind `history`. Getting this wrong does not look like a parsing bug when the
+benchmark reports it — it looks like the engineer skipped a check they actually
+ran. That failure mode is invisible in today's numbers because the corpus is
+hand-written normalized YAML that never goes through command parsing, so it is
+pinned by tests in `test_normalize.py` instead.
+
 ### What is deliberately not stored
 
 - **Tool output.** `StructuredToolResult.data` is never read.
@@ -153,9 +162,9 @@ largest source of false positives on the first benchmark run.
 
 The raw evidence score is a product of four terms below 1 (symptom similarity,
 root-cause agreement, match support, per-check support). It orders suggestions
-sensibly but its magnitude is meaningless: on the first run it read about 0.32
-for suggestions that turned out correct every single time, an expected
-calibration error of 0.50. A number like that is worse than no number, because a
+sensibly but its magnitude is meaningless: it reads about 0.32 for suggestions
+that turn out correct every single time, an expected calibration error of 0.354
+on the current corpus. A number like that is worse than no number, because a
 responder reads "32%" and discounts a check that is almost certainly worth
 running.
 
@@ -213,7 +222,11 @@ with ground-truth missing set `M` (weighted) and suggestion set `S`:
   Precision hides this: 80% over 25 suggestions is far worse than 80% over 4.
 - **Abstention rate** — with a breakdown by reason.
 - **Expected calibration error / Brier score** — whether the confidence attached
-  to a suggestion means anything. This is the check a raw top-k similarity score
+  to a suggestion means anything. ECE bins suggestions by confidence and compares
+  each bin's hit rate against the **mean stated confidence in that bin**, not the
+  bin's midpoint; the midpoint form collapses every value in a bin to one number
+  and caps the reported error at half a bin width however wrong the confidence
+  was. This is the check a raw top-k similarity score
   cannot pass on its own.
 - **Latency** — p50/p95 per validation.
 - **Storage cost** — mean serialized bytes per stored record.
@@ -314,7 +327,7 @@ weighted path recall        0.69
 suggestion precision        1.00
   ... weighted              1.00
 false positives per answer  0.00
-expected calibration error  0.050
+expected calibration error  0.010
 brier score                 0.000
 latency p50 (ms)            0.05
 latency p95 (ms)            0.12
@@ -324,7 +337,7 @@ llm tokens                  0
 
 calibration: platt(slope=2.20, intercept=0.35, l2=0.01)
              fitted on 80 leave-one-out samples, 44 positive
-  calibration error before: 0.350   after: 0.050
+  calibration error before: 0.354   after: 0.010
   brier before:             0.136   after: 0.000
 ```
 
@@ -334,7 +347,7 @@ Read honestly, on five held-out cases:
   Getting there took two fixes, both of which came out of the benchmark rather
   than out of review: the support-ratio filter, and refusing to name objects the
   investigation has never seen.
-- **Confidence now means something.** Calibration error fell from 0.350 to 0.050
+- **Confidence now means something.** Calibration error fell from 0.354 to 0.010
   out-of-sample.
 - **It is free.** Tens of microseconds, no tokens, ~1.4 KB per stored incident.
 - **It misses a third of what was skipped.** Coverage is 0.69 against 1.00

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -61,10 +61,34 @@ recall against precision differently.
 `tests/core/investigation_path/test_normalize.py` asserts each of these
 directly, including that a raw error string never survives into the record.
 
+### Suggestions that do not transfer
+
+Two incidents can share symptoms *and* a root cause while depending on entirely
+different services. The held-out `HOLD-005` is exactly that: a crash loop on
+refused connections, root cause `dependency_unreachable`, but the dependency is
+a message broker rather than Redis. Every matching incident in the pool names
+Redis, so the first version of the validator produced four confident
+suggestions telling the responder to go and check a service that does not exist
+in that cluster, and found none of the three checks actually skipped.
+
+The validator therefore drops any suggestion naming an object the current
+investigation has never seen. Two carve-outs:
+
+- Checks against the subject (`<subject>`) always transfer.
+- Metric and trace names normally transfer, since
+  `container_memory_working_set_bytes` means the same thing everywhere — unless
+  the name is built out of a foreign object's name. `redis_connected_clients` is
+  nominally a metric but only exists where Redis does, so it is dropped too.
+  Matching is on whole tokens, so a pod named `mem` cannot veto
+  `node_memory_MemAvailable_bytes`.
+
+This is a mitigation, not a solution. It stops the wrong advice; it does not
+produce the right advice. `HOLD-005` now yields nothing at all.
+
 ## 2. Corpus
 
-`tests/fixtures/investigation_path/corpus/` holds twelve resolved incidents, one
-YAML file each — eight in the retrieval pool, four held out.
+`tests/fixtures/investigation_path/corpus/` holds seventeen resolved incidents,
+one YAML file each — twelve in the retrieval pool, five held out.
 
 Every record carries a `root_cause` label from a controlled vocabulary, a
 `reference_path` (what *should* have been checked, decided once the cause was
@@ -76,9 +100,13 @@ Records are human-reviewed by construction. Harvesting paths from production
 automatically would teach the validator whatever mistake each original
 investigation made, which is the exact failure this design is trying to avoid.
 
-**Twelve incidents is not evidence.** The corpus exists to make the schema
+**Seventeen incidents is not evidence.** The corpus exists to make the schema
 concrete and the metrics runnable. It is far too small to justify shipping
 anything.
+
+Each root cause has at least three pool members, which is a requirement of the
+calibration fit rather than a nicety: leave-one-out removes one incident and
+retrieval needs two remaining to answer at all.
 
 ### Similar symptoms vs. same root cause
 
@@ -100,7 +128,54 @@ hold, and records which one:
 | `insufficient_support` | fewer than `min_matches` incidents share the cause |
 | `root_cause_disagreement` | candidates point at different causes |
 
-## 3. Metrics
+Surviving retrieval is not enough for a check to be suggested. It must also be
+run by at least `min_support_ratio` (default 0.6) of the matched incidents. A
+check that only one incident out of three ran is that incident's particular
+circumstance, not a property of the root cause — this filter was the single
+largest source of false positives on the first benchmark run.
+
+## 3. Confidence calibration
+
+The raw evidence score is a product of four terms below 1 (symptom similarity,
+root-cause agreement, match support, per-check support). It orders suggestions
+sensibly but its magnitude is meaningless: on the first run it read about 0.32
+for suggestions that turned out correct every single time, an expected
+calibration error of 0.50. A number like that is worse than no number, because a
+responder reads "32%" and discounts a check that is almost certainly worth
+running.
+
+`calibration.py` fits a **Platt scaling** map — a two-parameter logistic — from
+raw score to probability. Two parameters rather than something more flexible
+because the corpus is tiny and anything with more freedom would memorise it.
+
+Training data comes from **leave-one-out over the retrieval pool only**. Each
+pool incident is held out in turn, one reference check is removed to simulate an
+investigation that skipped it, and the validator runs against the remaining
+pool. Whether each suggestion was the removed check gives the label. The
+held-out split is never touched during fitting, so the calibration error
+measured on it is out-of-sample. On the current corpus this yields 80 training
+samples, 44 of them positive.
+
+Three details that were not optional:
+
+- **Platt's target smoothing** (fit towards `(N+1)/(N+2)` and `1/(N+2)` rather
+  than hard 1 and 0), or a separable sample drives the slope towards infinity
+  and the model claims 0.999 confidence from a few dozen examples.
+- **Standardizing the input.** Raw scores occupy a narrow band, roughly 0.2 to
+  0.5. An L2 penalty applied at that scale swamps the data term: the first
+  attempt converged to a slope of 2.74 and predicted 0.65 for a bucket whose
+  observed hit rate was 1.00. Standardizing makes the penalty mean the same
+  thing regardless of how the raw score happens to be scaled, so changing the
+  score formula later cannot quietly under- or over-regularize the fit.
+- **Cross-validating the penalty strength** rather than hardcoding it. A
+  constant tuned until the numbers looked good would be fitting the benchmark.
+
+The fit refuses to run — and falls back to passing the raw score through — when
+there are fewer than two samples, only one class present, or no variation in the
+score. Each of those would restate the training prior while looking like a
+measurement.
+
+## 4. Metrics
 
 Defined in `holmes/core/investigation_path/metrics.py`. For a held-out incident
 with ground-truth missing set `M` (weighted) and suggestion set `S`:
@@ -133,56 +208,72 @@ poetry run python -m holmes.core.investigation_path.offline_eval
 ## Current baseline
 
 ```
-cases                       4
-answered                    2
-abstention rate             0.50
-weighted path recall        0.67
-  ... when answering        1.00
-suggestion precision        0.75
-  ... weighted              0.73
-false positives per answer  1.00
-expected calibration error  0.500
-brier score                 0.303
-latency p50 (ms)            0.03
-latency p95 (ms)            0.08
-bytes per incident          1450
+cases                       5
+answered                    4
+abstention rate             0.20
+weighted path recall        0.69
+  ... when answering        0.75
+suggestion precision        1.00
+  ... weighted              1.00
+false positives per answer  0.00
+expected calibration error  0.050
+brier score                 0.000
+latency p50 (ms)            0.05
+latency p95 (ms)            0.12
+bytes per incident          1451
 llm calls                   0
+
+calibration: platt(slope=2.20, intercept=0.35, l2=0.01)
+             fitted on 80 leave-one-out samples, 44 positive
+  calibration error before: 0.350   after: 0.050
+  brier before:             0.136   after: 0.000
 ```
 
-Read honestly, on four held-out cases:
+Read honestly, on five held-out cases:
 
-- When it answers, it finds everything that was skipped, and it is free —
-  microseconds, no tokens.
-- It is wrong once per answer. Both false positives are real: a check that
-  genuinely helped in one past incident but does not belong in the reference
-  path here. Support and confidence filtering did not remove them.
-- It stays quiet half the time, once because only one past incident shared the
-  root cause and once because nothing resembled the incident at all. Both are
-  the desired behaviour, and both cost recall — which is why coverage sits at
-  0.67 while accuracy-when-answering sits at 1.00.
-- **Confidence is badly calibrated.** ECE of 0.50 means the score is close to
-  meaningless: it multiplies three sub-1 terms, so it reads around 0.3 for
-  suggestions that turn out correct every time. It must not be shown to a user
-  as a percentage in this state.
+- **Nothing it says is wrong.** Precision 1.00, zero false positives per answer.
+  Getting there took two fixes, both of which came out of the benchmark rather
+  than out of review: the support-ratio filter, and refusing to name objects the
+  investigation has never seen.
+- **Confidence now means something.** Calibration error fell from 0.350 to 0.050
+  out-of-sample.
+- **It is free.** Tens of microseconds, no tokens, ~1.4 KB per stored incident.
+- **It misses a third of what was skipped.** Coverage is 0.69 against 1.00
+  accuracy-when-it-speaks, and that gap is the whole story: it stays silent
+  rather than guessing. `HOLD-004` abstains because nothing resembles it, and
+  `HOLD-005` produces nothing because every candidate check named a service that
+  is not in that cluster.
+- **`HOLD-005` is an unsolved case, not a solved one.** The validator avoids
+  saying something wrong, which is the right call, but a responder gets no help
+  at all on an incident where three checks really were skipped.
+
+Precision of 1.00 and a Brier score of 0.000 on nine suggestions across five
+cases should be read as "no detectable problem at this sample size", not as
+"solved". With this little data those numbers have very wide error bars.
 
 ## What this does not answer
 
-- Whether any of it holds beyond twelve hand-written incidents.
+- Whether any of it holds beyond seventeen hand-written incidents. Precision
+  should be expected to fall once near-miss root causes enter the corpus.
 - Whether symptom keyword overlap is the right retrieval signal at all. It was
-  chosen because it is transparent and free, not because it was compared
-  against alternatives.
+  chosen because it is transparent and free, not because it beat an alternative.
+- How to transfer a dependency-specific check to an incident with a *different*
+  dependency — the `HOLD-005` gap. A `<dependency>` role token alongside
+  `<subject>` is the obvious idea, but it needs a way to work out what the
+  current incident's dependency is, which nothing here does.
 - How incidents would be collected and reviewed at any real scale.
 - Whether a responder mid-incident finds the suggestions useful or noisy. No
-  metric here measures that.
+  metric here measures that, and no offline metric can.
 
 ## Suggested next steps
 
-1. **Calibrate confidence**, then re-measure ECE. Until then no confidence
-   number should reach a user.
-2. **Grow the corpus** across more causes and more clusters, and re-run. Expect
-   precision to drop once near-miss causes appear.
+1. **Grow the corpus** across more causes and more clusters, and re-run. This is
+   the highest-value next step by a wide margin; every number above is limited
+   by sample size before it is limited by method.
+2. **Close the `HOLD-005` gap** with a dependency role token, so a check learned
+   against Redis can be suggested against a broker.
 3. **Sweep the policy knobs** (`min_symptom_similarity`, `min_matches`,
-   `min_root_cause_agreement`, `min_support`) and publish the risk-coverage
-   curve rather than a single operating point.
+   `min_root_cause_agreement`, `min_support_ratio`) and publish the
+   risk-coverage curve rather than a single operating point.
 4. **Only then** consider a runtime surface, off by default, showing provenance
    and rationale, and worded as advice rather than a checklist.

--- a/docs/design/2026-08-24_investigation-path-completeness.md
+++ b/docs/design/2026-08-24_investigation-path-completeness.md
@@ -14,7 +14,7 @@ question is not "does it work" but "how would we know".
 
 Three artifacts answer that: a **path schema**, a **corpus**, and a **metrics
 definition** with a runnable offline eval. The eval reports through the existing
-eval/Braintrust pipeline (section 5), so the policy builds a tracked history
+eval/Braintrust pipeline (section 6), so the policy builds a tracked history
 before anything user-facing depends on it.
 
 ## 1. Canonical path event
@@ -190,6 +190,12 @@ there are fewer than two samples, only one class present, or no variation in the
 score. Each of those would restate the training prior while looking like a
 measurement.
 
+Because that fallback is silent, every `Suggestion` carries a `calibrated` flag,
+and the rendered block states a percentage **only** when it is set. An
+uncalibrated score is still returned, because it ranks correctly — it is just
+never shown to a human as a probability, which is the failure mode the 0.32
+example above describes.
+
 ## 4. Metrics
 
 Defined in `holmes/core/investigation_path/metrics.py`. For a held-out incident
@@ -211,8 +217,11 @@ with ground-truth missing set `M` (weighted) and suggestion set `S`:
   cannot pass on its own.
 - **Latency** — p50/p95 per validation.
 - **Storage cost** — mean serialized bytes per stored record.
-- **LLM calls** — expected to be 0, tracked so a future model call shows up as a
-  cost regression rather than silently.
+- **Token cost and LLM calls** — both expected to be 0, and both measured rather
+  than one inferred from the other. A change routing this path through a model
+  moves them together; a change that reuses tokens the investigation already
+  spent moves only the token count, and that is the cost that would otherwise be
+  invisible.
 
 ### Running it
 
@@ -220,7 +229,42 @@ with ground-truth missing set `M` (weighted) and suggestion set `S`:
 poetry run python -m holmes.core.investigation_path.offline_eval
 ```
 
-## 5. Where the benchmark lives
+## 5. What a suggestion looks like
+
+`ValidationReport.to_markdown()` defines the output shape. It is written and
+tested but **not wired to any user-facing surface**, so it is a proposal, not a
+behaviour. A rendered block:
+
+```markdown
+## Investigation path check
+
+Resolved incidents with the same root cause (`dependency_unreachable`) also ran
+the checks below. These are suggestions from past evidence, not required steps -
+skip any that do not apply here.
+
+- **topology endpoints/redis** — Empty endpoints is the direct evidence that
+  traffic cannot reach the dependency, and is the check that separates this
+  cause from a slow dependency.
+  Seen in 3/3 similar resolved incidents: INC-001 (2026-01-14),
+  INC-009 (2026-05-18), INC-002 (2026-02-03). Confidence 97%
+```
+
+Four properties are deliberate:
+
+- **Provenance.** Every suggestion names the incidents it came from and when
+  they happened, so a responder can go and read them instead of trusting the
+  tool.
+- **Rationale.** The human-written reason the check mattered in those incidents,
+  carried through from the corpus rather than generated.
+- **Support, shown as a fraction.** `3/3` is a different claim from `1/3`, and
+  collapsing both into one confidence number hides that.
+- **Advisory wording, and a cap.** "not required steps — skip any that do not
+  apply here", with at most five suggestions. A checklist would push every
+  investigation towards whatever was investigated first, which is the
+  confirmation-bias risk in the original issue; an unbounded list is skipped
+  entirely, which is the same outcome as saying nothing.
+
+## 6. Where the benchmark lives
 
 The review asked for this to be established in the existing eval/Braintrust
 pipeline rather than coupled to the product, so it is wired in at two points and
@@ -276,6 +320,7 @@ latency p50 (ms)            0.05
 latency p95 (ms)            0.12
 bytes per incident          1451
 llm calls                   0
+llm tokens                  0
 
 calibration: platt(slope=2.20, intercept=0.35, l2=0.01)
              fitted on 80 leave-one-out samples, 44 positive

--- a/holmes/core/investigation_path/__init__.py
+++ b/holmes/core/investigation_path/__init__.py
@@ -15,6 +15,7 @@ The pieces are:
 - `metrics`     - how a retrieval policy is scored offline
 - `corpus`      - load the fixture corpus from disk
 - `offline_eval`- run a policy over the held-out set and score it
+- `reporting`   - publish a run through the existing eval/Braintrust pipeline
 
 `offline_eval` is deliberately not re-exported here: it is run as a script
 (`python -m holmes.core.investigation_path.offline_eval`), and importing it from
@@ -36,6 +37,11 @@ from holmes.core.investigation_path.normalize import (
     normalize_resource_kind,
     normalize_resource_name,
     path_from_tool_calls,
+)
+from holmes.core.investigation_path.reporting import (
+    benchmark_experiment_name,
+    benchmark_markdown,
+    log_benchmark_to_braintrust,
 )
 from holmes.core.investigation_path.retrieval import (
     RetrievalPolicy,
@@ -89,9 +95,12 @@ __all__ = [
     "SuggestionPolicy",
     "TimeWindow",
     "ValidationReport",
+    "benchmark_experiment_name",
+    "benchmark_markdown",
     "fit_calibration",
     "fit_platt",
     "load_corpus",
+    "log_benchmark_to_braintrust",
     "normalize_resource_kind",
     "normalize_resource_name",
     "path_from_tool_calls",

--- a/holmes/core/investigation_path/__init__.py
+++ b/holmes/core/investigation_path/__init__.py
@@ -1,0 +1,85 @@
+"""Canonical investigation paths and offline path-completeness validation.
+
+Groundwork for https://github.com/HolmesGPT/holmesgpt/issues/2046. Nothing in
+this package is wired into the investigation loop: it exists so the retrieval
+policy can be measured offline, against a human-validated corpus, before any
+product behavior changes.
+
+The pieces are:
+
+- `schema`     - the redacted canonical path event and the corpus record format
+- `normalize`  - executed tool calls -> canonical path events (with redaction)
+- `retrieval`  - find similar resolved incidents, or abstain
+- `validator`  - turn retrieved incidents into missing-check suggestions
+- `metrics`    - how a retrieval policy is scored offline
+- `corpus`     - load the fixture corpus from disk
+"""
+
+from holmes.core.investigation_path.corpus import load_corpus
+from holmes.core.investigation_path.metrics import (
+    CaseOutcome,
+    EvalMetrics,
+    score_cases,
+)
+from holmes.core.investigation_path.normalize import (
+    normalize_resource_kind,
+    normalize_resource_name,
+    path_from_tool_calls,
+)
+from holmes.core.investigation_path.retrieval import (
+    RetrievalPolicy,
+    RetrievalResult,
+    ScoredIncident,
+    retrieve,
+)
+from holmes.core.investigation_path.schema import (
+    SUBJECT_TOKEN,
+    EntityRef,
+    IncidentRecord,
+    InvestigationPath,
+    Outcome,
+    OutcomeStatus,
+    PathEvent,
+    QueryIntent,
+    ReferenceStep,
+    RootCause,
+    SignatureLevel,
+    TimeWindow,
+    signature_of,
+)
+from holmes.core.investigation_path.validator import (
+    Provenance,
+    Suggestion,
+    ValidationReport,
+    validate_path,
+)
+
+__all__ = [
+    "SUBJECT_TOKEN",
+    "CaseOutcome",
+    "EntityRef",
+    "EvalMetrics",
+    "IncidentRecord",
+    "InvestigationPath",
+    "Outcome",
+    "OutcomeStatus",
+    "PathEvent",
+    "Provenance",
+    "QueryIntent",
+    "ReferenceStep",
+    "RetrievalPolicy",
+    "RetrievalResult",
+    "RootCause",
+    "ScoredIncident",
+    "SignatureLevel",
+    "Suggestion",
+    "TimeWindow",
+    "ValidationReport",
+    "load_corpus",
+    "normalize_resource_kind",
+    "normalize_resource_name",
+    "path_from_tool_calls",
+    "score_cases",
+    "signature_of",
+    "validate_path",
+]

--- a/holmes/core/investigation_path/__init__.py
+++ b/holmes/core/investigation_path/__init__.py
@@ -7,14 +7,25 @@ product behavior changes.
 
 The pieces are:
 
-- `schema`     - the redacted canonical path event and the corpus record format
-- `normalize`  - executed tool calls -> canonical path events (with redaction)
-- `retrieval`  - find similar resolved incidents, or abstain
-- `validator`  - turn retrieved incidents into missing-check suggestions
-- `metrics`    - how a retrieval policy is scored offline
-- `corpus`     - load the fixture corpus from disk
+- `schema`      - the redacted canonical path event and the corpus record format
+- `normalize`   - executed tool calls -> canonical path events (with redaction)
+- `retrieval`   - find similar resolved incidents, or abstain
+- `validator`   - turn retrieved incidents into missing-check suggestions
+- `calibration` - make the reported confidence mean what it says
+- `metrics`     - how a retrieval policy is scored offline
+- `corpus`      - load the fixture corpus from disk
+- `offline_eval`- run a policy over the held-out set and score it
+
+`offline_eval` is deliberately not re-exported here: it is run as a script
+(`python -m holmes.core.investigation_path.offline_eval`), and importing it from
+the package `__init__` makes the module load twice under `-m`.
 """
 
+from holmes.core.investigation_path.calibration import (
+    CalibrationModel,
+    fit_calibration,
+    fit_platt,
+)
 from holmes.core.investigation_path.corpus import load_corpus
 from holmes.core.investigation_path.metrics import (
     CaseOutcome,
@@ -50,12 +61,14 @@ from holmes.core.investigation_path.schema import (
 from holmes.core.investigation_path.validator import (
     Provenance,
     Suggestion,
+    SuggestionPolicy,
     ValidationReport,
     validate_path,
 )
 
 __all__ = [
     "SUBJECT_TOKEN",
+    "CalibrationModel",
     "CaseOutcome",
     "EntityRef",
     "EvalMetrics",
@@ -73,8 +86,11 @@ __all__ = [
     "ScoredIncident",
     "SignatureLevel",
     "Suggestion",
+    "SuggestionPolicy",
     "TimeWindow",
     "ValidationReport",
+    "fit_calibration",
+    "fit_platt",
     "load_corpus",
     "normalize_resource_kind",
     "normalize_resource_name",

--- a/holmes/core/investigation_path/__init__.py
+++ b/holmes/core/investigation_path/__init__.py
@@ -11,7 +11,8 @@ The pieces are:
 - `normalize`   - executed tool calls -> canonical path events (with redaction)
 - `retrieval`   - find similar resolved incidents, or abstain
 - `validator`   - turn retrieved incidents into missing-check suggestions
-- `calibration` - make the reported confidence mean what it says
+- `calibration_model` - the fitted map from raw score to probability
+- `calibration` - how that map is fitted, by leave-one-out over the pool
 - `metrics`     - how a retrieval policy is scored offline
 - `corpus`      - load the fixture corpus from disk
 - `offline_eval`- run a policy over the held-out set and score it
@@ -22,11 +23,8 @@ The pieces are:
 the package `__init__` makes the module load twice under `-m`.
 """
 
-from holmes.core.investigation_path.calibration import (
-    CalibrationModel,
-    fit_calibration,
-    fit_platt,
-)
+from holmes.core.investigation_path.calibration import fit_calibration, fit_platt
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.corpus import load_corpus
 from holmes.core.investigation_path.metrics import (
     CaseOutcome,

--- a/holmes/core/investigation_path/calibration.py
+++ b/holmes/core/investigation_path/calibration.py
@@ -194,7 +194,18 @@ def fit_platt(
     fewer than two samples, only one class present, or no variation in the raw
     score. Claiming calibration on any of those would just restate the training
     prior while looking like a measurement.
+
+    Raises `ValueError` on a score/label length mismatch. That is a caller bug
+    rather than a property of the data, so it is not folded into the unfitted
+    cases above - returning a model would hide it.
     """
+    if len(raw_scores) != len(labels):
+        raise ValueError(
+            f"Got {len(raw_scores)} raw scores and {len(labels)} labels. "
+            "These are zipped during the fit, so a mismatch either drops samples "
+            "silently or indexes out of range in cross-validation."
+        )
+
     n = len(raw_scores)
     positives = sum(1 for label in labels if label)
     if n < 2 or positives == 0 or positives == n:

--- a/holmes/core/investigation_path/calibration.py
+++ b/holmes/core/investigation_path/calibration.py
@@ -1,0 +1,299 @@
+"""Turn the raw evidence score into something that means what it says.
+
+The raw score is a product of four terms below 1 (symptom similarity, root-cause
+agreement, match support, and per-check support). Multiplying them orders
+suggestions sensibly but drags the magnitude far below the real hit rate: on the
+first benchmark run it read about 0.32 for suggestions that turned out correct
+every single time, an expected calibration error of 0.50. A number like that is
+worse than no number, because a responder reads "32%" and discounts a check that
+is almost certainly worth running.
+
+This module fits a one-dimensional monotone map from raw score to probability,
+using **Platt scaling** - a two-parameter logistic fit. Two parameters rather
+than something more flexible (isotonic regression, say) because the corpus is
+tiny and anything with more freedom would memorise it.
+
+Training data comes from **leave-one-out over the retrieval pool only**. Each
+pool incident is held out in turn, one of its reference checks is removed to
+simulate an investigation that skipped it, and the validator runs against the
+remaining pool. Whether each resulting suggestion was the removed check gives
+the label. The held-out split is never touched during fitting, so the
+calibration error measured on it is an honest out-of-sample number.
+
+Three details that matter with this little data:
+
+- **Platt's target smoothing.** Labels are fitted towards `(N+1)/(N+2)` and
+  `1/(N+2)` instead of hard 1 and 0. Without it, a perfectly separable sample
+  pushes the fit towards infinite slope and the model claims 0.999 confidence
+  on the strength of a few dozen examples.
+- **The input is standardized first.** Raw scores occupy a narrow band (roughly
+  0.2 to 0.5), and an L2 penalty applied to an un-standardized input of that
+  scale overwhelms the data term: the first attempt here converged to a slope of
+  2.74 and predicted 0.65 for a bucket whose observed hit rate was 1.00.
+  Standardizing makes the penalty mean the same thing regardless of how the raw
+  score happens to be scaled, so changing the score formula later cannot quietly
+  under- or over-regularize the fit.
+- **The penalty strength is cross-validated, not chosen by hand.** A hand-picked
+  constant tuned until the numbers looked good would be fitting the benchmark.
+
+The fit is plain gradient descent rather than Newton/IRLS: two parameters over a
+few hundred samples converges in milliseconds, and it keeps the module free of a
+numerical dependency.
+"""
+
+import math
+import random
+from typing import List, Optional, Sequence, Tuple
+
+from pydantic import BaseModel, Field
+
+# Penalty strengths tried during cross-validation, on standardized inputs.
+L2_GRID = (0.01, 0.03, 0.1, 0.3, 1.0, 3.0)
+CV_FOLDS = 5
+DEFAULT_ITERATIONS = 3000
+DEFAULT_LEARNING_RATE = 0.5
+# Keeps log-loss finite when a fold predicts an outcome with near-certainty.
+_LOG_LOSS_EPSILON = 1e-12
+
+
+class CalibrationModel(BaseModel):
+    """A fitted logistic map from raw evidence score to probability."""
+
+    slope: float = 1.0
+    intercept: float = 0.0
+    mean: float = Field(default=0.0, description="Training mean, used to standardize the input.")
+    std: float = Field(default=1.0, description="Training standard deviation of the input.")
+    l2: float = Field(default=0.0, description="Penalty strength chosen by cross-validation.")
+    samples: int = Field(default=0, description="Leave-one-out examples the fit was built from.")
+    positives: int = Field(default=0, description="How many of those were genuinely missing checks.")
+    fitted: bool = False
+
+    def apply(self, raw_confidence: float) -> float:
+        """Map a raw score to a probability. Identity until the model is fitted."""
+        if not self.fitted:
+            return raw_confidence
+        standardized = (raw_confidence - self.mean) / self.std
+        return _sigmoid(self.slope * standardized + self.intercept)
+
+    def describe(self) -> str:
+        if not self.fitted:
+            return "uncalibrated (raw evidence score passed through unchanged)"
+        return (
+            f"platt(slope={self.slope:.2f}, intercept={self.intercept:.2f}, l2={self.l2:g}) "
+            f"fitted on {self.samples} leave-one-out samples, {self.positives} positive"
+        )
+
+
+def _sigmoid(x: float) -> float:
+    if x >= 0:
+        return 1.0 / (1.0 + math.exp(-x))
+    # Rearranged for negative inputs so exp() cannot overflow.
+    exp_x = math.exp(x)
+    return exp_x / (1.0 + exp_x)
+
+
+def _descend(
+    standardized: Sequence[float],
+    targets: Sequence[float],
+    l2: float,
+    iterations: int,
+    learning_rate: float,
+) -> Tuple[float, float]:
+    """Gradient descent for a two-parameter logistic fit. The intercept is unpenalized."""
+    slope, intercept = 0.0, 0.0
+    n = len(standardized)
+    for _ in range(iterations):
+        slope_gradient = 0.0
+        intercept_gradient = 0.0
+        for value, target in zip(standardized, targets):
+            error = _sigmoid(slope * value + intercept) - target
+            slope_gradient += error * value
+            intercept_gradient += error
+        slope -= learning_rate * (slope_gradient / n + l2 * slope)
+        intercept -= learning_rate * (intercept_gradient / n)
+    return slope, intercept
+
+
+def _smoothed_targets(labels: Sequence[bool]) -> List[float]:
+    """Platt's target smoothing: fit towards (N+1)/(N+2) and 1/(N+2), not 1 and 0."""
+    positives = sum(1 for label in labels if label)
+    negatives = len(labels) - positives
+    positive_target = (positives + 1.0) / (positives + 2.0)
+    negative_target = 1.0 / (negatives + 2.0)
+    return [positive_target if label else negative_target for label in labels]
+
+
+def _log_loss(predictions: Sequence[float], labels: Sequence[bool]) -> float:
+    total = 0.0
+    for prediction, label in zip(predictions, labels):
+        clamped = min(1.0 - _LOG_LOSS_EPSILON, max(_LOG_LOSS_EPSILON, prediction))
+        total -= math.log(clamped) if label else math.log(1.0 - clamped)
+    return total / len(predictions)
+
+
+def _select_l2(
+    standardized: Sequence[float],
+    labels: Sequence[bool],
+    iterations: int,
+    learning_rate: float,
+    folds: int = CV_FOLDS,
+) -> float:
+    """Pick the penalty strength by k-fold cross-validated log loss.
+
+    Log loss is scored against the true labels, not the smoothed targets: the
+    question is which penalty predicts unseen outcomes best, not which one best
+    reproduces the smoothing.
+    """
+    n = len(standardized)
+    folds = min(folds, n)
+    if folds < 2:
+        return L2_GRID[len(L2_GRID) // 2]
+
+    # Fixed seed: the same corpus must always produce the same model.
+    order = list(range(n))
+    random.Random(0).shuffle(order)
+    assignment = {index: position % folds for position, index in enumerate(order)}
+
+    best_l2, best_loss = L2_GRID[0], float("inf")
+    for l2 in L2_GRID:
+        losses = []
+        for fold in range(folds):
+            train = [i for i in range(n) if assignment[i] != fold]
+            test = [i for i in range(n) if assignment[i] == fold]
+            train_labels = [labels[i] for i in train]
+            if not test or len(set(train_labels)) < 2:
+                continue
+            slope, intercept = _descend(
+                [standardized[i] for i in train],
+                _smoothed_targets(train_labels),
+                l2,
+                iterations,
+                learning_rate,
+            )
+            predictions = [_sigmoid(slope * standardized[i] + intercept) for i in test]
+            losses.append(_log_loss(predictions, [labels[i] for i in test]))
+        if losses:
+            mean_loss = sum(losses) / len(losses)
+            if mean_loss < best_loss:
+                best_loss, best_l2 = mean_loss, l2
+    return best_l2
+
+
+def fit_platt(
+    raw_scores: Sequence[float],
+    labels: Sequence[bool],
+    l2: Optional[float] = None,
+    iterations: int = DEFAULT_ITERATIONS,
+    learning_rate: float = DEFAULT_LEARNING_RATE,
+) -> CalibrationModel:
+    """Fit `p = sigmoid(slope * z(raw) + intercept)` on standardized inputs.
+
+    `l2` is chosen by cross-validation unless one is passed explicitly.
+
+    Returns an unfitted (identity) model when there is not enough signal to fit:
+    fewer than two samples, only one class present, or no variation in the raw
+    score. Claiming calibration on any of those would just restate the training
+    prior while looking like a measurement.
+    """
+    n = len(raw_scores)
+    positives = sum(1 for label in labels if label)
+    if n < 2 or positives == 0 or positives == n:
+        return CalibrationModel(samples=n, positives=positives, fitted=False)
+
+    mean = sum(raw_scores) / n
+    variance = sum((raw - mean) ** 2 for raw in raw_scores) / n
+    std = math.sqrt(variance)
+    if std == 0:
+        return CalibrationModel(samples=n, positives=positives, fitted=False)
+
+    standardized = [(raw - mean) / std for raw in raw_scores]
+    chosen_l2 = l2 if l2 is not None else _select_l2(standardized, labels, iterations, learning_rate)
+    slope, intercept = _descend(
+        standardized, _smoothed_targets(labels), chosen_l2, iterations, learning_rate
+    )
+
+    return CalibrationModel(
+        slope=slope,
+        intercept=intercept,
+        mean=mean,
+        std=std,
+        l2=chosen_l2,
+        samples=n,
+        positives=positives,
+        fitted=True,
+    )
+
+
+def build_calibration_samples(
+    pool: Sequence["IncidentRecord"],  # noqa: F821 - imported lazily below
+    retrieval_policy: Optional["RetrievalPolicy"] = None,  # noqa: F821
+    signature_level: Optional["SignatureLevel"] = None,  # noqa: F821
+) -> List[Tuple[float, bool]]:
+    """Generate (raw score, was-correct) pairs by leave-one-out over the pool.
+
+    For every pool incident and every check in its reference path, drop that one
+    check, run retrieval against the *rest* of the pool, and label each
+    suggestion by whether it is the dropped check.
+
+    Suggestions are collected with the support filters switched off on purpose.
+    The filters exist to remove weakly supported checks, but the calibration map
+    is precisely what should learn how much a weakly supported check is worth -
+    so it needs to see the low-scoring, usually-wrong examples too.
+    """
+    from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
+    from holmes.core.investigation_path.schema import SignatureLevel
+    from holmes.core.investigation_path.validator import SuggestionPolicy, validate_path
+
+    retrieval_policy = retrieval_policy or RetrievalPolicy()
+    level = signature_level or retrieval_policy.signature_level
+    unfiltered = SuggestionPolicy(
+        min_support=1,
+        min_support_ratio=0.0,
+        min_confidence=0.0,
+        max_suggestions=1000,
+        signature_level=level,
+    )
+
+    samples: List[Tuple[float, bool]] = []
+    for index, incident in enumerate(pool):
+        others = [other for position, other in enumerate(pool) if position != index]
+        reference_signatures = {step.signature(level) for step in incident.reference_path}
+
+        for step in incident.reference_path:
+            dropped = step.signature(level)
+            observed = sorted(reference_signatures - {dropped})
+            # Same entity-transfer rule as inference, or the calibration map
+            # would be fitted on a suggestion distribution that never occurs.
+            known_entities = {
+                other.entity.name
+                for other in incident.reference_path
+                if other.entity.name and other is not step
+            }
+
+            retrieval = retrieve(incident.symptoms, others, retrieval_policy)
+            if retrieval.abstained:
+                continue
+            report = validate_path(
+                observed,
+                retrieval,
+                unfiltered,
+                subject=incident.subject,
+                known_entities=known_entities,
+            )
+            for suggestion in report.suggestions:
+                samples.append((suggestion.raw_confidence, suggestion.signature == dropped))
+    return samples
+
+
+def fit_calibration(
+    pool: Sequence["IncidentRecord"],  # noqa: F821
+    retrieval_policy: Optional["RetrievalPolicy"] = None,  # noqa: F821
+    signature_level: Optional["SignatureLevel"] = None,  # noqa: F821
+) -> CalibrationModel:
+    """Fit a calibration model from the retrieval pool alone."""
+    samples = build_calibration_samples(pool, retrieval_policy, signature_level)
+    if not samples:
+        return CalibrationModel(fitted=False)
+    raw_scores = [raw for raw, _ in samples]
+    labels = [label for _, label in samples]
+    return fit_platt(raw_scores, labels)

--- a/holmes/core/investigation_path/calibration.py
+++ b/holmes/core/investigation_path/calibration.py
@@ -2,9 +2,9 @@
 
 The raw score is a product of four terms below 1 (symptom similarity, root-cause
 agreement, match support, and per-check support). Multiplying them orders
-suggestions sensibly but drags the magnitude far below the real hit rate: on the
-first benchmark run it read about 0.32 for suggestions that turned out correct
-every single time, an expected calibration error of 0.50. A number like that is
+suggestions sensibly but drags the magnitude far below the real hit rate: it
+reads about 0.32 for suggestions that turn out correct every single time, an
+expected calibration error of 0.354 on the current corpus. A number like that is
 worse than no number, because a responder reads "32%" and discounts a check that
 is almost certainly worth running.
 
@@ -45,7 +45,10 @@ import math
 import random
 from typing import List, Optional, Sequence, Tuple
 
-from pydantic import BaseModel, Field
+from holmes.core.investigation_path.calibration_model import CalibrationModel, sigmoid
+from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
+from holmes.core.investigation_path.schema import IncidentRecord, SignatureLevel
+from holmes.core.investigation_path.validator import SuggestionPolicy, validate_path
 
 # Penalty strengths tried during cross-validation, on standardized inputs.
 L2_GRID = (0.01, 0.03, 0.1, 0.3, 1.0, 3.0)
@@ -54,42 +57,6 @@ DEFAULT_ITERATIONS = 3000
 DEFAULT_LEARNING_RATE = 0.5
 # Keeps log-loss finite when a fold predicts an outcome with near-certainty.
 _LOG_LOSS_EPSILON = 1e-12
-
-
-class CalibrationModel(BaseModel):
-    """A fitted logistic map from raw evidence score to probability."""
-
-    slope: float = 1.0
-    intercept: float = 0.0
-    mean: float = Field(default=0.0, description="Training mean, used to standardize the input.")
-    std: float = Field(default=1.0, description="Training standard deviation of the input.")
-    l2: float = Field(default=0.0, description="Penalty strength chosen by cross-validation.")
-    samples: int = Field(default=0, description="Leave-one-out examples the fit was built from.")
-    positives: int = Field(default=0, description="How many of those were genuinely missing checks.")
-    fitted: bool = False
-
-    def apply(self, raw_confidence: float) -> float:
-        """Map a raw score to a probability. Identity until the model is fitted."""
-        if not self.fitted:
-            return raw_confidence
-        standardized = (raw_confidence - self.mean) / self.std
-        return _sigmoid(self.slope * standardized + self.intercept)
-
-    def describe(self) -> str:
-        if not self.fitted:
-            return "uncalibrated (raw evidence score passed through unchanged)"
-        return (
-            f"platt(slope={self.slope:.2f}, intercept={self.intercept:.2f}, l2={self.l2:g}) "
-            f"fitted on {self.samples} leave-one-out samples, {self.positives} positive"
-        )
-
-
-def _sigmoid(x: float) -> float:
-    if x >= 0:
-        return 1.0 / (1.0 + math.exp(-x))
-    # Rearranged for negative inputs so exp() cannot overflow.
-    exp_x = math.exp(x)
-    return exp_x / (1.0 + exp_x)
 
 
 def _descend(
@@ -106,7 +73,7 @@ def _descend(
         slope_gradient = 0.0
         intercept_gradient = 0.0
         for value, target in zip(standardized, targets):
-            error = _sigmoid(slope * value + intercept) - target
+            error = sigmoid(slope * value + intercept) - target
             slope_gradient += error * value
             intercept_gradient += error
         slope -= learning_rate * (slope_gradient / n + l2 * slope)
@@ -170,7 +137,7 @@ def _select_l2(
                 iterations,
                 learning_rate,
             )
-            predictions = [_sigmoid(slope * standardized[i] + intercept) for i in test]
+            predictions = [sigmoid(slope * standardized[i] + intercept) for i in test]
             losses.append(_log_loss(predictions, [labels[i] for i in test]))
         if losses:
             mean_loss = sum(losses) / len(losses)
@@ -236,9 +203,9 @@ def fit_platt(
 
 
 def build_calibration_samples(
-    pool: Sequence["IncidentRecord"],  # noqa: F821 - imported lazily below
-    retrieval_policy: Optional["RetrievalPolicy"] = None,  # noqa: F821
-    signature_level: Optional["SignatureLevel"] = None,  # noqa: F821
+    pool: Sequence[IncidentRecord],
+    retrieval_policy: Optional[RetrievalPolicy] = None,
+    signature_level: Optional[SignatureLevel] = None,
 ) -> List[Tuple[float, bool]]:
     """Generate (raw score, was-correct) pairs by leave-one-out over the pool.
 
@@ -251,10 +218,6 @@ def build_calibration_samples(
     is precisely what should learn how much a weakly supported check is worth -
     so it needs to see the low-scoring, usually-wrong examples too.
     """
-    from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
-    from holmes.core.investigation_path.schema import SignatureLevel
-    from holmes.core.investigation_path.validator import SuggestionPolicy, validate_path
-
     retrieval_policy = retrieval_policy or RetrievalPolicy()
     level = signature_level or retrieval_policy.signature_level
     unfiltered = SuggestionPolicy(
@@ -297,9 +260,9 @@ def build_calibration_samples(
 
 
 def fit_calibration(
-    pool: Sequence["IncidentRecord"],  # noqa: F821
-    retrieval_policy: Optional["RetrievalPolicy"] = None,  # noqa: F821
-    signature_level: Optional["SignatureLevel"] = None,  # noqa: F821
+    pool: Sequence[IncidentRecord],
+    retrieval_policy: Optional[RetrievalPolicy] = None,
+    signature_level: Optional[SignatureLevel] = None,
 ) -> CalibrationModel:
     """Fit a calibration model from the retrieval pool alone."""
     samples = build_calibration_samples(pool, retrieval_policy, signature_level)

--- a/holmes/core/investigation_path/calibration_model.py
+++ b/holmes/core/investigation_path/calibration_model.py
@@ -1,0 +1,52 @@
+"""The fitted calibration map, separated from the code that fits it.
+
+`validator.py` needs to *apply* a calibration model; `calibration.py` needs the
+`validator` to *fit* one, because its training data comes from running the
+validator under leave-one-out. Keeping both in one module made that a cycle,
+which only worked because the fitting side imported the validator inside a
+function - against this repo's rule that imports live at module scope.
+
+Splitting on "the map you apply" versus "how the map is fitted" removes the
+cycle rather than hiding it. This module imports nothing from the package, so
+anything may depend on it.
+"""
+
+import math
+
+from pydantic import BaseModel, Field
+
+
+def sigmoid(x: float) -> float:
+    if x >= 0:
+        return 1.0 / (1.0 + math.exp(-x))
+    # Rearranged for negative inputs so exp() cannot overflow.
+    exp_x = math.exp(x)
+    return exp_x / (1.0 + exp_x)
+
+
+class CalibrationModel(BaseModel):
+    """A fitted logistic map from raw evidence score to probability."""
+
+    slope: float = 1.0
+    intercept: float = 0.0
+    mean: float = Field(default=0.0, description="Training mean, used to standardize the input.")
+    std: float = Field(default=1.0, description="Training standard deviation of the input.")
+    l2: float = Field(default=0.0, description="Penalty strength chosen by cross-validation.")
+    samples: int = Field(default=0, description="Leave-one-out examples the fit was built from.")
+    positives: int = Field(default=0, description="How many of those were genuinely missing checks.")
+    fitted: bool = False
+
+    def apply(self, raw_confidence: float) -> float:
+        """Map a raw score to a probability. Identity until the model is fitted."""
+        if not self.fitted:
+            return raw_confidence
+        standardized = (raw_confidence - self.mean) / self.std
+        return sigmoid(self.slope * standardized + self.intercept)
+
+    def describe(self) -> str:
+        if not self.fitted:
+            return "uncalibrated (raw evidence score passed through unchanged)"
+        return (
+            f"platt(slope={self.slope:.2f}, intercept={self.intercept:.2f}, l2={self.l2:g}) "
+            f"fitted on {self.samples} leave-one-out samples, {self.positives} positive"
+        )

--- a/holmes/core/investigation_path/corpus.py
+++ b/holmes/core/investigation_path/corpus.py
@@ -1,0 +1,55 @@
+"""Load the human-validated incident corpus from disk.
+
+Corpus entries are YAML files, one incident each, so that adding an incident is
+a reviewable diff rather than a row in an opaque blob. Loading is strict: a file
+that does not parse raises instead of being skipped, because a silently dropped
+incident changes eval results without changing any number a reader would notice.
+"""
+
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import yaml
+
+from holmes.core.investigation_path.schema import IncidentRecord
+
+DEFAULT_CORPUS_DIR = (
+    Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "investigation_path" / "corpus"
+)
+
+
+def load_corpus(
+    directory: Optional[Path] = None,
+    split: Optional[str] = None,
+) -> List[IncidentRecord]:
+    """Read every incident YAML in `directory`, optionally filtered by split.
+
+    Records come back sorted by incident id so eval runs are reproducible.
+    """
+    directory = Path(directory) if directory else DEFAULT_CORPUS_DIR
+    if not directory.is_dir():
+        raise FileNotFoundError(f"Incident corpus directory not found: {directory}")
+
+    records: List[IncidentRecord] = []
+    for path in sorted(directory.glob("*.yaml")):
+        with path.open() as handle:
+            payload = yaml.safe_load(handle)
+        if payload is None:
+            raise ValueError(f"Empty incident file: {path}")
+        try:
+            records.append(IncidentRecord.model_validate(payload))
+        except ValueError as e:
+            raise ValueError(f"Invalid incident record in {path}: {e}") from e
+
+    if split is not None:
+        records = [record for record in records if record.split == split]
+    records.sort(key=lambda record: record.incident_id)
+    return records
+
+
+def corpus_bytes_per_incident(records: Sequence[IncidentRecord]) -> float:
+    """Mean serialized size of a stored record, for the storage-cost metric."""
+    if not records:
+        return 0.0
+    total = sum(len(record.model_dump_json().encode("utf-8")) for record in records)
+    return total / len(records)

--- a/holmes/core/investigation_path/metrics.py
+++ b/holmes/core/investigation_path/metrics.py
@@ -39,7 +39,7 @@ set `S`, or abstains.
 """
 
 import math
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -145,6 +145,16 @@ class EvalMetrics(BaseModel):
         return "\n".join(lines)
 
 
+def _require_same_length(confidences: Sequence[float], correct: Sequence[bool]) -> None:
+    """Both scorers zip their inputs, so a mismatch silently drops the tail."""
+    if len(confidences) != len(correct):
+        raise ValueError(
+            f"Got {len(confidences)} confidences and {len(correct)} outcomes. "
+            "These are zipped, so a mismatch would score only the shorter prefix "
+            "and report the result as if it covered everything."
+        )
+
+
 def _percentile(values: Sequence[float], fraction: float) -> float:
     """Nearest-rank percentile.
 
@@ -165,25 +175,37 @@ def expected_calibration_error(
     correct: Sequence[bool],
     bins: int = DEFAULT_CALIBRATION_BINS,
 ) -> float:
-    """Mean gap between stated confidence and observed correctness, weighted by bin size."""
+    """Mean gap between stated confidence and observed correctness, weighted by bin size.
+
+    Each bin is compared against the **mean confidence of the values in it**,
+    not the bin's midpoint. Using the midpoint discards the very quantity being
+    measured: every value in a bin collapses to the same stated confidence, so
+    the reported error is capped at half a bin width however wrong the
+    confidence actually was. Ten correct suggestions at 0.91 scored 0.05 that
+    way instead of 0.09, and ten wrong ones at 0.901 scored 0.95 instead of
+    0.901.
+    """
+    _require_same_length(confidences, correct)
     if not confidences:
         return 0.0
-    buckets: Dict[int, List[int]] = {}
+
+    buckets: Dict[int, List[Tuple[float, bool]]] = {}
     for confidence, is_correct in zip(confidences, correct):
         index = min(bins - 1, max(0, int(confidence * bins)))
-        buckets.setdefault(index, []).append(1 if is_correct else 0)
+        buckets.setdefault(index, []).append((confidence, is_correct))
 
     total = len(confidences)
     error = 0.0
-    for index, outcomes in buckets.items():
-        observed = sum(outcomes) / len(outcomes)
-        stated = (index + 0.5) / bins
+    for outcomes in buckets.values():
+        observed = sum(1 for _, is_correct in outcomes if is_correct) / len(outcomes)
+        stated = sum(confidence for confidence, _ in outcomes) / len(outcomes)
         error += (len(outcomes) / total) * abs(observed - stated)
     return error
 
 
 def brier_score(confidences: Sequence[float], correct: Sequence[bool]) -> float:
     """Mean squared error between stated confidence and the 0/1 outcome."""
+    _require_same_length(confidences, correct)
     if not confidences:
         return 0.0
     return sum(

--- a/holmes/core/investigation_path/metrics.py
+++ b/holmes/core/investigation_path/metrics.py
@@ -65,6 +65,26 @@ class CaseOutcome(BaseModel):
     def false_positives(self) -> List[str]:
         return [s for s in self.suggested if s not in self.missing_weights]
 
+    @property
+    def missing_weight(self) -> float:
+        """Total weight of the checks this investigation actually skipped."""
+        return sum(self.missing_weights.values())
+
+    @property
+    def recovered_weight(self) -> float:
+        """Weight of the skipped checks the policy surfaced."""
+        return sum(self.missing_weights[s] for s in self.true_positives)
+
+    @property
+    def weighted_recall(self) -> float:
+        """Share of this incident's missing weight that the policy found."""
+        return _safe_divide(self.recovered_weight, self.missing_weight)
+
+    @property
+    def precision(self) -> float:
+        """Share of this incident's suggestions that were genuinely missing."""
+        return _safe_divide(len(self.true_positives), len(self.suggested))
+
 
 class EvalMetrics(BaseModel):
     """Scores for one retrieval policy over one held-out set."""
@@ -184,8 +204,8 @@ def score_cases(cases: Sequence[CaseOutcome], bytes_per_incident: float = 0.0) -
     abstain_reasons: Dict[str, int] = {}
 
     for case in cases:
-        case_missing_weight = sum(case.missing_weights.values())
-        case_recovered = sum(case.missing_weights[s] for s in case.true_positives)
+        case_missing_weight = case.missing_weight
+        case_recovered = case.recovered_weight
 
         total_missing_weight += case_missing_weight
         recovered_weight += case_recovered

--- a/holmes/core/investigation_path/metrics.py
+++ b/holmes/core/investigation_path/metrics.py
@@ -1,0 +1,242 @@
+"""How a path-completeness retrieval policy is scored offline.
+
+Definitions, stated once so results from different runs are comparable.
+
+For a held-out incident, the human-validated record gives a `reference_path`
+(the checks that should have been run) and an `observed_path` (what the
+investigation actually did). The ground-truth missing set `M` is
+`reference_path - observed_path`, and each of its steps carries a weight in
+[0, 1] saying how much skipping it cost. The policy answers with a suggestion
+set `S`, or abstains.
+
+- **Weighted path recall** - share of `M`'s weight that appears in `S`, summed
+  over every held-out incident. Abstentions contribute 0, so this is the
+  coverage number: it goes down when the policy stays quiet.
+- **Weighted path recall when answering** - the same, restricted to incidents
+  where the policy answered. Reported alongside recall because the two move in
+  opposite directions as the abstention threshold changes, and neither is
+  meaningful alone.
+- **Suggestion precision** - share of all suggestions that were genuinely
+  missing. `weighted_suggestion_precision` credits a true positive by its
+  weight and charges a false positive a flat 1.0, so surfacing a trivial check
+  cannot pay for a wrong one.
+- **False-positive burden** - mean count of wrong suggestions per answered
+  incident. Precision alone hides this: 80% precision over 25 suggestions is a
+  far worse experience than 80% over 4.
+- **Abstention rate** - share of incidents where the policy declined. Read with
+  recall and precision; on its own it is neither good nor bad.
+- **Expected calibration error / Brier score** - whether the confidence
+  attached to a suggestion means anything. ECE bins suggestions by confidence
+  and compares each bin's stated confidence to the share that were actually
+  correct. This is the check that a raw similarity score cannot pass by itself.
+- **Latency** - p50/p95 wall clock per validation.
+- **Storage cost** - mean serialized bytes per stored incident record.
+- **LLM calls** - expected to be 0. Tracked so that a future change which
+  quietly adds a model call to this path shows up as a cost regression.
+"""
+
+import math
+from typing import Dict, List, Optional, Sequence
+
+from pydantic import BaseModel, Field
+
+DEFAULT_CALIBRATION_BINS = 10
+
+
+class CaseOutcome(BaseModel):
+    """Everything measured for one held-out incident."""
+
+    incident_id: str
+    abstained: bool
+    abstain_reason: Optional[str] = None
+    missing_weights: Dict[str, float] = Field(
+        default_factory=dict, description="Ground-truth missing signatures and their weights."
+    )
+    suggested: List[str] = Field(default_factory=list)
+    suggestion_confidence: Dict[str, float] = Field(default_factory=dict)
+    latency_ms: float = 0.0
+    llm_calls: int = 0
+
+    @property
+    def true_positives(self) -> List[str]:
+        return [s for s in self.suggested if s in self.missing_weights]
+
+    @property
+    def false_positives(self) -> List[str]:
+        return [s for s in self.suggested if s not in self.missing_weights]
+
+
+class EvalMetrics(BaseModel):
+    """Scores for one retrieval policy over one held-out set."""
+
+    cases: int
+    answered_cases: int
+    abstention_rate: float
+    abstain_reasons: Dict[str, int] = Field(default_factory=dict)
+
+    weighted_path_recall: float
+    weighted_path_recall_when_answering: float
+    suggestion_precision: float
+    weighted_suggestion_precision: float
+    false_positive_burden: float
+
+    expected_calibration_error: float
+    brier_score: float
+
+    latency_p50_ms: float
+    latency_p95_ms: float
+    bytes_per_incident: float
+    llm_calls: int
+
+    def render(self) -> str:
+        """Plain-text report, so an eval run can be diffed between policies."""
+        rows = [
+            ("cases", f"{self.cases}"),
+            ("answered", f"{self.answered_cases}"),
+            ("abstention rate", f"{self.abstention_rate:.2f}"),
+            ("weighted path recall", f"{self.weighted_path_recall:.2f}"),
+            ("  ... when answering", f"{self.weighted_path_recall_when_answering:.2f}"),
+            ("suggestion precision", f"{self.suggestion_precision:.2f}"),
+            ("  ... weighted", f"{self.weighted_suggestion_precision:.2f}"),
+            ("false positives per answer", f"{self.false_positive_burden:.2f}"),
+            ("expected calibration error", f"{self.expected_calibration_error:.3f}"),
+            ("brier score", f"{self.brier_score:.3f}"),
+            ("latency p50 (ms)", f"{self.latency_p50_ms:.2f}"),
+            ("latency p95 (ms)", f"{self.latency_p95_ms:.2f}"),
+            ("bytes per incident", f"{self.bytes_per_incident:.0f}"),
+            ("llm calls", f"{self.llm_calls}"),
+        ]
+        width = max(len(label) for label, _ in rows)
+        lines = [f"{label.ljust(width)}  {value}" for label, value in rows]
+        if self.abstain_reasons:
+            lines.append("")
+            lines.append("abstain reasons:")
+            for reason, count in sorted(self.abstain_reasons.items()):
+                lines.append(f"  {reason}: {count}")
+        return "\n".join(lines)
+
+
+def _percentile(values: Sequence[float], fraction: float) -> float:
+    """Nearest-rank percentile.
+
+    Nearest-rank rather than interpolation because `round()` uses banker's
+    rounding, which makes the p50 of an even-length sample depend on whether
+    the midpoint index happens to be even.
+    """
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = math.ceil(fraction * len(ordered))
+    index = min(len(ordered) - 1, max(0, rank - 1))
+    return ordered[index]
+
+
+def expected_calibration_error(
+    confidences: Sequence[float],
+    correct: Sequence[bool],
+    bins: int = DEFAULT_CALIBRATION_BINS,
+) -> float:
+    """Mean gap between stated confidence and observed correctness, weighted by bin size."""
+    if not confidences:
+        return 0.0
+    buckets: Dict[int, List[int]] = {}
+    for confidence, is_correct in zip(confidences, correct):
+        index = min(bins - 1, max(0, int(confidence * bins)))
+        buckets.setdefault(index, []).append(1 if is_correct else 0)
+
+    total = len(confidences)
+    error = 0.0
+    for index, outcomes in buckets.items():
+        observed = sum(outcomes) / len(outcomes)
+        stated = (index + 0.5) / bins
+        error += (len(outcomes) / total) * abs(observed - stated)
+    return error
+
+
+def brier_score(confidences: Sequence[float], correct: Sequence[bool]) -> float:
+    """Mean squared error between stated confidence and the 0/1 outcome."""
+    if not confidences:
+        return 0.0
+    return sum(
+        (confidence - (1.0 if is_correct else 0.0)) ** 2
+        for confidence, is_correct in zip(confidences, correct)
+    ) / len(confidences)
+
+
+def score_cases(cases: Sequence[CaseOutcome], bytes_per_incident: float = 0.0) -> EvalMetrics:
+    """Aggregate per-incident outcomes into the reported metric set."""
+    if not cases:
+        raise ValueError("Cannot score an empty held-out set")
+
+    answered = [case for case in cases if not case.abstained]
+
+    total_missing_weight = 0.0
+    recovered_weight = 0.0
+    answered_missing_weight = 0.0
+    answered_recovered_weight = 0.0
+
+    true_positive_weight = 0.0
+    true_positives = 0
+    false_positives = 0
+
+    confidences: List[float] = []
+    correct: List[bool] = []
+    abstain_reasons: Dict[str, int] = {}
+
+    for case in cases:
+        case_missing_weight = sum(case.missing_weights.values())
+        case_recovered = sum(case.missing_weights[s] for s in case.true_positives)
+
+        total_missing_weight += case_missing_weight
+        recovered_weight += case_recovered
+
+        if case.abstained:
+            reason = case.abstain_reason or "unspecified"
+            abstain_reasons[reason] = abstain_reasons.get(reason, 0) + 1
+            continue
+
+        answered_missing_weight += case_missing_weight
+        answered_recovered_weight += case_recovered
+
+        true_positives += len(case.true_positives)
+        false_positives += len(case.false_positives)
+        true_positive_weight += case_recovered
+
+        for signature in case.suggested:
+            confidences.append(case.suggestion_confidence.get(signature, 0.0))
+            correct.append(signature in case.missing_weights)
+
+    suggested_total = true_positives + false_positives
+
+    return EvalMetrics(
+        cases=len(cases),
+        answered_cases=len(answered),
+        abstention_rate=(len(cases) - len(answered)) / len(cases),
+        abstain_reasons=abstain_reasons,
+        weighted_path_recall=_safe_divide(recovered_weight, total_missing_weight),
+        weighted_path_recall_when_answering=_safe_divide(
+            answered_recovered_weight, answered_missing_weight
+        ),
+        suggestion_precision=_safe_divide(true_positives, suggested_total),
+        weighted_suggestion_precision=_safe_divide(
+            true_positive_weight, true_positive_weight + false_positives
+        ),
+        false_positive_burden=_safe_divide(false_positives, len(answered)),
+        expected_calibration_error=expected_calibration_error(confidences, correct),
+        brier_score=brier_score(confidences, correct),
+        latency_p50_ms=_percentile([case.latency_ms for case in cases], 0.50),
+        latency_p95_ms=_percentile([case.latency_ms for case in cases], 0.95),
+        bytes_per_incident=bytes_per_incident,
+        llm_calls=sum(case.llm_calls for case in cases),
+    )
+
+
+def _safe_divide(numerator: float, denominator: float) -> float:
+    """Return 0.0 for an empty denominator rather than raising.
+
+    An empty denominator means the quantity was never exercised (no missing
+    checks, or no suggestions), which is not the same as a failure.
+    """
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator

--- a/holmes/core/investigation_path/metrics.py
+++ b/holmes/core/investigation_path/metrics.py
@@ -31,8 +31,11 @@ set `S`, or abstains.
   correct. This is the check that a raw similarity score cannot pass by itself.
 - **Latency** - p50/p95 wall clock per validation.
 - **Storage cost** - mean serialized bytes per stored incident record.
-- **LLM calls** - expected to be 0. Tracked so that a future change which
-  quietly adds a model call to this path shows up as a cost regression.
+- **Token cost / LLM calls** - both expected to be 0, and both tracked rather
+  than one inferred from the other. A change that routes this path through a
+  model would move them together, but a change that reuses tokens already spent
+  by the investigation would move only the token count, and that is exactly the
+  cost that would otherwise be invisible.
 """
 
 import math
@@ -56,6 +59,10 @@ class CaseOutcome(BaseModel):
     suggestion_confidence: Dict[str, float] = Field(default_factory=dict)
     latency_ms: float = 0.0
     llm_calls: int = 0
+    llm_tokens: int = Field(
+        default=0,
+        description="Tokens spent producing this suggestion set, prompt and completion.",
+    )
 
     @property
     def true_positives(self) -> List[str]:
@@ -107,6 +114,7 @@ class EvalMetrics(BaseModel):
     latency_p95_ms: float
     bytes_per_incident: float
     llm_calls: int
+    llm_tokens: int = 0
 
     def render(self) -> str:
         """Plain-text report, so an eval run can be diffed between policies."""
@@ -125,6 +133,7 @@ class EvalMetrics(BaseModel):
             ("latency p95 (ms)", f"{self.latency_p95_ms:.2f}"),
             ("bytes per incident", f"{self.bytes_per_incident:.0f}"),
             ("llm calls", f"{self.llm_calls}"),
+            ("llm tokens", f"{self.llm_tokens}"),
         ]
         width = max(len(label) for label, _ in rows)
         lines = [f"{label.ljust(width)}  {value}" for label, value in rows]
@@ -248,6 +257,7 @@ def score_cases(cases: Sequence[CaseOutcome], bytes_per_incident: float = 0.0) -
         latency_p95_ms=_percentile([case.latency_ms for case in cases], 0.95),
         bytes_per_incident=bytes_per_incident,
         llm_calls=sum(case.llm_calls for case in cases),
+        llm_tokens=sum(case.llm_tokens for case in cases),
     )
 
 

--- a/holmes/core/investigation_path/normalize.py
+++ b/holmes/core/investigation_path/normalize.py
@@ -30,8 +30,10 @@ from holmes.core.investigation_path.schema import (
 )
 
 # A shell command is reduced to at most this many words. Enough to keep
-# "kubectl get service redis", short enough to leave flags and pipelines out.
-MAX_COMMAND_WORDS = 4
+# "kubectl rollout history deployment catalog-service" - the longest shape that
+# still names a single resource - and short enough to leave flags and pipelines
+# out. Anything past the resource name is argument noise.
+MAX_COMMAND_WORDS = 5
 
 # ---------------------------------------------------------------------------
 # Parameter allow-lists. Anything outside these is never read.
@@ -115,6 +117,14 @@ _RESOURCE_ALIASES = {
 
 # Kinds that describe how components connect rather than a single workload.
 _TOPOLOGY_KINDS = frozenset({"service", "endpoints", "ingress", "networkpolicy"})
+
+# Verbs that take a sub-verb before the resource, as in
+# `kubectl rollout history deployment/catalog-service`. Without this the
+# sub-verb is read as the kind and the whole target ends up in the name.
+_COMMAND_SUB_VERBS = {
+    "rollout": frozenset({"history", "status", "undo", "restart", "pause", "resume"}),
+    "auth": frozenset({"can-i"}),
+}
 
 _PROMQL_KEYWORDS = frozenset(
     {
@@ -275,18 +285,52 @@ def _command_words(command: str) -> List[str]:
     return words
 
 
+def split_resource_target(token: str) -> Tuple[Optional[str], Optional[str]]:
+    """Split kubectl's `kind/name` shorthand into its two parts.
+
+    `deployment/catalog-service` and `deployment catalog-service` are the same
+    check, so they have to produce the same entity. Returns `(None, None)` for
+    anything that is not that shape, including a bare name and a path-like
+    argument such as `-f ./manifests/app.yaml`.
+    """
+    kind, separator, name = token.partition("/")
+    if not separator or not kind or not name or "/" in name:
+        return None, None
+    normalized_kind = normalize_resource_kind(kind)
+    if normalized_kind not in _RESOURCE_ALIASES.values():
+        return None, None
+    return normalized_kind, normalize_resource_name(name)
+
+
 def _entity_from_command_words(words: Sequence[str]) -> EntityRef:
-    """Read `<binary> <verb> [<kind>] [<name>]` out of a normalized command."""
+    """Read `<binary> <verb> [<sub-verb>] [<kind>] [<name>]` out of a command."""
     if len(words) < 3:
         return EntityRef()
-    kind = normalize_resource_kind(words[2])
-    name = normalize_resource_name(words[3]) if len(words) > 3 else None
-    # `kubectl logs my-pod` names a pod without saying so.
-    if kind not in _RESOURCE_ALIASES.values() and len(words) == 3:
-        if words[1] in ("logs", "log"):
-            return EntityRef(kind="pod", name=normalize_resource_name(words[2]))
-        return EntityRef(name=normalize_resource_name(words[2]))
-    return EntityRef(kind=kind or None, name=name or None)
+
+    verb = words[1]
+    rest = list(words[2:])
+
+    # `rollout history deploy/x`: the sub-verb sits where the kind would be, so
+    # the resource is one word further along than usual.
+    sub_verbs = _COMMAND_SUB_VERBS.get(verb)
+    if sub_verbs and rest[0] in sub_verbs:
+        rest = rest[1:]
+    if not rest:
+        return EntityRef()
+
+    kind, name = split_resource_target(rest[0])
+    if kind:
+        return EntityRef(kind=kind, name=name)
+
+    kind = normalize_resource_kind(rest[0])
+    if kind in _RESOURCE_ALIASES.values():
+        name = normalize_resource_name(rest[1]) if len(rest) > 1 else None
+        return EntityRef(kind=kind, name=name or None)
+
+    # A bare name. `kubectl logs my-pod` names a pod without saying so.
+    if verb in ("logs", "log"):
+        return EntityRef(kind="pod", name=normalize_resource_name(rest[0]))
+    return EntityRef(name=normalize_resource_name(rest[0]))
 
 
 def _metric_from_query(query: str) -> Optional[str]:

--- a/holmes/core/investigation_path/normalize.py
+++ b/holmes/core/investigation_path/normalize.py
@@ -1,0 +1,482 @@
+"""Turn executed tool calls into canonical, redacted path events.
+
+This is the only place that reads real tool-call data, so it is also the only
+place that has to enforce the schema's redaction rules. Three of them are worth
+stating outright, because they are easy to break by accident later:
+
+- **Only allow-listed parameters are read at all.** Anything not on one of the
+  key lists below is never looked at, so a new toolset cannot leak a parameter
+  into stored paths just by naming it something new.
+- **Tool output is never read.** `StructuredToolResult.data` is not touched.
+  Error text *is* read, but only to pick an `ErrorClass`, and is then dropped.
+- **Values that could be secrets are dropped, not stored.** Sensitive keys are
+  skipped, and high-entropy words inside shell commands are replaced.
+"""
+
+import re
+import shlex
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from holmes.core.investigation_path.schema import (
+    EntityRef,
+    ErrorClass,
+    InvestigationPath,
+    Outcome,
+    OutcomeStatus,
+    PathEvent,
+    QueryIntent,
+    TimeWindow,
+    bucket_lookback_seconds,
+)
+
+# A shell command is reduced to at most this many words. Enough to keep
+# "kubectl get service redis", short enough to leave flags and pipelines out.
+MAX_COMMAND_WORDS = 4
+
+# ---------------------------------------------------------------------------
+# Parameter allow-lists. Anything outside these is never read.
+# ---------------------------------------------------------------------------
+_KIND_PARAM_KEYS = ("kind", "resource_type", "resource_kind", "resource")
+_NAME_PARAM_KEYS = (
+    "name",
+    "resource_name",
+    "pod_name",
+    "pod",
+    "service_name",
+    "deployment_name",
+    "workload",
+)
+_NAMESPACE_PARAM_KEYS = ("namespace", "ns")
+_QUERY_PARAM_KEYS = ("query", "promql", "expr", "logql")
+_COMMAND_PARAM_KEYS = ("command", "cmd")
+_LOOKBACK_PARAM_KEYS = ("since", "lookback", "duration", "period", "range", "time_range")
+_START_PARAM_KEYS = ("start", "start_time", "from")
+_END_PARAM_KEYS = ("end", "end_time", "to")
+
+# Substrings that mark a parameter as possibly secret. Matching keys are
+# skipped even if they also appear on an allow-list above.
+_SENSITIVE_KEY_TOKENS = (
+    "api_key",
+    "apikey",
+    "auth",
+    "bearer",
+    "cert",
+    "cookie",
+    "credential",
+    "passwd",
+    "password",
+    "private",
+    "secret",
+    "session",
+    "signature",
+    "token",
+)
+
+_REDACTED = "<redacted>"
+
+# ---------------------------------------------------------------------------
+# Kubernetes naming
+# ---------------------------------------------------------------------------
+_RESOURCE_ALIASES = {
+    "cj": "cronjob",
+    "cronjobs": "cronjob",
+    "cm": "configmap",
+    "configmaps": "configmap",
+    "ds": "daemonset",
+    "daemonsets": "daemonset",
+    "deploy": "deployment",
+    "deployments": "deployment",
+    "ep": "endpoints",
+    "endpoint": "endpoints",
+    "events": "event",
+    "hpa": "horizontalpodautoscaler",
+    "horizontalpodautoscalers": "horizontalpodautoscaler",
+    "ing": "ingress",
+    "ingresses": "ingress",
+    "jobs": "job",
+    "no": "node",
+    "nodes": "node",
+    "ns": "namespace",
+    "namespaces": "namespace",
+    "po": "pod",
+    "pods": "pod",
+    "pv": "persistentvolume",
+    "persistentvolumes": "persistentvolume",
+    "pvc": "persistentvolumeclaim",
+    "persistentvolumeclaims": "persistentvolumeclaim",
+    "rs": "replicaset",
+    "replicasets": "replicaset",
+    "secrets": "secret",
+    "sts": "statefulset",
+    "statefulsets": "statefulset",
+    "svc": "service",
+    "services": "service",
+}
+
+# Kinds that describe how components connect rather than a single workload.
+_TOPOLOGY_KINDS = frozenset({"service", "endpoints", "ingress", "networkpolicy"})
+
+_PROMQL_KEYWORDS = frozenset(
+    {
+        "abs", "absent", "and", "avg", "avg_over_time", "bool", "bottomk", "by",
+        "ceil", "changes", "clamp_max", "clamp_min", "count", "count_over_time",
+        "count_values", "delta", "deriv", "floor", "group_left", "group_right",
+        "histogram_quantile", "idelta", "ignoring", "increase", "irate",
+        "label_join", "label_replace", "last_over_time", "max", "max_over_time",
+        "min", "min_over_time", "offset", "on", "or", "predict_linear",
+        "quantile", "rate", "resets", "round", "scalar", "sort", "sort_desc",
+        "stddev", "stdvar", "sum", "sum_over_time", "time", "timestamp", "topk",
+        "unless", "vector", "without",
+    }
+)
+
+# Flags whose *next* token is a value rather than part of the check.
+_VALUE_FLAGS = frozenset(
+    {
+        "-c", "-l", "-n", "-o", "--container", "--context", "--field-selector",
+        "--namespace", "--output", "--selector", "--since", "--tail",
+    }
+)
+
+_SHELL_SEPARATORS = frozenset({"|", "||", "&&", ";", ">", ">>"})
+
+_IDENTIFIER_RE = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
+
+_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhdw])?\s*$", re.IGNORECASE)
+
+_DURATION_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+
+# ---------------------------------------------------------------------------
+# Intent inference
+# ---------------------------------------------------------------------------
+# Checked in order; the first tool-name substring that matches wins.
+_INTENT_BY_TOOL_KEYWORD: Tuple[Tuple[Tuple[str, ...], QueryIntent], ...] = (
+    (("log",), QueryIntent.LOGS),
+    (("event",), QueryIntent.EVENTS),
+    (("trace", "span", "tempo"), QueryIntent.TRACES),
+    (("metric", "prometheus", "promql", "query_range", "victoriametrics"), QueryIntent.METRICS),
+    (("top", "usage", "utilization", "recommendation", "capacity"), QueryIntent.RESOURCE_USAGE),
+    (("endpoint", "connectivity", "network", "lineage", "topology"), QueryIntent.TOPOLOGY),
+    (("change", "rollout", "revision", "helm", "argocd", "history"), QueryIntent.CONFIG_HISTORY),
+    (("describe", "get_by_name", "detail"), QueryIntent.DESCRIBE),
+    (("list", "count", "find", "search", "jq_query", "tabular_query"), QueryIntent.LIST),
+)
+
+# Shell verbs take priority over tool name for command-running tools, because
+# every such call has the same tool name.
+_INTENT_BY_COMMAND_VERB = {
+    "describe": QueryIntent.DESCRIBE,
+    "events": QueryIntent.EVENTS,
+    "logs": QueryIntent.LOGS,
+    "rollout": QueryIntent.CONFIG_HISTORY,
+    "top": QueryIntent.RESOURCE_USAGE,
+}
+
+_ERROR_KEYWORDS: Tuple[Tuple[Tuple[str, ...], ErrorClass], ...] = (
+    (("not found", "notfound", "404", "no such"), ErrorClass.NOT_FOUND),
+    (("forbidden", "permission denied", "unauthorized", "401", "403"), ErrorClass.FORBIDDEN),
+    (("timed out", "timeout", "deadline exceeded"), ErrorClass.TIMEOUT),
+    (("invalid", "parse error", "bad request", "syntax", "400"), ErrorClass.INVALID_QUERY),
+    (("unavailable", "connection refused", "503", "502"), ErrorClass.UNAVAILABLE),
+)
+
+_UNUSABLE_STATUSES = frozenset({"approval_required", "frontend_pause"})
+
+
+# ---------------------------------------------------------------------------
+# Name and kind normalization
+# ---------------------------------------------------------------------------
+def looks_like_instance_id(token: str) -> bool:
+    """True for generated suffixes: a ReplicaSet hash or a StatefulSet ordinal."""
+    if not token:
+        return False
+    if token.isdigit():
+        return True
+    if len(token) < 5:
+        return False
+    return any(c.isdigit() for c in token) and any(c.isalpha() for c in token)
+
+
+def normalize_resource_name(name: str) -> str:
+    """Strip the generated part of a name so instances of one workload match.
+
+    At most two suffixes are removed, which is what Kubernetes appends: a
+    ReplicaSet hash plus a pod suffix.
+    """
+    cleaned = name.strip().lower()
+    if not cleaned:
+        return ""
+    parts = cleaned.split("-")
+    for _ in range(2):
+        if len(parts) > 1 and looks_like_instance_id(parts[-1]):
+            parts.pop()
+        else:
+            break
+    return "-".join(parts)
+
+
+def normalize_resource_kind(kind: str) -> str:
+    cleaned = kind.strip().lower()
+    return _RESOURCE_ALIASES.get(cleaned, cleaned)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(token in lowered for token in _SENSITIVE_KEY_TOKENS)
+
+
+def _looks_high_entropy(word: str) -> bool:
+    """Rough test for an inline secret: long, mixed-case or mixed-class, no dashes."""
+    if len(word) < 20 or "-" in word or "/" in word:
+        return False
+    has_digit = any(c.isdigit() for c in word)
+    has_alpha = any(c.isalpha() for c in word)
+    return has_digit and has_alpha
+
+
+def _read_param(params: Dict[str, Any], keys: Sequence[str]) -> Optional[str]:
+    """Read the first allow-listed key present, skipping anything secret-looking."""
+    for key in keys:
+        if _is_sensitive_key(key):
+            continue
+        value = params.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Command parsing
+# ---------------------------------------------------------------------------
+def _command_words(command: str) -> List[str]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        # Unbalanced quotes: split naively and drop stray quote characters so
+        # the same command still maps to the same check.
+        tokens = [token.strip("'\"") for token in command.split()]
+
+    words: List[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in _SHELL_SEPARATORS:
+            break
+        if token.startswith("-"):
+            skip_next = token in _VALUE_FLAGS
+            continue
+        words.append(_REDACTED if _looks_high_entropy(token) else token)
+        if len(words) == MAX_COMMAND_WORDS:
+            break
+    return words
+
+
+def _entity_from_command_words(words: Sequence[str]) -> EntityRef:
+    """Read `<binary> <verb> [<kind>] [<name>]` out of a normalized command."""
+    if len(words) < 3:
+        return EntityRef()
+    kind = normalize_resource_kind(words[2])
+    name = normalize_resource_name(words[3]) if len(words) > 3 else None
+    # `kubectl logs my-pod` names a pod without saying so.
+    if kind not in _RESOURCE_ALIASES.values() and len(words) == 3:
+        if words[1] in ("logs", "log"):
+            return EntityRef(kind="pod", name=normalize_resource_name(words[2]))
+        return EntityRef(name=normalize_resource_name(words[2]))
+    return EntityRef(kind=kind or None, name=name or None)
+
+
+def _metric_from_query(query: str) -> Optional[str]:
+    """Pull the queried metric out of a PromQL/LogQL expression."""
+    for match in _IDENTIFIER_RE.finditer(query):
+        token = match.group(0)
+        if token.lower() in _PROMQL_KEYWORDS:
+            continue
+        return token
+    return None
+
+
+def _parse_duration_seconds(value: str) -> Optional[float]:
+    match = _DURATION_RE.match(value)
+    if not match:
+        return None
+    amount = float(match.group(1))
+    unit = (match.group(2) or "s").lower()
+    return amount * _DURATION_UNIT_SECONDS[unit]
+
+
+# ---------------------------------------------------------------------------
+# Event construction
+# ---------------------------------------------------------------------------
+def _infer_intent(tool_name: str, command_words: Sequence[str], entity: EntityRef) -> QueryIntent:
+    if command_words:
+        verb = command_words[1] if len(command_words) > 1 else ""
+        if verb in _INTENT_BY_COMMAND_VERB:
+            return _INTENT_BY_COMMAND_VERB[verb]
+        if verb == "get":
+            if entity.kind in _TOPOLOGY_KINDS:
+                return QueryIntent.TOPOLOGY
+            return QueryIntent.DESCRIBE if entity.name else QueryIntent.LIST
+
+    lowered = tool_name.lower()
+    for keywords, intent in _INTENT_BY_TOOL_KEYWORD:
+        if any(keyword in lowered for keyword in keywords):
+            return intent
+
+    if entity.kind in _TOPOLOGY_KINDS:
+        return QueryIntent.TOPOLOGY
+    if entity.name:
+        return QueryIntent.DESCRIBE
+    if entity.kind:
+        return QueryIntent.LIST
+    return QueryIntent.OTHER
+
+
+def _entity_from_params(params: Dict[str, Any]) -> EntityRef:
+    kind = _read_param(params, _KIND_PARAM_KEYS)
+    name = _read_param(params, _NAME_PARAM_KEYS)
+    namespace = _read_param(params, _NAMESPACE_PARAM_KEYS)
+
+    if kind or name:
+        return EntityRef(
+            kind=normalize_resource_kind(kind) if kind else None,
+            name=normalize_resource_name(name) if name else None,
+            namespace=normalize_resource_name(namespace) if namespace else None,
+        )
+
+    query = _read_param(params, _QUERY_PARAM_KEYS)
+    if query:
+        metric = _metric_from_query(query)
+        return EntityRef(
+            kind="metric" if metric else None,
+            name=metric,
+            namespace=normalize_resource_name(namespace) if namespace else None,
+        )
+    return EntityRef(namespace=normalize_resource_name(namespace) if namespace else None)
+
+
+def _time_window_from_params(params: Dict[str, Any], intent: QueryIntent) -> Optional[TimeWindow]:
+    lookback = _read_param(params, _LOOKBACK_PARAM_KEYS)
+    if lookback:
+        seconds = _parse_duration_seconds(lookback)
+        bucketed = bucket_lookback_seconds(seconds)
+        if bucketed is not None:
+            return TimeWindow(lookback_seconds=bucketed)
+
+    # Explicit start/end are absolute timestamps and therefore unstable. Only
+    # their span is kept.
+    start = _read_param(params, _START_PARAM_KEYS)
+    end = _read_param(params, _END_PARAM_KEYS)
+    if start and end:
+        span = _span_seconds(start, end)
+        bucketed = bucket_lookback_seconds(span)
+        if bucketed is not None:
+            return TimeWindow(lookback_seconds=bucketed)
+
+    if intent in (QueryIntent.DESCRIBE, QueryIntent.LIST, QueryIntent.TOPOLOGY):
+        return TimeWindow(is_point_in_time=True)
+    return None
+
+
+def _span_seconds(start: str, end: str) -> Optional[float]:
+    try:
+        return abs(float(end) - float(start))
+    except (TypeError, ValueError):
+        return None
+
+
+def classify_error(error_text: Optional[str]) -> ErrorClass:
+    """Collapse a raw error into a class. The text itself is never stored."""
+    if not error_text:
+        return ErrorClass.OTHER
+    lowered = error_text.lower()
+    for keywords, error_class in _ERROR_KEYWORDS:
+        if any(keyword in lowered for keyword in keywords):
+            return error_class
+    return ErrorClass.OTHER
+
+
+def _read_tool_call(tool_call: Any) -> Tuple[Optional[str], Dict[str, Any], Optional[str], Optional[str], Optional[str]]:
+    """Read (tool_name, params, status, error, evidence_ref) from a tool call.
+
+    Accepts both `ToolCallResult` objects and the client dicts produced by
+    `ToolCallResult.to_client_dict()`.
+    """
+    if isinstance(tool_call, dict):
+        tool_name = tool_call.get("tool_name") or tool_call.get("name")
+        evidence_ref = tool_call.get("tool_call_id")
+        result: Any = tool_call.get("result")
+    else:
+        tool_name = getattr(tool_call, "tool_name", None)
+        evidence_ref = getattr(tool_call, "tool_call_id", None)
+        result = getattr(tool_call, "result", None)
+
+    if isinstance(result, dict):
+        params = result.get("params")
+        status = result.get("status")
+        error = result.get("error")
+    else:
+        params = getattr(result, "params", None)
+        status = getattr(result, "status", None)
+        error = getattr(result, "error", None)
+
+    if status is not None and not isinstance(status, str):
+        status = getattr(status, "value", None)
+    if not isinstance(params, dict):
+        params = {}
+    if error is not None and not isinstance(error, str):
+        error = str(error)
+    return tool_name, params, status, error, evidence_ref
+
+
+def event_from_tool_call(tool_call: Any, ordinal: int) -> Optional[PathEvent]:
+    """Build one canonical path event, or None if the call is not a real check."""
+    tool_name, params, status, error, evidence_ref = _read_tool_call(tool_call)
+    if not tool_name:
+        return None
+    if status and status.lower() in _UNUSABLE_STATUSES:
+        return None
+
+    command = _read_param(params, _COMMAND_PARAM_KEYS)
+    command_words = _command_words(command) if command else []
+
+    entity = _entity_from_params(params)
+    if not entity.kind and not entity.name and command_words:
+        command_entity = _entity_from_command_words(command_words)
+        entity = EntityRef(
+            kind=command_entity.kind,
+            name=command_entity.name,
+            namespace=entity.namespace,
+        )
+
+    intent = _infer_intent(tool_name, command_words, entity)
+
+    if status == "error":
+        outcome = Outcome(status=OutcomeStatus.ERROR, error_class=classify_error(error))
+    elif status == "no_data":
+        outcome = Outcome(status=OutcomeStatus.NO_DATA)
+    else:
+        outcome = Outcome(status=OutcomeStatus.SUCCESS)
+
+    return PathEvent(
+        ordinal=ordinal,
+        tool=tool_name,
+        intent=intent,
+        entity=entity,
+        time_window=_time_window_from_params(params, intent),
+        outcome=outcome,
+        evidence_ref=evidence_ref,
+    )
+
+
+def path_from_tool_calls(tool_calls: Optional[Sequence[Any]]) -> InvestigationPath:
+    """Reduce an investigation's tool calls to a canonical, ordered, redacted path."""
+    events: List[PathEvent] = []
+    for tool_call in tool_calls or []:
+        event = event_from_tool_call(tool_call, ordinal=len(events))
+        if event is not None:
+            events.append(event)
+    return InvestigationPath(events=events)

--- a/holmes/core/investigation_path/normalize.py
+++ b/holmes/core/investigation_path/normalize.py
@@ -106,6 +106,8 @@ _RESOURCE_ALIASES = {
     "persistentvolumes": "persistentvolume",
     "pvc": "persistentvolumeclaim",
     "persistentvolumeclaims": "persistentvolumeclaim",
+    "netpol": "networkpolicy",
+    "networkpolicies": "networkpolicy",
     "rs": "replicaset",
     "replicasets": "replicaset",
     "secrets": "secret",
@@ -117,6 +119,12 @@ _RESOURCE_ALIASES = {
 
 # Kinds that describe how components connect rather than a single workload.
 _TOPOLOGY_KINDS = frozenset({"service", "endpoints", "ingress", "networkpolicy"})
+
+# Every kind the command parser will recognize. Deriving this from the alias
+# table alone silently excludes any canonical kind that happens to have no
+# abbreviation, which reads as "not a kind at all" and sends the name into the
+# entity as if it were a resource name.
+_KNOWN_KINDS = frozenset(_RESOURCE_ALIASES.values()) | _TOPOLOGY_KINDS
 
 # Verbs that take a sub-verb before the resource, as in
 # `kubectl rollout history deployment/catalog-service`. Without this the
@@ -297,7 +305,7 @@ def split_resource_target(token: str) -> Tuple[Optional[str], Optional[str]]:
     if not separator or not kind or not name or "/" in name:
         return None, None
     normalized_kind = normalize_resource_kind(kind)
-    if normalized_kind not in _RESOURCE_ALIASES.values():
+    if normalized_kind not in _KNOWN_KINDS:
         return None, None
     return normalized_kind, normalize_resource_name(name)
 
@@ -323,7 +331,7 @@ def _entity_from_command_words(words: Sequence[str]) -> EntityRef:
         return EntityRef(kind=kind, name=name)
 
     kind = normalize_resource_kind(rest[0])
-    if kind in _RESOURCE_ALIASES.values():
+    if kind in _KNOWN_KINDS:
         name = normalize_resource_name(rest[1]) if len(rest) > 1 else None
         return EntityRef(kind=kind, name=name or None)
 

--- a/holmes/core/investigation_path/offline_eval.py
+++ b/holmes/core/investigation_path/offline_eval.py
@@ -75,6 +75,7 @@ def evaluate_case(
         suggestion_confidence={s.signature: s.confidence for s in report.suggestions},
         latency_ms=latency_ms,
         llm_calls=0,
+        llm_tokens=0,
     )
 
 

--- a/holmes/core/investigation_path/offline_eval.py
+++ b/holmes/core/investigation_path/offline_eval.py
@@ -163,12 +163,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     raw_metrics, _, _ = run_offline_eval(calibrate=False)
     metrics, outcomes, calibration = run_offline_eval(calibrate=True)
 
-    experiment_url = (
-        log_benchmark_to_braintrust(metrics, outcomes, calibration)
-        if args.braintrust
-        else None
-    )
-
+    # Local output first. Uploading to a remote service before printing the
+    # numbers means an outage there loses the numbers too, and the CI step is
+    # `continue-on-error` - the build would stay green with the benchmark
+    # silently missing from the pull request comment.
     print("Investigation path completeness - offline eval")
     print("=" * 46)
     print(metrics.render())
@@ -185,6 +183,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     print()
     print(render_case_detail(outcomes))
 
+    experiment_url = (
+        log_benchmark_to_braintrust(metrics, outcomes, calibration)
+        if args.braintrust
+        else None
+    )
     if experiment_url:
         print()
         print(f"braintrust: {experiment_url}")

--- a/holmes/core/investigation_path/offline_eval.py
+++ b/holmes/core/investigation_path/offline_eval.py
@@ -20,7 +20,8 @@ import time
 from pathlib import Path
 from typing import List, Optional, Sequence, Set, Tuple
 
-from holmes.core.investigation_path.calibration import CalibrationModel, fit_calibration
+from holmes.core.investigation_path.calibration import fit_calibration
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.corpus import corpus_bytes_per_incident, load_corpus
 from holmes.core.investigation_path.metrics import CaseOutcome, EvalMetrics, score_cases
 from holmes.core.investigation_path.reporting import (

--- a/holmes/core/investigation_path/offline_eval.py
+++ b/holmes/core/investigation_path/offline_eval.py
@@ -14,13 +14,23 @@ Run it directly to print a report:
 
 import time
 from pathlib import Path
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Set, Tuple
 
+from holmes.core.investigation_path.calibration import CalibrationModel, fit_calibration
 from holmes.core.investigation_path.corpus import corpus_bytes_per_incident, load_corpus
 from holmes.core.investigation_path.metrics import CaseOutcome, EvalMetrics, score_cases
 from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
-from holmes.core.investigation_path.schema import IncidentRecord, SignatureLevel
+from holmes.core.investigation_path.schema import (
+    IncidentRecord,
+    ReferenceStep,
+    SignatureLevel,
+)
 from holmes.core.investigation_path.validator import SuggestionPolicy, validate_path
+
+
+def entities_seen_in(steps: Sequence[ReferenceStep]) -> Set[str]:
+    """Object names an investigation has actually looked at."""
+    return {step.entity.name for step in steps if step.entity.name}
 
 
 def evaluate_case(
@@ -29,6 +39,7 @@ def evaluate_case(
     retrieval_policy: RetrievalPolicy,
     suggestion_policy: SuggestionPolicy,
     level: SignatureLevel = SignatureLevel.FINE,
+    calibration: Optional[CalibrationModel] = None,
 ) -> CaseOutcome:
     """Score one held-out incident against the retrieval pool."""
     missing_weights = {
@@ -42,6 +53,8 @@ def evaluate_case(
         retrieval=retrieval,
         policy=suggestion_policy,
         subject=case.subject,
+        calibration=calibration,
+        known_entities=entities_seen_in(case.observed_path),
     )
     latency_ms = (time.perf_counter() - started) * 1000
 
@@ -61,8 +74,14 @@ def run_offline_eval(
     corpus_dir: Optional[Path] = None,
     retrieval_policy: Optional[RetrievalPolicy] = None,
     suggestion_policy: Optional[SuggestionPolicy] = None,
-) -> Tuple[EvalMetrics, List[CaseOutcome]]:
-    """Score a policy over every held-out incident. Returns metrics and per-case detail."""
+    calibrate: bool = True,
+) -> Tuple[EvalMetrics, List[CaseOutcome], CalibrationModel]:
+    """Score a policy over every held-out incident.
+
+    The calibration model is fitted on the retrieval pool by leave-one-out and
+    only then applied to the held-out cases, so the calibration error reported
+    here is out-of-sample. Pass `calibrate=False` to measure the raw score.
+    """
     retrieval_policy = retrieval_policy or RetrievalPolicy()
     suggestion_policy = suggestion_policy or SuggestionPolicy()
 
@@ -73,6 +92,12 @@ def run_offline_eval(
     if not holdout:
         raise ValueError("Held-out set is empty; nothing to evaluate")
 
+    calibration = (
+        fit_calibration(pool, retrieval_policy, retrieval_policy.signature_level)
+        if calibrate
+        else CalibrationModel(fitted=False)
+    )
+
     outcomes = [
         evaluate_case(
             case,
@@ -80,11 +105,12 @@ def run_offline_eval(
             retrieval_policy,
             suggestion_policy,
             retrieval_policy.signature_level,
+            calibration,
         )
         for case in holdout
     ]
     metrics = score_cases(outcomes, bytes_per_incident=corpus_bytes_per_incident(pool))
-    return metrics, outcomes
+    return metrics, outcomes, calibration
 
 
 def render_case_detail(outcomes: Sequence[CaseOutcome]) -> str:
@@ -104,10 +130,22 @@ def render_case_detail(outcomes: Sequence[CaseOutcome]) -> str:
 
 
 def main() -> None:
-    metrics, outcomes = run_offline_eval()
+    raw_metrics, _, _ = run_offline_eval(calibrate=False)
+    metrics, outcomes, calibration = run_offline_eval(calibrate=True)
+
     print("Investigation path completeness - offline eval")
     print("=" * 46)
     print(metrics.render())
+    print()
+    print(f"calibration: {calibration.describe()}")
+    print(
+        f"  calibration error before: {raw_metrics.expected_calibration_error:.3f}"
+        f"  after: {metrics.expected_calibration_error:.3f}"
+    )
+    print(
+        f"  brier before: {raw_metrics.brier_score:.3f}"
+        f"  after: {metrics.brier_score:.3f}"
+    )
     print()
     print(render_case_detail(outcomes))
 

--- a/holmes/core/investigation_path/offline_eval.py
+++ b/holmes/core/investigation_path/offline_eval.py
@@ -1,0 +1,116 @@
+"""Run a retrieval policy over the held-out corpus and score it.
+
+This is the benchmark the reviewer asked for on issue #2046: it exists so that
+a retrieval policy can be compared against another one before either is allowed
+anywhere near a user-facing investigation. Nothing here imports the
+investigation loop, and no LLM is called - `llm_calls` in the result is asserted
+to stay at zero so that a future change which adds a model call to this path
+shows up as a cost regression rather than a silent one.
+
+Run it directly to print a report:
+
+    poetry run python -m holmes.core.investigation_path.offline_eval
+"""
+
+import time
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from holmes.core.investigation_path.corpus import corpus_bytes_per_incident, load_corpus
+from holmes.core.investigation_path.metrics import CaseOutcome, EvalMetrics, score_cases
+from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
+from holmes.core.investigation_path.schema import IncidentRecord, SignatureLevel
+from holmes.core.investigation_path.validator import SuggestionPolicy, validate_path
+
+
+def evaluate_case(
+    case: IncidentRecord,
+    pool: Sequence[IncidentRecord],
+    retrieval_policy: RetrievalPolicy,
+    suggestion_policy: SuggestionPolicy,
+    level: SignatureLevel = SignatureLevel.FINE,
+) -> CaseOutcome:
+    """Score one held-out incident against the retrieval pool."""
+    missing_weights = {
+        step.signature(level): step.weight for step in case.missing_steps(level)
+    }
+
+    started = time.perf_counter()
+    retrieval = retrieve(case.symptoms, pool, retrieval_policy)
+    report = validate_path(
+        observed_signatures=sorted(case.observed_signatures(level)),
+        retrieval=retrieval,
+        policy=suggestion_policy,
+        subject=case.subject,
+    )
+    latency_ms = (time.perf_counter() - started) * 1000
+
+    return CaseOutcome(
+        incident_id=case.incident_id,
+        abstained=report.abstained,
+        abstain_reason=retrieval.abstain_reason.value if retrieval.abstain_reason else None,
+        missing_weights=missing_weights,
+        suggested=[s.signature for s in report.suggestions],
+        suggestion_confidence={s.signature: s.confidence for s in report.suggestions},
+        latency_ms=latency_ms,
+        llm_calls=0,
+    )
+
+
+def run_offline_eval(
+    corpus_dir: Optional[Path] = None,
+    retrieval_policy: Optional[RetrievalPolicy] = None,
+    suggestion_policy: Optional[SuggestionPolicy] = None,
+) -> Tuple[EvalMetrics, List[CaseOutcome]]:
+    """Score a policy over every held-out incident. Returns metrics and per-case detail."""
+    retrieval_policy = retrieval_policy or RetrievalPolicy()
+    suggestion_policy = suggestion_policy or SuggestionPolicy()
+
+    pool = load_corpus(corpus_dir, split="corpus")
+    holdout = load_corpus(corpus_dir, split="holdout")
+    if not pool:
+        raise ValueError("Retrieval pool is empty; nothing to evaluate against")
+    if not holdout:
+        raise ValueError("Held-out set is empty; nothing to evaluate")
+
+    outcomes = [
+        evaluate_case(
+            case,
+            pool,
+            retrieval_policy,
+            suggestion_policy,
+            retrieval_policy.signature_level,
+        )
+        for case in holdout
+    ]
+    metrics = score_cases(outcomes, bytes_per_incident=corpus_bytes_per_incident(pool))
+    return metrics, outcomes
+
+
+def render_case_detail(outcomes: Sequence[CaseOutcome]) -> str:
+    lines = ["per-case:"]
+    for outcome in outcomes:
+        if outcome.abstained:
+            lines.append(f"  {outcome.incident_id}: abstained ({outcome.abstain_reason})")
+            continue
+        lines.append(
+            f"  {outcome.incident_id}: {len(outcome.true_positives)} correct, "
+            f"{len(outcome.false_positives)} wrong, "
+            f"{len(outcome.missing_weights)} genuinely missing"
+        )
+        for signature in outcome.false_positives:
+            lines.append(f"    wrong: {signature}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    metrics, outcomes = run_offline_eval()
+    print("Investigation path completeness - offline eval")
+    print("=" * 46)
+    print(metrics.render())
+    print()
+    print(render_case_detail(outcomes))
+
+
+if __name__ == "__main__":
+    main()

--- a/holmes/core/investigation_path/offline_eval.py
+++ b/holmes/core/investigation_path/offline_eval.py
@@ -10,8 +10,12 @@ shows up as a cost regression rather than a silent one.
 Run it directly to print a report:
 
     poetry run python -m holmes.core.investigation_path.offline_eval
+
+`--markdown` and `--braintrust` publish the same run through the existing eval
+reporting pipeline; see `reporting.py`.
 """
 
+import argparse
 import time
 from pathlib import Path
 from typing import List, Optional, Sequence, Set, Tuple
@@ -19,6 +23,10 @@ from typing import List, Optional, Sequence, Set, Tuple
 from holmes.core.investigation_path.calibration import CalibrationModel, fit_calibration
 from holmes.core.investigation_path.corpus import corpus_bytes_per_incident, load_corpus
 from holmes.core.investigation_path.metrics import CaseOutcome, EvalMetrics, score_cases
+from holmes.core.investigation_path.reporting import (
+    benchmark_markdown,
+    log_benchmark_to_braintrust,
+)
 from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
 from holmes.core.investigation_path.schema import (
     IncidentRecord,
@@ -129,9 +137,35 @@ def render_case_detail(outcomes: Sequence[CaseOutcome]) -> str:
     return "\n".join(lines)
 
 
-def main() -> None:
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m holmes.core.investigation_path.offline_eval",
+        description="Score the path-completeness retrieval policy offline.",
+    )
+    parser.add_argument(
+        "--markdown",
+        metavar="PATH",
+        help="Write a pull-request-ready report to PATH.",
+    )
+    parser.add_argument(
+        "--braintrust",
+        action="store_true",
+        help="Log the run to Braintrust. No-op without BRAINTRUST_API_KEY.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+
     raw_metrics, _, _ = run_offline_eval(calibrate=False)
     metrics, outcomes, calibration = run_offline_eval(calibrate=True)
+
+    experiment_url = (
+        log_benchmark_to_braintrust(metrics, outcomes, calibration)
+        if args.braintrust
+        else None
+    )
 
     print("Investigation path completeness - offline eval")
     print("=" * 46)
@@ -148,6 +182,18 @@ def main() -> None:
     )
     print()
     print(render_case_detail(outcomes))
+
+    if experiment_url:
+        print()
+        print(f"braintrust: {experiment_url}")
+
+    if args.markdown:
+        report = benchmark_markdown(
+            metrics, outcomes, calibration, raw_metrics, experiment_url
+        )
+        Path(args.markdown).write_text(report, encoding="utf-8")
+        print()
+        print(f"wrote {args.markdown}")
 
 
 if __name__ == "__main__":

--- a/holmes/core/investigation_path/reporting.py
+++ b/holmes/core/investigation_path/reporting.py
@@ -68,6 +68,7 @@ def case_metadata(outcome: CaseOutcome) -> Dict[str, Any]:
         "confidence": {k: round(v, 4) for k, v in outcome.suggestion_confidence.items()},
         "latency_ms": round(outcome.latency_ms, 3),
         "llm_calls": outcome.llm_calls,
+        "llm_tokens": outcome.llm_tokens,
     }
 
 
@@ -100,6 +101,7 @@ def summary_metadata(
         "latency_p95_ms": round(metrics.latency_p95_ms, 3),
         "bytes_per_incident": round(metrics.bytes_per_incident, 1),
         "llm_calls": metrics.llm_calls,
+        "llm_tokens": metrics.llm_tokens,
     }
     if calibration is not None:
         metadata["calibration"] = calibration.describe()
@@ -181,7 +183,7 @@ def _summary_rows(metrics: EvalMetrics) -> List[Tuple[str, str]]:
         ("Brier score", f"{metrics.brier_score:.3f}"),
         ("Latency p50 / p95 (ms)", f"{metrics.latency_p50_ms:.1f} / {metrics.latency_p95_ms:.1f}"),
         ("Bytes per stored incident", f"{metrics.bytes_per_incident:.0f}"),
-        ("LLM calls", f"{metrics.llm_calls}"),
+        ("LLM calls / tokens", f"{metrics.llm_calls} / {metrics.llm_tokens}"),
     ]
 
 

--- a/holmes/core/investigation_path/reporting.py
+++ b/holmes/core/investigation_path/reporting.py
@@ -22,7 +22,7 @@ correctness number that is measuring something else entirely.
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from holmes.core.investigation_path.calibration import CalibrationModel
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.metrics import CaseOutcome, EvalMetrics
 from holmes.core.tracing import SpanType, TracingFactory, get_experiment_name
 

--- a/holmes/core/investigation_path/reporting.py
+++ b/holmes/core/investigation_path/reporting.py
@@ -1,0 +1,248 @@
+"""Publish the path-completeness benchmark through the existing eval pipeline.
+
+The reviewer on issue #2046 asked for the benchmark to be established in the
+eval/Braintrust pipeline rather than bolted onto the product, so that a
+retrieval policy has a tracked history before anything user-facing depends on
+it. This module is that seam, and it does two things:
+
+- `benchmark_markdown` renders a run for a pull request comment, in the same
+  place the LLM evals post theirs.
+- `log_benchmark_to_braintrust` writes the run to Braintrust as its own
+  experiment, one span per held-out incident plus a summary span.
+
+Both are reporting only. Neither imports the investigation loop, and the
+Braintrust path degrades to a no-op when `BRAINTRUST_API_KEY` is unset, so the
+benchmark stays runnable by a contributor with no credentials.
+
+The benchmark gets its own experiment name rather than joining the ask_holmes
+run: its scores are deterministic and would otherwise be averaged into a
+correctness number that is measuring something else entirely.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from holmes.core.investigation_path.calibration import CalibrationModel
+from holmes.core.investigation_path.metrics import CaseOutcome, EvalMetrics
+from holmes.core.tracing import SpanType, TracingFactory, get_experiment_name
+
+BENCHMARK_SUFFIX = "investigation-path"
+BENCHMARK_TAGS = ["investigation-path", "benchmark", "offline"]
+
+
+def benchmark_experiment_name(base: Optional[str] = None) -> str:
+    """Name the experiment after the run that produced it, kept separate.
+
+    Sharing `EXPERIMENT_ID` with the ask_holmes evals would put deterministic
+    rows in the same average as model-scored ones.
+    """
+    return f"{base or get_experiment_name()}-{BENCHMARK_SUFFIX}"
+
+
+def case_scores(outcome: CaseOutcome) -> Dict[str, float]:
+    """Scores for one held-out incident.
+
+    An abstention scores 0 recall and is not charged for precision - it made no
+    claim. `answered` is logged alongside so the two can never be read apart.
+    """
+    scores = {
+        "answered": 0.0 if outcome.abstained else 1.0,
+        "path_recall": outcome.weighted_recall,
+    }
+    if not outcome.abstained and outcome.suggested:
+        scores["suggestion_precision"] = outcome.precision
+    return scores
+
+
+def case_metadata(outcome: CaseOutcome) -> Dict[str, Any]:
+    return {
+        "incident_id": outcome.incident_id,
+        "abstained": outcome.abstained,
+        "abstain_reason": outcome.abstain_reason,
+        "suggested": outcome.suggested,
+        "true_positives": outcome.true_positives,
+        "false_positives": outcome.false_positives,
+        "missing_signatures": sorted(outcome.missing_weights),
+        "missing_weight": round(outcome.missing_weight, 4),
+        "recovered_weight": round(outcome.recovered_weight, 4),
+        "confidence": {k: round(v, 4) for k, v in outcome.suggestion_confidence.items()},
+        "latency_ms": round(outcome.latency_ms, 3),
+        "llm_calls": outcome.llm_calls,
+    }
+
+
+def summary_scores(metrics: EvalMetrics) -> Dict[str, float]:
+    """The aggregate numbers worth tracking run over run.
+
+    Latency and storage are deliberately absent: they are costs, not scores,
+    and Braintrust averages scores across rows.
+    """
+    return {
+        "weighted_path_recall": metrics.weighted_path_recall,
+        "weighted_path_recall_when_answering": metrics.weighted_path_recall_when_answering,
+        "suggestion_precision": metrics.suggestion_precision,
+        "weighted_suggestion_precision": metrics.weighted_suggestion_precision,
+        "abstention_rate": metrics.abstention_rate,
+    }
+
+
+def summary_metadata(
+    metrics: EvalMetrics, calibration: Optional[CalibrationModel] = None
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {
+        "cases": metrics.cases,
+        "answered_cases": metrics.answered_cases,
+        "abstain_reasons": metrics.abstain_reasons,
+        "false_positive_burden": round(metrics.false_positive_burden, 4),
+        "expected_calibration_error": round(metrics.expected_calibration_error, 4),
+        "brier_score": round(metrics.brier_score, 4),
+        "latency_p50_ms": round(metrics.latency_p50_ms, 3),
+        "latency_p95_ms": round(metrics.latency_p95_ms, 3),
+        "bytes_per_incident": round(metrics.bytes_per_incident, 1),
+        "llm_calls": metrics.llm_calls,
+    }
+    if calibration is not None:
+        metadata["calibration"] = calibration.describe()
+        metadata["calibration_samples"] = calibration.samples
+    return metadata
+
+
+def log_benchmark_to_braintrust(
+    metrics: EvalMetrics,
+    outcomes: Sequence[CaseOutcome],
+    calibration: Optional[CalibrationModel] = None,
+    experiment_name: Optional[str] = None,
+) -> Optional[str]:
+    """Write one benchmark run to Braintrust. Returns the experiment URL, or None.
+
+    Returns None when tracing is unavailable, which is the normal case locally.
+    Failures here are logged and swallowed: a reporting outage must not turn a
+    passing benchmark into a red build.
+    """
+    tracer = TracingFactory.create_tracer("braintrust")
+    experiment = tracer.start_experiment(
+        experiment_name=benchmark_experiment_name(experiment_name),
+        additional_metadata={
+            "benchmark": BENCHMARK_SUFFIX,
+            "issue": "2046",
+            **summary_metadata(metrics, calibration),
+        },
+    )
+    if experiment is None:
+        logging.debug("Braintrust not configured; investigation path benchmark not logged")
+        return None
+
+    try:
+        for outcome in outcomes:
+            with tracer.start_trace(
+                name=f"path-completeness[{outcome.incident_id}]", span_type=SpanType.EVAL
+            ) as span:
+                span.log(
+                    input=outcome.incident_id,
+                    output=outcome.suggested,
+                    expected=sorted(outcome.missing_weights),
+                    scores=case_scores(outcome),
+                    metadata=case_metadata(outcome),
+                    tags=BENCHMARK_TAGS
+                    + (["abstained"] if outcome.abstained else []),
+                )
+
+        with tracer.start_trace(
+            name="path-completeness[summary]", span_type=SpanType.EVAL
+        ) as span:
+            span.log(
+                input="offline eval over the held-out corpus",
+                output=metrics.render(),
+                scores=summary_scores(metrics),
+                metadata=summary_metadata(metrics, calibration),
+                tags=BENCHMARK_TAGS + ["summary"],
+            )
+
+        flush = getattr(experiment, "flush", None)
+        if callable(flush):
+            flush()
+        return tracer.get_trace_url()
+    except Exception:
+        logging.exception("Failed to log investigation path benchmark to Braintrust")
+        return None
+
+
+def _summary_rows(metrics: EvalMetrics) -> List[Tuple[str, str]]:
+    return [
+        ("Held-out cases", f"{metrics.cases}"),
+        ("Answered", f"{metrics.answered_cases}"),
+        ("Abstention rate", f"{metrics.abstention_rate:.2f}"),
+        ("Weighted path recall", f"{metrics.weighted_path_recall:.2f}"),
+        ("Weighted path recall (answering)", f"{metrics.weighted_path_recall_when_answering:.2f}"),
+        ("Suggestion precision", f"{metrics.suggestion_precision:.2f}"),
+        ("Weighted suggestion precision", f"{metrics.weighted_suggestion_precision:.2f}"),
+        ("False positives per answer", f"{metrics.false_positive_burden:.2f}"),
+        ("Expected calibration error", f"{metrics.expected_calibration_error:.3f}"),
+        ("Brier score", f"{metrics.brier_score:.3f}"),
+        ("Latency p50 / p95 (ms)", f"{metrics.latency_p50_ms:.1f} / {metrics.latency_p95_ms:.1f}"),
+        ("Bytes per stored incident", f"{metrics.bytes_per_incident:.0f}"),
+        ("LLM calls", f"{metrics.llm_calls}"),
+    ]
+
+
+def benchmark_markdown(
+    metrics: EvalMetrics,
+    outcomes: Sequence[CaseOutcome],
+    calibration: Optional[CalibrationModel] = None,
+    raw_metrics: Optional[EvalMetrics] = None,
+    experiment_url: Optional[str] = None,
+) -> str:
+    """Render a benchmark run for a pull request comment."""
+    lines = [
+        "## Investigation path completeness benchmark",
+        "",
+        "Offline only. No runtime behaviour depends on these numbers "
+        "([#2046](https://github.com/HolmesGPT/holmesgpt/issues/2046)).",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+    ]
+    lines += [f"| {label} | {value} |" for label, value in _summary_rows(metrics)]
+
+    if calibration is not None:
+        calibration_line = f"**Confidence calibration:** {calibration.describe()}"
+        if raw_metrics is not None:
+            calibration_line += (
+                f". Calibration error {raw_metrics.expected_calibration_error:.3f} → "
+                f"{metrics.expected_calibration_error:.3f}, "
+                f"Brier {raw_metrics.brier_score:.3f} → {metrics.brier_score:.3f}"
+            )
+        lines += ["", calibration_line + "."]
+
+    lines += [
+        "",
+        "<details><summary>Per-incident results</summary>",
+        "",
+        "| Incident | Result | Found | Wrong | Skipped checks |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for outcome in outcomes:
+        if outcome.abstained:
+            result = f"abstained ({outcome.abstain_reason})"
+        elif not outcome.suggested:
+            # Retrieval found a match but every candidate check was filtered out.
+            # Reads identically to an abstention to a human, so say so.
+            result = "no suggestions"
+        else:
+            result = "answered"
+        lines.append(
+            f"| {outcome.incident_id} | {result} | {len(outcome.true_positives)} | "
+            f"{len(outcome.false_positives)} | {len(outcome.missing_weights)} |"
+        )
+    lines += ["", "</details>"]
+
+    if metrics.abstain_reasons:
+        reasons = ", ".join(
+            f"{reason}: {count}" for reason, count in sorted(metrics.abstain_reasons.items())
+        )
+        lines += ["", f"**Abstained because** {reasons}."]
+
+    if experiment_url:
+        lines += ["", f"[View in Braintrust]({experiment_url})"]
+
+    return "\n".join(lines) + "\n"

--- a/holmes/core/investigation_path/reporting.py
+++ b/holmes/core/investigation_path/reporting.py
@@ -120,21 +120,28 @@ def log_benchmark_to_braintrust(
     Returns None when tracing is unavailable, which is the normal case locally.
     Failures here are logged and swallowed: a reporting outage must not turn a
     passing benchmark into a red build.
-    """
-    tracer = TracingFactory.create_tracer("braintrust")
-    experiment = tracer.start_experiment(
-        experiment_name=benchmark_experiment_name(experiment_name),
-        additional_metadata={
-            "benchmark": BENCHMARK_SUFFIX,
-            "issue": "2046",
-            **summary_metadata(metrics, calibration),
-        },
-    )
-    if experiment is None:
-        logging.debug("Braintrust not configured; investigation path benchmark not logged")
-        return None
 
+    Building the tracer and starting the experiment are inside the guard, not
+    before it. `start_experiment` calls `braintrust.init`, which does network
+    I/O, so it is the likeliest step to raise and the earliest - there is no
+    span yet for the failure to surface on.
+    """
     try:
+        tracer = TracingFactory.create_tracer("braintrust")
+        experiment = tracer.start_experiment(
+            experiment_name=benchmark_experiment_name(experiment_name),
+            additional_metadata={
+                "benchmark": BENCHMARK_SUFFIX,
+                "issue": "2046",
+                **summary_metadata(metrics, calibration),
+            },
+        )
+        if experiment is None:
+            logging.debug(
+                "Braintrust not configured; investigation path benchmark not logged"
+            )
+            return None
+
         for outcome in outcomes:
             with tracer.start_trace(
                 name=f"path-completeness[{outcome.incident_id}]", span_type=SpanType.EVAL

--- a/holmes/core/investigation_path/retrieval.py
+++ b/holmes/core/investigation_path/retrieval.py
@@ -36,24 +36,43 @@ class AbstainReason(str, Enum):
 
 
 class RetrievalPolicy(BaseModel):
-    """Every knob that decides whether to answer, and how confidently."""
+    """Every knob that decides whether to answer, and how confidently.
+
+    The bounds are load-bearing, not decoration. This is the surface a
+    contributor sweeps when exploring the recall/precision tradeoff, and an
+    out-of-range value does not announce itself: a similarity floor above 1.0
+    abstains on everything and a candidate cap of 0 finds nothing, both of
+    which report as a policy result rather than as the typo they are.
+    `full_support_matches=0` is the one that fails loudly, dividing by zero
+    when confidence is computed.
+    """
 
     min_symptom_similarity: float = Field(
-        default=0.35, description="Symptom overlap below this is treated as no match at all."
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description="Symptom overlap below this is treated as no match at all.",
     )
     max_candidates: int = Field(
-        default=5, description="How many ranked candidates to consider before filtering by cause."
+        default=5,
+        gt=0,
+        description="How many ranked candidates to consider before filtering by cause.",
     )
     min_matches: int = Field(
         default=2,
+        ge=1,
         description="Answering on a single past incident overfits to it, so require at least this many.",
     )
     min_root_cause_agreement: float = Field(
         default=0.6,
+        ge=0.0,
+        le=1.0,
         description="Share of candidates that must agree on the root cause before answering.",
     )
     full_support_matches: int = Field(
-        default=3, description="Match count at which the support term of confidence reaches 1.0."
+        default=3,
+        gt=0,
+        description="Match count at which the support term of confidence reaches 1.0.",
     )
     signature_level: SignatureLevel = SignatureLevel.FINE
 

--- a/holmes/core/investigation_path/retrieval.py
+++ b/holmes/core/investigation_path/retrieval.py
@@ -1,0 +1,178 @@
+"""Find resolved incidents similar to the one being investigated, or abstain.
+
+Two ideas drive this module.
+
+**Similar symptoms and same root cause are different questions.** Retrieval
+ranks by symptom overlap, because symptoms are all that is known while an
+incident is still open. But the checks worth suggesting come from the *cause*,
+not the presentation. So after ranking, the candidates are collapsed to the
+single root cause most of them share, and everything that disagrees is dropped.
+If the candidates do not agree, there is no defensible cause to borrow checks
+from and the retrieval abstains.
+
+**Abstention is a first-class outcome, not an error.** A wrong suggestion costs
+a responder attention during an incident, so answering is only worth it when
+similarity, support and cause agreement all hold. Every abstention carries a
+reason so the offline eval can report *why* coverage was lost.
+
+The confidence score here is a deliberately simple product of three signals. It
+is not assumed to be calibrated - `metrics.py` measures its calibration error,
+which is the whole point of doing this offline first.
+"""
+
+from enum import Enum
+from typing import List, Optional, Sequence, Tuple
+
+from pydantic import BaseModel, Field
+
+from holmes.core.investigation_path.schema import IncidentRecord, SignatureLevel
+
+
+class AbstainReason(str, Enum):
+    NO_CANDIDATES = "no_candidates"
+    LOW_SIMILARITY = "low_similarity"
+    INSUFFICIENT_SUPPORT = "insufficient_support"
+    ROOT_CAUSE_DISAGREEMENT = "root_cause_disagreement"
+
+
+class RetrievalPolicy(BaseModel):
+    """Every knob that decides whether to answer, and how confidently."""
+
+    min_symptom_similarity: float = Field(
+        default=0.35, description="Symptom overlap below this is treated as no match at all."
+    )
+    max_candidates: int = Field(
+        default=5, description="How many ranked candidates to consider before filtering by cause."
+    )
+    min_matches: int = Field(
+        default=2,
+        description="Answering on a single past incident overfits to it, so require at least this many.",
+    )
+    min_root_cause_agreement: float = Field(
+        default=0.6,
+        description="Share of candidates that must agree on the root cause before answering.",
+    )
+    full_support_matches: int = Field(
+        default=3, description="Match count at which the support term of confidence reaches 1.0."
+    )
+    signature_level: SignatureLevel = SignatureLevel.FINE
+
+
+class ScoredIncident(BaseModel):
+    incident: IncidentRecord
+    symptom_similarity: float
+
+
+class RetrievalResult(BaseModel):
+    """What retrieval found, including the candidates it then rejected."""
+
+    candidates: List[ScoredIncident] = Field(
+        default_factory=list, description="Everything above the similarity floor, ranked."
+    )
+    matches: List[ScoredIncident] = Field(
+        default_factory=list, description="Candidates sharing the modal root cause. Empty when abstaining."
+    )
+    modal_root_cause: Optional[str] = None
+    symptom_confidence: float = 0.0
+    root_cause_agreement: float = 0.0
+    confidence: float = Field(
+        default=0.0, description="Product of symptom confidence, cause agreement and support."
+    )
+    abstained: bool = True
+    abstain_reason: Optional[AbstainReason] = None
+
+    def explain_abstention(self) -> str:
+        reasons = {
+            AbstainReason.NO_CANDIDATES: "no past incident resembled this one",
+            AbstainReason.LOW_SIMILARITY: "the closest past incidents were not similar enough",
+            AbstainReason.INSUFFICIENT_SUPPORT: "too few past incidents shared this root cause",
+            AbstainReason.ROOT_CAUSE_DISAGREEMENT: (
+                "similar past incidents had different root causes"
+            ),
+        }
+        if self.abstain_reason is None:
+            return ""
+        return reasons[self.abstain_reason]
+
+
+def symptom_similarity(left: Sequence[str], right: Sequence[str]) -> float:
+    """Jaccard overlap of two curated symptom keyword sets, in [0, 1]."""
+    left_set, right_set = {s.lower() for s in left}, {s.lower() for s in right}
+    if not left_set or not right_set:
+        return 0.0
+    return len(left_set & right_set) / len(left_set | right_set)
+
+
+def _modal_root_cause(candidates: Sequence[ScoredIncident]) -> Tuple[Optional[str], float]:
+    """The most common root-cause label among candidates, and its share.
+
+    Ties are broken by summed similarity so the winner is the cause the closest
+    incidents point at, not just the alphabetically first one.
+    """
+    if not candidates:
+        return None, 0.0
+    counts: dict = {}
+    weights: dict = {}
+    for candidate in candidates:
+        label = candidate.incident.root_cause.label
+        counts[label] = counts.get(label, 0) + 1
+        weights[label] = weights.get(label, 0.0) + candidate.symptom_similarity
+    label = max(counts, key=lambda key: (counts[key], weights[key]))
+    return label, counts[label] / len(candidates)
+
+
+def retrieve(
+    symptoms: Sequence[str],
+    corpus: Sequence[IncidentRecord],
+    policy: Optional[RetrievalPolicy] = None,
+) -> RetrievalResult:
+    """Rank the corpus by symptom overlap and decide whether it is safe to answer."""
+    policy = policy or RetrievalPolicy()
+
+    scored = [
+        ScoredIncident(incident=incident, symptom_similarity=symptom_similarity(symptoms, incident.symptoms))
+        for incident in corpus
+    ]
+    above_floor = [s for s in scored if s.symptom_similarity >= policy.min_symptom_similarity]
+    # Ties break on incident id ascending so that two equally similar incidents
+    # always rank in the same order, whatever order the corpus loaded in.
+    above_floor.sort(key=lambda s: (-s.symptom_similarity, s.incident.incident_id))
+    candidates = above_floor[: policy.max_candidates]
+
+    if not candidates:
+        any_overlap = any(s.symptom_similarity > 0 for s in scored)
+        return RetrievalResult(
+            abstained=True,
+            abstain_reason=AbstainReason.LOW_SIMILARITY if any_overlap else AbstainReason.NO_CANDIDATES,
+        )
+
+    modal_label, agreement = _modal_root_cause(candidates)
+    base = RetrievalResult(
+        candidates=candidates,
+        modal_root_cause=modal_label,
+        root_cause_agreement=agreement,
+    )
+
+    if agreement < policy.min_root_cause_agreement:
+        return base.model_copy(
+            update={"abstained": True, "abstain_reason": AbstainReason.ROOT_CAUSE_DISAGREEMENT}
+        )
+
+    matches = [c for c in candidates if c.incident.root_cause.label == modal_label]
+    if len(matches) < policy.min_matches:
+        return base.model_copy(
+            update={"abstained": True, "abstain_reason": AbstainReason.INSUFFICIENT_SUPPORT}
+        )
+
+    symptom_confidence = sum(m.symptom_similarity for m in matches) / len(matches)
+    support = min(1.0, len(matches) / policy.full_support_matches)
+
+    return base.model_copy(
+        update={
+            "matches": matches,
+            "symptom_confidence": symptom_confidence,
+            "confidence": symptom_confidence * agreement * support,
+            "abstained": False,
+            "abstain_reason": None,
+        }
+    )

--- a/holmes/core/investigation_path/schema.py
+++ b/holmes/core/investigation_path/schema.py
@@ -1,0 +1,307 @@
+"""The redacted canonical path event, and the corpus record built on top of it.
+
+An investigation is reduced to an ordered list of `PathEvent`s. Each event says
+*what was checked*, *why*, *over what time range* and *how it turned out* - and
+deliberately nothing else. Two rules govern every field here:
+
+1. **Nothing unbounded or secret is stored.** No raw tool output, no raw error
+   strings, no credentials, no free-form provider parameters. Error text is
+   collapsed to an `error_class`; evidence is an opaque `evidence_ref` that
+   points at output held elsewhere rather than a copy of it.
+2. **Nothing unstable is stored.** Values that change between two runs of the
+   same check - pod hashes, exact timestamps, request ids - are normalized or
+   bucketed away, so that the same check in two incidents compares equal.
+
+`signature_of()` is what comparison actually runs on. It exists at two
+granularities because they answer different questions: COARSE asks "did anyone
+look at the service topology at all", FINE asks "did anyone look at
+`service/redis`".
+"""
+
+from enum import Enum
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+# Stands in for "the workload this incident is about" inside a stored path.
+# Without it, a reference path from a payment-service incident could never match
+# an orders-service one, because every signature would carry a workload name
+# that appears in exactly one incident. Corpus paths are authored with this
+# token; live paths get it substituted in by passing `subject=` to the signature
+# helpers.
+SUBJECT_TOKEN = "<subject>"
+
+# Lookback windows are bucketed to these boundaries (in seconds) so that
+# "--since 5m" and "--since 7m" do not look like two different checks.
+LOOKBACK_BUCKETS_SECONDS = (
+    300,  # 5m
+    900,  # 15m
+    3600,  # 1h
+    21600,  # 6h
+    86400,  # 24h
+    604800,  # 7d
+)
+
+
+class QueryIntent(str, Enum):
+    """Why a check was run, independent of which tool ran it.
+
+    Intent is what makes paths comparable across toolsets: `kubectl logs`,
+    `fetch_pod_logs` and a Loki query are all `LOGS`, so an investigation that
+    used one is not told it skipped the others.
+    """
+
+    DESCRIBE = "describe"  # inspect one named object's spec/status
+    LIST = "list"  # enumerate objects of a kind
+    LOGS = "logs"
+    EVENTS = "events"
+    METRICS = "metrics"
+    TRACES = "traces"
+    TOPOLOGY = "topology"  # services, endpoints, reachability, ownership
+    RESOURCE_USAGE = "resource_usage"  # utilization, limits, capacity
+    CONFIG_HISTORY = "config_history"  # deploys, rollouts, config changes
+    OTHER = "other"
+
+
+class OutcomeStatus(str, Enum):
+    SUCCESS = "success"
+    NO_DATA = "no_data"
+    ERROR = "error"
+
+
+class ErrorClass(str, Enum):
+    """Normalized failure reason. Raw error text is never stored."""
+
+    NOT_FOUND = "not_found"
+    FORBIDDEN = "forbidden"
+    TIMEOUT = "timeout"
+    INVALID_QUERY = "invalid_query"
+    UNAVAILABLE = "unavailable"
+    OTHER = "other"
+
+
+class SignatureLevel(str, Enum):
+    """How precisely two checks must match to count as the same check."""
+
+    COARSE = "coarse"  # intent + entity kind
+    FINE = "fine"  # intent + entity kind + entity name
+
+
+class EntityRef(BaseModel):
+    """What a check looked at, normalized so instances of one workload match.
+
+    `name` has generated suffixes stripped by `normalize.normalize_resource_name`,
+    so `payment-service-7d9f8b6c5-x2k9p` is stored as `payment-service`.
+    """
+
+    kind: Optional[str] = Field(
+        default=None,
+        description="Normalized singular kind: 'pod', 'service', 'metric', 'trace'.",
+    )
+    name: Optional[str] = Field(
+        default=None, description="Normalized object or metric name, without instance suffixes."
+    )
+    namespace: Optional[str] = Field(
+        default=None,
+        description="Kept for provenance display only; never part of a signature.",
+    )
+
+    def describe(self) -> str:
+        if self.kind and self.name:
+            return f"{self.kind}/{self.name}"
+        return self.name or self.kind or "-"
+
+
+class TimeWindow(BaseModel):
+    """The time range a check covered, bucketed so it is stable across runs."""
+
+    lookback_seconds: Optional[int] = Field(
+        default=None,
+        description="Relative lookback, snapped to LOOKBACK_BUCKETS_SECONDS.",
+    )
+    is_point_in_time: bool = Field(
+        default=False,
+        description="True for checks that read current state rather than a range.",
+    )
+
+    def describe(self) -> str:
+        if self.is_point_in_time:
+            return "now"
+        if self.lookback_seconds is None:
+            return "unspecified"
+        return _humanize_seconds(self.lookback_seconds)
+
+
+class Outcome(BaseModel):
+    """How a check turned out, with the failure reason collapsed to a class."""
+
+    status: OutcomeStatus
+    error_class: Optional[ErrorClass] = None
+
+
+class PathEvent(BaseModel):
+    """One check inside an investigation, in canonical redacted form."""
+
+    ordinal: int = Field(description="0-based position in the investigation, preserving order.")
+    tool: str = Field(description="Tool name as executed. Kept for provenance, not for matching.")
+    intent: QueryIntent
+    entity: EntityRef = Field(default_factory=EntityRef)
+    time_window: Optional[TimeWindow] = None
+    outcome: Outcome
+    evidence_ref: Optional[str] = Field(
+        default=None,
+        description="Opaque pointer to the output (e.g. a tool call id). Never the output itself.",
+    )
+
+    def describe(self) -> str:
+        return f"{self.intent.value} {self.entity.describe()}"
+
+
+class InvestigationPath(BaseModel):
+    """An ordered, de-duplicated view of everything one investigation checked."""
+
+    events: List[PathEvent] = Field(default_factory=list)
+
+    def signatures(
+        self,
+        level: SignatureLevel = SignatureLevel.FINE,
+        subject: Optional[str] = None,
+    ) -> List[str]:
+        """Signatures in execution order, first occurrence wins."""
+        seen: set = set()
+        ordered: List[str] = []
+        for event in self.events:
+            key = signature_of(event, level, subject)
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(key)
+        return ordered
+
+    def signature_set(
+        self,
+        level: SignatureLevel = SignatureLevel.FINE,
+        subject: Optional[str] = None,
+    ) -> set:
+        return set(self.signatures(level, subject))
+
+
+class RootCause(BaseModel):
+    """What an incident actually turned out to be.
+
+    Held separately from symptoms on purpose: two incidents can present
+    identically and still have unrelated causes, and suggesting the checks from
+    the wrong cause is worse than suggesting nothing.
+    """
+
+    label: str = Field(description="Controlled vocabulary id, e.g. 'dependency_unreachable'.")
+    summary: str = Field(description="One line of human-readable explanation.")
+
+
+class ReferenceStep(BaseModel):
+    """A check a human decided belongs in the path for this kind of incident."""
+
+    intent: QueryIntent
+    entity: EntityRef = Field(default_factory=EntityRef)
+    weight: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="How much skipping this check would have hurt. Drives weighted recall.",
+    )
+    rationale: str = Field(
+        description="Why this check matters. Shown to the user so a suggestion is auditable."
+    )
+
+    def signature(self, level: SignatureLevel = SignatureLevel.FINE) -> str:
+        return _signature(self.intent, self.entity, level)
+
+
+class IncidentRecord(BaseModel):
+    """One human-validated resolved incident in the corpus."""
+
+    incident_id: str
+    occurred_at: str
+    source_type: str
+    title: str
+    subject: Optional[str] = Field(
+        default=None,
+        description="The workload the incident was about. Paths refer to it as SUBJECT_TOKEN.",
+    )
+    symptoms: List[str] = Field(
+        default_factory=list, description="Curated keywords describing how the incident presented."
+    )
+    root_cause: RootCause
+    reference_path: List[ReferenceStep] = Field(
+        default_factory=list,
+        description="The checks a good investigation of this incident should include.",
+    )
+    observed_path: List[ReferenceStep] = Field(
+        default_factory=list,
+        description="What an investigation actually did. Only set on held-out cases, "
+        "where reference_path minus observed_path is the ground-truth missing set.",
+    )
+    validated_by: str = Field(description="Who reviewed this record. Corpus entries are not auto-generated.")
+    validated_at: str
+    split: Literal["corpus", "holdout"] = "corpus"
+
+    def reference_signatures(self, level: SignatureLevel = SignatureLevel.FINE) -> set:
+        return {step.signature(level) for step in self.reference_path}
+
+    def observed_signatures(self, level: SignatureLevel = SignatureLevel.FINE) -> set:
+        return {step.signature(level) for step in self.observed_path}
+
+    def missing_steps(self, level: SignatureLevel = SignatureLevel.FINE) -> List[ReferenceStep]:
+        """Ground truth: reference checks the observed investigation did not run."""
+        observed = self.observed_signatures(level)
+        return [step for step in self.reference_path if step.signature(level) not in observed]
+
+
+def signature_of(
+    event: PathEvent,
+    level: SignatureLevel = SignatureLevel.FINE,
+    subject: Optional[str] = None,
+) -> str:
+    """The comparison key for a path event.
+
+    Note that `tool` is intentionally excluded: the same check run through two
+    different toolsets must compare equal, or an investigation gets told it
+    skipped a check it actually performed.
+    """
+    return _signature(event.intent, event.entity, level, subject)
+
+
+def _signature(
+    intent: QueryIntent,
+    entity: EntityRef,
+    level: SignatureLevel,
+    subject: Optional[str] = None,
+) -> str:
+    kind = entity.kind or "-"
+    if level == SignatureLevel.COARSE:
+        return f"{intent.value}:{kind}"
+    name = entity.name or "-"
+    if subject and name == normalize_subject(subject):
+        name = SUBJECT_TOKEN
+    return f"{intent.value}:{kind}:{name}"
+
+
+def normalize_subject(subject: str) -> str:
+    return subject.strip().lower()
+
+
+def bucket_lookback_seconds(seconds: Optional[float]) -> Optional[int]:
+    """Snap a lookback to the nearest bucket boundary at or above it."""
+    if seconds is None or seconds <= 0:
+        return None
+    for bucket in LOOKBACK_BUCKETS_SECONDS:
+        if seconds <= bucket:
+            return bucket
+    return LOOKBACK_BUCKETS_SECONDS[-1]
+
+
+def _humanize_seconds(seconds: int) -> str:
+    for amount, unit in ((86400, "d"), (3600, "h"), (60, "m")):
+        if seconds % amount == 0:
+            return f"{seconds // amount}{unit}"
+    return f"{seconds}s"

--- a/holmes/core/investigation_path/validator.py
+++ b/holmes/core/investigation_path/validator.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Sequence, Set
 
 from pydantic import BaseModel, Field
 
-from holmes.core.investigation_path.calibration import CalibrationModel
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.retrieval import RetrievalResult
 from holmes.core.investigation_path.schema import (
     SUBJECT_TOKEN,

--- a/holmes/core/investigation_path/validator.py
+++ b/holmes/core/investigation_path/validator.py
@@ -1,12 +1,16 @@
 """Turn retrieved incidents into auditable missing-check suggestions.
 
 A suggestion is only useful if a responder can decide, in a few seconds,
-whether to act on it. So every suggestion carries three things beyond the check
+whether to act on it. So every suggestion carries four things beyond the check
 itself:
 
 - **provenance** - which resolved incident it came from, and when
 - **rationale** - the human-written reason that check mattered there
 - **support** - how many of the matched incidents ran it, out of how many
+- **confidence** - stated as a probability *only* when a fitted calibration
+  model produced it. Uncalibrated, the score is a product of terms below 1: it
+  ranks correctly but reads far below the real hit rate, and showing it as a
+  percentage would train responders to ignore the whole block.
 
 The wording is advisory throughout. One historical path is evidence, not a plan,
 and presenting it as a required checklist would push every investigation towards
@@ -87,6 +91,14 @@ class Suggestion(BaseModel):
         description="Calibrated probability that this check is genuinely missing, "
         "when a calibration model is supplied. Equals raw_confidence otherwise."
     )
+    calibrated: bool = Field(
+        default=False,
+        description=(
+            "Whether `confidence` came from a fitted calibration model. False means "
+            "it is a raw evidence score that orders suggestions correctly but is not "
+            "a probability, and must not be rendered to a user as a percentage."
+        ),
+    )
     provenance: List[Provenance] = Field(default_factory=list)
 
     def describe(self, subject: Optional[str] = None) -> str:
@@ -133,10 +145,16 @@ class ValidationReport(BaseModel):
             sources = ", ".join(
                 f"{p.incident_id} ({p.occurred_at})" for p in suggestion.provenance
             )
-            lines.append(
+            evidence = (
                 f"  Seen in {suggestion.support}/{suggestion.out_of} similar resolved "
                 f"incidents: {sources}"
             )
+            # Only a calibrated score is stated as a probability. The raw score is
+            # a product of terms below 1, so printing it as a percentage would
+            # understate the real hit rate and teach responders to ignore it.
+            if suggestion.calibrated:
+                evidence += f". Confidence {suggestion.confidence:.0%}"
+            lines.append(evidence)
         return "\n".join(lines)
 
 
@@ -253,6 +271,7 @@ def validate_path(
             continue
         best = max(steps, key=lambda step: step.weight)
         raw_confidence = retrieval.confidence * (support / out_of)
+        is_calibrated = calibration is not None and calibration.fitted
         confidence = calibration.apply(raw_confidence) if calibration else raw_confidence
         if confidence < policy.min_confidence:
             continue
@@ -267,6 +286,7 @@ def validate_path(
                 out_of=out_of,
                 raw_confidence=raw_confidence,
                 confidence=confidence,
+                calibrated=is_calibrated,
                 provenance=provenance_by_signature[signature],
             )
         )

--- a/holmes/core/investigation_path/validator.py
+++ b/holmes/core/investigation_path/validator.py
@@ -47,11 +47,22 @@ _NAME_TOKEN_RE = re.compile(r"[^a-z0-9]+")
 
 
 class SuggestionPolicy(BaseModel):
+    """What survives the filters and gets shown.
+
+    Bounded for the same reason as `RetrievalPolicy`: a ratio above 1.0 or a
+    cap of 0 silently suppresses every suggestion, which scores as perfect
+    precision and zero recall rather than as the misconfiguration it is.
+    """
+
     min_support: int = Field(
-        default=1, description="Matched incidents that must have run a check before it is suggested."
+        default=1,
+        ge=1,
+        description="Matched incidents that must have run a check before it is suggested.",
     )
     min_support_ratio: float = Field(
         default=0.6,
+        ge=0.0,
+        le=1.0,
         description=(
             "Share of matched incidents that must have run a check. A check only one "
             "incident out of three ran is that incident's particular circumstance, not "
@@ -59,10 +70,15 @@ class SuggestionPolicy(BaseModel):
         ),
     )
     min_confidence: float = Field(
-        default=0.15, description="Suggestions below this confidence are dropped rather than shown."
+        default=0.15,
+        ge=0.0,
+        le=1.0,
+        description="Suggestions below this confidence are dropped rather than shown.",
     )
     max_suggestions: int = Field(
-        default=5, description="Cap on suggestions per report, to bound the reading cost."
+        default=5,
+        gt=0,
+        description="Cap on suggestions per report, to bound the reading cost.",
     )
     signature_level: SignatureLevel = SignatureLevel.FINE
 

--- a/holmes/core/investigation_path/validator.py
+++ b/holmes/core/investigation_path/validator.py
@@ -1,0 +1,189 @@
+"""Turn retrieved incidents into auditable missing-check suggestions.
+
+A suggestion is only useful if a responder can decide, in a few seconds,
+whether to act on it. So every suggestion carries three things beyond the check
+itself:
+
+- **provenance** - which resolved incident it came from, and when
+- **rationale** - the human-written reason that check mattered there
+- **support** - how many of the matched incidents ran it, out of how many
+
+The wording is advisory throughout. One historical path is evidence, not a plan,
+and presenting it as a required checklist would push every investigation towards
+whatever was investigated first. `max_suggestions` exists for the same reason:
+an unbounded list is ignored, so the report is capped and ranked by how much a
+skipped check cost in the past.
+"""
+
+from typing import Dict, List, Optional, Sequence
+
+from pydantic import BaseModel, Field
+
+from holmes.core.investigation_path.retrieval import RetrievalResult
+from holmes.core.investigation_path.schema import (
+    SUBJECT_TOKEN,
+    EntityRef,
+    QueryIntent,
+    ReferenceStep,
+    SignatureLevel,
+)
+
+
+class SuggestionPolicy(BaseModel):
+    min_support: int = Field(
+        default=1, description="Matched incidents that must have run a check before it is suggested."
+    )
+    min_confidence: float = Field(
+        default=0.15, description="Suggestions below this confidence are dropped rather than shown."
+    )
+    max_suggestions: int = Field(
+        default=5, description="Cap on suggestions per report, to bound the reading cost."
+    )
+    signature_level: SignatureLevel = SignatureLevel.FINE
+
+
+class Provenance(BaseModel):
+    """Where one suggestion came from, so the user can go and check."""
+
+    incident_id: str
+    title: str
+    occurred_at: str
+    root_cause_label: str
+
+
+class Suggestion(BaseModel):
+    signature: str
+    intent: QueryIntent
+    entity: EntityRef
+    rationale: str
+    weight: float = Field(description="Importance of this check in the reference paths that had it.")
+    support: int
+    out_of: int
+    confidence: float
+    provenance: List[Provenance] = Field(default_factory=list)
+
+    def describe(self, subject: Optional[str] = None) -> str:
+        rendered = self.entity.describe()
+        if subject:
+            rendered = rendered.replace(SUBJECT_TOKEN, subject)
+        return f"{self.intent.value} {rendered}"
+
+
+class ValidationReport(BaseModel):
+    """The outcome of validating one investigation path."""
+
+    abstained: bool
+    abstain_reason: Optional[str] = None
+    modal_root_cause: Optional[str] = None
+    confidence: float = 0.0
+    subject: Optional[str] = Field(
+        default=None, description="Workload under investigation, used to render SUBJECT_TOKEN."
+    )
+    suggestions: List[Suggestion] = Field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.suggestions
+
+    def to_markdown(self) -> str:
+        """Render the advisory block a user would see. Not wired into any output yet."""
+        if self.abstained:
+            return ""
+        if self.is_empty:
+            return ""
+
+        lines = [
+            "## Investigation path check",
+            "",
+            "Resolved incidents with the same root cause "
+            f"(`{self.modal_root_cause}`) also ran the checks below. "
+            "These are suggestions from past evidence, not required steps - "
+            "skip any that do not apply here.",
+            "",
+        ]
+        for suggestion in self.suggestions:
+            lines.append(f"- **{suggestion.describe(self.subject)}** — {suggestion.rationale}")
+            sources = ", ".join(
+                f"{p.incident_id} ({p.occurred_at})" for p in suggestion.provenance
+            )
+            lines.append(
+                f"  Seen in {suggestion.support}/{suggestion.out_of} similar resolved "
+                f"incidents: {sources}"
+            )
+        return "\n".join(lines)
+
+
+def validate_path(
+    observed_signatures: Sequence[str],
+    retrieval: RetrievalResult,
+    policy: Optional[SuggestionPolicy] = None,
+    subject: Optional[str] = None,
+) -> ValidationReport:
+    """Compare an investigation's checks against the reference paths of its matches."""
+    policy = policy or SuggestionPolicy()
+
+    if retrieval.abstained:
+        return ValidationReport(
+            abstained=True,
+            abstain_reason=retrieval.explain_abstention(),
+            modal_root_cause=retrieval.modal_root_cause,
+            confidence=retrieval.confidence,
+            subject=subject,
+        )
+
+    performed = set(observed_signatures)
+    out_of = len(retrieval.matches)
+
+    steps_by_signature: Dict[str, List[ReferenceStep]] = {}
+    provenance_by_signature: Dict[str, List[Provenance]] = {}
+    for match in retrieval.matches:
+        incident = match.incident
+        # De-duplicate within one incident so a repeated reference step cannot
+        # inflate its own support count.
+        seen_here = set()
+        for step in incident.reference_path:
+            signature = step.signature(policy.signature_level)
+            if signature in performed or signature in seen_here:
+                continue
+            seen_here.add(signature)
+            steps_by_signature.setdefault(signature, []).append(step)
+            provenance_by_signature.setdefault(signature, []).append(
+                Provenance(
+                    incident_id=incident.incident_id,
+                    title=incident.title,
+                    occurred_at=incident.occurred_at,
+                    root_cause_label=incident.root_cause.label,
+                )
+            )
+
+    suggestions: List[Suggestion] = []
+    for signature, steps in steps_by_signature.items():
+        support = len(steps)
+        if support < policy.min_support:
+            continue
+        best = max(steps, key=lambda step: step.weight)
+        confidence = retrieval.confidence * (support / out_of)
+        if confidence < policy.min_confidence:
+            continue
+        suggestions.append(
+            Suggestion(
+                signature=signature,
+                intent=best.intent,
+                entity=best.entity,
+                rationale=best.rationale,
+                weight=best.weight,
+                support=support,
+                out_of=out_of,
+                confidence=confidence,
+                provenance=provenance_by_signature[signature],
+            )
+        )
+
+    suggestions.sort(key=lambda s: (-(s.weight * s.support), s.signature))
+    return ValidationReport(
+        abstained=False,
+        modal_root_cause=retrieval.modal_root_cause,
+        confidence=retrieval.confidence,
+        subject=subject,
+        suggestions=suggestions[: policy.max_suggestions],
+    )

--- a/holmes/core/investigation_path/validator.py
+++ b/holmes/core/investigation_path/validator.py
@@ -15,23 +15,44 @@ an unbounded list is ignored, so the report is capped and ranked by how much a
 skipped check cost in the past.
 """
 
-from typing import Dict, List, Optional, Sequence
+import re
+from typing import Dict, List, Optional, Sequence, Set
 
 from pydantic import BaseModel, Field
 
+from holmes.core.investigation_path.calibration import CalibrationModel
 from holmes.core.investigation_path.retrieval import RetrievalResult
 from holmes.core.investigation_path.schema import (
     SUBJECT_TOKEN,
     EntityRef,
+    IncidentRecord,
     QueryIntent,
     ReferenceStep,
     SignatureLevel,
 )
 
 
+# Kinds whose names usually mean the same thing in every incident. A metric
+# called `container_memory_working_set_bytes` exists in any cluster, so
+# suggesting it transfers. A pod called `redis` does not: in an incident about a
+# message broker, that suggestion sends the responder to a service that is not
+# there.
+GENERIC_ENTITY_KINDS = frozenset({"metric", "trace"})
+
+_NAME_TOKEN_RE = re.compile(r"[^a-z0-9]+")
+
+
 class SuggestionPolicy(BaseModel):
     min_support: int = Field(
         default=1, description="Matched incidents that must have run a check before it is suggested."
+    )
+    min_support_ratio: float = Field(
+        default=0.6,
+        description=(
+            "Share of matched incidents that must have run a check. A check only one "
+            "incident out of three ran is that incident's particular circumstance, not "
+            "a property of the root cause, and suggesting it is how false positives get in."
+        ),
     )
     min_confidence: float = Field(
         default=0.15, description="Suggestions below this confidence are dropped rather than shown."
@@ -59,7 +80,13 @@ class Suggestion(BaseModel):
     weight: float = Field(description="Importance of this check in the reference paths that had it.")
     support: int
     out_of: int
-    confidence: float
+    raw_confidence: float = Field(
+        description="Uncalibrated evidence score. Useful for ranking, not a probability."
+    )
+    confidence: float = Field(
+        description="Calibrated probability that this check is genuinely missing, "
+        "when a calibration model is supplied. Equals raw_confidence otherwise."
+    )
     provenance: List[Provenance] = Field(default_factory=list)
 
     def describe(self, subject: Optional[str] = None) -> str:
@@ -113,13 +140,71 @@ class ValidationReport(BaseModel):
         return "\n".join(lines)
 
 
+def _foreign_entities(
+    incident: IncidentRecord, known_entities: Optional[Set[str]]
+) -> Set[str]:
+    """Objects a past incident named that the current investigation has never seen."""
+    if known_entities is None:
+        return set()
+    return {
+        step.entity.name
+        for step in incident.reference_path
+        if step.entity.name
+        and step.entity.name != SUBJECT_TOKEN
+        and step.entity.kind not in GENERIC_ENTITY_KINDS
+        and step.entity.name not in known_entities
+    }
+
+
+def _names_a_foreign_entity(name: str, foreign: Set[str]) -> bool:
+    """True for a generic-kind name built out of a foreign object's name.
+
+    `redis_connected_clients` is nominally a metric, and metric names normally
+    transfer between incidents - but that one only exists where Redis does.
+    Matching whole tokens rather than substrings so that a metric like
+    `node_memory_MemAvailable_bytes` is not rejected because some incident
+    happened to name a pod `mem`.
+    """
+    tokens = set(_NAME_TOKEN_RE.split(name.lower())) - {""}
+    return any(entity.lower() in tokens for entity in foreign)
+
+
+def _transfers_to_this_incident(
+    entity: EntityRef, known_entities: Optional[Set[str]], foreign: Set[str]
+) -> bool:
+    """Whether a reference check makes sense against the incident being validated.
+
+    Returns True when no `known_entities` set was supplied, so callers that
+    cannot determine it are not silently filtered.
+    """
+    if known_entities is None:
+        return True
+    if entity.name is None or entity.name == SUBJECT_TOKEN:
+        return True
+    if entity.kind in GENERIC_ENTITY_KINDS:
+        return not _names_a_foreign_entity(entity.name, foreign)
+    return entity.name in known_entities
+
+
 def validate_path(
     observed_signatures: Sequence[str],
     retrieval: RetrievalResult,
     policy: Optional[SuggestionPolicy] = None,
     subject: Optional[str] = None,
+    calibration: Optional[CalibrationModel] = None,
+    known_entities: Optional[Set[str]] = None,
 ) -> ValidationReport:
-    """Compare an investigation's checks against the reference paths of its matches."""
+    """Compare an investigation's checks against the reference paths of its matches.
+
+    Without a `calibration` model the reported confidence is the raw evidence
+    score, which orders suggestions correctly but is not a probability and must
+    not be shown to a user as one.
+
+    `known_entities` is the set of object names the current investigation has
+    actually seen. Pass it to suppress suggestions that name something from a
+    past incident which does not exist in this one - two incidents can share
+    symptoms and a root cause while depending on entirely different services.
+    """
     policy = policy or SuggestionPolicy()
 
     if retrieval.abstained:
@@ -138,12 +223,15 @@ def validate_path(
     provenance_by_signature: Dict[str, List[Provenance]] = {}
     for match in retrieval.matches:
         incident = match.incident
+        foreign = _foreign_entities(incident, known_entities)
         # De-duplicate within one incident so a repeated reference step cannot
         # inflate its own support count.
         seen_here = set()
         for step in incident.reference_path:
             signature = step.signature(policy.signature_level)
             if signature in performed or signature in seen_here:
+                continue
+            if not _transfers_to_this_incident(step.entity, known_entities, foreign):
                 continue
             seen_here.add(signature)
             steps_by_signature.setdefault(signature, []).append(step)
@@ -161,8 +249,11 @@ def validate_path(
         support = len(steps)
         if support < policy.min_support:
             continue
+        if support / out_of < policy.min_support_ratio:
+            continue
         best = max(steps, key=lambda step: step.weight)
-        confidence = retrieval.confidence * (support / out_of)
+        raw_confidence = retrieval.confidence * (support / out_of)
+        confidence = calibration.apply(raw_confidence) if calibration else raw_confidence
         if confidence < policy.min_confidence:
             continue
         suggestions.append(
@@ -174,6 +265,7 @@ def validate_path(
                 weight=best.weight,
                 support=support,
                 out_of=out_of,
+                raw_confidence=raw_confidence,
                 confidence=confidence,
                 provenance=provenance_by_signature[signature],
             )

--- a/tests/core/investigation_path/test_calibration.py
+++ b/tests/core/investigation_path/test_calibration.py
@@ -1,0 +1,136 @@
+"""Calibration: does the confidence number mean what it says?
+
+The raw evidence score is a product of four terms below 1, so it reads far lower
+than the real hit rate. These tests pin down that the fit corrects that, refuses
+to fit when there is no signal, and does not quietly become over-confident on a
+small sample.
+"""
+
+import pytest
+
+from holmes.core.investigation_path.calibration import (
+    CalibrationModel,
+    build_calibration_samples,
+    fit_calibration,
+    fit_platt,
+)
+from holmes.core.investigation_path.corpus import load_corpus
+from holmes.core.investigation_path.metrics import expected_calibration_error
+
+
+def separable_sample(n=60):
+    """Low scores mostly wrong, high scores mostly right - like the real data."""
+    raw = [0.2] * n + [0.5] * n
+    labels = [False] * n + [True] * n
+    return raw, labels
+
+
+class TestFitting:
+    def test_a_fitted_model_separates_the_two_score_levels(self):
+        model = fit_platt(*separable_sample())
+        assert model.fitted
+        assert model.apply(0.5) > 0.8
+        assert model.apply(0.2) < 0.2
+
+    def test_the_map_is_monotone(self):
+        model = fit_platt(*separable_sample())
+        probabilities = [model.apply(x / 100) for x in range(0, 101)]
+        assert probabilities == sorted(probabilities)
+
+    def test_output_is_always_a_probability(self):
+        model = fit_platt(*separable_sample())
+        for x in (-5.0, 0.0, 0.5, 1.0, 100.0):
+            assert 0.0 <= model.apply(x) <= 1.0
+
+    def test_the_fit_is_deterministic(self):
+        first = fit_platt(*separable_sample())
+        second = fit_platt(*separable_sample())
+        assert first.slope == second.slope
+        assert first.intercept == second.intercept
+        assert first.l2 == second.l2
+
+    def test_the_penalty_is_chosen_by_cross_validation(self):
+        model = fit_platt(*separable_sample())
+        assert model.l2 > 0
+
+    def test_an_explicit_penalty_overrides_the_search(self):
+        assert fit_platt(*separable_sample(), l2=3.0).l2 == 3.0
+
+    def test_standardizing_makes_the_fit_independent_of_input_scale(self):
+        """The first attempt used un-standardized inputs; a fixed penalty then
+        crushed the slope because raw scores sit in a narrow band near zero."""
+        raw, labels = separable_sample()
+        scaled = fit_platt([r / 100 for r in raw], labels)
+        normal = fit_platt(raw, labels)
+        assert scaled.apply(0.005) == pytest.approx(normal.apply(0.5), abs=0.05)
+
+
+class TestRefusingToFit:
+    def test_all_positive_labels_will_not_fit(self):
+        model = fit_platt([0.1, 0.5, 0.9], [True, True, True])
+        assert not model.fitted
+
+    def test_all_negative_labels_will_not_fit(self):
+        model = fit_platt([0.1, 0.5, 0.9], [False, False, False])
+        assert not model.fitted
+
+    def test_a_single_sample_will_not_fit(self):
+        assert not fit_platt([0.5], [True]).fitted
+
+    def test_no_variation_in_score_will_not_fit(self):
+        assert not fit_platt([0.4, 0.4, 0.4, 0.4], [True, False, True, False]).fitted
+
+    def test_an_unfitted_model_passes_the_raw_score_through(self):
+        model = CalibrationModel(fitted=False)
+        assert model.apply(0.37) == 0.37
+
+    def test_an_unfitted_model_says_so(self):
+        assert "uncalibrated" in CalibrationModel(fitted=False).describe()
+
+    def test_no_samples_gives_an_unfitted_model(self):
+        assert not fit_calibration([]).fitted
+
+
+class TestSmallSampleSafety:
+    def test_a_tiny_separable_sample_does_not_claim_near_certainty(self):
+        """Target smoothing exists so four examples cannot buy 99% confidence."""
+        model = fit_platt([0.1, 0.2, 0.8, 0.9], [False, False, True, True])
+        assert model.apply(0.9) < 0.95
+
+    def test_more_evidence_permits_more_confidence(self):
+        small = fit_platt([0.1, 0.2, 0.8, 0.9], [False, False, True, True])
+        large = fit_platt([0.1, 0.2, 0.8, 0.9] * 40, [False, False, True, True] * 40)
+        assert large.apply(0.9) > small.apply(0.9)
+
+
+class TestOnTheRealCorpus:
+    @pytest.fixture(scope="class")
+    def pool(self):
+        return load_corpus(split="corpus")
+
+    def test_leave_one_out_produces_both_outcomes(self, pool):
+        """A single-class training set would teach the prior, not a mapping."""
+        samples = build_calibration_samples(pool)
+        labels = [label for _, label in samples]
+        assert len(samples) > 20
+        assert 0 < sum(labels) < len(labels)
+
+    def test_the_corpus_fits_a_usable_model(self, pool):
+        model = fit_calibration(pool)
+        assert model.fitted
+        assert model.samples > 20
+
+    def test_the_fit_reduces_calibration_error_on_its_own_training_data(self, pool):
+        samples = build_calibration_samples(pool)
+        raw = [r for r, _ in samples]
+        labels = [label for _, label in samples]
+        model = fit_calibration(pool)
+
+        before = expected_calibration_error(raw, labels)
+        after = expected_calibration_error([model.apply(r) for r in raw], labels)
+        assert after < before
+
+    def test_the_model_is_serializable(self, pool):
+        model = fit_calibration(pool)
+        restored = CalibrationModel.model_validate_json(model.model_dump_json())
+        assert restored.apply(0.4) == pytest.approx(model.apply(0.4))

--- a/tests/core/investigation_path/test_calibration.py
+++ b/tests/core/investigation_path/test_calibration.py
@@ -23,6 +23,26 @@ from holmes.core.investigation_path.metrics import expected_calibration_error
 PACKAGE_DIR = pathlib.Path(__file__).parents[3] / "holmes" / "core" / "investigation_path"
 
 
+TESTS_DIR = pathlib.Path(__file__).parent
+
+
+def function_scope_imports(directory):
+    """Every import sitting inside a function, reported as file:line.
+
+    Collected rather than raised on the first hit so a contributor who added
+    several sees all of them in one run.
+    """
+    offenders = []
+    for path in sorted(directory.glob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    offenders.append(f"{path.name}:{inner.lineno} inside {node.name}()")
+    return sorted(set(offenders))
+
+
 def import_graph():
     """Which modules in the package import which, read from the source."""
     graph = {}
@@ -154,16 +174,13 @@ class TestModuleLayout:
         assert "validator" in import_graph()["calibration"]
 
     def test_no_module_imports_inside_a_function(self):
-        for path in sorted(PACKAGE_DIR.glob("*.py")):
-            tree = ast.parse(path.read_text())
-            for node in ast.walk(tree):
-                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    continue
-                for inner in ast.walk(node):
-                    if isinstance(inner, (ast.Import, ast.ImportFrom)):
-                        raise AssertionError(
-                            f"{path.name}:{inner.lineno} imports inside {node.name}()"
-                        )
+        assert function_scope_imports(PACKAGE_DIR) == []
+
+    def test_no_test_imports_inside_a_function(self):
+        """The rule covers the tests too, and this is where it drifted first: a
+        one-line local import is the path of least resistance when adding a
+        case, and nothing complained until review did."""
+        assert function_scope_imports(TESTS_DIR) == []
 
 
 class TestMismatchedInput:

--- a/tests/core/investigation_path/test_calibration.py
+++ b/tests/core/investigation_path/test_calibration.py
@@ -91,6 +91,35 @@ class TestRefusingToFit:
         assert not fit_calibration([]).fitted
 
 
+class TestMismatchedInput:
+    """Scores and labels are zipped during the fit, so a length mismatch is
+    silent corruption rather than an error. It is a caller bug, so it raises
+    instead of returning an unfitted model, which would hide it.
+    """
+
+    def test_more_scores_than_labels_raises(self):
+        """Previously an IndexError from deep inside cross-validation."""
+        with pytest.raises(ValueError, match="raw scores and"):
+            fit_platt([0.1 * i for i in range(10)], [True, False] * 3)
+
+    def test_more_labels_than_scores_raises(self):
+        """Previously returned a model claiming 7 positives out of 6 samples."""
+        with pytest.raises(ValueError, match="raw scores and"):
+            fit_platt([0.1 * i for i in range(6)], [True] * 7 + [False] * 3)
+
+    def test_the_error_names_both_lengths(self):
+        """A bare 'length mismatch' leaves the caller guessing which is wrong."""
+        with pytest.raises(ValueError, match=r"3 raw scores and 2 labels"):
+            fit_platt([0.1, 0.5, 0.9], [True, False])
+
+    def test_empty_and_empty_is_still_an_unfitted_model_not_an_error(self):
+        """Equal lengths, just no data. That is a data condition, not a bug."""
+        assert not fit_platt([], []).fitted
+
+    def test_matching_lengths_are_unaffected(self):
+        assert fit_platt(*separable_sample()).fitted
+
+
 class TestSmallSampleSafety:
     def test_a_tiny_separable_sample_does_not_claim_near_certainty(self):
         """Target smoothing exists so four examples cannot buy 99% confidence."""

--- a/tests/core/investigation_path/test_calibration.py
+++ b/tests/core/investigation_path/test_calibration.py
@@ -6,16 +6,36 @@ to fit when there is no signal, and does not quietly become over-confident on a
 small sample.
 """
 
+import ast
+import pathlib
+
 import pytest
 
 from holmes.core.investigation_path.calibration import (
-    CalibrationModel,
     build_calibration_samples,
     fit_calibration,
     fit_platt,
 )
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.corpus import load_corpus
 from holmes.core.investigation_path.metrics import expected_calibration_error
+
+PACKAGE_DIR = pathlib.Path(__file__).parents[3] / "holmes" / "core" / "investigation_path"
+
+
+def import_graph():
+    """Which modules in the package import which, read from the source."""
+    graph = {}
+    for path in sorted(PACKAGE_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        deps = set()
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if "investigation_path" in node.module:
+                    deps.add(node.module.rsplit(".", 1)[-1])
+        graph[path.stem] = deps
+    return graph
 
 
 def separable_sample(n=60):
@@ -89,6 +109,61 @@ class TestRefusingToFit:
 
     def test_no_samples_gives_an_unfitted_model(self):
         assert not fit_calibration([]).fitted
+
+
+class TestModuleLayout:
+    """`validator` applies a calibration model; `calibration` needs `validator`
+    to fit one. Holding both in one module made that a cycle, worked around by
+    importing inside a function - against the repo rule that imports live at
+    module scope. `calibration_model` exists to break it properly.
+    """
+
+    def test_the_package_has_no_import_cycle(self):
+        graph = import_graph()
+        colour = dict.fromkeys(graph, "white")
+        stack = []
+
+        def visit(module):
+            colour[module] = "grey"
+            stack.append(module)
+            for dep in sorted(graph.get(module, ())):
+                if dep not in graph:
+                    continue
+                if colour[dep] == "grey":
+                    return stack[stack.index(dep):] + [dep]
+                if colour[dep] == "white":
+                    found = visit(dep)
+                    if found:
+                        return found
+            colour[module] = "black"
+            stack.pop()
+            return None
+
+        for module in sorted(graph):
+            if colour[module] == "white":
+                cycle = visit(module)
+                assert cycle is None, "import cycle: " + " -> ".join(cycle)
+
+    def test_the_applied_model_depends_on_nothing_in_the_package(self):
+        """It is imported by both sides of the old cycle, so it has to stay a leaf."""
+        assert import_graph()["calibration_model"] == set()
+
+    def test_the_fitting_side_imports_the_validator_at_module_scope(self):
+        """The whole point of the split. A lazy import here would mean the cycle
+        was hidden rather than removed."""
+        assert "validator" in import_graph()["calibration"]
+
+    def test_no_module_imports_inside_a_function(self):
+        for path in sorted(PACKAGE_DIR.glob("*.py")):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for inner in ast.walk(node):
+                    if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                        raise AssertionError(
+                            f"{path.name}:{inner.lineno} imports inside {node.name}()"
+                        )
 
 
 class TestMismatchedInput:

--- a/tests/core/investigation_path/test_corpus_and_offline_eval.py
+++ b/tests/core/investigation_path/test_corpus_and_offline_eval.py
@@ -26,6 +26,7 @@ from holmes.core.investigation_path.validator import GENERIC_ENTITY_KINDS, Sugge
 
 KNOWN_ROOT_CAUSES = {
     "dependency_unreachable",
+    "connection_pool_exhausted",
     "oom_kill",
     "image_pull_failure",
     "node_disk_pressure",
@@ -160,6 +161,20 @@ class TestCorpus:
                 assert "empty endpoints is the direct evidence" not in step.rationale.lower(), (
                     f"{record.incident_id}: a NetworkPolicy leaves endpoints populated"
                 )
+
+    def test_nothing_is_filed_as_unreachable_that_says_it_was_reachable(self, records):
+        """Retrieval collapses candidates to one root cause and scores agreement
+        on the label, so a saturation incident filed under a reachability label
+        is a source of false agreement. INC-003 was exactly that: a drained
+        connection pool whose own summary said the database stayed reachable.
+        """
+        for record in records:
+            if record.root_cause.label != "dependency_unreachable":
+                continue
+            summary = record.root_cause.summary.lower()
+            assert "was reachable" not in summary and "stayed reachable" not in summary, (
+                f"{record.incident_id}: labelled unreachable but says it was reachable"
+            )
 
     def test_every_referenced_kind_is_one_the_command_parser_knows(self, records):
         """A reference step naming a kind the parser cannot produce can never be

--- a/tests/core/investigation_path/test_corpus_and_offline_eval.py
+++ b/tests/core/investigation_path/test_corpus_and_offline_eval.py
@@ -191,6 +191,17 @@ class TestOfflineEvalBaseline:
         metrics, _, _ = result
         assert metrics.llm_calls == 0
 
+    def test_no_tokens_are_spent(self, result):
+        """Tracked separately from llm_calls: a change that reuses tokens the
+        investigation already spent would move this and not that."""
+        metrics, _, _ = result
+        assert metrics.llm_tokens == 0
+
+    def test_token_cost_is_reported_not_merely_implied(self, result):
+        """The reviewer asked for token cost. Zero has to be a measured zero."""
+        metrics, _, _ = result
+        assert "llm tokens" in metrics.render()
+
     def test_validation_is_fast_enough_to_be_free(self, result):
         metrics, _, _ = result
         assert metrics.latency_p95_ms < 50

--- a/tests/core/investigation_path/test_corpus_and_offline_eval.py
+++ b/tests/core/investigation_path/test_corpus_and_offline_eval.py
@@ -1,0 +1,225 @@
+"""The fixture corpus and the benchmark it feeds.
+
+The thresholds below are a recorded baseline for the current policy on the
+current corpus, not a quality bar anyone should be satisfied with. They exist so
+that a change to retrieval shows up as a number moving, which is the point of
+running this offline before wiring anything into an investigation.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from holmes.core.investigation_path.corpus import (
+    DEFAULT_CORPUS_DIR,
+    corpus_bytes_per_incident,
+    load_corpus,
+)
+from holmes.core.investigation_path.offline_eval import run_offline_eval
+from holmes.core.investigation_path.retrieval import RetrievalPolicy
+from holmes.core.investigation_path.schema import SUBJECT_TOKEN, SignatureLevel
+from holmes.core.investigation_path.validator import SuggestionPolicy
+
+KNOWN_ROOT_CAUSES = {
+    "dependency_unreachable",
+    "oom_kill",
+    "image_pull_failure",
+    "node_disk_pressure",
+    "config_regression",
+    "certificate_expired",
+}
+
+# Patterns that would mean a record carries a value the schema has no place for.
+# Deliberately matched as key/value shapes rather than bare words, so that prose
+# like "names the secret the certificate is read from" is not a false alarm.
+LEAK_PATTERNS = (
+    re.compile(r"(password|secret|token|api[_-]?key|credential)\s*[:=]\s*\S", re.IGNORECASE),
+    re.compile(r"bearer\s+\S", re.IGNORECASE),
+    re.compile(r"https?://", re.IGNORECASE),
+    re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+"),
+)
+
+
+class TestCorpus:
+    @pytest.fixture(scope="class")
+    def records(self):
+        return load_corpus()
+
+    def test_corpus_loads(self, records):
+        assert records
+
+    def test_every_record_is_attributed_to_a_human_reviewer(self, records):
+        for record in records:
+            assert record.validated_by
+            assert record.validated_at
+
+    def test_root_causes_come_from_the_controlled_vocabulary(self, records):
+        for record in records:
+            assert record.root_cause.label in KNOWN_ROOT_CAUSES, record.incident_id
+
+    def test_incident_ids_are_unique(self, records):
+        ids = [record.incident_id for record in records]
+        assert len(ids) == len(set(ids))
+
+    def test_reference_steps_always_explain_themselves(self, records):
+        for record in records:
+            for step in record.reference_path:
+                assert step.rationale.strip(), record.incident_id
+
+    def test_weights_are_within_range(self, records):
+        for record in records:
+            for step in record.reference_path:
+                assert 0.0 <= step.weight <= 1.0
+
+    def test_the_affected_workload_is_referred_to_by_token(self, records):
+        """A path naming a real workload can only ever match that workload."""
+        for record in records:
+            if not record.subject:
+                continue
+            for step in record.reference_path + record.observed_path:
+                assert step.entity.name != record.subject, (
+                    f"{record.incident_id} names its own subject instead of {SUBJECT_TOKEN}"
+                )
+
+    def test_no_record_contains_anything_sensitive(self, records):
+        for record in records:
+            serialized = record.model_dump_json()
+            for pattern in LEAK_PATTERNS:
+                assert not pattern.search(serialized), (
+                    f"{record.incident_id} matches leak pattern {pattern.pattern!r}"
+                )
+
+    def test_the_leak_check_would_catch_a_real_leak(self):
+        """Guards the guard: a crude substring list here would pass anything."""
+        assert any(p.search('{"summary": "password: hunter2"}') for p in LEAK_PATTERNS)
+        assert any(p.search('{"summary": "see https://internal.example"}') for p in LEAK_PATTERNS)
+        assert any(p.search('{"summary": "ping ops@example.com"}') for p in LEAK_PATTERNS)
+        assert not any(p.search('{"rationale": "names the secret it reads"}') for p in LEAK_PATTERNS)
+
+    def test_holdout_cases_have_both_a_reference_and_an_observed_path(self):
+        for record in load_corpus(split="holdout"):
+            assert record.reference_path
+            assert record.observed_path
+
+    def test_holdout_cases_actually_skipped_something(self):
+        for record in load_corpus(split="holdout"):
+            assert record.missing_steps(), f"{record.incident_id} has nothing missing to find"
+
+    def test_pool_records_have_no_observed_path(self):
+        for record in load_corpus(split="corpus"):
+            assert record.observed_path == []
+
+    def test_the_two_splits_do_not_overlap(self):
+        pool = {r.incident_id for r in load_corpus(split="corpus")}
+        holdout = {r.incident_id for r in load_corpus(split="holdout")}
+        assert not (pool & holdout)
+
+    def test_storage_cost_is_measured(self, records):
+        assert corpus_bytes_per_incident(records) > 0
+
+    def test_storage_cost_of_an_empty_corpus_is_zero(self):
+        assert corpus_bytes_per_incident([]) == 0.0
+
+
+class TestCorpusLoading:
+    def test_a_missing_directory_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_corpus(tmp_path / "nope")
+
+    def test_a_malformed_record_raises_instead_of_being_skipped(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(yaml.safe_dump({"incident_id": "X"}))
+        with pytest.raises(ValueError, match="Invalid incident record"):
+            load_corpus(tmp_path)
+
+    def test_an_empty_file_raises(self, tmp_path):
+        (tmp_path / "empty.yaml").write_text("")
+        with pytest.raises(ValueError, match="Empty incident file"):
+            load_corpus(tmp_path)
+
+    def test_records_load_in_a_stable_order(self):
+        assert [r.incident_id for r in load_corpus()] == sorted(
+            r.incident_id for r in load_corpus()
+        )
+
+    def test_the_default_corpus_directory_exists(self):
+        assert DEFAULT_CORPUS_DIR.is_dir()
+
+
+class TestOfflineEvalBaseline:
+    @pytest.fixture(scope="class")
+    def result(self):
+        return run_offline_eval()
+
+    def test_every_holdout_case_is_scored(self, result):
+        metrics, outcomes = result
+        assert metrics.cases == len(outcomes) == len(load_corpus(split="holdout"))
+
+    def test_no_llm_call_is_made(self, result):
+        metrics, _ = result
+        assert metrics.llm_calls == 0
+
+    def test_validation_is_fast_enough_to_be_free(self, result):
+        metrics, _ = result
+        assert metrics.latency_p95_ms < 50
+
+    def test_when_it_answers_it_finds_what_was_skipped(self, result):
+        metrics, _ = result
+        assert metrics.weighted_path_recall_when_answering >= 0.9
+
+    def test_most_suggestions_are_genuinely_missing(self, result):
+        metrics, _ = result
+        assert metrics.suggestion_precision >= 0.7
+
+    def test_wrong_suggestions_stay_within_the_reading_budget(self, result):
+        metrics, _ = result
+        assert metrics.false_positive_burden <= 1.5
+
+    def test_abstention_is_not_the_default_answer(self, result):
+        metrics, _ = result
+        assert metrics.abstention_rate <= 0.6
+
+    def test_confidence_is_not_yet_calibrated(self, result):
+        """Recorded as a known weakness, not a passing grade.
+
+        The score multiplies three sub-1 terms, so it reads far lower than the
+        observed hit rate. Calibrating it is the next piece of work, and this
+        assertion is here to catch it getting worse in the meantime.
+        """
+        metrics, _ = result
+        assert metrics.expected_calibration_error <= 0.55
+
+    def test_abstains_when_only_one_incident_shares_the_root_cause(self, result):
+        _, outcomes = result
+        by_id = {outcome.incident_id: outcome for outcome in outcomes}
+        assert by_id["HOLD-003"].abstained
+        assert by_id["HOLD-003"].abstain_reason == "insufficient_support"
+
+    def test_abstains_on_an_incident_type_it_has_never_seen(self, result):
+        _, outcomes = result
+        by_id = {outcome.incident_id: outcome for outcome in outcomes}
+        assert by_id["HOLD-004"].abstained
+        assert by_id["HOLD-004"].abstain_reason == "no_candidates"
+
+
+class TestPolicyTradeoffs:
+    def test_demanding_more_support_trades_recall_for_precision(self):
+        lenient, _ = run_offline_eval(suggestion_policy=SuggestionPolicy(min_support=1))
+        strict, _ = run_offline_eval(suggestion_policy=SuggestionPolicy(min_support=2))
+        assert strict.suggestion_precision >= lenient.suggestion_precision
+        assert strict.false_positive_burden <= lenient.false_positive_burden
+
+    def test_raising_the_similarity_floor_raises_abstention(self):
+        base, _ = run_offline_eval()
+        strict, _ = run_offline_eval(
+            retrieval_policy=RetrievalPolicy(min_symptom_similarity=0.9)
+        )
+        assert strict.abstention_rate >= base.abstention_rate
+        assert strict.weighted_path_recall <= base.weighted_path_recall
+
+    def test_coarse_signatures_change_the_scores(self):
+        coarse, _ = run_offline_eval(
+            retrieval_policy=RetrievalPolicy(signature_level=SignatureLevel.COARSE),
+            suggestion_policy=SuggestionPolicy(signature_level=SignatureLevel.COARSE),
+        )
+        assert 0.0 <= coarse.suggestion_precision <= 1.0

--- a/tests/core/investigation_path/test_corpus_and_offline_eval.py
+++ b/tests/core/investigation_path/test_corpus_and_offline_eval.py
@@ -18,10 +18,11 @@ from holmes.core.investigation_path.corpus import (
     corpus_bytes_per_incident,
     load_corpus,
 )
+from holmes.core.investigation_path.normalize import _KNOWN_KINDS
 from holmes.core.investigation_path.offline_eval import run_offline_eval
 from holmes.core.investigation_path.retrieval import RetrievalPolicy
 from holmes.core.investigation_path.schema import SUBJECT_TOKEN, SignatureLevel
-from holmes.core.investigation_path.validator import SuggestionPolicy
+from holmes.core.investigation_path.validator import GENERIC_ENTITY_KINDS, SuggestionPolicy
 
 KNOWN_ROOT_CAUSES = {
     "dependency_unreachable",
@@ -139,6 +140,36 @@ class TestCorpus:
                 assert label not in pool_counts
             else:
                 assert pool_counts[label] >= 3, f"{record.incident_id} can never be answered"
+
+    def test_an_empty_endpoints_claim_matches_the_stated_cause(self, records):
+        """The corpus is the ground truth, so a wrong rationale is not cosmetic.
+
+        A NetworkPolicy is enforced by the CNI: it blocks traffic while the
+        Service and its endpoints stay healthy. INC-002 claimed empty endpoints
+        as the evidence for exactly that cause, contradicting its own summary,
+        which would teach retrieval that reading endpoints identifies a blocked
+        network path.
+        """
+        for record in records:
+            summary = record.root_cause.summary.lower()
+            if "networkpolicy" not in summary:
+                continue
+            for step in record.reference_path:
+                if step.entity.kind != "endpoints":
+                    continue
+                assert "empty endpoints is the direct evidence" not in step.rationale.lower(), (
+                    f"{record.incident_id}: a NetworkPolicy leaves endpoints populated"
+                )
+
+    def test_every_referenced_kind_is_one_the_command_parser_knows(self, records):
+        """A reference step naming a kind the parser cannot produce can never be
+        matched by a real tool call, so it would score as permanently skipped."""
+        for record in records:
+            for step in record.reference_path:
+                kind = step.entity.kind
+                if not kind or kind in GENERIC_ENTITY_KINDS:
+                    continue
+                assert kind in _KNOWN_KINDS, f"{record.incident_id}: unknown kind {kind!r}"
 
     def test_storage_cost_is_measured(self, records):
         assert corpus_bytes_per_incident(records) > 0
@@ -271,12 +302,41 @@ class TestPolicyTradeoffs:
         assert strict.suggestion_precision >= lenient.suggestion_precision
         assert strict.false_positive_burden <= lenient.false_positive_burden
 
-    def test_the_support_ratio_filter_is_what_removes_the_false_positives(self):
+    def test_the_support_ratio_filter_removes_false_positives_on_its_own(self):
+        """Isolated from the confidence floor, which also clears these.
+
+        Comparing against the default policy conflated the two: a weakly
+        supported check is also a low-confidence one, so whichever filter runs
+        first gets the credit, and the assertion passed without showing that
+        the support ratio does anything. Holding `min_confidence` at zero
+        leaves the support ratio as the only thing that can change the result.
+        """
+        unfiltered = dict(min_confidence=0.0, max_suggestions=20)
         without, _, _ = run_offline_eval(
-            suggestion_policy=SuggestionPolicy(min_support_ratio=0.0)
+            suggestion_policy=SuggestionPolicy(min_support_ratio=0.0, **unfiltered),
+            calibrate=False,
         )
-        with_filter, _, _ = run_offline_eval()
+        with_filter, _, _ = run_offline_eval(
+            suggestion_policy=SuggestionPolicy(min_support_ratio=0.6, **unfiltered),
+            calibrate=False,
+        )
         assert without.false_positive_burden > with_filter.false_positive_burden
+        assert with_filter.suggestion_precision > without.suggestion_precision
+
+    def test_a_false_positive_is_still_reachable(self):
+        """Precision of 1.00 has to be an achievement, not an impossibility.
+
+        If no policy setting could produce a wrong suggestion, the corpus would
+        no longer be able to measure precision at all and the headline number
+        would be vacuous.
+        """
+        loose, _, _ = run_offline_eval(
+            suggestion_policy=SuggestionPolicy(
+                min_support_ratio=0.0, min_confidence=0.0, max_suggestions=20
+            ),
+            calibrate=False,
+        )
+        assert loose.suggestion_precision < 1.0
 
     def test_raising_the_similarity_floor_raises_abstention(self):
         base, _, _ = run_offline_eval()

--- a/tests/core/investigation_path/test_corpus_and_offline_eval.py
+++ b/tests/core/investigation_path/test_corpus_and_offline_eval.py
@@ -11,6 +11,7 @@ import re
 import pytest
 import yaml
 
+from holmes.core.investigation_path.calibration import build_calibration_samples
 from holmes.core.investigation_path.corpus import (
     DEFAULT_CORPUS_DIR,
     corpus_bytes_per_incident,
@@ -147,78 +148,111 @@ class TestCorpusLoading:
 
 
 class TestOfflineEvalBaseline:
+    """Recorded baseline for the current policy on the current corpus.
+
+    These are thresholds so a regression shows up, not a quality bar anyone
+    should be satisfied with. Five held-out cases cannot establish that this
+    works; they establish that it has not silently got worse.
+    """
+
     @pytest.fixture(scope="class")
     def result(self):
         return run_offline_eval()
 
     def test_every_holdout_case_is_scored(self, result):
-        metrics, outcomes = result
+        metrics, outcomes, _ = result
         assert metrics.cases == len(outcomes) == len(load_corpus(split="holdout"))
 
     def test_no_llm_call_is_made(self, result):
-        metrics, _ = result
+        metrics, _, _ = result
         assert metrics.llm_calls == 0
 
     def test_validation_is_fast_enough_to_be_free(self, result):
-        metrics, _ = result
+        metrics, _, _ = result
         assert metrics.latency_p95_ms < 50
 
-    def test_when_it_answers_it_finds_what_was_skipped(self, result):
-        metrics, _ = result
-        assert metrics.weighted_path_recall_when_answering >= 0.9
+    def test_it_finds_what_was_skipped(self, result):
+        metrics, _, _ = result
+        assert metrics.weighted_path_recall_when_answering >= 0.7
 
-    def test_most_suggestions_are_genuinely_missing(self, result):
-        metrics, _ = result
-        assert metrics.suggestion_precision >= 0.7
+    def test_no_suggestion_is_wrong(self, result):
+        metrics, _, _ = result
+        assert metrics.suggestion_precision >= 0.95
 
     def test_wrong_suggestions_stay_within_the_reading_budget(self, result):
-        metrics, _ = result
-        assert metrics.false_positive_burden <= 1.5
+        metrics, _, _ = result
+        assert metrics.false_positive_burden <= 0.5
 
     def test_abstention_is_not_the_default_answer(self, result):
-        metrics, _ = result
-        assert metrics.abstention_rate <= 0.6
+        metrics, _, _ = result
+        assert metrics.abstention_rate <= 0.4
 
-    def test_confidence_is_not_yet_calibrated(self, result):
-        """Recorded as a known weakness, not a passing grade.
+    def test_confidence_is_calibrated(self, result):
+        metrics, _, _ = result
+        assert metrics.expected_calibration_error <= 0.10
+        assert metrics.brier_score <= 0.10
 
-        The score multiplies three sub-1 terms, so it reads far lower than the
-        observed hit rate. Calibrating it is the next piece of work, and this
-        assertion is here to catch it getting worse in the meantime.
-        """
-        metrics, _ = result
-        assert metrics.expected_calibration_error <= 0.55
+    def test_calibration_is_a_large_improvement_on_the_raw_score(self):
+        """The raw evidence score is a product of four terms below 1, so it
+        reads far below the observed hit rate. This is the gap being closed."""
+        raw, _, _ = run_offline_eval(calibrate=False)
+        calibrated, _, model = run_offline_eval(calibrate=True)
+        assert model.fitted
+        assert calibrated.expected_calibration_error < raw.expected_calibration_error / 2
 
-    def test_abstains_when_only_one_incident_shares_the_root_cause(self, result):
-        _, outcomes = result
-        by_id = {outcome.incident_id: outcome for outcome in outcomes}
-        assert by_id["HOLD-003"].abstained
-        assert by_id["HOLD-003"].abstain_reason == "insufficient_support"
+    def test_calibration_is_fitted_only_on_the_pool(self, result):
+        """Fitting on the held-out cases would make the reported error meaningless."""
+        _, _, model = result
+        assert model.samples == len(build_calibration_samples(load_corpus(split="corpus")))
 
     def test_abstains_on_an_incident_type_it_has_never_seen(self, result):
-        _, outcomes = result
+        _, outcomes, _ = result
         by_id = {outcome.incident_id: outcome for outcome in outcomes}
         assert by_id["HOLD-004"].abstained
         assert by_id["HOLD-004"].abstain_reason == "no_candidates"
 
+    def test_says_nothing_rather_than_something_wrong_on_the_hard_case(self, result):
+        """HOLD-005 matches the cache incidents on symptoms and root cause, but
+        its dependency is a broker. Suggesting the Redis checks would be four
+        confident wrong answers; the correct behaviour is to stay quiet."""
+        _, outcomes, _ = result
+        hard = {outcome.incident_id: outcome for outcome in outcomes}["HOLD-005"]
+        assert hard.false_positives == []
+
+    def test_the_hard_case_is_a_known_gap_not_a_success(self, result):
+        """Staying quiet costs recall, and that cost should stay visible."""
+        _, outcomes, _ = result
+        hard = {outcome.incident_id: outcome for outcome in outcomes}["HOLD-005"]
+        assert hard.missing_weights
+        assert hard.true_positives == []
+
 
 class TestPolicyTradeoffs:
     def test_demanding_more_support_trades_recall_for_precision(self):
-        lenient, _ = run_offline_eval(suggestion_policy=SuggestionPolicy(min_support=1))
-        strict, _ = run_offline_eval(suggestion_policy=SuggestionPolicy(min_support=2))
+        lenient, _, _ = run_offline_eval(
+            suggestion_policy=SuggestionPolicy(min_support_ratio=0.0)
+        )
+        strict, _, _ = run_offline_eval(suggestion_policy=SuggestionPolicy())
         assert strict.suggestion_precision >= lenient.suggestion_precision
         assert strict.false_positive_burden <= lenient.false_positive_burden
 
+    def test_the_support_ratio_filter_is_what_removes_the_false_positives(self):
+        without, _, _ = run_offline_eval(
+            suggestion_policy=SuggestionPolicy(min_support_ratio=0.0)
+        )
+        with_filter, _, _ = run_offline_eval()
+        assert without.false_positive_burden > with_filter.false_positive_burden
+
     def test_raising_the_similarity_floor_raises_abstention(self):
-        base, _ = run_offline_eval()
-        strict, _ = run_offline_eval(
+        base, _, _ = run_offline_eval()
+        strict, _, _ = run_offline_eval(
             retrieval_policy=RetrievalPolicy(min_symptom_similarity=0.9)
         )
         assert strict.abstention_rate >= base.abstention_rate
         assert strict.weighted_path_recall <= base.weighted_path_recall
 
     def test_coarse_signatures_change_the_scores(self):
-        coarse, _ = run_offline_eval(
+        coarse, _, _ = run_offline_eval(
             retrieval_policy=RetrievalPolicy(signature_level=SignatureLevel.COARSE),
             suggestion_policy=SuggestionPolicy(signature_level=SignatureLevel.COARSE),
         )

--- a/tests/core/investigation_path/test_corpus_and_offline_eval.py
+++ b/tests/core/investigation_path/test_corpus_and_offline_eval.py
@@ -7,6 +7,7 @@ running this offline before wiring anything into an investigation.
 """
 
 import re
+from collections import Counter
 
 import pytest
 import yaml
@@ -115,6 +116,29 @@ class TestCorpus:
         pool = {r.incident_id for r in load_corpus(split="corpus")}
         holdout = {r.incident_id for r in load_corpus(split="holdout")}
         assert not (pool & holdout)
+
+    def test_root_cause_coverage_is_recorded_accurately(self):
+        """Pins the real spread, so prose about it cannot drift out of date.
+
+        A cause needs three pool members to be usable: leave-one-out removes one
+        and retrieval needs two left to answer. Two causes do not clear that bar,
+        and the docs must keep saying so until someone adds incidents.
+        """
+        counts = Counter(r.root_cause.label for r in load_corpus(split="corpus"))
+        usable = {label for label, count in counts.items() if count >= 3}
+        assert usable == {"dependency_unreachable", "oom_kill", "config_regression"}
+        assert counts["image_pull_failure"] == 1
+        assert counts["node_disk_pressure"] == 1
+
+    def test_every_answerable_holdout_cause_is_represented_in_the_pool(self):
+        pool_counts = Counter(r.root_cause.label for r in load_corpus(split="corpus"))
+        for record in load_corpus(split="holdout"):
+            label = record.root_cause.label
+            # HOLD-004 is deliberately a cause the pool has never seen.
+            if label == "certificate_expired":
+                assert label not in pool_counts
+            else:
+                assert pool_counts[label] >= 3, f"{record.incident_id} can never be answered"
 
     def test_storage_cost_is_measured(self, records):
         assert corpus_bytes_per_incident(records) > 0

--- a/tests/core/investigation_path/test_metrics.py
+++ b/tests/core/investigation_path/test_metrics.py
@@ -1,0 +1,185 @@
+"""The metric definitions, checked against hand-computed values."""
+
+import pytest
+
+from holmes.core.investigation_path.metrics import (
+    CaseOutcome,
+    brier_score,
+    expected_calibration_error,
+    score_cases,
+)
+
+
+def case(
+    incident_id="HOLD-1",
+    abstained=False,
+    missing=None,
+    suggested=None,
+    confidence=None,
+    latency_ms=1.0,
+    abstain_reason=None,
+):
+    return CaseOutcome(
+        incident_id=incident_id,
+        abstained=abstained,
+        abstain_reason=abstain_reason,
+        missing_weights=missing or {},
+        suggested=suggested or [],
+        suggestion_confidence=confidence or {},
+        latency_ms=latency_ms,
+    )
+
+
+class TestCaseClassification:
+    def test_suggestions_split_into_correct_and_wrong(self):
+        outcome = case(missing={"a": 1.0}, suggested=["a", "b"])
+        assert outcome.true_positives == ["a"]
+        assert outcome.false_positives == ["b"]
+
+
+class TestRecall:
+    def test_recovering_every_missing_check_gives_full_recall(self):
+        metrics = score_cases([case(missing={"a": 1.0, "b": 0.5}, suggested=["a", "b"])])
+        assert metrics.weighted_path_recall == 1.0
+
+    def test_recall_is_weighted_by_importance(self):
+        # Finding the 0.9 check out of 0.9 + 0.1 is worth much more than the 0.1.
+        metrics = score_cases([case(missing={"heavy": 0.9, "light": 0.1}, suggested=["heavy"])])
+        assert metrics.weighted_path_recall == pytest.approx(0.9)
+
+    def test_abstaining_costs_recall(self):
+        metrics = score_cases(
+            [
+                case("A", missing={"a": 1.0}, suggested=["a"]),
+                case("B", abstained=True, missing={"b": 1.0}, abstain_reason="no_candidates"),
+            ]
+        )
+        assert metrics.weighted_path_recall == 0.5
+
+    def test_recall_when_answering_ignores_abstentions(self):
+        metrics = score_cases(
+            [
+                case("A", missing={"a": 1.0}, suggested=["a"]),
+                case("B", abstained=True, missing={"b": 1.0}, abstain_reason="no_candidates"),
+            ]
+        )
+        assert metrics.weighted_path_recall_when_answering == 1.0
+
+    def test_a_case_with_nothing_missing_does_not_break_recall(self):
+        metrics = score_cases([case(missing={}, suggested=[])])
+        assert metrics.weighted_path_recall == 0.0
+
+
+class TestPrecisionAndBurden:
+    def test_precision_counts_wrong_suggestions(self):
+        metrics = score_cases([case(missing={"a": 1.0}, suggested=["a", "b", "c"])])
+        assert metrics.suggestion_precision == pytest.approx(1 / 3)
+
+    def test_a_trivial_correct_check_cannot_pay_for_a_wrong_one(self):
+        # One true positive worth 0.1 against one false positive charged 1.0.
+        metrics = score_cases([case(missing={"a": 0.1}, suggested=["a", "wrong"])])
+        assert metrics.suggestion_precision == 0.5
+        assert metrics.weighted_suggestion_precision == pytest.approx(0.1 / 1.1)
+
+    def test_false_positive_burden_is_per_answered_case(self):
+        metrics = score_cases(
+            [
+                case("A", missing={"a": 1.0}, suggested=["a", "x", "y"]),
+                case("B", missing={"b": 1.0}, suggested=["b"]),
+            ]
+        )
+        assert metrics.false_positive_burden == 1.0
+
+    def test_precision_hides_burden_which_is_why_both_are_reported(self):
+        few = score_cases([case(missing={"a": 1.0, "b": 1.0, "c": 1.0, "d": 1.0}, suggested=["a", "b", "c", "d", "x"])])
+        many = score_cases(
+            [
+                case(
+                    missing={str(i): 1.0 for i in range(20)},
+                    suggested=[str(i) for i in range(20)] + ["x", "y", "z", "w", "v"],
+                )
+            ]
+        )
+        assert few.suggestion_precision == pytest.approx(0.8)
+        assert many.suggestion_precision == pytest.approx(0.8)
+        assert many.false_positive_burden > few.false_positive_burden
+
+
+class TestAbstention:
+    def test_abstention_rate_and_reasons_are_reported(self):
+        metrics = score_cases(
+            [
+                case("A", missing={"a": 1.0}, suggested=["a"]),
+                case("B", abstained=True, abstain_reason="no_candidates"),
+                case("C", abstained=True, abstain_reason="no_candidates"),
+                case("D", abstained=True, abstain_reason="insufficient_support"),
+            ]
+        )
+        assert metrics.abstention_rate == 0.75
+        assert metrics.abstain_reasons == {"no_candidates": 2, "insufficient_support": 1}
+
+    def test_abstained_suggestions_are_excluded_from_precision(self):
+        metrics = score_cases(
+            [case("A", abstained=True, missing={"a": 1.0}, abstain_reason="no_candidates")]
+        )
+        assert metrics.suggestion_precision == 0.0
+        assert metrics.answered_cases == 0
+
+
+class TestCalibration:
+    def test_perfect_calibration_scores_near_zero(self):
+        # Everything stated at ~0.95 and everything correct.
+        assert expected_calibration_error([0.95] * 10, [True] * 10) == pytest.approx(0.05)
+
+    def test_confident_and_wrong_scores_high(self):
+        assert expected_calibration_error([0.95] * 10, [False] * 10) == pytest.approx(0.95)
+
+    def test_underconfidence_is_penalised_too(self):
+        # Always right but only ever claims 0.25 confidence.
+        assert expected_calibration_error([0.25] * 8, [True] * 8) == pytest.approx(0.75)
+
+    def test_empty_input_is_zero(self):
+        assert expected_calibration_error([], []) == 0.0
+        assert brier_score([], []) == 0.0
+
+    def test_brier_rewards_confident_correctness(self):
+        assert brier_score([1.0, 1.0], [True, True]) == 0.0
+        assert brier_score([0.0, 0.0], [True, True]) == 1.0
+
+
+class TestAggregation:
+    def test_scoring_an_empty_holdout_is_an_error(self):
+        with pytest.raises(ValueError):
+            score_cases([])
+
+    def test_latency_percentiles_are_reported(self):
+        cases = [case(str(i), missing={"a": 1.0}, suggested=["a"], latency_ms=float(i)) for i in range(1, 11)]
+        metrics = score_cases(cases)
+        assert metrics.latency_p50_ms == pytest.approx(5.0)
+        assert metrics.latency_p95_ms == pytest.approx(10.0)
+
+    def test_latency_percentiles_of_a_single_case(self):
+        metrics = score_cases([case(missing={"a": 1.0}, suggested=["a"], latency_ms=3.0)])
+        assert metrics.latency_p50_ms == 3.0
+        assert metrics.latency_p95_ms == 3.0
+
+    def test_llm_calls_are_tracked_and_expected_to_be_zero(self):
+        metrics = score_cases([case(missing={"a": 1.0}, suggested=["a"])])
+        assert metrics.llm_calls == 0
+
+    def test_report_renders_every_metric(self):
+        rendered = score_cases(
+            [
+                case("A", missing={"a": 1.0}, suggested=["a"], confidence={"a": 0.4}),
+                case("B", abstained=True, abstain_reason="no_candidates"),
+            ]
+        ).render()
+        for label in [
+            "weighted path recall",
+            "suggestion precision",
+            "false positives per answer",
+            "expected calibration error",
+            "brier score",
+            "abstain reasons",
+        ]:
+            assert label in rendered

--- a/tests/core/investigation_path/test_metrics.py
+++ b/tests/core/investigation_path/test_metrics.py
@@ -142,6 +142,46 @@ class TestCalibration:
         assert expected_calibration_error([], []) == 0.0
         assert brier_score([], []) == 0.0
 
+    def test_the_gap_is_measured_from_the_stated_confidence_not_the_bin_midpoint(self):
+        """0.95 and 0.25 above are bin midpoints, so they pass either way.
+
+        Binning by midpoint collapses every value in a bin to the same stated
+        confidence, which caps the reported error at half a bin width however
+        wrong the confidence was. 0.91 is in the same bin as 0.95 but is a
+        different claim.
+        """
+        assert expected_calibration_error([0.91] * 10, [True] * 10) == pytest.approx(0.09)
+
+    def test_a_near_perfect_claim_that_holds_scores_near_zero(self):
+        """Midpoint binning floored this at 0.05 - the same score as 0.95."""
+        assert expected_calibration_error([0.999] * 10, [True] * 10) == pytest.approx(0.001)
+
+    def test_a_confident_claim_that_fails_is_charged_in_full(self):
+        """Midpoint binning inflated this to 0.95."""
+        assert expected_calibration_error([0.901] * 10, [False] * 10) == pytest.approx(0.901)
+
+    def test_two_different_claims_in_one_bin_score_differently(self):
+        """The direct statement of the bug: these share bin 9."""
+        low = expected_calibration_error([0.90] * 10, [True] * 10)
+        high = expected_calibration_error([0.99] * 10, [True] * 10)
+        assert low > high
+
+    def test_a_bin_averages_the_confidences_inside_it(self):
+        """Half at 0.90 and half at 1.00, all correct: mean stated 0.95, gap 0.05."""
+        confidences = [0.90] * 5 + [1.0] * 5
+        assert expected_calibration_error(confidences, [True] * 10) == pytest.approx(0.05)
+
+    def test_perfect_confidence_that_always_holds_is_exactly_zero(self):
+        assert expected_calibration_error([1.0] * 10, [True] * 10) == 0.0
+
+    def test_mismatched_lengths_raise_rather_than_scoring_a_prefix(self):
+        with pytest.raises(ValueError, match="confidences and"):
+            expected_calibration_error([0.9, 0.8, 0.7], [True, False])
+
+    def test_brier_rejects_mismatched_lengths_too(self):
+        with pytest.raises(ValueError, match="confidences and"):
+            brier_score([0.9, 0.8, 0.7], [True, False])
+
     def test_brier_rewards_confident_correctness(self):
         assert brier_score([1.0, 1.0], [True, True]) == 0.0
         assert brier_score([0.0, 0.0], [True, True]) == 1.0

--- a/tests/core/investigation_path/test_normalize.py
+++ b/tests/core/investigation_path/test_normalize.py
@@ -9,12 +9,14 @@ from holmes.core.investigation_path.normalize import (
     normalize_resource_kind,
     normalize_resource_name,
     path_from_tool_calls,
+    split_resource_target,
 )
 from holmes.core.investigation_path.schema import (
     ErrorClass,
     OutcomeStatus,
     QueryIntent,
     SignatureLevel,
+    signature_of,
 )
 from holmes.core.models import ToolCallResult
 from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
@@ -160,8 +162,6 @@ class TestIntentInference:
         assert event.intent == intent
 
     def test_same_check_through_two_toolsets_shares_a_signature(self):
-        from holmes.core.investigation_path.schema import signature_of
-
         via_bash = event_from_tool_call(
             tool_call("run_bash_command", {"command": "kubectl logs api-7d9f8b6c5-x2k9p"}), 0
         )
@@ -198,8 +198,6 @@ class TestCommandTargets:
         """INC-012 stores `config_history:deployment:<subject>`. Parsing the
         command to `config_history:history:deployment/catalog-service` made the
         benchmark score an executed check as missing."""
-        from holmes.core.investigation_path.schema import signature_of
-
         event = event_from_tool_call(
             tool_call(
                 "run_bash_command",
@@ -221,16 +219,12 @@ class TestCommandTargets:
         ],
     )
     def test_the_slash_form_and_the_spaced_form_are_one_check(self, slashed, spaced):
-        from holmes.core.investigation_path.schema import signature_of
-
         a = event_from_tool_call(tool_call("run_bash_command", {"command": slashed}), 0)
         b = event_from_tool_call(tool_call("run_bash_command", {"command": spaced}), 1)
         assert signature_of(a) == signature_of(b)
 
     def test_an_unknown_kind_before_a_slash_is_not_treated_as_a_target(self):
         """Otherwise a path argument would be parsed as a resource."""
-        from holmes.core.investigation_path.normalize import split_resource_target
-
         assert split_resource_target("./manifests/app.yaml") == (None, None)
         assert split_resource_target("notakind/thing") == (None, None)
         assert split_resource_target("plainname") == (None, None)

--- a/tests/core/investigation_path/test_normalize.py
+++ b/tests/core/investigation_path/test_normalize.py
@@ -171,6 +171,87 @@ class TestIntentInference:
         assert signature_of(via_bash) == signature_of(via_toolset)
 
 
+class TestCommandTargets:
+    """Reading the resource out of a shell command.
+
+    A command that names a resource must produce the same entity however the
+    resource was written, or the benchmark reports a check as skipped after it
+    was executed - a false positive caused entirely by parsing.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kubectl rollout history deployment/catalog-service",
+            "kubectl rollout history deployment catalog-service",
+            "kubectl rollout history deploy/catalog-service",
+            "kubectl rollout status deployment/catalog-service",
+        ],
+    )
+    def test_a_rollout_target_is_read_past_the_sub_verb(self, command):
+        """`history` sits where the kind normally goes; it is not the kind."""
+        event = event_from_tool_call(tool_call("run_bash_command", {"command": command}), 0)
+        assert event.entity.kind == "deployment"
+        assert event.entity.name == "catalog-service"
+
+    def test_a_rollout_check_matches_the_corpus_reference_step(self):
+        """INC-012 stores `config_history:deployment:<subject>`. Parsing the
+        command to `config_history:history:deployment/catalog-service` made the
+        benchmark score an executed check as missing."""
+        from holmes.core.investigation_path.schema import signature_of
+
+        event = event_from_tool_call(
+            tool_call(
+                "run_bash_command",
+                {"command": "kubectl rollout history deployment/catalog-service"},
+            ),
+            0,
+        )
+        assert (
+            signature_of(event, subject="catalog-service")
+            == "config_history:deployment:<subject>"
+        )
+
+    @pytest.mark.parametrize(
+        "slashed, spaced",
+        [
+            ("kubectl describe deployment/checkout-api", "kubectl describe deployment checkout-api"),
+            ("kubectl get pod/checkout-api", "kubectl get pod checkout-api"),
+            ("kubectl get svc/redis", "kubectl get service redis"),
+        ],
+    )
+    def test_the_slash_form_and_the_spaced_form_are_one_check(self, slashed, spaced):
+        from holmes.core.investigation_path.schema import signature_of
+
+        a = event_from_tool_call(tool_call("run_bash_command", {"command": slashed}), 0)
+        b = event_from_tool_call(tool_call("run_bash_command", {"command": spaced}), 1)
+        assert signature_of(a) == signature_of(b)
+
+    def test_an_unknown_kind_before_a_slash_is_not_treated_as_a_target(self):
+        """Otherwise a path argument would be parsed as a resource."""
+        from holmes.core.investigation_path.normalize import split_resource_target
+
+        assert split_resource_target("./manifests/app.yaml") == (None, None)
+        assert split_resource_target("notakind/thing") == (None, None)
+        assert split_resource_target("plainname") == (None, None)
+        assert split_resource_target("deployment/") == (None, None)
+
+    def test_a_bare_name_after_logs_is_still_a_pod(self):
+        event = event_from_tool_call(
+            tool_call("run_bash_command", {"command": "kubectl logs checkout-api-7d9f8b6c5-x2k9p"}),
+            0,
+        )
+        assert event.entity.kind == "pod"
+        assert event.entity.name == "checkout-api"
+
+    def test_a_kind_with_no_name_keeps_the_kind(self):
+        event = event_from_tool_call(
+            tool_call("run_bash_command", {"command": "kubectl get pods"}), 0
+        )
+        assert event.entity.kind == "pod"
+        assert event.entity.name is None
+
+
 class TestEntityAndTimeWindow:
     def test_kind_and_name_are_combined(self):
         event = event_from_tool_call(tool_call("kubectl_get", {"kind": "svc", "name": "redis"}), 0)

--- a/tests/core/investigation_path/test_normalize.py
+++ b/tests/core/investigation_path/test_normalize.py
@@ -3,6 +3,8 @@
 import pytest
 
 from holmes.core.investigation_path.normalize import (
+    _KNOWN_KINDS,
+    _TOPOLOGY_KINDS,
     classify_error,
     event_from_tool_call,
     looks_like_instance_id,
@@ -222,6 +224,27 @@ class TestCommandTargets:
         a = event_from_tool_call(tool_call("run_bash_command", {"command": slashed}), 0)
         b = event_from_tool_call(tool_call("run_bash_command", {"command": spaced}), 1)
         assert signature_of(a) == signature_of(b)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kubectl get networkpolicy/redis",
+            "kubectl get networkpolicy redis",
+            "kubectl get netpol/redis",
+            "kubectl describe networkpolicy redis",
+        ],
+    )
+    def test_a_kind_with_no_abbreviation_is_still_a_kind(self, command):
+        """`networkpolicy` had no alias, and the parser took the known-kind set
+        from the alias table, so every form above lost the name entirely."""
+        event = event_from_tool_call(tool_call("run_bash_command", {"command": command}), 0)
+        assert event.entity.kind == "networkpolicy"
+        assert event.entity.name == "redis"
+
+    def test_every_topology_kind_is_a_kind_the_parser_knows(self):
+        """The schema treats these as topology; the parser has to agree, or a
+        reference step can name a kind no command can ever match."""
+        assert _TOPOLOGY_KINDS <= _KNOWN_KINDS
 
     def test_an_unknown_kind_before_a_slash_is_not_treated_as_a_target(self):
         """Otherwise a path argument would be parsed as a resource."""

--- a/tests/core/investigation_path/test_normalize.py
+++ b/tests/core/investigation_path/test_normalize.py
@@ -1,0 +1,281 @@
+"""Normalization and, more importantly, the redaction rules the schema promises."""
+
+import pytest
+
+from holmes.core.investigation_path.normalize import (
+    classify_error,
+    event_from_tool_call,
+    looks_like_instance_id,
+    normalize_resource_kind,
+    normalize_resource_name,
+    path_from_tool_calls,
+)
+from holmes.core.investigation_path.schema import (
+    ErrorClass,
+    OutcomeStatus,
+    QueryIntent,
+    SignatureLevel,
+)
+from holmes.core.models import ToolCallResult
+from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
+
+
+def tool_call(
+    tool_name,
+    params,
+    status=StructuredToolResultStatus.SUCCESS,
+    data="raw tool output that must never be stored",
+    error=None,
+    call_id="call-1",
+):
+    return ToolCallResult(
+        tool_call_id=call_id,
+        tool_name=tool_name,
+        description=tool_name,
+        result=StructuredToolResult(status=status, data=data, error=error, params=params),
+    )
+
+
+class TestNameNormalization:
+    @pytest.mark.parametrize(
+        "token,expected",
+        [("x2k9p", True), ("7d9f8b6c5", True), ("0", True), ("cache", False), ("redis", False)],
+    )
+    def test_looks_like_instance_id(self, token, expected):
+        assert looks_like_instance_id(token) is expected
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("payment-service-7d9f8b6c5-x2k9p", "payment-service"),
+            ("redis-0", "redis"),
+            ("redis-cache", "redis-cache"),
+            ("  Redis  ", "redis"),
+            ("", ""),
+        ],
+    )
+    def test_normalize_resource_name(self, name, expected):
+        assert normalize_resource_name(name) == expected
+
+    def test_two_pods_of_one_deployment_normalize_together(self):
+        assert normalize_resource_name("payment-service-7d9f8b6c5-x2k9p") == normalize_resource_name(
+            "payment-service-5f4d2a1b7-qq8lm"
+        )
+
+    @pytest.mark.parametrize(
+        "kind,expected", [("po", "pod"), ("svc", "service"), ("Pod", "pod"), ("widget", "widget")]
+    )
+    def test_normalize_resource_kind(self, kind, expected):
+        assert normalize_resource_kind(kind) == expected
+
+
+class TestRedaction:
+    def test_tool_output_is_never_stored(self):
+        event = event_from_tool_call(
+            tool_call("kubectl_get", {"kind": "svc", "name": "redis"}, data="SECRET PAYLOAD"),
+            ordinal=0,
+        )
+        assert "SECRET PAYLOAD" not in event.model_dump_json()
+
+    def test_raw_error_text_is_replaced_by_a_class(self):
+        event = event_from_tool_call(
+            tool_call(
+                "kubectl_get",
+                {"kind": "svc", "name": "redis"},
+                status=StructuredToolResultStatus.ERROR,
+                error='Error from server (Forbidden): user "svc-acct-xyz" cannot list services',
+            ),
+            ordinal=0,
+        )
+        assert event.outcome.status == OutcomeStatus.ERROR
+        assert event.outcome.error_class == ErrorClass.FORBIDDEN
+        assert "svc-acct-xyz" not in event.model_dump_json()
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"name": "redis", "password": "hunter2"},
+            {"name": "redis", "api_key": "sk-abc123"},
+            {"name": "redis", "authorization": "Bearer abc.def.ghi"},
+            {"name": "redis", "session_token": "zzz"},
+        ],
+    )
+    def test_sensitive_parameters_are_never_read(self, params):
+        event = event_from_tool_call(tool_call("kubectl_get", params), ordinal=0)
+        dumped = event.model_dump_json()
+        for value in params.values():
+            if value != "redis":
+                assert value not in dumped
+
+    def test_unknown_parameters_are_ignored_entirely(self):
+        event = event_from_tool_call(
+            tool_call("kubectl_get", {"kind": "svc", "name": "redis", "vendor_blob": "leak-me"}),
+            ordinal=0,
+        )
+        assert "leak-me" not in event.model_dump_json()
+
+    def test_high_entropy_words_in_commands_are_redacted(self):
+        event = event_from_tool_call(
+            tool_call("run_bash_command", {"command": "curl h7sk39dnq82mfk20xbz1qq host"}),
+            ordinal=0,
+        )
+        assert "h7sk39dnq82mfk20xbz1qq" not in event.model_dump_json()
+
+    def test_evidence_is_a_reference_not_a_copy(self):
+        event = event_from_tool_call(
+            tool_call("kubectl_get", {"kind": "svc", "name": "redis"}, call_id="call-42"),
+            ordinal=0,
+        )
+        assert event.evidence_ref == "call-42"
+
+
+class TestIntentInference:
+    @pytest.mark.parametrize(
+        "command,intent",
+        [
+            ("kubectl describe pod payment-service-7d9f8b6c5-x2k9p", QueryIntent.DESCRIBE),
+            ("kubectl logs payment-service-7d9f8b6c5-x2k9p", QueryIntent.LOGS),
+            ("kubectl get endpoints redis", QueryIntent.TOPOLOGY),
+            ("kubectl get svc redis", QueryIntent.TOPOLOGY),
+            ("kubectl get pods", QueryIntent.LIST),
+            ("kubectl top pods", QueryIntent.RESOURCE_USAGE),
+            ("kubectl rollout history deployment/api", QueryIntent.CONFIG_HISTORY),
+        ],
+    )
+    def test_intent_comes_from_the_command_verb(self, command, intent):
+        event = event_from_tool_call(tool_call("run_bash_command", {"command": command}), ordinal=0)
+        assert event.intent == intent
+
+    @pytest.mark.parametrize(
+        "tool_name,intent",
+        [
+            ("fetch_pod_logs", QueryIntent.LOGS),
+            ("prometheus_query", QueryIntent.METRICS),
+            ("fetch_traces", QueryIntent.TRACES),
+            ("kubectl_events", QueryIntent.EVENTS),
+        ],
+    )
+    def test_intent_falls_back_to_the_tool_name(self, tool_name, intent):
+        event = event_from_tool_call(tool_call(tool_name, {"name": "api"}), ordinal=0)
+        assert event.intent == intent
+
+    def test_same_check_through_two_toolsets_shares_a_signature(self):
+        from holmes.core.investigation_path.schema import signature_of
+
+        via_bash = event_from_tool_call(
+            tool_call("run_bash_command", {"command": "kubectl logs api-7d9f8b6c5-x2k9p"}), 0
+        )
+        via_toolset = event_from_tool_call(
+            tool_call("fetch_pod_logs", {"kind": "pod", "name": "api-5f4d2a1b7-qq8lm"}), 1
+        )
+        assert signature_of(via_bash) == signature_of(via_toolset)
+
+
+class TestEntityAndTimeWindow:
+    def test_kind_and_name_are_combined(self):
+        event = event_from_tool_call(tool_call("kubectl_get", {"kind": "svc", "name": "redis"}), 0)
+        assert event.entity.kind == "service"
+        assert event.entity.name == "redis"
+
+    def test_metric_is_read_out_of_a_promql_query(self):
+        event = event_from_tool_call(
+            tool_call("prometheus_query", {"query": 'sum(rate(redis_connected_clients{a="b"}[5m]))'}),
+            0,
+        )
+        assert event.entity.kind == "metric"
+        assert event.entity.name == "redis_connected_clients"
+
+    def test_lookback_is_bucketed_so_near_identical_ranges_match(self):
+        seven = event_from_tool_call(tool_call("fetch_pod_logs", {"name": "api", "since": "7m"}), 0)
+        ten = event_from_tool_call(tool_call("fetch_pod_logs", {"name": "api", "since": "10m"}), 1)
+        assert seven.time_window.lookback_seconds == ten.time_window.lookback_seconds == 900
+
+    def test_state_reads_are_marked_point_in_time(self):
+        event = event_from_tool_call(tool_call("kubectl_get", {"kind": "svc", "name": "redis"}), 0)
+        assert event.time_window.is_point_in_time is True
+
+
+class TestPathConstruction:
+    def test_ordering_is_preserved(self):
+        path = path_from_tool_calls(
+            [
+                tool_call("kubectl_describe", {"kind": "pod", "name": "api"}, call_id="a"),
+                tool_call("fetch_pod_logs", {"kind": "pod", "name": "api"}, call_id="b"),
+                tool_call("kubectl_get", {"kind": "svc", "name": "redis"}, call_id="c"),
+            ]
+        )
+        assert [event.ordinal for event in path.events] == [0, 1, 2]
+        assert path.signatures() == [
+            "describe:pod:api",
+            "logs:pod:api",
+            "topology:service:redis",
+        ]
+
+    def test_repeated_checks_collapse_but_keep_first_position(self):
+        path = path_from_tool_calls(
+            [
+                tool_call("fetch_pod_logs", {"kind": "pod", "name": "api-7d9f8b6c5-x2k9p"}, call_id="a"),
+                tool_call("kubectl_get", {"kind": "svc", "name": "redis"}, call_id="b"),
+                tool_call("fetch_pod_logs", {"kind": "pod", "name": "api-5f4d2a1b7-qq8lm"}, call_id="c"),
+            ]
+        )
+        assert path.signatures() == ["logs:pod:api", "topology:service:redis"]
+
+    def test_client_dicts_are_accepted(self):
+        path = path_from_tool_calls(
+            [tool_call("kubectl_get", {"kind": "svc", "name": "redis"}).to_client_dict()]
+        )
+        assert path.signatures() == ["topology:service:redis"]
+
+    def test_paused_tool_calls_are_not_checks(self):
+        path = path_from_tool_calls(
+            [
+                tool_call(
+                    "kubectl_get",
+                    {"kind": "svc"},
+                    status=StructuredToolResultStatus.APPROVAL_REQUIRED,
+                )
+            ]
+        )
+        assert path.events == []
+
+    def test_failed_checks_are_kept_with_their_failure_class(self):
+        path = path_from_tool_calls(
+            [
+                tool_call(
+                    "kubectl_get",
+                    {"kind": "svc", "name": "redis"},
+                    status=StructuredToolResultStatus.ERROR,
+                    error="services 'redis' not found",
+                )
+            ]
+        )
+        assert path.events[0].outcome.error_class == ErrorClass.NOT_FOUND
+
+    def test_coarse_signatures_drop_the_entity_name(self):
+        path = path_from_tool_calls([tool_call("kubectl_get", {"kind": "svc", "name": "redis"})])
+        assert path.signatures(SignatureLevel.COARSE) == ["topology:service"]
+
+    def test_subject_substitution_makes_workloads_comparable(self):
+        path = path_from_tool_calls([tool_call("fetch_pod_logs", {"kind": "pod", "name": "orders-service"})])
+        assert path.signatures(subject="orders-service") == ["logs:pod:<subject>"]
+
+    def test_no_tool_calls_gives_an_empty_path(self):
+        assert path_from_tool_calls(None).events == []
+
+
+class TestErrorClassification:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Error from server (NotFound)", ErrorClass.NOT_FOUND),
+            ("permission denied", ErrorClass.FORBIDDEN),
+            ("context deadline exceeded", ErrorClass.TIMEOUT),
+            ("parse error at char 3", ErrorClass.INVALID_QUERY),
+            ("connection refused", ErrorClass.UNAVAILABLE),
+            ("something else entirely", ErrorClass.OTHER),
+            (None, ErrorClass.OTHER),
+        ],
+    )
+    def test_classify_error(self, text, expected):
+        assert classify_error(text) == expected

--- a/tests/core/investigation_path/test_reporting.py
+++ b/tests/core/investigation_path/test_reporting.py
@@ -1,0 +1,312 @@
+"""Publishing a benchmark run through the eval/Braintrust pipeline.
+
+The point of these tests is that reporting cannot change a result and cannot
+break a build: a contributor with no Braintrust credentials must get the same
+numbers as CI, and a Braintrust outage must not turn a passing benchmark red.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from holmes.core.investigation_path.calibration import CalibrationModel
+from holmes.core.investigation_path.metrics import CaseOutcome, score_cases
+from holmes.core.investigation_path.offline_eval import main, run_offline_eval
+from holmes.core.investigation_path.reporting import (
+    BENCHMARK_SUFFIX,
+    benchmark_experiment_name,
+    benchmark_markdown,
+    case_scores,
+    log_benchmark_to_braintrust,
+    summary_scores,
+)
+
+ANSWERED = CaseOutcome(
+    incident_id="HOLD-100",
+    abstained=False,
+    missing_weights={"logs:pod:<subject>": 1.0, "events:pod:<subject>": 0.5},
+    suggested=["logs:pod:<subject>", "metrics:node:cpu"],
+    suggestion_confidence={"logs:pod:<subject>": 0.8, "metrics:node:cpu": 0.6},
+    latency_ms=1.0,
+)
+
+ABSTAINED = CaseOutcome(
+    incident_id="HOLD-101",
+    abstained=True,
+    abstain_reason="no_candidates",
+    missing_weights={"logs:pod:<subject>": 1.0},
+    latency_ms=2.0,
+)
+
+SILENT = CaseOutcome(
+    incident_id="HOLD-102",
+    abstained=False,
+    missing_weights={"logs:pod:<subject>": 1.0},
+    latency_ms=3.0,
+)
+
+
+class FakeSpan:
+    def __init__(self, name, sink):
+        self.name = name
+        self._sink = sink
+
+    def log(self, **kwargs):
+        self._sink.append({"name": self.name, **kwargs})
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeExperiment:
+    def __init__(self):
+        self.flushed = False
+
+    def flush(self):
+        self.flushed = True
+
+
+class FakeTracer:
+    """Stands in for BraintrustTracer with a key present."""
+
+    def __init__(self, experiment=None, url="https://braintrust.example/exp"):
+        self.logged = []
+        self.experiment = experiment if experiment is not None else FakeExperiment()
+        self.experiment_name = None
+        self.experiment_metadata = None
+        self._url = url
+
+    def start_experiment(self, experiment_name=None, additional_metadata=None):
+        self.experiment_name = experiment_name
+        self.experiment_metadata = additional_metadata
+        return self.experiment
+
+    def start_trace(self, name, span_type=None):
+        return FakeSpan(name, self.logged)
+
+    def get_trace_url(self):
+        return self._url
+
+
+class TestCaseScores:
+    def test_an_answer_is_scored_on_both_recall_and_precision(self):
+        scores = case_scores(ANSWERED)
+        assert scores["answered"] == 1.0
+        assert scores["path_recall"] == pytest.approx(1.0 / 1.5)
+        assert scores["suggestion_precision"] == 0.5
+
+    def test_an_abstention_scores_zero_recall(self):
+        scores = case_scores(ABSTAINED)
+        assert scores["answered"] == 0.0
+        assert scores["path_recall"] == 0.0
+
+    def test_an_abstention_is_not_charged_for_precision(self):
+        """It made no claim, so a precision of 0 would be a lie about it."""
+        assert "suggestion_precision" not in case_scores(ABSTAINED)
+
+    def test_answering_with_nothing_is_not_charged_for_precision_either(self):
+        assert "suggestion_precision" not in case_scores(SILENT)
+
+    def test_recall_of_a_case_with_nothing_missing_is_not_a_divide_by_zero(self):
+        clean = CaseOutcome(incident_id="HOLD-103", abstained=False)
+        assert case_scores(clean)["path_recall"] == 0.0
+
+
+class TestSummaryScores:
+    @pytest.fixture(scope="class")
+    def metrics(self):
+        return score_cases([ANSWERED, ABSTAINED, SILENT])
+
+    def test_every_reported_score_is_a_probability(self, metrics):
+        for name, value in summary_scores(metrics).items():
+            assert 0.0 <= value <= 1.0, name
+
+    def test_costs_are_not_reported_as_scores(self, metrics):
+        """Braintrust averages scores; latency and bytes would be nonsense there."""
+        names = summary_scores(metrics)
+        assert "latency_p95_ms" not in names
+        assert "bytes_per_incident" not in names
+
+
+class TestExperimentNaming:
+    def test_the_benchmark_gets_its_own_experiment(self):
+        """Sharing one with ask_holmes would average deterministic scores into
+        a model-scored correctness number."""
+        assert benchmark_experiment_name("run-7") == f"run-7-{BENCHMARK_SUFFIX}"
+
+    def test_the_name_falls_back_to_the_ambient_experiment_id(self, monkeypatch):
+        monkeypatch.setenv("EXPERIMENT_ID", "github-42")
+        assert benchmark_experiment_name() == f"github-42-{BENCHMARK_SUFFIX}"
+
+
+class TestBraintrustLogging:
+    def test_without_credentials_it_does_nothing_and_says_so(self, monkeypatch):
+        monkeypatch.delenv("BRAINTRUST_API_KEY", raising=False)
+        metrics = score_cases([ANSWERED, ABSTAINED])
+        assert log_benchmark_to_braintrust(metrics, [ANSWERED, ABSTAINED]) is None
+
+    def test_one_span_per_case_plus_a_summary(self):
+        tracer = FakeTracer()
+        metrics = score_cases([ANSWERED, ABSTAINED, SILENT])
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            url = log_benchmark_to_braintrust(metrics, [ANSWERED, ABSTAINED, SILENT])
+
+        assert url == "https://braintrust.example/exp"
+        assert len(tracer.logged) == 4
+        assert tracer.logged[-1]["name"] == "path-completeness[summary]"
+
+    def test_a_case_span_carries_what_was_suggested_and_what_was_missing(self):
+        tracer = FakeTracer()
+        metrics = score_cases([ANSWERED])
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            log_benchmark_to_braintrust(metrics, [ANSWERED])
+
+        span = tracer.logged[0]
+        assert span["input"] == "HOLD-100"
+        assert span["output"] == ANSWERED.suggested
+        assert span["expected"] == sorted(ANSWERED.missing_weights)
+        assert span["metadata"]["false_positives"] == ["metrics:node:cpu"]
+
+    def test_an_abstention_is_tagged_so_it_can_be_filtered_out(self):
+        tracer = FakeTracer()
+        metrics = score_cases([ABSTAINED])
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            log_benchmark_to_braintrust(metrics, [ABSTAINED])
+        assert "abstained" in tracer.logged[0]["tags"]
+
+    def test_the_experiment_records_the_zero_llm_call_budget(self):
+        tracer = FakeTracer()
+        metrics = score_cases([ANSWERED])
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            log_benchmark_to_braintrust(
+                metrics, [ANSWERED], CalibrationModel(fitted=False), "run-9"
+            )
+        assert tracer.experiment_name == f"run-9-{BENCHMARK_SUFFIX}"
+        assert tracer.experiment_metadata["llm_calls"] == 0
+        assert tracer.experiment_metadata["issue"] == "2046"
+
+    def test_results_are_flushed_before_the_process_exits(self):
+        tracer = FakeTracer()
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            log_benchmark_to_braintrust(score_cases([ANSWERED]), [ANSWERED])
+        assert tracer.experiment.flushed
+
+    def test_a_reporting_failure_does_not_fail_the_benchmark(self):
+        """A Braintrust outage must not read as a policy regression."""
+        tracer = FakeTracer()
+        tracer.start_trace = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            assert log_benchmark_to_braintrust(score_cases([ANSWERED]), [ANSWERED]) is None
+
+
+class TestMarkdown:
+    @pytest.fixture(scope="class")
+    def report(self):
+        metrics = score_cases([ANSWERED, ABSTAINED, SILENT])
+        return benchmark_markdown(metrics, [ANSWERED, ABSTAINED, SILENT])
+
+    def test_it_states_that_nothing_is_wired_to_runtime(self, report):
+        assert "Offline only" in report
+        assert "2046" in report
+
+    def test_every_case_appears(self, report):
+        for outcome in (ANSWERED, ABSTAINED, SILENT):
+            assert outcome.incident_id in report
+
+    def test_an_abstention_shows_its_reason(self, report):
+        assert "abstained (no_candidates)" in report
+
+    def test_answering_with_nothing_is_not_shown_as_an_answer(self, report):
+        """0 found and 0 wrong under 'answered' reads like a success."""
+        assert "no suggestions" in report
+
+    def test_the_tables_are_well_formed(self, report):
+        for line in report.splitlines():
+            if line.startswith("|") and not line.startswith("| ---"):
+                assert line.endswith("|")
+
+    def test_the_calibration_line_is_one_paragraph(self):
+        """A leading space here silently becomes a code block in some renderers."""
+        metrics = score_cases([ANSWERED])
+        report = benchmark_markdown(
+            metrics, [ANSWERED], CalibrationModel(fitted=False), metrics
+        )
+        assert "Confidence calibration" in report
+        assert not any(line.startswith(" ") for line in report.splitlines())
+
+    def test_a_braintrust_link_is_included_when_there_is_one(self):
+        report = benchmark_markdown(
+            score_cases([ANSWERED]), [ANSWERED], experiment_url="https://bt.example/x"
+        )
+        assert "[View in Braintrust](https://bt.example/x)" in report
+
+    def test_no_link_is_shown_when_the_run_was_not_logged(self, report):
+        assert "View in Braintrust" not in report
+
+
+class TestCli:
+    def test_it_writes_the_report_where_asked(self, tmp_path):
+        target = tmp_path / "report.md"
+        main(["--markdown", str(target)])
+        assert "Investigation path completeness benchmark" in target.read_text()
+
+    def test_the_report_matches_the_run_it_reports_on(self, tmp_path):
+        target = tmp_path / "report.md"
+        main(["--markdown", str(target)])
+        metrics, _, _ = run_offline_eval()
+        assert f"| Held-out cases | {metrics.cases} |" in target.read_text()
+
+    def test_it_prints_a_report_without_being_asked_for_a_file(self, capsys):
+        main([])
+        assert "weighted path recall" in capsys.readouterr().out
+
+    def test_asking_for_braintrust_without_a_key_is_not_an_error(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        monkeypatch.delenv("BRAINTRUST_API_KEY", raising=False)
+        main(["--braintrust", "--markdown", str(tmp_path / "r.md")])
+        assert "braintrust:" not in capsys.readouterr().out
+
+    def test_reporting_cannot_change_the_result(self, tmp_path):
+        """The CLI must not be a second, drifting implementation of the eval.
+
+        Latency is excluded: it is measured wall clock, so it is the one field
+        that is legitimately allowed to differ between two identical runs.
+        """
+        timing = {"latency_p50_ms", "latency_p95_ms"}
+        before, _, _ = run_offline_eval()
+        main(["--markdown", str(tmp_path / "r.md")])
+        after, _, _ = run_offline_eval()
+        assert {k: v for k, v in before.model_dump().items() if k not in timing} == {
+            k: v for k, v in after.model_dump().items() if k not in timing
+        }
+
+
+class TestPackaging:
+    def test_the_benchmark_is_runnable_as_documented(self):
+        """The design doc and CI both invoke it this way."""
+        module = Path("holmes/core/investigation_path/offline_eval.py")
+        assert module.is_file()
+        assert "__main__" in module.read_text()

--- a/tests/core/investigation_path/test_reporting.py
+++ b/tests/core/investigation_path/test_reporting.py
@@ -220,6 +220,36 @@ class TestBraintrustLogging:
         ):
             assert log_benchmark_to_braintrust(score_cases([ANSWERED]), [ANSWERED]) is None
 
+    def test_an_outage_starting_the_experiment_is_survivable(self):
+        """`braintrust.init` does network I/O, so it is the likeliest thing to
+        raise - and it runs before any span exists to fail on."""
+        tracer = FakeTracer()
+        tracer.start_experiment = lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("braintrust.init: connection reset")
+        )
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            assert log_benchmark_to_braintrust(score_cases([ANSWERED]), [ANSWERED]) is None
+
+    def test_an_outage_building_the_tracer_is_survivable(self):
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            side_effect=RuntimeError("no braintrust package"),
+        ):
+            assert log_benchmark_to_braintrust(score_cases([ANSWERED]), [ANSWERED]) is None
+
+    def test_a_failure_reading_back_the_url_is_survivable(self):
+        """The run is already logged by then; losing the link is not a failure."""
+        tracer = FakeTracer()
+        tracer.get_trace_url = lambda: (_ for _ in ()).throw(RuntimeError("no session"))
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            return_value=tracer,
+        ):
+            assert log_benchmark_to_braintrust(score_cases([ANSWERED]), [ANSWERED]) is None
+
 
 class TestMarkdown:
     @pytest.fixture(scope="class")
@@ -288,6 +318,24 @@ class TestCli:
         monkeypatch.delenv("BRAINTRUST_API_KEY", raising=False)
         main(["--braintrust", "--markdown", str(tmp_path / "r.md")])
         assert "braintrust:" not in capsys.readouterr().out
+
+    def test_a_braintrust_outage_still_leaves_the_numbers_behind(self, capsys, tmp_path):
+        """The failure that matters is silent loss, not the traceback.
+
+        Braintrust is logged before the results are printed and before the
+        markdown is written, so an exception there takes the whole report with
+        it. In CI the step is `continue-on-error`, so the build would stay
+        green while the benchmark section vanished from the PR comment.
+        """
+        target = tmp_path / "report.md"
+        with patch(
+            "holmes.core.investigation_path.reporting.TracingFactory.create_tracer",
+            side_effect=RuntimeError("braintrust is down"),
+        ):
+            main(["--braintrust", "--markdown", str(target)])
+
+        assert "weighted path recall" in capsys.readouterr().out
+        assert "Investigation path completeness benchmark" in target.read_text()
 
     def test_reporting_cannot_change_the_result(self, tmp_path):
         """The CLI must not be a second, drifting implementation of the eval.

--- a/tests/core/investigation_path/test_reporting.py
+++ b/tests/core/investigation_path/test_reporting.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from holmes.core.investigation_path.calibration import CalibrationModel
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.metrics import CaseOutcome, score_cases
 from holmes.core.investigation_path.offline_eval import main, run_offline_eval
 from holmes.core.investigation_path.reporting import (

--- a/tests/core/investigation_path/test_retrieval.py
+++ b/tests/core/investigation_path/test_retrieval.py
@@ -1,0 +1,144 @@
+"""Retrieval: symptom ranking, root-cause separation, and every abstention path."""
+
+import pytest
+
+from holmes.core.investigation_path.retrieval import (
+    AbstainReason,
+    RetrievalPolicy,
+    retrieve,
+    symptom_similarity,
+)
+from holmes.core.investigation_path.schema import IncidentRecord, RootCause
+
+
+def incident(incident_id, symptoms, root_cause="dependency_unreachable"):
+    return IncidentRecord(
+        incident_id=incident_id,
+        occurred_at="2026-01-01",
+        source_type="prometheus",
+        title=incident_id,
+        symptoms=symptoms,
+        root_cause=RootCause(label=root_cause, summary="summary"),
+        validated_by="test",
+        validated_at="2026-01-01",
+    )
+
+
+class TestSymptomSimilarity:
+    def test_identical_sets_score_one(self):
+        assert symptom_similarity(["redis", "crash"], ["crash", "redis"]) == 1.0
+
+    def test_disjoint_sets_score_zero(self):
+        assert symptom_similarity(["redis"], ["postgres"]) == 0.0
+
+    def test_empty_input_scores_zero(self):
+        assert symptom_similarity([], ["redis"]) == 0.0
+
+    def test_partial_overlap(self):
+        assert symptom_similarity(["a", "b"], ["b", "c"]) == pytest.approx(1 / 3)
+
+    def test_matching_ignores_case(self):
+        assert symptom_similarity(["Redis"], ["redis"]) == 1.0
+
+
+class TestAbstention:
+    def test_empty_corpus_abstains_with_no_candidates(self):
+        result = retrieve(["redis", "crash"], [])
+        assert result.abstained
+        assert result.abstain_reason == AbstainReason.NO_CANDIDATES
+
+    def test_unrelated_corpus_abstains_with_no_candidates(self):
+        result = retrieve(["tls", "certificate"], [incident("A", ["redis", "crash", "pod"])])
+        assert result.abstain_reason == AbstainReason.NO_CANDIDATES
+
+    def test_weak_overlap_abstains_with_low_similarity(self):
+        pool = [incident("A", ["redis", "crash", "pod", "restart", "timeout", "payment"])]
+        result = retrieve(["redis", "tls", "certificate", "expired", "ingress"], pool)
+        assert result.abstain_reason == AbstainReason.LOW_SIMILARITY
+
+    def test_a_single_matching_incident_abstains(self):
+        pool = [incident("A", ["redis", "crash", "pod"])]
+        result = retrieve(["redis", "crash", "pod"], pool)
+        assert result.abstain_reason == AbstainReason.INSUFFICIENT_SUPPORT
+
+    def test_disagreeing_root_causes_abstain(self):
+        pool = [
+            incident("A", ["redis", "crash", "pod"], root_cause="dependency_unreachable"),
+            incident("B", ["redis", "crash", "pod"], root_cause="oom_kill"),
+            incident("C", ["redis", "crash", "pod"], root_cause="config_regression"),
+        ]
+        result = retrieve(["redis", "crash", "pod"], pool)
+        assert result.abstain_reason == AbstainReason.ROOT_CAUSE_DISAGREEMENT
+        assert result.root_cause_agreement == pytest.approx(1 / 3)
+
+    def test_rejected_candidates_are_still_reported(self):
+        pool = [incident("A", ["redis", "crash", "pod"])]
+        result = retrieve(["redis", "crash", "pod"], pool)
+        assert [c.incident.incident_id for c in result.candidates] == ["A"]
+        assert result.matches == []
+
+    def test_every_abstention_has_a_readable_reason(self):
+        for reason in AbstainReason:
+            from holmes.core.investigation_path.retrieval import RetrievalResult
+
+            result = RetrievalResult(abstained=True, abstain_reason=reason)
+            assert result.explain_abstention()
+
+
+class TestAnswering:
+    @pytest.fixture
+    def pool(self):
+        return [
+            incident("A", ["redis", "crash", "pod", "restart"]),
+            incident("B", ["redis", "crash", "pod", "timeout"]),
+            incident("C", ["disk", "node", "evicted"], root_cause="node_disk_pressure"),
+        ]
+
+    def test_two_agreeing_incidents_are_enough_to_answer(self, pool):
+        result = retrieve(["redis", "crash", "pod", "restart"], pool)
+        assert not result.abstained
+        assert [m.incident.incident_id for m in result.matches] == ["A", "B"]
+        assert result.modal_root_cause == "dependency_unreachable"
+
+    def test_unrelated_incidents_are_not_matched(self, pool):
+        result = retrieve(["redis", "crash", "pod", "restart"], pool)
+        assert "C" not in [m.incident.incident_id for m in result.matches]
+
+    def test_matches_are_ranked_by_similarity(self, pool):
+        result = retrieve(["redis", "crash", "pod", "restart"], pool)
+        scores = [m.symptom_similarity for m in result.matches]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_minority_root_causes_are_dropped_from_matches(self):
+        pool = [
+            incident("A", ["redis", "crash", "pod"], root_cause="dependency_unreachable"),
+            incident("B", ["redis", "crash", "pod"], root_cause="dependency_unreachable"),
+            incident("C", ["redis", "crash", "pod"], root_cause="oom_kill"),
+        ]
+        result = retrieve(["redis", "crash", "pod"], pool)
+        assert [m.incident.incident_id for m in result.matches] == ["A", "B"]
+        assert len(result.candidates) == 3
+
+    def test_confidence_rises_with_more_agreeing_incidents(self):
+        symptoms = ["redis", "crash", "pod"]
+        two = retrieve(symptoms, [incident("A", symptoms), incident("B", symptoms)])
+        three = retrieve(
+            symptoms, [incident("A", symptoms), incident("B", symptoms), incident("C", symptoms)]
+        )
+        assert three.confidence > two.confidence
+
+    def test_confidence_stays_within_zero_and_one(self):
+        symptoms = ["redis", "crash", "pod"]
+        result = retrieve(symptoms, [incident(str(i), symptoms) for i in range(5)])
+        assert 0.0 <= result.confidence <= 1.0
+
+    def test_candidate_count_is_capped(self):
+        symptoms = ["redis", "crash", "pod"]
+        pool = [incident(f"INC-{i}", symptoms) for i in range(10)]
+        result = retrieve(symptoms, pool, RetrievalPolicy(max_candidates=3))
+        assert len(result.candidates) == 3
+
+    def test_raising_the_similarity_floor_forces_abstention(self):
+        pool = [incident("A", ["redis", "crash", "pod"]), incident("B", ["redis", "crash", "pod"])]
+        strict = retrieve(["redis", "crash"], pool, RetrievalPolicy(min_symptom_similarity=0.95))
+        assert strict.abstained

--- a/tests/core/investigation_path/test_retrieval.py
+++ b/tests/core/investigation_path/test_retrieval.py
@@ -1,6 +1,7 @@
 """Retrieval: symptom ranking, root-cause separation, and every abstention path."""
 
 import pytest
+from pydantic import ValidationError
 
 from holmes.core.investigation_path.retrieval import (
     AbstainReason,
@@ -142,3 +143,56 @@ class TestAnswering:
         pool = [incident("A", ["redis", "crash", "pod"]), incident("B", ["redis", "crash", "pod"])]
         strict = retrieve(["redis", "crash"], pool, RetrievalPolicy(min_symptom_similarity=0.95))
         assert strict.abstained
+
+
+class TestPolicyValidation:
+    """A bad knob has to fail where it is set, not where it is used.
+
+    These are the values a sweep produces by accident. Most do not crash; they
+    quietly turn the benchmark into a measurement of nothing, which is the
+    failure this guards against.
+    """
+
+    def test_a_zero_support_denominator_is_refused(self):
+        """It divides into the confidence score."""
+        with pytest.raises(ValidationError):
+            RetrievalPolicy(full_support_matches=0)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"full_support_matches": 0},
+            {"full_support_matches": -3},
+            {"max_candidates": 0},
+            {"max_candidates": -1},
+            {"min_matches": 0},
+            {"min_matches": -5},
+            {"min_symptom_similarity": -0.1},
+            {"min_symptom_similarity": 1.5},
+            {"min_root_cause_agreement": -2.0},
+            {"min_root_cause_agreement": 1.01},
+        ],
+    )
+    def test_out_of_range_retrieval_knobs_are_refused(self, kwargs):
+        with pytest.raises(ValidationError):
+            RetrievalPolicy(**kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"min_symptom_similarity": 0.0},
+            {"min_symptom_similarity": 1.0},
+            {"max_candidates": 1},
+            {"min_matches": 1},
+            {"min_root_cause_agreement": 0.0},
+            {"full_support_matches": 1},
+        ],
+    )
+    def test_the_edges_of_the_range_are_still_usable(self, kwargs):
+        """Bounds must not outlaw a legitimate sweep endpoint."""
+        assert RetrievalPolicy(**kwargs) is not None
+
+    def test_the_default_policy_satisfies_its_own_bounds(self):
+        assert RetrievalPolicy() == RetrievalPolicy.model_validate(
+            RetrievalPolicy().model_dump()
+        )

--- a/tests/core/investigation_path/test_retrieval.py
+++ b/tests/core/investigation_path/test_retrieval.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from holmes.core.investigation_path.retrieval import (
     AbstainReason,
     RetrievalPolicy,
+    RetrievalResult,
     retrieve,
     symptom_similarity,
 )
@@ -80,8 +81,6 @@ class TestAbstention:
 
     def test_every_abstention_has_a_readable_reason(self):
         for reason in AbstainReason:
-            from holmes.core.investigation_path.retrieval import RetrievalResult
-
             result = RetrievalResult(abstained=True, abstain_reason=reason)
             assert result.explain_abstention()
 

--- a/tests/core/investigation_path/test_validator.py
+++ b/tests/core/investigation_path/test_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from holmes.core.investigation_path.calibration import CalibrationModel
+from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
 from holmes.core.investigation_path.schema import (
     EntityRef,

--- a/tests/core/investigation_path/test_validator.py
+++ b/tests/core/investigation_path/test_validator.py
@@ -1,0 +1,176 @@
+"""Suggestions: what gets surfaced, with what provenance, and how it reads."""
+
+import pytest
+
+from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
+from holmes.core.investigation_path.schema import (
+    EntityRef,
+    IncidentRecord,
+    QueryIntent,
+    ReferenceStep,
+    RootCause,
+)
+from holmes.core.investigation_path.validator import SuggestionPolicy, validate_path
+
+
+def step(intent, kind, name, weight=1.0, rationale="because it matters"):
+    return ReferenceStep(
+        intent=intent,
+        entity=EntityRef(kind=kind, name=name),
+        weight=weight,
+        rationale=rationale,
+    )
+
+
+def incident(incident_id, symptoms, reference_path, root_cause="dependency_unreachable"):
+    return IncidentRecord(
+        incident_id=incident_id,
+        occurred_at="2026-01-01",
+        source_type="prometheus",
+        title=f"Title for {incident_id}",
+        symptoms=symptoms,
+        root_cause=RootCause(label=root_cause, summary="summary"),
+        reference_path=reference_path,
+        validated_by="test",
+        validated_at="2026-01-01",
+    )
+
+
+SYMPTOMS = ["redis", "crash", "pod", "restart"]
+
+
+@pytest.fixture
+def retrieval():
+    pool = [
+        incident(
+            "INC-001",
+            SYMPTOMS,
+            [
+                step(QueryIntent.LOGS, "pod", "<subject>"),
+                step(QueryIntent.TOPOLOGY, "endpoints", "redis", weight=1.0),
+                step(QueryIntent.TOPOLOGY, "service", "redis", weight=0.9),
+            ],
+        ),
+        incident(
+            "INC-002",
+            SYMPTOMS,
+            [
+                step(QueryIntent.LOGS, "pod", "<subject>"),
+                step(QueryIntent.TOPOLOGY, "endpoints", "redis", weight=1.0),
+                step(QueryIntent.METRICS, "metric", "redis_memory_used_bytes", weight=0.3),
+            ],
+        ),
+    ]
+    return retrieve(SYMPTOMS, pool)
+
+
+class TestSuggestions:
+    def test_checks_already_performed_are_not_suggested(self, retrieval):
+        report = validate_path(["logs:pod:<subject>", "topology:endpoints:redis"], retrieval)
+        assert "logs:pod:<subject>" not in [s.signature for s in report.suggestions]
+        assert "topology:endpoints:redis" not in [s.signature for s in report.suggestions]
+
+    def test_skipped_checks_are_suggested(self, retrieval):
+        report = validate_path(["logs:pod:<subject>"], retrieval)
+        assert "topology:endpoints:redis" in [s.signature for s in report.suggestions]
+
+    def test_support_counts_how_many_incidents_ran_the_check(self, retrieval):
+        report = validate_path([], retrieval)
+        by_signature = {s.signature: s for s in report.suggestions}
+        assert by_signature["topology:endpoints:redis"].support == 2
+        assert by_signature["topology:service:redis"].support == 1
+        assert by_signature["topology:endpoints:redis"].out_of == 2
+
+    def test_more_important_and_better_supported_checks_come_first(self, retrieval):
+        report = validate_path([], retrieval)
+        ranking = [s.weight * s.support for s in report.suggestions]
+        assert ranking == sorted(ranking, reverse=True)
+        assert report.suggestions[-1].signature == "metrics:metric:redis_memory_used_bytes"
+
+    def test_every_suggestion_carries_provenance(self, retrieval):
+        report = validate_path([], retrieval)
+        for suggestion in report.suggestions:
+            assert suggestion.provenance
+            for source in suggestion.provenance:
+                assert source.incident_id
+                assert source.occurred_at
+                assert source.root_cause_label
+
+    def test_every_suggestion_carries_a_rationale(self, retrieval):
+        report = validate_path([], retrieval)
+        assert all(s.rationale for s in report.suggestions)
+
+    def test_confidence_scales_with_support(self, retrieval):
+        report = validate_path([], retrieval)
+        by_signature = {s.signature: s for s in report.suggestions}
+        assert by_signature["topology:endpoints:redis"].confidence > (
+            by_signature["topology:service:redis"].confidence
+        )
+
+    def test_raising_min_support_drops_minority_checks(self, retrieval):
+        report = validate_path([], retrieval, SuggestionPolicy(min_support=2))
+        assert "topology:service:redis" not in [s.signature for s in report.suggestions]
+        assert "topology:endpoints:redis" in [s.signature for s in report.suggestions]
+
+    def test_suggestion_count_is_capped(self, retrieval):
+        report = validate_path([], retrieval, SuggestionPolicy(max_suggestions=1))
+        assert len(report.suggestions) == 1
+
+    def test_low_confidence_suggestions_are_dropped(self, retrieval):
+        report = validate_path([], retrieval, SuggestionPolicy(min_confidence=0.99))
+        assert report.suggestions == []
+
+    def test_a_repeated_reference_step_cannot_inflate_its_own_support(self):
+        pool = [
+            incident("INC-001", SYMPTOMS, [step(QueryIntent.LOGS, "pod", "api")] * 3),
+            incident("INC-002", SYMPTOMS, [step(QueryIntent.LOGS, "pod", "api")]),
+        ]
+        report = validate_path([], retrieve(SYMPTOMS, pool))
+        assert report.suggestions[0].support == 2
+
+
+class TestAbstainedReports:
+    def test_an_abstained_retrieval_produces_no_suggestions(self):
+        report = validate_path([], retrieve(["tls", "certificate"], []))
+        assert report.abstained
+        assert report.suggestions == []
+
+    def test_an_abstained_report_explains_itself(self):
+        report = validate_path([], retrieve(["tls", "certificate"], []))
+        assert "no past incident resembled this one" in report.abstain_reason
+
+    def test_an_abstained_report_renders_nothing(self):
+        assert validate_path([], retrieve(["tls", "certificate"], [])).to_markdown() == ""
+
+
+class TestRendering:
+    def test_the_subject_token_is_rendered_as_the_real_workload(self, retrieval):
+        report = validate_path([], retrieval, subject="orders-service")
+        assert "<subject>" not in report.to_markdown()
+        assert "orders-service" in report.to_markdown()
+
+    def test_the_report_is_worded_as_advice_not_a_requirement(self, retrieval):
+        markdown = validate_path([], retrieval, subject="orders-service").to_markdown()
+        assert "not required steps" in markdown
+
+    def test_the_report_names_its_sources(self, retrieval):
+        markdown = validate_path([], retrieval, subject="orders-service").to_markdown()
+        assert "INC-001" in markdown
+        assert "2026-01-01" in markdown
+
+    def test_the_report_names_the_shared_root_cause(self, retrieval):
+        markdown = validate_path([], retrieval, subject="orders-service").to_markdown()
+        assert "dependency_unreachable" in markdown
+
+    def test_nothing_missing_renders_nothing(self, retrieval):
+        report = validate_path(
+            [
+                "logs:pod:<subject>",
+                "topology:endpoints:redis",
+                "topology:service:redis",
+                "metrics:metric:redis_memory_used_bytes",
+            ],
+            retrieval,
+        )
+        assert report.is_empty
+        assert report.to_markdown() == ""

--- a/tests/core/investigation_path/test_validator.py
+++ b/tests/core/investigation_path/test_validator.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from holmes.core.investigation_path.calibration import CalibrationModel
 from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
 from holmes.core.investigation_path.schema import (
     EntityRef,
@@ -254,6 +255,46 @@ class TestRendering:
     def test_the_report_names_the_shared_root_cause(self, retrieval):
         markdown = validate_path([], retrieval, subject="orders-service").to_markdown()
         assert "dependency_unreachable" in markdown
+
+    def test_an_uncalibrated_score_is_never_shown_as_a_percentage(self, retrieval):
+        """The raw score is a product of terms below 1, so it reads far below the
+        real hit rate. Printing it teaches responders to ignore the block."""
+        markdown = validate_path([], retrieval, subject="orders-service").to_markdown()
+        assert "Confidence" not in markdown
+
+    def test_a_calibrated_score_is_shown(self, retrieval):
+        """It is computed either way; not showing it wastes the calibration."""
+        report = validate_path(
+            [],
+            retrieval,
+            subject="orders-service",
+            calibration=CalibrationModel(slope=2.2, intercept=0.35, fitted=True),
+        )
+        assert "Confidence" in report.to_markdown()
+        assert all(s.calibrated for s in report.suggestions)
+
+    def test_an_unfitted_model_counts_as_uncalibrated(self, retrieval):
+        """`fit_calibration` returns an unfitted model when the pool is too small,
+        and that must not silently start printing percentages."""
+        report = validate_path(
+            [],
+            retrieval,
+            subject="orders-service",
+            calibration=CalibrationModel(fitted=False),
+        )
+        assert not any(s.calibrated for s in report.suggestions)
+        assert "Confidence" not in report.to_markdown()
+
+    def test_the_shown_percentage_is_the_calibrated_one(self, retrieval):
+        report = validate_path(
+            [],
+            retrieval,
+            subject="orders-service",
+            calibration=CalibrationModel(slope=2.2, intercept=0.35, fitted=True),
+        )
+        top = report.suggestions[0]
+        assert top.confidence != top.raw_confidence
+        assert f"Confidence {top.confidence:.0%}" in report.to_markdown()
 
     def test_nothing_missing_renders_nothing(self, retrieval):
         report = validate_path(

--- a/tests/core/investigation_path/test_validator.py
+++ b/tests/core/investigation_path/test_validator.py
@@ -38,6 +38,10 @@ def incident(incident_id, symptoms, reference_path, root_cause="dependency_unrea
 
 SYMPTOMS = ["redis", "crash", "pod", "restart"]
 
+# Turns off the support-ratio filter, for tests that need to see the minority
+# suggestions the default policy is designed to remove.
+PERMISSIVE = SuggestionPolicy(min_support_ratio=0.0)
+
 
 @pytest.fixture
 def retrieval():
@@ -75,14 +79,14 @@ class TestSuggestions:
         assert "topology:endpoints:redis" in [s.signature for s in report.suggestions]
 
     def test_support_counts_how_many_incidents_ran_the_check(self, retrieval):
-        report = validate_path([], retrieval)
+        report = validate_path([], retrieval, PERMISSIVE)
         by_signature = {s.signature: s for s in report.suggestions}
         assert by_signature["topology:endpoints:redis"].support == 2
         assert by_signature["topology:service:redis"].support == 1
         assert by_signature["topology:endpoints:redis"].out_of == 2
 
     def test_more_important_and_better_supported_checks_come_first(self, retrieval):
-        report = validate_path([], retrieval)
+        report = validate_path([], retrieval, PERMISSIVE)
         ranking = [s.weight * s.support for s in report.suggestions]
         assert ranking == sorted(ranking, reverse=True)
         assert report.suggestions[-1].signature == "metrics:metric:redis_memory_used_bytes"
@@ -101,7 +105,7 @@ class TestSuggestions:
         assert all(s.rationale for s in report.suggestions)
 
     def test_confidence_scales_with_support(self, retrieval):
-        report = validate_path([], retrieval)
+        report = validate_path([], retrieval, PERMISSIVE)
         by_signature = {s.signature: s for s in report.suggestions}
         assert by_signature["topology:endpoints:redis"].confidence > (
             by_signature["topology:service:redis"].confidence
@@ -111,6 +115,34 @@ class TestSuggestions:
         report = validate_path([], retrieval, SuggestionPolicy(min_support=2))
         assert "topology:service:redis" not in [s.signature for s in report.suggestions]
         assert "topology:endpoints:redis" in [s.signature for s in report.suggestions]
+
+
+class TestSupportRatioFilter:
+    """A check only one incident out of several ran is that incident's own
+    circumstance, not a property of the root cause. Suggesting it anyway was the
+    single largest source of false positives on the benchmark."""
+
+    def test_minority_checks_are_dropped_by_default(self, retrieval):
+        signatures = [s.signature for s in validate_path([], retrieval).suggestions]
+        assert "topology:service:redis" not in signatures
+        assert "metrics:metric:redis_memory_used_bytes" not in signatures
+
+    def test_unanimous_checks_survive(self, retrieval):
+        signatures = [s.signature for s in validate_path([], retrieval).suggestions]
+        assert "topology:endpoints:redis" in signatures
+        assert "logs:pod:<subject>" in signatures
+
+    def test_the_ratio_is_measured_against_the_match_count(self):
+        # Two of three is 0.67, which clears the default 0.6 floor.
+        pool = [
+            incident("INC-001", SYMPTOMS, [step(QueryIntent.LOGS, "pod", "api")]),
+            incident("INC-002", SYMPTOMS, [step(QueryIntent.LOGS, "pod", "api")]),
+            incident("INC-003", SYMPTOMS, [step(QueryIntent.EVENTS, "pod", "api")]),
+        ]
+        report = validate_path([], retrieve(SYMPTOMS, pool))
+        signatures = [s.signature for s in report.suggestions]
+        assert "logs:pod:api" in signatures
+        assert "events:pod:api" not in signatures
 
     def test_suggestion_count_is_capped(self, retrieval):
         report = validate_path([], retrieval, SuggestionPolicy(max_suggestions=1))
@@ -127,6 +159,67 @@ class TestSuggestions:
         ]
         report = validate_path([], retrieve(SYMPTOMS, pool))
         assert report.suggestions[0].support == 2
+
+
+class TestEntityTransfer:
+    """Two incidents can share symptoms and a root cause while depending on
+    completely different services. Suggesting the other incident's dependency by
+    name sends a responder to something that does not exist here."""
+
+    @pytest.fixture
+    def redis_retrieval(self):
+        path = [
+            step(QueryIntent.LOGS, "pod", "<subject>"),
+            step(QueryIntent.TOPOLOGY, "service", "redis"),
+            step(QueryIntent.TOPOLOGY, "endpoints", "redis"),
+            step(QueryIntent.METRICS, "metric", "redis_connected_clients"),
+            step(QueryIntent.RESOURCE_USAGE, "metric", "container_memory_working_set_bytes"),
+        ]
+        pool = [incident("INC-001", SYMPTOMS, path), incident("INC-002", SYMPTOMS, path)]
+        return retrieve(SYMPTOMS, pool)
+
+    def test_an_object_the_investigation_never_saw_is_not_suggested(self, redis_retrieval):
+        report = validate_path([], redis_retrieval, known_entities={"queue-worker"})
+        signatures = [s.signature for s in report.suggestions]
+        assert "topology:service:redis" not in signatures
+        assert "topology:endpoints:redis" not in signatures
+
+    def test_an_object_the_investigation_did_see_is_still_suggested(self, redis_retrieval):
+        report = validate_path([], redis_retrieval, known_entities={"redis"})
+        assert "topology:service:redis" in [s.signature for s in report.suggestions]
+
+    def test_a_metric_named_after_a_foreign_object_is_not_suggested(self, redis_retrieval):
+        """`redis_connected_clients` is a metric, but only where Redis exists."""
+        report = validate_path([], redis_retrieval, known_entities={"queue-worker"})
+        assert "metrics:metric:redis_connected_clients" not in [
+            s.signature for s in report.suggestions
+        ]
+
+    def test_a_genuinely_generic_metric_still_transfers(self, redis_retrieval):
+        report = validate_path([], redis_retrieval, known_entities={"queue-worker"})
+        assert "resource_usage:metric:container_memory_working_set_bytes" in [
+            s.signature for s in report.suggestions
+        ]
+
+    def test_subject_relative_checks_always_transfer(self, redis_retrieval):
+        report = validate_path([], redis_retrieval, known_entities={"queue-worker"})
+        assert "logs:pod:<subject>" in [s.signature for s in report.suggestions]
+
+    def test_token_matching_does_not_reject_on_a_substring(self):
+        """A pod named `mem` must not veto `node_memory_MemAvailable_bytes`."""
+        path = [
+            step(QueryIntent.DESCRIBE, "pod", "mem"),
+            step(QueryIntent.METRICS, "metric", "node_memory_MemAvailable_bytes"),
+        ]
+        pool = [incident("INC-001", SYMPTOMS, path), incident("INC-002", SYMPTOMS, path)]
+        report = validate_path([], retrieve(SYMPTOMS, pool), known_entities={"other"})
+        signatures = [s.signature for s in report.suggestions]
+        assert "metrics:metric:node_memory_MemAvailable_bytes" in signatures
+        assert "describe:pod:mem" not in signatures
+
+    def test_callers_that_cannot_supply_known_entities_are_not_filtered(self, redis_retrieval):
+        report = validate_path([], redis_retrieval, known_entities=None)
+        assert "topology:service:redis" in [s.signature for s in report.suggestions]
 
 
 class TestAbstainedReports:

--- a/tests/core/investigation_path/test_validator.py
+++ b/tests/core/investigation_path/test_validator.py
@@ -1,6 +1,7 @@
 """Suggestions: what gets surfaced, with what provenance, and how it reads."""
 
 import pytest
+from pydantic import ValidationError
 
 from holmes.core.investigation_path.calibration_model import CalibrationModel
 from holmes.core.investigation_path.retrieval import RetrievalPolicy, retrieve
@@ -308,3 +309,49 @@ class TestRendering:
         )
         assert report.is_empty
         assert report.to_markdown() == ""
+
+
+class TestPolicyValidation:
+    """An out-of-range filter suppresses every suggestion in silence.
+
+    That scores as perfect precision with zero recall - a plausible-looking
+    result that is really a typo - so the bounds are enforced at construction.
+    """
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"min_support": 0},
+            {"min_support": -1},
+            {"max_suggestions": 0},
+            {"max_suggestions": -1},
+            {"min_support_ratio": -0.1},
+            {"min_support_ratio": 1.5},
+            {"min_confidence": -1.0},
+            {"min_confidence": 1.01},
+        ],
+    )
+    def test_out_of_range_suggestion_knobs_are_refused(self, kwargs):
+        with pytest.raises(ValidationError):
+            SuggestionPolicy(**kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"min_support_ratio": 0.0},
+            {"min_support_ratio": 1.0},
+            {"min_confidence": 0.0},
+            {"min_confidence": 1.0},
+            {"min_support": 1},
+            {"max_suggestions": 1},
+        ],
+    )
+    def test_the_edges_of_the_range_are_still_usable(self, kwargs):
+        assert SuggestionPolicy(**kwargs) is not None
+
+    def test_the_calibration_sweep_policy_is_still_constructible(self):
+        """`build_calibration_samples` deliberately turns every filter off; the
+        bounds must not make that unreachable."""
+        assert SuggestionPolicy(
+            min_support=1, min_support_ratio=0.0, min_confidence=0.0, max_suggestions=1000
+        ) is not None

--- a/tests/fixtures/investigation_path/corpus/HOLD-001.yaml
+++ b/tests/fixtures/investigation_path/corpus/HOLD-001.yaml
@@ -1,0 +1,66 @@
+# Held-out case: should ANSWER. Two corpus incidents share both the symptoms
+# and the root cause, and the observed investigation stopped at the dependency
+# pod without checking whether the Service still routed to it.
+incident_id: HOLD-001
+occurred_at: "2026-06-11"
+source_type: prometheus
+title: Orders service crash looping on refused cache connections
+subject: orders-service
+split: holdout
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - crashloopbackoff
+  - pod
+  - restart
+  - redis
+  - connection
+  - refused
+  - orders
+
+root_cause:
+  label: dependency_unreachable
+  summary: >-
+    A Redis StatefulSet rename left the Service selector pointing at labels no
+    pod carried, so the Service had no endpoints.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: Shows the restart reason and which container is failing.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: The application error names the dependency that is failing.
+  - intent: describe
+    entity: {kind: pod, name: redis}
+    weight: 0.5
+    rationale: Rules out the dependency itself being down.
+  - intent: topology
+    entity: {kind: service, name: redis}
+    weight: 0.9
+    rationale: A healthy dependency pod does not prove the Service still selects it.
+  - intent: topology
+    entity: {kind: endpoints, name: redis}
+    weight: 1.0
+    rationale: Empty endpoints is the direct evidence that traffic cannot reach the dependency.
+  - intent: metrics
+    entity: {kind: metric, name: redis_connected_clients}
+    weight: 0.6
+    rationale: Confirms whether any client is reaching the dependency at all.
+
+observed_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: Ran.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: Ran.
+  - intent: describe
+    entity: {kind: pod, name: redis}
+    weight: 0.5
+    rationale: Ran, and the healthy pod was taken as proof the dependency was fine.

--- a/tests/fixtures/investigation_path/corpus/HOLD-002.yaml
+++ b/tests/fixtures/investigation_path/corpus/HOLD-002.yaml
@@ -1,0 +1,57 @@
+# Held-out case: should ANSWER. Both corpus OOM incidents match, and the
+# observed investigation never looked at usage against the limit.
+incident_id: HOLD-002
+occurred_at: "2026-06-24"
+source_type: prometheus
+title: Reporting service terminated repeatedly on memory
+subject: reporting-service
+split: holdout
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - oomkilled
+  - pod
+  - restart
+  - memory
+  - limit
+  - reporting
+  - terminated
+
+root_cause:
+  label: oom_kill
+  summary: >-
+    A month-end report built its result set in memory. Usage crossed the limit
+    only on the last day of the month, so the workload looked stable in review.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Shows the last terminated state and the exit code.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.7
+    rationale: The work in progress before the kill explains what the memory went on.
+  - intent: events
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The OOMKilled event confirms the kernel killed the container.
+  - intent: resource_usage
+    entity: {kind: metric, name: container_memory_working_set_bytes}
+    weight: 1.0
+    rationale: Shows how close the container ran to its limit before the kill.
+  - intent: describe
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.9
+    rationale: The memory limit lives on the workload spec, not in pod status.
+
+observed_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Ran.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.7
+    rationale: Ran, and the restart was reported as a generic crash.

--- a/tests/fixtures/investigation_path/corpus/HOLD-003.yaml
+++ b/tests/fixtures/investigation_path/corpus/HOLD-003.yaml
@@ -1,0 +1,47 @@
+# Held-out case: should ABSTAIN with insufficient_support. Exactly one corpus
+# incident (INC-008) shares this root cause, and answering from a single past
+# incident overfits to it. This case costs recall on purpose - it is how the
+# eval shows the price of the min_matches threshold.
+incident_id: HOLD-003
+occurred_at: "2026-07-02"
+source_type: prometheus
+title: Billing API degraded shortly after a release
+subject: billing-api
+split: holdout
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - http
+  - error
+  - deploy
+  - release
+  - billing
+  - latency
+  - rollout
+
+root_cause:
+  label: config_regression
+  summary: >-
+    A release swapped the retry policy for one that gave up before the upstream
+    could answer, so a share of requests failed on healthy pods.
+
+reference_path:
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The error shape separates a code fault from a configuration one.
+  - intent: config_history
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 1.0
+    rationale: Lines the error up against the release that introduced it.
+  - intent: metrics
+    entity: {kind: metric, name: http_requests_total}
+    weight: 0.8
+    rationale: Shows whether the errors began exactly at the rollout.
+
+observed_path:
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: Ran.

--- a/tests/fixtures/investigation_path/corpus/HOLD-004.yaml
+++ b/tests/fixtures/investigation_path/corpus/HOLD-004.yaml
@@ -1,0 +1,42 @@
+# Held-out case: should ABSTAIN with no_candidates. Nothing in the corpus
+# resembles a certificate expiry, and the correct behaviour is silence rather
+# than borrowing checks from an unrelated cause.
+incident_id: HOLD-004
+occurred_at: "2026-07-19"
+source_type: prometheus
+title: Ingress serving an expired certificate
+subject: public-ingress
+split: holdout
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - tls
+  - certificate
+  - expired
+  - ingress
+  - handshake
+  - browser
+  - untrusted
+
+root_cause:
+  label: certificate_expired
+  summary: >-
+    Certificate renewal had been failing silently for weeks. The certificate
+    expired and every browser began rejecting the handshake.
+
+reference_path:
+  - intent: describe
+    entity: {kind: ingress, name: "<subject>"}
+    weight: 0.9
+    rationale: Names the secret the certificate is read from.
+  - intent: events
+    entity: {kind: ingress, name: "<subject>"}
+    weight: 0.8
+    rationale: Renewal failures are reported as events, not as workload health.
+
+observed_path:
+  - intent: describe
+    entity: {kind: ingress, name: "<subject>"}
+    weight: 0.9
+    rationale: Ran.

--- a/tests/fixtures/investigation_path/corpus/HOLD-005.yaml
+++ b/tests/fixtures/investigation_path/corpus/HOLD-005.yaml
@@ -1,0 +1,65 @@
+# Held-out adversarial case. The symptoms match the cache incidents almost
+# exactly, and the root cause label is the same - but the dependency is a
+# message broker, not Redis. Every reference path in the pool names Redis, so a
+# naive validator confidently suggests four checks against a service that does
+# not exist here, and finds none of the three that were actually skipped.
+#
+# This case exists because a held-out set made only of incidents the method
+# handles cannot measure precision or calibration at all. It is the reason the
+# validator drops suggestions naming an object the investigation never saw.
+incident_id: HOLD-005
+occurred_at: "2026-07-28"
+source_type: prometheus
+title: Queue worker crash looping on refused broker connections
+subject: queue-worker
+split: holdout
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - crashloopbackoff
+  - pod
+  - restart
+  - connection
+  - refused
+  - timeout
+  - queue
+
+root_cause:
+  label: dependency_unreachable
+  summary: >-
+    The broker StatefulSet was scaled to zero during a maintenance window that
+    overran. The Service still existed, so name resolution succeeded and every
+    connection was refused.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Shows the restart reason and which container is failing.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: The application error names the dependency that is failing.
+  - intent: topology
+    entity: {kind: service, name: rabbitmq}
+    weight: 0.9
+    rationale: A resolving Service name does not mean anything is behind it.
+  - intent: topology
+    entity: {kind: endpoints, name: rabbitmq}
+    weight: 1.0
+    rationale: Zero endpoints is the direct evidence that the broker is scaled down.
+  - intent: metrics
+    entity: {kind: metric, name: rabbitmq_connections}
+    weight: 0.6
+    rationale: Confirms whether any client is reaching the broker at all.
+
+observed_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Ran.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: Ran.

--- a/tests/fixtures/investigation_path/corpus/INC-001.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-001.yaml
@@ -1,0 +1,53 @@
+incident_id: INC-001
+occurred_at: "2026-01-14"
+source_type: prometheus
+title: Payment service crash looping against an unreachable cache
+subject: payment-service
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - crashloopbackoff
+  - pod
+  - restart
+  - redis
+  - connection
+  - timeout
+  - payment
+
+root_cause:
+  label: dependency_unreachable
+  summary: >-
+    A label edit on the Redis pods stopped the Redis Service selector matching
+    them. The Service kept resolving but had no endpoints, so every client
+    connection timed out.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: Shows the restart reason and which container is failing.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: The application error names the dependency that is failing.
+  - intent: describe
+    entity: {kind: pod, name: redis}
+    weight: 0.5
+    rationale: Rules out the dependency itself being down.
+  - intent: topology
+    entity: {kind: service, name: redis}
+    weight: 0.9
+    rationale: A healthy dependency pod does not prove the Service still selects it.
+  - intent: topology
+    entity: {kind: endpoints, name: redis}
+    weight: 1.0
+    rationale: >-
+      Empty endpoints is the direct evidence that traffic cannot reach the
+      dependency, and is the check that separates this cause from a slow
+      dependency.
+  - intent: metrics
+    entity: {kind: metric, name: redis_connected_clients}
+    weight: 0.6
+    rationale: Confirms whether any client is reaching the dependency at all.

--- a/tests/fixtures/investigation_path/corpus/INC-002.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-002.yaml
@@ -20,8 +20,8 @@ root_cause:
   label: dependency_unreachable
   summary: >-
     A NetworkPolicy rollout dropped traffic from the checkout namespace to
-    Redis. The Service resolved and Redis was healthy, but no client could
-    open a connection.
+    Redis. The Service resolved, Redis was healthy and its endpoints stayed
+    populated, but no client could open a connection.
 
 reference_path:
   - intent: logs
@@ -38,11 +38,18 @@ reference_path:
     rationale: A healthy dependency pod does not prove the Service still selects it.
   - intent: topology
     entity: {kind: endpoints, name: redis}
+    weight: 0.7
+    rationale: >-
+      Endpoints were populated, which is what ruled out a selector problem and
+      moved the investigation to the network layer. It is a necessary
+      elimination here, not the evidence that identifies the cause.
+  - intent: topology
+    entity: {kind: networkpolicy, name: redis}
     weight: 1.0
     rationale: >-
-      Empty endpoints is the direct evidence that traffic cannot reach the
-      dependency, and is the check that separates this cause from a slow
-      dependency.
+      A NetworkPolicy is enforced by the CNI and leaves the Service and its
+      endpoints looking healthy, so reading the policies that select the
+      dependency is the only check that names this cause.
   - intent: metrics
     entity: {kind: metric, name: redis_connected_clients}
     weight: 0.6

--- a/tests/fixtures/investigation_path/corpus/INC-002.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-002.yaml
@@ -1,0 +1,56 @@
+incident_id: INC-002
+occurred_at: "2026-02-03"
+source_type: prometheus
+title: Checkout API timing out on cache reads
+subject: checkout-api
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - redis
+  - connection
+  - pod
+  - restart
+  - timeout
+  - checkout
+  - latency
+
+root_cause:
+  label: dependency_unreachable
+  summary: >-
+    A NetworkPolicy rollout dropped traffic from the checkout namespace to
+    Redis. The Service resolved and Redis was healthy, but no client could
+    open a connection.
+
+reference_path:
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: The application error names the dependency that is failing.
+  - intent: describe
+    entity: {kind: pod, name: redis}
+    weight: 0.5
+    rationale: Rules out the dependency itself being down.
+  - intent: topology
+    entity: {kind: service, name: redis}
+    weight: 0.9
+    rationale: A healthy dependency pod does not prove the Service still selects it.
+  - intent: topology
+    entity: {kind: endpoints, name: redis}
+    weight: 1.0
+    rationale: >-
+      Empty endpoints is the direct evidence that traffic cannot reach the
+      dependency, and is the check that separates this cause from a slow
+      dependency.
+  - intent: metrics
+    entity: {kind: metric, name: redis_connected_clients}
+    weight: 0.6
+    rationale: Confirms whether any client is reaching the dependency at all.
+  # Kept deliberately: this check was useful here but is not part of the
+  # reference path for the held-out cache incidents, so it is a real
+  # false-positive source for the offline eval rather than a synthetic one.
+  - intent: metrics
+    entity: {kind: metric, name: redis_memory_used_bytes}
+    weight: 0.3
+    rationale: Ruled out eviction pressure as an alternative explanation.

--- a/tests/fixtures/investigation_path/corpus/INC-003.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-003.yaml
@@ -17,10 +17,11 @@ symptoms:
   - latency
 
 root_cause:
-  label: dependency_unreachable
+  label: connection_pool_exhausted
   summary: >-
     A slow query held pool connections open until the pool was empty. The
-    database was reachable, but the workload behaved as if it were not.
+    database was reachable throughout; the workload only behaved as if it were
+    not, which is why the label is not dependency_unreachable.
 
 reference_path:
   - intent: logs

--- a/tests/fixtures/investigation_path/corpus/INC-003.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-003.yaml
@@ -1,0 +1,41 @@
+incident_id: INC-003
+occurred_at: "2026-02-19"
+source_type: prometheus
+title: Cart service exhausting its database connection pool
+subject: cart-service
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - postgres
+  - connection
+  - pool
+  - exhausted
+  - cart
+  - database
+  - latency
+
+root_cause:
+  label: dependency_unreachable
+  summary: >-
+    A slow query held pool connections open until the pool was empty. The
+    database was reachable, but the workload behaved as if it were not.
+
+reference_path:
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: Pool exhaustion is reported by the client, not the database.
+  - intent: metrics
+    entity: {kind: metric, name: pg_stat_activity_count}
+    weight: 0.9
+    rationale: Distinguishes an exhausted pool from an unreachable database.
+  - intent: topology
+    entity: {kind: service, name: postgres}
+    weight: 0.5
+    rationale: Confirms the dependency is still routable before blaming the client.
+  - intent: describe
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.6
+    rationale: The pool size is set on the workload spec, not observable from the pod.

--- a/tests/fixtures/investigation_path/corpus/INC-004.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-004.yaml
@@ -1,0 +1,47 @@
+incident_id: INC-004
+occurred_at: "2026-03-08"
+source_type: prometheus
+title: Inventory service killed for exceeding its memory limit
+subject: inventory-service
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - oomkilled
+  - pod
+  - restart
+  - memory
+  - limit
+  - inventory
+  - terminated
+
+root_cause:
+  label: oom_kill
+  summary: >-
+    A batch reconciliation loaded the whole catalogue into memory. The limit
+    had been sized for steady-state traffic only.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Shows the last terminated state and the exit code.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.7
+    rationale: The work in progress before the kill explains what the memory went on.
+  - intent: events
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The OOMKilled event confirms the kernel killed the container.
+  - intent: resource_usage
+    entity: {kind: metric, name: container_memory_working_set_bytes}
+    weight: 1.0
+    rationale: >-
+      Shows how close the container ran to its limit and whether the growth was
+      gradual or a spike. Without it, a restart loop and an OOM look alike.
+  - intent: describe
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.9
+    rationale: The memory limit lives on the workload spec, not in pod status.

--- a/tests/fixtures/investigation_path/corpus/INC-005.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-005.yaml
@@ -1,0 +1,52 @@
+incident_id: INC-005
+occurred_at: "2026-03-27"
+source_type: prometheus
+title: User service restarting after a memory limit reduction
+subject: user-service
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - oomkilled
+  - pod
+  - restart
+  - memory
+  - limit
+  - user
+  - exit
+
+root_cause:
+  label: oom_kill
+  summary: >-
+    A cost-tuning change halved the memory limit. Steady-state usage already
+    sat above the new limit, so pods were killed within minutes of rollout.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Shows the last terminated state and the exit code.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.7
+    rationale: The work in progress before the kill explains what the memory went on.
+  - intent: events
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The OOMKilled event confirms the kernel killed the container.
+  - intent: resource_usage
+    entity: {kind: metric, name: container_memory_working_set_bytes}
+    weight: 1.0
+    rationale: >-
+      Shows how close the container ran to its limit and whether the growth was
+      gradual or a spike. Without it, a restart loop and an OOM look alike.
+  - intent: describe
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.9
+    rationale: The memory limit lives on the workload spec, not in pod status.
+  # Only present here, so it is a genuine minority-support suggestion in the eval.
+  - intent: config_history
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.4
+    rationale: A recent limit change is a common trigger for a sudden OOM.

--- a/tests/fixtures/investigation_path/corpus/INC-006.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-006.yaml
@@ -1,0 +1,37 @@
+incident_id: INC-006
+occurred_at: "2026-04-02"
+source_type: prometheus
+title: Notification worker stuck pulling its image
+subject: notification-worker
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - imagepullbackoff
+  - pod
+  - pending
+  - registry
+  - image
+  - notification
+  - pull
+
+root_cause:
+  label: image_pull_failure
+  summary: >-
+    The deployment referenced a tag that was never pushed. The registry
+    answered, so the failure looked like an outage rather than a bad reference.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The waiting reason distinguishes a missing tag from a registry outage.
+  - intent: events
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: The pull error from the kubelet carries the exact rejected reference.
+  - intent: config_history
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.8
+    rationale: Shows which change introduced the image reference that cannot be pulled.

--- a/tests/fixtures/investigation_path/corpus/INC-007.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-007.yaml
@@ -1,0 +1,42 @@
+incident_id: INC-007
+occurred_at: "2026-04-21"
+source_type: prometheus
+title: Worker node evicting pods under disk pressure
+subject: worker-node
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - node
+  - diskpressure
+  - evicted
+  - pod
+  - disk
+  - filesystem
+  - worker
+
+root_cause:
+  label: node_disk_pressure
+  summary: >-
+    Container logs were never rotated on one node. The kubelet crossed its
+    eviction threshold and started evicting pods, which looked like random
+    workload failures.
+
+reference_path:
+  - intent: describe
+    entity: {kind: node, name: "<subject>"}
+    weight: 1.0
+    rationale: The DiskPressure condition is only visible on the node, not on the pods.
+  - intent: events
+    entity: {kind: node, name: "<subject>"}
+    weight: 0.8
+    rationale: Eviction events tie the evicted pods back to the node.
+  - intent: resource_usage
+    entity: {kind: metric, name: node_filesystem_avail_bytes}
+    weight: 0.9
+    rationale: Separates a slow fill from a sudden one, which changes the fix.
+  - intent: list
+    entity: {kind: pod, name: null}
+    weight: 0.5
+    rationale: Shows the blast radius across every workload on the node.

--- a/tests/fixtures/investigation_path/corpus/INC-008.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-008.yaml
@@ -1,0 +1,43 @@
+incident_id: INC-008
+occurred_at: "2026-05-06"
+source_type: prometheus
+title: Search API returning errors after a release
+subject: search-api
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - http
+  - error
+  - deploy
+  - release
+  - search
+  - latency
+  - rollout
+
+root_cause:
+  label: config_regression
+  summary: >-
+    A release changed a default timeout to a value below the upstream response
+    time, so a share of requests failed while the pods stayed healthy.
+
+reference_path:
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The error shape separates a code fault from a configuration one.
+  - intent: config_history
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 1.0
+    rationale: >-
+      Lines the error up against the release that introduced it. Without it,
+      a healthy-looking workload gives no starting point.
+  - intent: metrics
+    entity: {kind: metric, name: http_requests_total}
+    weight: 0.8
+    rationale: Shows whether the errors began exactly at the rollout.
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.4
+    rationale: Confirms the pods themselves are healthy, ruling out a crash loop.

--- a/tests/fixtures/investigation_path/corpus/INC-009.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-009.yaml
@@ -1,0 +1,51 @@
+incident_id: INC-009
+occurred_at: "2026-05-18"
+source_type: prometheus
+title: Session service failing every cache read
+subject: session-service
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - crashloopbackoff
+  - pod
+  - restart
+  - redis
+  - connection
+  - timeout
+  - sessions
+
+root_cause:
+  label: dependency_unreachable
+  summary: >-
+    The Redis Service was recreated with the wrong port name, so the Service
+    resolved but forwarded to a port nothing was listening on.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: Shows the restart reason and which container is failing.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 1.0
+    rationale: The application error names the dependency that is failing.
+  - intent: describe
+    entity: {kind: pod, name: redis}
+    weight: 0.5
+    rationale: Rules out the dependency itself being down.
+  - intent: topology
+    entity: {kind: service, name: redis}
+    weight: 0.9
+    rationale: >-
+      The Service spec is where a wrong port or selector shows up, and it looks
+      healthy from every other angle.
+  - intent: topology
+    entity: {kind: endpoints, name: redis}
+    weight: 1.0
+    rationale: Confirms whether traffic can actually reach the dependency.
+  - intent: metrics
+    entity: {kind: metric, name: redis_connected_clients}
+    weight: 0.6
+    rationale: Confirms whether any client is reaching the dependency at all.

--- a/tests/fixtures/investigation_path/corpus/INC-010.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-010.yaml
@@ -1,0 +1,47 @@
+incident_id: INC-010
+occurred_at: "2026-05-29"
+source_type: prometheus
+title: Metrics exporter killed during a scrape backlog
+subject: metrics-exporter
+split: corpus
+validated_by: corpus-review
+validated_at: "2026-08-24"
+
+symptoms:
+  - oomkilled
+  - pod
+  - restart
+  - memory
+  - limit
+  - exporter
+  - terminated
+
+root_cause:
+  label: oom_kill
+  summary: >-
+    A scrape backlog queued in memory faster than it drained. The container
+    crossed its limit during the backlog and was killed mid-scrape.
+
+reference_path:
+  - intent: describe
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.8
+    rationale: Shows the last terminated state and the exit code.
+  - intent: logs
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.7
+    rationale: The work in progress before the kill explains what the memory went on.
+  - intent: events
+    entity: {kind: pod, name: "<subject>"}
+    weight: 0.9
+    rationale: The OOMKilled event confirms the kernel killed the container.
+  - intent: resource_usage
+    entity: {kind: metric, name: container_memory_working_set_bytes}
+    weight: 1.0
+    rationale: >-
+      Shows how close the container ran to its limit and whether growth was
+      gradual or a spike. Without it, a restart loop and an OOM look alike.
+  - intent: describe
+    entity: {kind: deployment, name: "<subject>"}
+    weight: 0.9
+    rationale: The memory limit lives on the workload spec, not in pod status.

--- a/tests/fixtures/investigation_path/corpus/INC-011.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-011.yaml
@@ -1,11 +1,9 @@
-# Held-out case: should ANSWER. Three corpus incidents share this root cause,
-# and the observed investigation read the logs but never checked what changed.
-incident_id: HOLD-003
-occurred_at: "2026-07-02"
+incident_id: INC-011
+occurred_at: "2026-06-02"
 source_type: prometheus
-title: Billing API degraded shortly after a release
-subject: billing-api
-split: holdout
+title: Gateway rejecting a share of requests after a release
+subject: api-gateway
+split: corpus
 validated_by: corpus-review
 validated_at: "2026-08-24"
 
@@ -14,15 +12,15 @@ symptoms:
   - error
   - deploy
   - release
-  - billing
+  - gateway
   - latency
   - rollout
 
 root_cause:
   label: config_regression
   summary: >-
-    A release swapped the retry policy for one that gave up before the upstream
-    could answer, so a share of requests failed on healthy pods.
+    A release tightened a request size limit below what one client sends, so a
+    fixed share of requests were rejected while the pods stayed healthy.
 
 reference_path:
   - intent: logs
@@ -41,9 +39,8 @@ reference_path:
     entity: {kind: pod, name: "<subject>"}
     weight: 0.4
     rationale: Confirms the pods themselves are healthy, ruling out a crash loop.
-
-observed_path:
-  - intent: logs
-    entity: {kind: pod, name: "<subject>"}
-    weight: 0.9
-    rationale: Ran.
+  # Only present here, so it stays a genuine minority-support case for the eval.
+  - intent: traces
+    entity: {kind: trace, name: "<subject>"}
+    weight: 0.3
+    rationale: Showed which client was sending the oversized requests.

--- a/tests/fixtures/investigation_path/corpus/INC-012.yaml
+++ b/tests/fixtures/investigation_path/corpus/INC-012.yaml
@@ -1,11 +1,9 @@
-# Held-out case: should ANSWER. Three corpus incidents share this root cause,
-# and the observed investigation read the logs but never checked what changed.
-incident_id: HOLD-003
-occurred_at: "2026-07-02"
+incident_id: INC-012
+occurred_at: "2026-06-05"
 source_type: prometheus
-title: Billing API degraded shortly after a release
-subject: billing-api
-split: holdout
+title: Catalog service erroring after a configuration rollout
+subject: catalog-service
+split: corpus
 validated_by: corpus-review
 validated_at: "2026-08-24"
 
@@ -14,15 +12,15 @@ symptoms:
   - error
   - deploy
   - release
-  - billing
+  - catalog
   - latency
   - rollout
 
 root_cause:
   label: config_regression
   summary: >-
-    A release swapped the retry policy for one that gave up before the upstream
-    could answer, so a share of requests failed on healthy pods.
+    A rollout pointed the service at a feature-flag endpoint that did not exist
+    in that environment, so every request that consulted a flag failed.
 
 reference_path:
   - intent: logs
@@ -41,9 +39,3 @@ reference_path:
     entity: {kind: pod, name: "<subject>"}
     weight: 0.4
     rationale: Confirms the pods themselves are healthy, ruling out a crash loop.
-
-observed_path:
-  - intent: logs
-    entity: {kind: pod, name: "<subject>"}
-    weight: 0.9
-    rationale: Ran.

--- a/tests/fixtures/investigation_path/corpus/README.md
+++ b/tests/fixtures/investigation_path/corpus/README.md
@@ -50,12 +50,18 @@ A root cause needs **at least three pool incidents** to be usable. Leave-one-out
 calibration removes one and needs two left for retrieval to answer at all, so a
 cause with fewer contributes nothing and can never be answered on.
 
-Today only `dependency_unreachable` (4), `oom_kill` (3) and `config_regression`
-(3) clear that bar. Note that the four `dependency_unreachable` incidents are
-four *different* mechanisms — a selector edit, a NetworkPolicy, a wrong port and
-a drained connection pool — which share a label but not a reference path. `image_pull_failure` and `node_disk_pressure` have one each
-and are dead weight — the most useful thing anyone can add to this corpus is two
-more incidents for each of those.
+Today only `dependency_unreachable` (3), `oom_kill` (3) and `config_regression`
+(3) clear that bar. `connection_pool_exhausted`, `image_pull_failure` and
+`node_disk_pressure` have one each and are dead weight — the most useful thing
+anyone can add to this corpus is two more incidents for each of those.
+
+The three `dependency_unreachable` incidents are three *different* mechanisms —
+a selector edit, a NetworkPolicy and a wrong port name — which share a label but
+not a reference path. What they do share is that traffic genuinely could not
+reach the dependency. That is the whole content of the label, and it is the test
+for whether a new record belongs under it: INC-003 was filed here while its own
+summary said the database stayed reachable, which is a different failure wearing
+the same symptoms.
 
 The held-out set must include cases the method gets **wrong**. `HOLD-005` is
 there for that reason: it matches the cache incidents on both symptoms and root
@@ -67,6 +73,7 @@ the method handles cannot measure precision or calibration at all.
 | label | meaning |
 |---|---|
 | `dependency_unreachable` | The workload could not reach a service it depends on |
+| `connection_pool_exhausted` | The dependency was reachable, but the client had no free connection |
 | `oom_kill` | A container exceeded its memory limit and was killed |
 | `image_pull_failure` | The container image could not be pulled |
 | `node_disk_pressure` | A node ran out of disk and evicted workloads |

--- a/tests/fixtures/investigation_path/corpus/README.md
+++ b/tests/fixtures/investigation_path/corpus/README.md
@@ -21,10 +21,18 @@ incidents are a smoke test, not evidence.
 4. **Weights are honest.** `1.0` means skipping the check would have hidden the
    cause. `0.3` means it was mildly useful. Inflated weights make recall look
    good and mean nothing.
-5. **Refer to the affected workload as `<subject>`**, never by its real name.
+5. **The rationale must be true of *this* cause.** The corpus is the ground
+   truth, so a plausible-sounding wrong reason is not cosmetic — it teaches
+   retrieval to recommend a check that cannot show what the record claims.
+   INC-002 got this wrong: it is a NetworkPolicy incident, which the CNI
+   enforces while the Service and its endpoints stay perfectly healthy, yet it
+   claimed empty endpoints as the identifying evidence. Reading the check
+   against the cause, and asking whether it could actually produce that
+   evidence, is worth doing before adding a record.
+6. **Refer to the affected workload as `<subject>`**, never by its real name.
    A path that names `payment-service` can only ever match `payment-service`.
    Shared infrastructure (`redis`, a node, a metric) keeps its real name.
-6. **Nothing sensitive.** No customer names, no hostnames outside the cluster, no
+7. **Nothing sensitive.** No customer names, no hostnames outside the cluster, no
    URLs, no identifiers that could re-identify a real tenant. Records here are
    redacted by construction: the schema has nowhere to put tool output.
 
@@ -43,7 +51,9 @@ calibration removes one and needs two left for retrieval to answer at all, so a
 cause with fewer contributes nothing and can never be answered on.
 
 Today only `dependency_unreachable` (4), `oom_kill` (3) and `config_regression`
-(3) clear that bar. `image_pull_failure` and `node_disk_pressure` have one each
+(3) clear that bar. Note that the four `dependency_unreachable` incidents are
+four *different* mechanisms — a selector edit, a NetworkPolicy, a wrong port and
+a drained connection pool — which share a label but not a reference path. `image_pull_failure` and `node_disk_pressure` have one each
 and are dead weight — the most useful thing anyone can add to this corpus is two
 more incidents for each of those.
 

--- a/tests/fixtures/investigation_path/corpus/README.md
+++ b/tests/fixtures/investigation_path/corpus/README.md
@@ -30,12 +30,22 @@ incidents are a smoke test, not evidence.
 
 ## Splits
 
-- `split: corpus` — the retrieval pool.
+- `split: corpus` — the retrieval pool. Also the only data the confidence
+  calibration is fitted on, via leave-one-out.
 - `split: holdout` — evaluation cases. These also carry an `observed_path`;
   `reference_path` minus `observed_path` is the ground-truth missing set.
 
 A holdout incident must never appear in the pool, and the two must not describe
 the same underlying event.
+
+Keep **at least three incidents per root cause** in the pool. Leave-one-out
+calibration removes one and needs two left for retrieval to answer at all, so a
+cause with only two members contributes nothing to the fit.
+
+The held-out set must include cases the method gets **wrong**. `HOLD-005` is
+there for that reason: it matches the cache incidents on both symptoms and root
+cause, but its dependency is a message broker. A held-out set made only of cases
+the method handles cannot measure precision or calibration at all.
 
 ## Root cause vocabulary
 

--- a/tests/fixtures/investigation_path/corpus/README.md
+++ b/tests/fixtures/investigation_path/corpus/README.md
@@ -38,9 +38,14 @@ incidents are a smoke test, not evidence.
 A holdout incident must never appear in the pool, and the two must not describe
 the same underlying event.
 
-Keep **at least three incidents per root cause** in the pool. Leave-one-out
+A root cause needs **at least three pool incidents** to be usable. Leave-one-out
 calibration removes one and needs two left for retrieval to answer at all, so a
-cause with only two members contributes nothing to the fit.
+cause with fewer contributes nothing and can never be answered on.
+
+Today only `dependency_unreachable` (4), `oom_kill` (3) and `config_regression`
+(3) clear that bar. `image_pull_failure` and `node_disk_pressure` have one each
+and are dead weight — the most useful thing anyone can add to this corpus is two
+more incidents for each of those.
 
 The held-out set must include cases the method gets **wrong**. `HOLD-005` is
 there for that reason: it matches the cache incidents on both symptoms and root

--- a/tests/fixtures/investigation_path/corpus/README.md
+++ b/tests/fixtures/investigation_path/corpus/README.md
@@ -1,0 +1,49 @@
+# Investigation path corpus
+
+A small set of **resolved** incidents used to measure path-completeness retrieval
+offline. See `docs/design/2026-08-24_investigation-path-completeness.md` for what
+the fields mean and how the metrics are computed.
+
+This corpus is deliberately tiny. It exists to make the metrics runnable and the
+schema concrete, not to prove that retrieval works. Numbers produced from twelve
+incidents are a smoke test, not evidence.
+
+## Rules for adding an incident
+
+1. **A human must have resolved it and reviewed the record.** Set `validated_by`
+   to that person and `validated_at` to the review date. Never generate entries
+   from production traffic automatically — an unreviewed path teaches the
+   validator whatever mistake the original investigation made.
+2. **`root_cause.label` comes from the controlled vocabulary** (see below). Add a
+   new label only when no existing one fits, and say so in the pull request.
+3. **`reference_path` is what *should* have been checked**, decided after the
+   cause was known — not a transcript of what was actually run.
+4. **Weights are honest.** `1.0` means skipping the check would have hidden the
+   cause. `0.3` means it was mildly useful. Inflated weights make recall look
+   good and mean nothing.
+5. **Refer to the affected workload as `<subject>`**, never by its real name.
+   A path that names `payment-service` can only ever match `payment-service`.
+   Shared infrastructure (`redis`, a node, a metric) keeps its real name.
+6. **Nothing sensitive.** No customer names, no hostnames outside the cluster, no
+   URLs, no identifiers that could re-identify a real tenant. Records here are
+   redacted by construction: the schema has nowhere to put tool output.
+
+## Splits
+
+- `split: corpus` — the retrieval pool.
+- `split: holdout` — evaluation cases. These also carry an `observed_path`;
+  `reference_path` minus `observed_path` is the ground-truth missing set.
+
+A holdout incident must never appear in the pool, and the two must not describe
+the same underlying event.
+
+## Root cause vocabulary
+
+| label | meaning |
+|---|---|
+| `dependency_unreachable` | The workload could not reach a service it depends on |
+| `oom_kill` | A container exceeded its memory limit and was killed |
+| `image_pull_failure` | The container image could not be pulled |
+| `node_disk_pressure` | A node ran out of disk and evicted workloads |
+| `config_regression` | A configuration or deployment change broke the workload |
+| `certificate_expired` | A TLS certificate expired |


### PR DESCRIPTION
## Summary

Offline benchmark for #2046 — path schema, redacted fixture corpus, metrics, and a runnable eval.

**No runtime change.** `holmes/` is untouched outside the new `holmes/core/investigation_path/` package. Per the review: measure the retrieval policy before it talks to a user.

Covers the suggested first slice:

1. **Path event** (`schema.py`) — tool, entity, intent, time window, outcome/error class, evidence ref, ordinal. No credentials, no raw output, no unstable params. Matching runs on **intent**, not tool name, so `kubectl logs` and a Loki query count as the same check.
2. **Corpus** — 17 human-validated incidents (12 pool, 5 held out) with root-cause labels and weighted reference paths. Retrieval ranks on symptoms, then filters to the shared root cause. Abstains with one of 4 reasons when that fails.
3. **Offline eval** — weighted recall, precision, false-positive burden, abstention, ECE/Brier, latency, storage and token cost.
4. **Suggestions** carry source incident + date, the human rationale, and support as a fraction. Worded as advice, capped at 5. Confidence shown as a percentage only when a fitted calibration model produced it.
5. **Runs in the eval pipeline** — asserted on every PR under `-m "not llm"`; `eval-regression.yaml` appends its report to `evals_report.md` and logs to its own Braintrust experiment. No-ops without `BRAINTRUST_API_KEY`.

## Baseline (5 held-out cases)

```
weighted path recall        0.69   suggestion precision        1.00
  ... when answering        0.75   false positives per answer  0.00
abstention rate             0.20   expected calibration error  0.050
latency p95 (ms)            0.12   llm calls / tokens          0 / 0
```

Raw similarity scored ~0.32 for suggestions correct every time (ECE 0.350). Platt calibration, fitted leave-one-out on the pool only, brings it to 0.050 out-of-sample.

**These numbers are 9 suggestions over 5 hand-written cases** — "no problem detectable at this sample size", not "solved".

## Next steps

1. Grow the corpus — every number above is limited by sample size first.
2. Close the `HOLD-005` gap with a `<dependency>` role token.
3. Sweep the policy knobs, publish a risk-coverage curve.
4. **Wire into `holmes investigate`** — separate PR, off by default behind a config flag.

Happy to open a tracking issue for step 4 if you'd rather agree the runtime shape up front.

## Test plan

- [x] `pytest tests/core/investigation_path` — 221 pass
- [x] `pytest tests/core` — 916 pass, no regressions
- [x] `python -m holmes.core.investigation_path.offline_eval` — prints the baseline
- [x] `git diff master...HEAD -- holmes/ ':!holmes/core/investigation_path/'` is empty

Design doc: `docs/design/2026-08-24_investigation-path-completeness.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added investigation-path analysis that identifies missing diagnostic checks and provides ranked, confidence-scored suggestions.
  * Added privacy-conscious normalization and incident-based retrieval with explicit abstention handling.
  * Added offline benchmarking with calibration, performance metrics, Markdown reports, and optional CI reporting.
  * Added a curated incident corpus with held-out benchmark cases.

* **Documentation**
  * Added design documentation covering the schema, evaluation approach, metrics, privacy safeguards, and limitations.

* **Tests**
  * Added comprehensive coverage for normalization, retrieval, validation, calibration, reporting, corpus loading, and offline evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->