### PR TITLE
fix(otel): report per-iteration usage and prompt-cache split on gen_ai.chat spans

### DIFF
--- a/docs/reference/opentelemetry.md
+++ b/docs/reference/opentelemetry.md
@@ -72,10 +72,14 @@ holmesgpt.investigation (root span)
 **LLM spans** (`gen_ai.chat`):
 - `gen_ai.system` — LLM provider (`litellm`)
 - `gen_ai.request.model` — model name
-- `gen_ai.usage.input_tokens` — prompt tokens
-- `gen_ai.usage.output_tokens` — completion tokens
-- `gen_ai.usage.total_tokens` — total tokens
+- `gen_ai.usage.input_tokens` — prompt tokens of this LLM call (inclusive of the two cache buckets below)
+- `gen_ai.usage.output_tokens` — completion tokens of this LLM call
+- `gen_ai.usage.total_tokens` — total tokens of this LLM call
+- `gen_ai.usage.cache_read_input_tokens` — prompt tokens served from the provider's prompt cache (subset of `input_tokens`; `0` when the provider reports none)
+- `gen_ai.usage.cache_creation_input_tokens` — prompt tokens written to the provider's prompt cache (subset of `input_tokens`; `0` when the provider reports none)
 - `holmesgpt.iteration` — iteration number (0-based)
+
+Usage attributes are **per iteration**: each `gen_ai.chat` span reports only its own LLM call, never a running total for the request, so backends that sum spans (Langfuse, etc.) arrive at the correct request total. The cache attributes let such backends price cache reads and writes at their own rates rather than the full input rate.
 
 **Tool spans** (`holmesgpt.tool.<name>`):
 - `holmesgpt.tool.name` — tool name

--- a/holmes/core/otel_tracing.py
+++ b/holmes/core/otel_tracing.py
@@ -145,6 +145,10 @@ ATTR_GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
 ATTR_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
 ATTR_GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+# Anthropic-style prompt-cache buckets (subsets of input_tokens). Langfuse and
