### PR TITLE
feat: add OrcaRouter as a first-class AI provider

### DIFF
--- a/docs/ai-providers/.nav.yml
+++ b/docs/ai-providers/.nav.yml
@@ -9,6 +9,7 @@ nav:
 - Google Vertex AI: google-vertex-ai.md
 - Ollama: ollama.md
 - OpenRouter: openrouter.md
+- OrcaRouter: orcarouter.md
 - OpenAI: openai.md
 - OpenAI-Compatible: openai-compatible.md
 - Other: other.md

--- a/docs/ai-providers/index.md
+++ b/docs/ai-providers/index.md
@@ -14,6 +14,7 @@ HolmesGPT supports multiple AI providers, giving you flexibility in choosing the
 -   [:fontawesome-brands-openai:{ .lg .middle } **OpenAI**](openai.md)
 -   [:material-api:{ .lg .middle } **OpenAI-Compatible** (LiteLLM Proxy, etc.)](openai-compatible.md)
 -   [:material-earth:{ .lg .middle } **OpenRouter**](openrouter.md)
+-   [:material-orca:{ .lg .middle } **OrcaRouter**](orcarouter.md)
 -   [:material-robot:{ .lg .middle } **Robusta AI**](robusta-ai.md)
 -   [:material-layers-triple:{ .lg .middle } **Using Multiple Providers**](using-multiple-providers.md)
 

