### PR TITLE
fix: namespace filter for kubernetes_tabular_query and SuggestSkills truncation

### DIFF
--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -1498,7 +1498,37 @@ class ToolCallingLLM:
                 # If either type of pause is needed, emit a single APPROVAL_REQUIRED
                 # event that carries both pending_approvals and pending_frontend_tool_calls.
                 # The client checks which lists are populated and handles accordingly.
+                #
+                # Special case: when the model produced content AND only frontend tool
+                # calls (no regular tool calls needing approval), treat this as a
+                # terminal answer.  The frontend calls (e.g. SuggestSkills) are
+                # side-effects that should not force another LLM turn; continuing the
+                # loop would cause the model to re-answer with a shorter, truncated
+                # version that loses the original detail.  See #2428.
                 if pending_approvals or pending_frontend_calls:
+                    if (
+                        message
+                        and pending_frontend_calls
+                        and not pending_approvals
+                    ):
+                        # Model answered + frontend-only tools → terminal
+                        deduped: dict[str, dict] = {}
+                        for tc in all_tool_calls:
+                            deduped[tc.get("tool_call_id", id(tc))] = tc
+                        yield StreamMessage(
+                            event=StreamEvents.ANSWER_END,
+                            data={
+                                "content": message,
+                                "messages": messages,
+                                "metadata": metadata,
+                                "tool_calls": list(deduped.values()),
+                                "num_llm_calls": i,
+                                "prompt": json.dumps(messages, indent=2),
+                                "costs": stats.model_dump(),
+                            },
+                        )
+                        return
+
                     yield StreamMessage(
                         event=StreamEvents.APPROVAL_REQUIRED,
                         data={

--- a/holmes/plugins/toolsets/kubernetes.yaml
+++ b/holmes/plugins/toolsets/kubernetes.yaml
@@ -192,7 +192,7 @@ toolsets:
                 - Include grep-ready keys/values; avoid repeating entire objects or unchanged defaults
 
       - name: "kubernetes_tabular_query"
-        user_description: "filter: kubectl get {{kind}} columns='{{columns}}'{% if filter_pattern %} filter={{filter_pattern}}{% endif %}"
+        user_description: "filter: kubectl get {{kind}} columns='{{columns}}'{% if filter_pattern %} filter={{filter_pattern}}{% endif %}{% if namespace %} ns={{namespace}}{% endif %}"
         description: >
           Extract specific fields from Kubernetes resources in tabular format with optional filtering.
           Returns a JSON object with keys: "count" (number of rows), "header" (column header line),
@@ -201,6 +201,7 @@ toolsets:
           Column specification format: HEADER:FIELD_PATH,HEADER2:FIELD_PATH2,...
           e.g. NAME:.metadata.name,STATUS:.status.phase,IMAGE:.spec.containers[0].image
           Optional filter_pattern matches any column (grep regex), e.g. filter_pattern="Running".
+          Optional namespace restricts the query to a single namespace (avoids OOM on large clusters).
 
           LIMITATIONS - not allowed characters in columns: ' / ; and newline.
           Label keys containing dots or slashes (e.g. kubernetes.io/arch, app.kubernetes.io/name)
@@ -216,7 +217,12 @@ toolsets:
           KIND={{ kind }}
           CUSTOM_COLUMNS={{ columns }}
           err_file=$(mktemp)
-          output=$(kubectl get "$KIND" --all-namespaces -o custom-columns="$CUSTOM_COLUMNS" 2>"$err_file")
+          NAMESPACE={{ namespace }}
+          if [ -n "$NAMESPACE" ]; then
+            output=$(kubectl get "$KIND" -n "$NAMESPACE" -o custom-columns="$CUSTOM_COLUMNS" 2>"$err_file")
+          else
+            output=$(kubectl get "$KIND" --all-namespaces -o custom-columns="$CUSTOM_COLUMNS" 2>"$err_file")
+          fi
           kubectl_exit=$?
           err_content=$(cat "$err_file" 2>/dev/null)
           rm -f "$err_file"


### PR DESCRIPTION
## Changes

1. **Add optional `namespace` parameter to `kubernetes_tabular_query`** (Fixes #2438)
   - When provided, uses `-n <namespace>` instead of `--all-namespaces`
   - Prevents OOM on large clusters (e.g. 14k+ pods)
   - Parameter is optional, defaults to cluster-wide query

2. **Fix SuggestSkills truncation** (Fixes #2428)
   - When a model produces content AND only frontend tool calls (like SuggestSkills) in the same turn, treat this as a terminal answer
   - Prevents the model from re-answering with a shorter, truncated version that loses the original detail

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses can now complete immediately when only frontend tool calls remain, reducing unnecessary additional processing.
  * Kubernetes tabular queries now support filtering results by an optional namespace.

* **Improvements**
  * Bash approvals are now tracked separately by agent and validated against signed approvals.
  * Updated Kubernetes query guidance to clarify pagination, returned fields, and plural resource-kind requirements.
  * Namespace-specific tabular queries now target the selected namespace instead of all namespaces.
  * Improved Kubernetes resource-kind matching and Prometheus target handling for more reliable queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->