### PR TITLE
fix(tests): check inline preview length against constant in context limiter test

### DIFF
--- a/tests/core/tools_utils/test_tool_context_window_limiter.py
+++ b/tests/core/tools_utils/test_tool_context_window_limiter.py
@@ -8,6 +8,7 @@ from holmes.core.llm import LLM, ContextWindowUsage
 from holmes.core.models import ToolCallResult
 from holmes.core.tools import StructuredToolResult, StructuredToolResultStatus
 from holmes.core.tools_utils.tool_context_window_limiter import (
+    ERROR_INLINE_PREVIEW_CHARS,
     spill_oversized_tool_result,
 )
 
@@ -336,8 +337,9 @@ class TestPreventOverlyBigToolResponse:
         assert tcr.result.status == StructuredToolResultStatus.ERROR
         assert tcr.result.error is None
         # Inline preview leads with the error text and is capped at ~500 chars
-        assert "the record changed while you were investigating" in tcr.result.data
-        assert len(tcr.result.data) < 1200
+        preview = tcr.result.data.split("\nPreview:\n", 1)[1]
+        assert preview.startswith("the record changed while you were investigating")
+        assert len(preview) == ERROR_INLINE_PREVIEW_CHARS
         # The file holds the full error + payload
         saved = next(tmp_path.iterdir()).read_text()
         assert saved.startswith("the record changed while you were investigating")


### PR DESCRIPTION
## Summary
In `test_error_result_spills_with_short_inline_preview`, the assertion `len(tcr.result.data) < 1200` fails on macOS
because the temporary directory path (`/private/var/folders/lr/...`) is significantly longer than `/tmp` and is repeated 4
times across the boilerplate output, exceeding 1200 characters.

This updates the test to directly verify the preview substring length against `ERROR_INLINE_PREVIEW_CHARS`.

## Testing
- `poetry run pytest tests/core/tools_utils/test_tool_context_window_limiter.py -vv --no-cov` (11 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened coverage for error results that exceed the context window.
  - Verified that spilled data includes a dedicated preview section with the expected formatting and exact preview length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->