### PR TITLE
Fix compaction test error handler raising TypeError and masking the real failure

### DIFF
--- a/tests/llm/test_compaction.py
+++ b/tests/llm/test_compaction.py
@@ -249,7 +249,6 @@ def test_compaction(
             test_case=test_case,
             model=model,
             result=None,
-            mock_generation_config=None,
         )
         raise
 


### PR DESCRIPTION
`handle_test_error` accepts six parameters and has no `**kwargs`
(`tests/llm/utils/property_manager.py:299`):

```python
def handle_test_error(
    request,
    error: Exception,
    eval_span=None,
    test_case=None,
    model: Optional[str] = None,
    result=None,
) -> None:
```

but `tests/llm/test_compaction.py` passes a seventh, `mock_generation_config=None`,
so the call raises `TypeError: handle_test_error() got an unexpected keyword
argument 'mock_generation_config'`.

### Why this matters more than a normal arity slip

The call is the body of the test's error handler:

```python
except Exception as e:
    error = e
    handle_test_error(
        request=request,
        error=e,
        ...
        result=None,
        mock_generation_config=None,
    )
    raise
```

So whenever a compaction test genuinely fails, the real failure is discarded and
replaced by a `TypeError` originating in the error handler — the `raise` at the
end is never reached, and the actual assertion error never surfaces. The
centralized reporting this helper exists to provide (Braintrust logging,
property recording) is also skipped entirely for this file.

### The other call sites are already correct

| Call site | Extra arg | Status |
|---|---|---|
| `tests/llm/test_ask_holmes.py:140` | — | ✅ |
| `tests/llm/test_holmes_checks.py:244` | — | ✅ |
| `tests/llm/test_compaction.py:252` | `mock_generation_config` | ❌ |

`test_ask_holmes.py:140` passes exactly the same keyword set as this call site
minus `mock_generation_config`, which makes the intended shape unambiguous.

Binding the real upstream signature against all three, with the two working
call sites as the control group:

```
handle_test_error (request, error, eval_span=None, test_case=None, model=None, result=None)
  TypeError tests/llm/test_compaction.py:252 (+mock_generation_config) -> got an unexpected keyword argument 'mock_generation_config'
  OK        CONTROL tests/llm/test_ask_holmes.py:140
  OK        CONTROL tests/llm/test_holmes_checks.py:244
```

`mock_generation_config` is not referenced anywhere else in the repository, so
this drops the single stale line rather than adding a parameter nothing reads.
`ruff check` passes, and the change is format-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated compaction test error handling to align with the current interface.
  * No end-user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->