--- a/docs/ai-providers/orcarouter.md
+++ b/docs/ai-providers/orcarouter.md
@@ -1,0 +1,223 @@
+# OrcaRouter
+
+Configure HolmesGPT to use [OrcaRouter](https://www.orcarouter.ai) for access to multiple AI models through a single OpenAI-compatible endpoint.
+
+OrcaRouter is an OpenAI-compatible AI gateway for models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+## Methods
+
+### Method 1: Native `orcarouter/` Model Prefix (Recommended)
+
+HolmesGPT has built-in support for OrcaRouter. Only `ORCAROUTER_API_KEY` is required. Models use the `orcarouter/` prefix and are automatically routed to `https://api.orcarouter.ai/v1` through LiteLLM's OpenAI-compatible path.
+
+=== "Holmes CLI"
+
+    ```bash
+    export ORCAROUTER_API_KEY="sk-orca-..."  # your OrcaRouter key
+    holmes ask "hello" --model="orcarouter/anthropic/claude-sonnet-4.5" --no-interactive
+    ```
+
+=== "Holmes Helm Chart"
+
+    **Create Kubernetes Secret:**
+    ```bash
+    kubectl create secret generic holmes-secrets \
+      --from-literal=orcarouter-api-key="sk-orca-..." \
+      -n <namespace>
+    ```
+
+    **Configure Helm Values:**
+    ```yaml
+    # values.yaml
+    additionalEnvVars:
+      - name: ORCAROUTER_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: holmes-secrets
+            key: orcarouter-api-key
+
+    # Configure at least one model using modelList
+    modelList:
+      claude-sonnet-4:
+        api_key: "{{ env.ORCAROUTER_API_KEY }}"
+        model: orcarouter/anthropic/claude-sonnet-4.5-20250929
+        temperature: 1
+        thinking:
+          budget_tokens: 10000
+          type: enabled
+
+      claude-opus-4:
+        api_key: "{{ env.ORCAROUTER_API_KEY }}"
+        model: orcarouter/anthropic/claude-opus-4.5-20251101
+        temperature: 1
+
+    # Optional: Set default model (use modelList key name)
+    config:
+      model: "claude-sonnet-4"  # This refers to the key name in modelList above
+    ```
+
+=== "Robusta Helm Chart"
+
+    **Create Kubernetes Secret:**
+    ```bash
+    kubectl create secret generic robusta-holmes-secret \
+      --from-literal=orcarouter-api-key="sk-orca-..." \
+      -n <namespace>
+    ```
+
+    **Configure Helm Values:**
+    ```yaml
+    # values.yaml
+    holmes:
+      additionalEnvVars:
+        - name: ORCAROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: robusta-holmes-secret
+              key: orcarouter-api-key
+
+      # Configure at least one model using modelList
+      modelList:
+        claude-sonnet-4:
+          api_key: "{{ env.ORCAROUTER_API_KEY }}"
+          model: orcarouter/anthropic/claude-sonnet-4.5-20250929
+          temperature: 1
+          thinking:
+            budget_tokens: 10000
+            type: enabled
+
+        claude-opus-4:
+          api_key: "{{ env.ORCAROUTER_API_KEY }}"
+          model: orcarouter/anthropic/claude-opus-4.5-20251101
+          temperature: 1
+
+      # Optional: Set default model (use modelList key name)
+      config:
+        model: "claude-sonnet-4"  # This refers to the key name in modelList above
+    ```
+
+**Optional environment variables:**
+
+- `ORCAROUTER_API_BASE` - Custom API base URL (defaults to `https://api.orcarouter.ai/v1`)
+
+### Method 2: OpenAI-Compatible Endpoint
+
+Alternatively, you can use OrcaRouter's OpenAI-compatible endpoint by setting the base URL and using `OPENAI_API_KEY`. Note the `openai/` prefix instead of `orcarouter/`.
+
+!!! warning "Token Limits"
+    With this method, HolmesGPT cannot automatically determine token limits for the model. You may need to set `OVERRIDE_MAX_CONTENT_SIZE` and `OVERRIDE_MAX_OUTPUT_TOKEN` environment variables manually.
+
+=== "Holmes CLI"
+
+    ```bash
+    export OPENAI_API_BASE="https://api.orcarouter.ai/v1"
+    export OPENAI_API_KEY="sk-orca-..."  # your OrcaRouter key
+    holmes ask "hello" --model="openai/anthropic/claude-sonnet-4.5" --no-interactive
+    ```
+
+=== "Holmes Helm Chart"
+
+    **Create Kubernetes Secret:**
+    ```bash
+    kubectl create secret generic holmes-secrets \
+      --from-literal=openai-api-key="sk-orca-..." \
+      -n <namespace>
+    ```
+
+    **Configure Helm Values:**
+    ```yaml
+    # values.yaml
+    additionalEnvVars:
+      - name: OPENAI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: holmes-secrets
+            key: openai-api-key
+      - name: OPENAI_API_BASE
+        value: "https://api.orcarouter.ai/v1"
+
+    # Configure at least one model using modelList
+    modelList:
+      claude-sonnet-4:
+        api_key: "{{ env.OPENAI_API_KEY }}"
+        api_base: "https://api.orcarouter.ai/v1"
+        model: openai/anthropic/claude-sonnet-4.5-20250929
+        temperature: 1
+        thinking:
+          budget_tokens: 10000
+          type: enabled
+
+      claude-opus-4:
+        api_key: "{{ env.OPENAI_API_KEY }}"
+        api_base: "https://api.orcarouter.ai/v1"
+        model: openai/anthropic/claude-opus-4.5-20251101
+        temperature: 1
+
+    # Optional: Set default model (use modelList key name)
+    config:
+      model: "claude-sonnet-4"  # This refers to the key name in modelList above
+    ```
+
+=== "Robusta Helm Chart"
+
+    **Create Kubernetes Secret:**
+    ```bash
+    kubectl create secret generic robusta-holmes-secret \
+      --from-literal=openai-api-key="sk-orca-..." \
+      -n <namespace>
+    ```
+
+    **Configure Helm Values:**
+    ```yaml
+    # values.yaml
+    holmes:
+      additionalEnvVars:
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: robusta-holmes-secret
+              key: openai-api-key
+        - name: OPENAI_API_BASE
+          value: "https://api.orcarouter.ai/v1"
+
+      # Configure at least one model using modelList
+      modelList:
+        claude-sonnet-4:
+          api_key: "{{ env.OPENAI_API_KEY }}"
+          api_base: "https://api.orcarouter.ai/v1"
+          model: openai/anthropic/claude-sonnet-4.5-20250929
+          temperature: 1
+          thinking:
+            budget_tokens: 10000
+            type: enabled
+
+        claude-opus-4:
+          api_key: "{{ env.OPENAI_API_KEY }}"
+          api_base: "https://api.orcarouter.ai/v1"
+          model: openai/anthropic/claude-opus-4.5-20251101
+          temperature: 1
+
+      # Optional: Set default model (use modelList key name)
+      config:
+        model: "claude-sonnet-4"  # This refers to the key name in modelList above
+    ```
+
+## Available Models
+
+You can use any model available on OrcaRouter. The model prefix depends on which method you use:
+
+**Method 1 (Native):** Use `orcarouter/` prefix
+
+- `orcarouter/anthropic/claude-sonnet-4.5`
+- `orcarouter/anthropic/claude-opus-4.5`
+- `orcarouter/openai/gpt-4o`
+- `orcarouter/google/gemini-2.5-pro`
+
+**Method 2 (OpenAI-Compatible):** Use `openai/` prefix
+
+- `openai/anthropic/claude-sonnet-4.5`
+- `openai/anthropic/claude-opus-4.5`
+- `openai/openai/gpt-4o`
+- `openai/google/gemini-2.5-pro`
+
+See the [OrcaRouter models page](https://www.orcarouter.ai) for a complete list of available models.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -11,6 +11,10 @@ This page documents all environment variables that can be used to configure Holm
 ### Anthropic
 - `ANTHROPIC_API_KEY` - API key for Anthropic Claude models
 
+### OrcaRouter
+- `ORCAROUTER_API_KEY` - API key for OrcaRouter (an OpenAI-compatible AI gateway). Models use the `orcarouter/` prefix and default to `https://api.orcarouter.ai/v1`. See [OrcaRouter](../ai-providers/orcarouter.md) for details.
+- `ORCAROUTER_API_BASE` - Custom base URL for OrcaRouter (defaults to `https://api.orcarouter.ai/v1`)
+
 ### Google
 - `GEMINI_API_KEY` - API key for Google Gemini models
 - `GOOGLE_API_KEY` - Alternative API key for Google services

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -60,6 +60,17 @@ _warned_missing_model_lookups: set[tuple[str, str]] = set()
 # Prevents spam when _init_models re-runs (e.g. Robusta resync path).
 _warned_unknown_cost_models: set[str] = set()
 
+# OrcaRouter is an OpenAI-compatible AI gateway (like OpenRouter). LiteLLM has
+# no native provider prefix for it, so `orcarouter/` models are rewritten to
+# `openai/` and routed to this base URL through LiteLLM's OpenAI-compatible
+# path - the same approach Robusta-hosted models use.
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
+
+
+def is_orcarouter_model(model_name: str) -> bool:
+    """True if the model is served through OrcaRouter's OpenAI-compatible endpoint."""
+    return model_name.startswith("orcarouter/")
+
 
 def _litellm_name_for_entry(entry: "ModelEntry") -> str:
     """Return the model-name string that will be passed to litellm.completion.
@@ -70,6 +81,11 @@ def _litellm_name_for_entry(entry: "ModelEntry") -> str:
     if entry.is_robusta_model:
         split = entry.model.split("/")
         return split[0] if len(split) == 1 else f"openai/{split[1]}"
+    if is_orcarouter_model(entry.model):
+        # OrcaRouter models are rewritten to `openai/` at completion time
+        # (see DefaultLLM.completion), so pricing must register under the same
+        # name or usage-event costs would resolve to 0.
+        return f"openai/{entry.model.split('/', 1)[1]}"
     return entry.model
 
 
@@ -409,10 +425,22 @@ class DefaultLLM(LLM):
             return
         args = args or {}
         logging.debug(f"Checking LiteLLM model {model}")
-        lookup = litellm.get_llm_provider(model)
+        # OrcaRouter has no native LiteLLM provider prefix; the model is
+        # validated as an OpenAI-compatible model pointing at OrcaRouter's
+        # base URL (see get_litellm_corrected_name_for_robusta_ai).
+        if is_orcarouter_model(model):
+            lookup = ("openai", "openai")
+        else:
+            lookup = litellm.get_llm_provider(model)
         if not lookup:
             raise Exception(f"Unknown provider for model {model}")
         provider = lookup[1]
+        # OrcaRouter models are validated under their OpenAI-compatible name
+        # (`orcarouter/<m>` -> `openai/<m>`), so a missing key is caught here
+        # instead of litellm treating the unknown prefix as requiring nothing.
+        validate_model = (
+            f"openai/{model.split('/', 1)[1]}" if is_orcarouter_model(model) else model
+        )
         if provider == "watsonx":
             # NOTE: LiteLLM's validate_environment does not currently include checks for IBM WatsonX.
             # The following WatsonX-specific variables are set based on documentation from:
@@ -492,7 +520,7 @@ class DefaultLLM(LLM):
 
         else:
             model_requirements = litellm.validate_environment(
-                model=model, api_key=api_key, api_base=api_base
+                model=validate_model, api_key=api_key, api_base=api_base
             )
 
         if not model_requirements["keys_in_environment"]:
@@ -733,6 +761,14 @@ class DefaultLLM(LLM):
         ]
 
         litellm_model_name = self.get_litellm_corrected_name_for_robusta_ai()
+
+        # OrcaRouter models are routed through LiteLLM's OpenAI-compatible path
+        # with a default base URL, so a bare `orcarouter/<model>` entry works
+        # out of the box (no explicit api_base required in model_list.yaml).
+        is_orcarouter = is_orcarouter_model(litellm_model_name)
+        if is_orcarouter:
+            litellm_model_name = f"openai/{litellm_model_name.split('/', 1)[1]}"
+            self.api_base = self.api_base or ORCAROUTER_API_BASE
 
         # When Azure AD (Entra ID) token auth is enabled, obtain a cached token
         # and pass it to litellm instead of an API key.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
           - "Google Vertex AI": ai-providers/google-vertex-ai.md
           - Ollama: ai-providers/ollama.md
           - OpenRouter: ai-providers/openrouter.md
+          - OrcaRouter: ai-providers/orcarouter.md
           - OpenAI: ai-providers/openai.md
           - "OpenAI-Compatible": ai-providers/openai-compatible.md
           - Other: ai-providers/other.md

--- a/tests/core/test_llm_orcarouter.py
+++ b/tests/core/test_llm_orcarouter.py
@@ -1,0 +1,134 @@
+"""Tests for OrcaRouter provider support in DefaultLLM.
+
+OrcaRouter is an OpenAI-compatible AI gateway. LiteLLM has no native
+`orcarouter/` provider prefix, so DefaultLLM rewrites `orcarouter/<model>`
+to `openai/<model>` and routes it to OrcaRouter's base URL (mirroring how
+Robusta-hosted models are rewritten in get_litellm_corrected_name_for_robusta_ai).
+"""
+from unittest.mock import patch
+
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+from holmes.core.llm import (
+    ORCAROUTER_API_BASE,
+    DefaultLLM,
+    ModelEntry,
+    _litellm_name_for_entry,
+)
+
+
+def _mock_model_response() -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-test",
+        choices=[
+            Choices(
+                index=0,
+                message=Message(role="assistant", content="ok", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test-model",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def _make_llm(model: str = "orcarouter/anthropic/claude-sonnet-4.5", **attrs) -> DefaultLLM:
+    """Build a DefaultLLM bypassing __init__/check_llm so we can control attrs."""
+    llm = DefaultLLM.__new__(DefaultLLM)
+    llm.model = model
+    llm.api_key = "sk-orca-test"
+    llm.api_base = None
+    llm.api_version = None
+    llm.args = {}
+    llm.tracer = None
+    llm.name = None
+    llm.is_robusta_model = False
+    llm.max_context_size = None
+    for k, v in attrs.items():
+        setattr(llm, k, v)
+    return llm
+
+
+class TestCheckLLMOrcaRouter:
+    """check_llm must accept `orcarouter/` models as OpenAI-compatible without
+    letting litellm.get_llm_provider reject the unknown prefix."""
+
+    def test_check_llm_orcarouter_accepts_with_api_key(self):
+        llm = _make_llm()
+        # Should not raise even though litellm has no `orcarouter/` provider.
+        llm.check_llm(
+            model=llm.model,
+            api_key="sk-orca-test",
+            api_base=ORCAROUTER_API_BASE,
+            api_version=None,
+        )
+
+    def test_check_llm_orcarouter_missing_key_still_raises(self):
+        llm = _make_llm()
+        with pytest.raises(
+            Exception,
+            match="requires the following environment variables",
+        ):
+            llm.check_llm(
+                model=llm.model,
+                api_key=None,
+                api_base=ORCAROUTER_API_BASE,
+                api_version=None,
+            )
+
+    def test_check_llm_orcarouter_does_not_call_get_llm_provider(self):
+        llm = _make_llm()
+        with patch("holmes.core.llm.litellm.get_llm_provider") as mock_get_provider:
+            llm.check_llm(
+                model=llm.model,
+                api_key="sk-orca-test",
+                api_base=ORCAROUTER_API_BASE,
+                api_version=None,
+            )
+        mock_get_provider.assert_not_called()
+
+
+class TestCompletionOrcaRouter:
+    """completion must rewrite `orcarouter/` models to `openai/` and default
+    the base URL to OrcaRouter's OpenAI-compatible endpoint."""
+
+    def test_completion_rewrites_model_and_defaults_base_url(self):
+        llm = _make_llm()
+        with patch("holmes.core.llm.litellm.completion", return_value=_mock_model_response()) as mock:
+            llm.completion(messages=[{"role": "user", "content": "hi"}])
+        kwargs = mock.call_args.kwargs
+        assert kwargs["model"] == "openai/anthropic/claude-sonnet-4.5"
+        assert kwargs["base_url"] == ORCAROUTER_API_BASE
+        assert kwargs["api_key"] == "sk-orca-test"
+
+    def test_completion_respects_explicit_api_base(self):
+        llm = _make_llm(api_base="https://custom.orcarouter.example/v1")
+        with patch("holmes.core.llm.litellm.completion", return_value=_mock_model_response()) as mock:
+            llm.completion(messages=[{"role": "user", "content": "hi"}])
+        kwargs = mock.call_args.kwargs
+        assert kwargs["base_url"] == "https://custom.orcarouter.example/v1"
+        assert kwargs["model"] == "openai/anthropic/claude-sonnet-4.5"
+
+    def test_non_orcarouter_model_unchanged(self):
+        llm = _make_llm(model="openai/gpt-4o", api_base=None)
+        with patch("holmes.core.llm.litellm.completion", return_value=_mock_model_response()) as mock:
+            llm.completion(messages=[{"role": "user", "content": "hi"}])
+        kwargs = mock.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-4o"
+        assert kwargs["base_url"] is None
+
+
+class TestLitellmNameForEntry:
+    """_litellm_name_for_entry must register OrcaRouter pricing under the same
+    `openai/` name the completion call actually uses."""
+
+    def test_orcarouter_entry_uses_corrected_litellm_name(self):
+        entry = ModelEntry(
+            model="orcarouter/anthropic/claude-sonnet-4.5",
+        )
+        assert _litellm_name_for_entry(entry) == "openai/anthropic/claude-sonnet-4.5"
+
+    def test_non_orcarouter_entry_unchanged(self):
+        entry = ModelEntry(model="openai/gpt-4o")
+        assert _litellm_name_for_entry(entry) == "openai/gpt-4o"


### PR DESCRIPTION
## Summary

HolmesGPT is an open-source AI agent for investigating production incidents and finding root causes — and like many of its users, you already reach for a gateway to get the model that fits each investigation across providers. Today that means configuring OpenRouter (or an anonymous OpenAI-compatible base URL) by hand.

This PR makes [OrcaRouter](https://www.orcarouter.ai) a first-class AI provider, mirroring how HolmesGPT already ships OpenRouter support.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means HolmesGPT users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- **`holmes/core/llm.py`** — models using the `orcarouter/` prefix are now rewritten to `openai/<model>` and routed to `https://api.orcarouter.ai/v1` through LiteLLM's OpenAI-compatible path (the same approach Robusta-hosted models use in `get_litellm_corrected_name_for_robusta_ai`). A bare `model: orcarouter/<model>` entry in `model_list.yaml` now works out of the box — no explicit `api_base` required. An explicit `api_base` still wins if you self-host or override.
- **`tests/core/test_llm_orcarouter.py`** — new unit tests covering the prefix rewrite, the default base URL, explicit-base override, non-OrcaRouter models being untouched, and cost-map name normalization.
- **`docs/ai-providers/orcarouter.md`** — new provider page mirroring the existing OpenRouter page: native `orcarouter/` prefix method plus the OpenAI-compatible method, for CLI, Holmes Helm chart, and Robusta Helm chart.
- **`docs/ai-providers/index.md`, `docs/ai-providers/.nav.yml`, `mkdocs.yml`** — OrcaRouter added to the AI Providers index and navigation.
- **`docs/reference/environment-variables.md`** — `ORCAROUTER_API_KEY` and `ORCAROUTER_API_BASE` documented.

## How to use it

```bash
export ORCAROUTER_API_KEY="sk-orca-..."
holmes ask "what pods are failing?" --model="orcarouter/anthropic/claude-sonnet-4.5" --no-interactive
```

## Verification

- Unit tests: `tests/core/test_llm_orcarouter.py` plus the existing LLM suites (`test_llm_completion_*`, `test_llm_model_registry_*`, `test_llm_api_base_version`) all pass — 54 passed.
- Live check: ran a real completion through the new `orcarouter/` code path against `https://api.orcarouter.ai/v1` with a valid key and received a `200`-class response (`RESPONSE: 'OK'`).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OrcaRouter as an AI provider.
  * Configure OrcaRouter using an API key, optional custom API base URL, and `orcarouter/<model>` names.
  * Added support for both native OrcaRouter routing and OpenAI-compatible integrations.
  * Added documentation with CLI and Helm configuration examples, supported model formats, and token-limit guidance.

* **Documentation**
  * Added OrcaRouter to the AI Providers navigation and configuration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->