### PR TITLE
fix(code_quality): Missing docstring on public function `pytest_report_header` 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -206,6 +206,7 @@ def pytest_configure(config):
 
 
 def pytest_report_header(config):
+    """Add a Braintrust experiment URL to the pytest report header when BRAINTRUST_API_KEY is set."""
     braintrust_api_key = os.environ.get("BRAINTRUST_API_KEY")
     if not braintrust_api_key:
         return ""


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `pytest_report_header` in conftest.py (HolmesGPT/holmesgpt)

**Wedge type:** `code_quality`

**Issue:** https://github.com/HolmesGPT/holmesgpt/blob/main/conftest.py

## Changes

- `conftest.py`

**Diff size:** 1 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation explaining when a Braintrust experiment URL appears in the pytest report header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->