+# other GenAI backends recognise these names and price them at cache rates.
+ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read_input_tokens"
+ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
 
 # ---------------------------------------------------------------------------
 # Metric dimension keys — underscore-delimited for backend compatibility

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -49,6 +49,8 @@ from holmes.core.tools_utils.tool_executor import ToolExecutor
 from holmes.core.otel_tracing import (
     ATTR_GEN_AI_REQUEST_MODEL,
     ATTR_GEN_AI_SYSTEM,
+    ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+    ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
     ATTR_GEN_AI_USAGE_INPUT_TOKENS,
     ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
     ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
@@ -1251,13 +1253,22 @@ class ToolCallingLLM:
                     llm_duration = time.time() - _llm_call_start
                     otel_metrics.llm_call_duration.record(llm_duration, model_attrs)
 
-                # Log GenAI semantic convention attributes on the LLM child span
+                # Log GenAI semantic convention attributes on the LLM child span.
+                # Per-ITERATION usage (response_stats), not the request accumulator
+                # (stats): each gen_ai.chat span is one LLM call, and backends such
+                # as Langfuse sum spans — stamping the running total on every span
+                # over-counts an n-iteration request roughly n/2 times.
+                # input_tokens is litellm's prompt_tokens, i.e. INCLUSIVE of the
+                # cache buckets; the cache attributes let backends price cache
+                # reads/writes at their own rates instead of the full input rate.
                 llm_span.log(metadata={
                     ATTR_GEN_AI_SYSTEM: "litellm",
                     ATTR_GEN_AI_REQUEST_MODEL: self.llm.model,
-                    ATTR_GEN_AI_USAGE_INPUT_TOKENS: stats.prompt_tokens,
-                    ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: stats.completion_tokens,
-                    ATTR_GEN_AI_USAGE_TOTAL_TOKENS: stats.total_tokens,
+                    ATTR_GEN_AI_USAGE_INPUT_TOKENS: response_stats.prompt_tokens,
+                    ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: response_stats.completion_tokens,
+                    ATTR_GEN_AI_USAGE_TOTAL_TOKENS: response_stats.total_tokens,
+                    ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: response_stats.cached_tokens or 0,
+                    ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS: response_stats.cache_creation_tokens or 0,
                     "holmesgpt.iteration": i,
                 })
 

--- a/tests/test_tool_calling_llm.py
+++ b/tests/test_tool_calling_llm.py
@@ -23,6 +23,13 @@ import pytest
 from holmes.core.llm import LLM, ContextWindowUsage
 from holmes.core.models import PendingToolApproval, ToolApprovalDecision, ToolCallResult
 from holmes.core.llm_usage import RequestStats
+from holmes.core.otel_tracing import (
+    ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+    ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+    ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+    ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
+)
 from holmes.core.tool_calling_llm import LLMInterruptedError, ToolCallingLLM
 from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
 from holmes.core.tools_utils.tool_executor import ToolExecutor
@@ -81,8 +88,14 @@ def _make_mock_tool_call(tool_call_id="tc_1", tool_name="kubectl_get", arguments
     return tc
 
 
-def _make_llm_response(content="done", tool_calls=None, cost=0.001, prompt_tokens=50, completion_tokens=20):
-    """Create a mock LLM response matching litellm ModelResponse shape."""
+def _make_llm_response(content="done", tool_calls=None, cost=0.001, prompt_tokens=50, completion_tokens=20,
+                       cached_tokens=None, cache_creation_tokens=None):
+    """Create a mock LLM response matching litellm ModelResponse shape.
+
+    cached_tokens / cache_creation_tokens mimic the litellm prompt-cache usage
+    fields (prompt_tokens_details.cached_tokens / cache_creation_input_tokens);
+    None means the provider reported nothing, as before.
+    """
     resp = MagicMock()
     resp.choices = [MagicMock()]
     msg = MagicMock()
@@ -116,8 +129,11 @@ def _make_llm_response(content="done", tool_calls=None, cost=0.001, prompt_token
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
         "total_tokens": prompt_tokens + completion_tokens,
-        "prompt_tokens_details": None,
+        "prompt_tokens_details": (
+            {"cached_tokens": cached_tokens} if cached_tokens is not None else None
+        ),
         "completion_tokens_details": None,
+        "cache_creation_input_tokens": cache_creation_tokens,
     }.get(key, default)
     resp.usage = usage
 
@@ -1703,3 +1719,140 @@ class TestFrontendNoopToolFlow:
         tool_names = [t["function"]["name"] for t in tools_sent]
         assert "kubectl_get" in tool_names, "Backend tool should be included"
         assert "navigate_to_page" in tool_names, "Noop tool should be included"
+
+
+# ---------------------------------------------------------------------------
+# Test 21: gen_ai.chat span usage is per iteration and carries the cache split
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSpan:
+    """Minimal trace_span double: records child spans and their log() calls."""
+
+    def __init__(self, name: Optional[str] = None):
+        self.name = name
+        self.children: List["_RecordingSpan"] = []
+        self.log_calls: List[Dict[str, Any]] = []
+
+    def start_span(self, name: Optional[str] = None, **_kwargs) -> "_RecordingSpan":
+        child = _RecordingSpan(name=name)
+        self.children.append(child)
+        return child
+
+    def log(self, *_args, **kwargs) -> None:
+        self.log_calls.append(kwargs)
+
+    def end(self) -> None:
+        pass
+
+    def set_attributes(self, *_args, **_kwargs) -> None:
+        pass
+
+    def __enter__(self) -> "_RecordingSpan":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        pass
+
+
+def _span_metadata(span: _RecordingSpan) -> Dict[str, Any]:
+    """Merge every metadata dict logged on a span."""
+    merged: Dict[str, Any] = {}
+    for call in span.log_calls:
+        if isinstance(call.get("metadata"), dict):
+            merged.update(call["metadata"])
+    return merged
+
+
+class TestGenAiChatSpanUsage:
+    """Each gen_ai.chat span must report the usage of ITS OWN LLM call.
+
+    Backends such as Langfuse sum spans; stamping the request-level running
+    total on every span over-counts an n-iteration request ~n/2 times.
+    The span must also carry the prompt-cache split so those backends can
+    price cache reads/writes at cache rates.
+    """
+
+    @patch(LIMIT_PATCH, side_effect=_make_context_limiter_passthrough)
+    def test_span_usage_is_per_iteration_with_cache_split(
+        self, _mock_limit, make_ai, mock_llm
+    ):
+        tc = _make_mock_tool_call()
+        resp_with_tool = _make_llm_response(
+            content="Let me check",
+            tool_calls=[tc],
+            prompt_tokens=100,
+            completion_tokens=10,
+            cached_tokens=0,
+            cache_creation_tokens=90,
+        )
+        resp_final = _make_llm_response(
+            content="All pods are running",
+            tool_calls=None,
+            prompt_tokens=150,
+            completion_tokens=20,
+            cached_tokens=100,
+            cache_creation_tokens=40,
+        )
+        mock_llm.completion.side_effect = [resp_with_tool, resp_final]
+
+        ai = make_ai()
+        ai._invoke_llm_tool_call = MagicMock(return_value=_make_tool_call_result())
+
+        root = _RecordingSpan(name="root")
+        events = _collect_stream_events(
+            ai.call_stream(
+                msgs=[{"role": "user", "content": "What pods are running?"}],
+                trace_span=root,
+            )
+        )
+
+        chat_spans = [s for s in root.children if s.name == "gen_ai.chat"]
+        assert len(chat_spans) == 2
+        usage = [_span_metadata(s) for s in chat_spans]
+
+        # Per-iteration values — NOT the running total (which would be 100, 250).
+        assert [u[ATTR_GEN_AI_USAGE_INPUT_TOKENS] for u in usage] == [100, 150]
+        assert [u[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] for u in usage] == [10, 20]
+        assert [u[ATTR_GEN_AI_USAGE_TOTAL_TOKENS] for u in usage] == [110, 170]
+        # Cache buckets (subsets of input_tokens), also per iteration.
+        assert [u[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] for u in usage] == [0, 100]
+        assert [u[ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] for u in usage] == [
+            90,
+            40,
+        ]
+        assert [u["holmesgpt.iteration"] for u in usage] == [1, 2]
+
+        # The request-level accumulator is unchanged: ANSWER_END still carries the sum.
+        answer_end = _events_of_type(events, StreamEvents.ANSWER_END)[0]
+        assert answer_end.data["costs"]["prompt_tokens"] == 250
+        assert answer_end.data["costs"]["completion_tokens"] == 30
+        assert answer_end.data["costs"]["cached_tokens"] == 100
+        assert answer_end.data["costs"]["cache_creation_tokens"] == 130
+
+    @patch(LIMIT_PATCH, side_effect=_make_context_limiter_passthrough)
+    def test_span_cache_attributes_are_zero_when_provider_reports_none(
+        self, _mock_limit, make_ai, mock_llm
+    ):
+        """No cache info from the provider => numeric 0, never None (OTel would stringify it)."""
+        mock_llm.completion.return_value = _make_llm_response(
+            content="answer",
+            tool_calls=None,
+            prompt_tokens=50,
+            completion_tokens=20,
+        )
+        ai = make_ai()
+
+        root = _RecordingSpan(name="root")
+        _collect_stream_events(
+            ai.call_stream(msgs=[{"role": "user", "content": "hello"}], trace_span=root)
+        )
+
+        chat_spans = [s for s in root.children if s.name == "gen_ai.chat"]
+        assert len(chat_spans) == 1
+        usage = _span_metadata(chat_spans[0])
+        assert usage[ATTR_GEN_AI_USAGE_INPUT_TOKENS] == 50
+        assert usage[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert usage[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 0
+        assert usage[ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] == 0
+        assert usage["holmesgpt.iteration"] == 1


### PR DESCRIPTION
## Problem

The per-iteration `gen_ai.chat` span in `ToolCallingLLM.call_stream()` is stamped with the **request-level accumulator** (`stats.prompt_tokens` / `completion_tokens` / `total_tokens`, right after `stats += response_stats`) instead of that iteration's `response_stats` — the OTel *metrics* a few lines above already use the per-iteration value. Any backend that sums spans (Langfuse, and most trace-based cost views) therefore counts an n-iteration investigation roughly n/2 times over. The signature in a trace: both `input_tokens` and `output_tokens` grow monotonically span after span.

Independently, the span carries no prompt-cache split, so backends price cache reads (0.1× on Anthropic) and cache writes (1.25×) at the full input rate. In a real deployment 60–95 % of Holmes's input tokens are cache reads (each iteration re-reads the whole previous prompt from cache and writes only the new tail).

Measured on one production day (Anthropic `claude-opus-5`, ~30 investigations): Langfuse showed **$149.69**; Holmes's own `TRACE_TOKEN_USAGE` cost lines summed to **~$17**.

## Fix

- `gen_ai.chat` spans now carry **this iteration's** `response_stats`.
- Two new attributes, `gen_ai.usage.cache_read_input_tokens` and `gen_ai.usage.cache_creation_input_tokens`, from `RequestStats.cached_tokens` / `cache_creation_tokens` (already extracted from litellm).
- `gen_ai.usage.input_tokens` deliberately stays litellm's `prompt_tokens`, which is **inclusive** of both cache buckets: that is the semantics the generic `gen_ai.usage.*` extractors expect (Langfuse computes `input = input_tokens − cache_read − cache_creation` and prices each bucket from its model table). No cost attribute is emitted — an ingested cost point would suppress per-bucket pricing on the backend.
- Docs: `docs/reference/opentelemetry.md` states the per-iteration semantics and lists the two attributes.

## Verification

- Unit test `TestGenAiChatSpanUsage` (in `tests/test_tool_calling_llm.py`) drives `call_stream()` through two iterations with a fake LLM and a recording span: asserts input `[100, 150]` (not `[100, 250]`), the cache buckets per iteration, `holmesgpt.iteration` `[1, 2]`, and that `ANSWER_END.costs` still carries the request totals. Red on `master`, green with this change; `tests/test_otel_tracing.py` + `tests/test_tool_calling_llm.py` = 86 passed.
- End-to-end against a live Langfuse project with the `robustadev/holmes:0.40.0` image (this branch bind-mounted): a 4-iteration `claude-sonnet-4-5` drill — Langfuse **$0.1839 before, $0.0332 after**, equal to Holmes's litellm cost line and to a hand recompute at Anthropic list rates, per iteration to six decimals; `usageDetails` show `input` (uncached remainder), `input_cached_tokens`, `input_cache_creation`, `output`.
- ruff / isort / mypy: no findings on the changed lines.

## Not in scope (follow-ups)

- Compaction LLM calls (`holmes/core/truncation/compaction.py`) have no span, so their usage is invisible to span-summing backends (it is still in `RequestStats` / the cost line).
- The non-streaming path (`server.py`) logs request-level totals on the **root** `holmesgpt.investigation` span via `OTelSpan.log(metrics=…)` → `gen_ai.usage.*`; a span-summing backend double-counts that next to the per-iteration spans.
- `docs/reference/opentelemetry.md` says `holmesgpt.iteration` is 0-based; `call_stream` increments before opening the span, so spans carry 1-based values (the test asserts `[1, 2]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHjSZjh6WmW791hkfFPmpa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry tracing now reports per-iteration input, output, and total token usage for LLM calls.
  * Cache-read and cache-creation token usage is now captured to support provider-specific cache pricing.
* **Bug Fixes**
  * Corrected token metrics so individual spans no longer report accumulated request totals.
  * Request-level cost totals remain accumulated across all iterations.
* **Documentation**
  * Expanded guidance explains per-iteration usage reporting and cache-related attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->