### PR TITLE
docs(contributing): require dependency release waiting period

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ We encourage those interested to contribute code and also appreciate when issues
 - Keep pull requests small and focused—if you have multiple changes, open a separate PR for each
 - All new features require unit tests
 - New toolsets require integration tests
+- For dependency upgrades or new dependencies, only use versions that have been publicly available for at least two weeks to reduce supply-chain security risks
 - Maintain 40% minimum test coverage
 - Use `git commit -s --no-verify` when committing to skip local pre-commit hooks (they will run in CI)
 - Always create commits and merge (never force push or rebase)


### PR DESCRIPTION
## Summary
- require dependency versions to be publicly available for at least two weeks before adoption
- apply the policy to both upgrades and newly introduced dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a contribution guideline requiring dependency upgrades and new dependencies to use versions that have been publicly available for at least two weeks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->