### PR TITLE
fix(code_quality): Missing docstring on public function `patch_supabase` in con

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -222,6 +222,11 @@ pytest_terminal_summary = show_llm_summary_report
 
 @pytest.fixture(autouse=True)
 def patch_supabase(monkeypatch):
+    """Patch Supabase connection settings with safe test values for every test.
+
+    Applied automatically (autouse=True) so all tests run without requiring a
+    real Supabase instance or valid credentials.
+    """
     monkeypatch.setattr("holmes.core.supabase_dal.ROBUSTA_ACCOUNT_ID", "test-cluster")
     monkeypatch.setattr(
         "holmes.core.supabase_dal.STORE_URL", "https://fakesupabaseref.supabase.co"


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `patch_supabase` in conftest.py (HolmesGPT/holmesgpt)

**Wedge type:** `code_quality`

**Issue:** https://github.com/HolmesGPT/holmesgpt/blob/main/conftest.py

## Changes

- `conftest.py`

**Diff size:** 5 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory documentation for test setup, clarifying that tests use safe connection settings and do not require a live Supabase instance or valid credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->