### PR TITLE
fix(code_quality): Missing docstring on public function `storage_dal_mock` in c

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -238,6 +238,15 @@ def patch_supabase(monkeypatch):
 
 @pytest.fixture(autouse=True, scope="session")
 def storage_dal_mock():
+    """Session-scoped fixture that mocks SupabaseDal to avoid real database calls during tests.
+
+    Patches ``holmes.config.SupabaseDal`` with a :class:`unittest.mock.MagicMock` and
+    pre-configures common return values (``sign_in``, ``get_ai_credentials``) so that any
+    code path relying on the storage DAL works without a live Supabase instance.
+
+    Yields:
+        MagicMock: The configured mock instance of ``SupabaseDal``.
+    """
     with patch("holmes.config.SupabaseDal") as MockSupabaseDal:
         mock_supabase_dal_instance = MagicMock()
         MockSupabaseDal.return_value = mock_supabase_dal_instance


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `storage_dal_mock` in conftest.py (HolmesGPT/holmesgpt)

**Wedge type:** `code_quality`

**Issue:** https://github.com/HolmesGPT/holmesgpt/blob/main/conftest.py

## Changes

- `conftest.py`

**Diff size:** 9 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the test fixture that mocks storage access and provides preset authentication and credential responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->