### PR TITLE
fix(investigator): harden TodoWrite and interactive renderer against loose task formats

### DIFF
--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -385,15 +385,22 @@ def _size_bar(output_len: int, max_width: int = 12) -> str:
 
 def _build_task_panel(tasks: list) -> Panel:
     """Build a Rich Panel showing the task list with checkbox-style icons."""
-    completed = sum(1 for t in tasks if t.get("status") == "completed")
+    content = Text()
+    completed = 0
     total = len(tasks)
 
-    content = Text()
     for i, task in enumerate(tasks):
-        status = task.get("status", "pending")
-        task_content = task.get("content", "")
+        status = getattr(task, "status", None) or (
+            task.get("status") if isinstance(task, dict) else "pending"
+        )
+        if hasattr(status, "value"):
+            status = status.value
+        task_content = getattr(task, "content", None) or (
+            task.get("content") if isinstance(task, dict) else str(task)
+        )
 
         if status == "completed":
+            completed += 1
             content.append(" ☑ ", style="green")
             content.append(task_content, style="dim strike")
         elif status == "in_progress":
@@ -405,7 +412,7 @@ def _build_task_panel(tasks: list) -> Panel:
         else:
             content.append(" ☐ ", style="dim")
             content.append(task_content, style="dim")
-        if i < len(tasks) - 1:
+        if i < total - 1:
             content.append("\n")
 
     # Title with progress
@@ -651,28 +658,38 @@ class AgenticProgressRenderer:
         # --- Tasks section ---
         if self._live_tasks:
             tasks_text = Text()
-            completed = sum(1 for t in self._live_tasks if t.get("status") == "completed")
+            completed = 0
             total = len(self._live_tasks)
             for task in self._live_tasks:
-                status = task.get("status", "pending")
-                tc = task.get("content", "")
+                status = getattr(task, "status", None) or (
+                    task.get("status") if isinstance(task, dict) else "pending"
+                )
+                if hasattr(status, "value"):
+                    status = status.value
+                task_content = getattr(task, "content", None) or (
+                    task.get("content") if isinstance(task, dict) else str(task)
+                )
+
+                if status == "completed":
+                    completed += 1
+
                 if self._approval_pending:
                     # All tasks dim when waiting for approval
                     icon = " ☑ " if status == "completed" else " ☒ " if status == "failed" else " ☐ "
                     tasks_text.append(icon, style="dim")
-                    tasks_text.append(tc, style="dim")
+                    tasks_text.append(task_content, style="dim")
                 elif status == "completed":
                     tasks_text.append(" ☑ ", style="green")
-                    tasks_text.append(tc, style="dim strike")
+                    tasks_text.append(task_content, style="dim strike")
                 elif status == "in_progress":
                     tasks_text.append(" ☐ ", style="bold yellow")
-                    tasks_text.append(tc, style="bold yellow")
+                    tasks_text.append(task_content, style="bold yellow")
                 elif status == "failed":
                     tasks_text.append(" ☒ ", style="bold red")
-                    tasks_text.append(tc, style="red")
+                    tasks_text.append(task_content, style="red")
                 else:
                     tasks_text.append(" ☐ ", style="dim")
-                    tasks_text.append(tc, style="dim")
+                    tasks_text.append(task_content, style="dim")
                 tasks_text.append("\n")
             # Remove trailing newline
             if tasks_text.plain.endswith("\n"):
@@ -856,7 +873,10 @@ class AgenticProgressRenderer:
                             if self._scroll_offset >= max_start:
                                 self._scroll_offset = 0
                                 self._scroll_pause = 6  # ~1s pause at wrap
-                    self._live.update(self._build_display())
+                    try:
+                        self._live.update(self._build_display())
+                    except Exception:
+                        logging.debug("Live display update failed", exc_info=True)
 
     def start(self) -> None:
         """Start the Live display with the initial 'Thinking...' spinner."""
@@ -955,7 +975,7 @@ class AgenticProgressRenderer:
 
         for item in self._completed:
             _num, name, desc, toolset, elapsed, output_len, is_error, extra = item
-            if name == _TODO_WRITE_TOOL_NAME and extra:
+            if name == _TODO_WRITE_TOOL_NAME and extra is not None:
                 self._live_tasks = extra
             else:
                 self._tool_history.append((name, desc, toolset, elapsed, output_len or 0, is_error))
@@ -1066,7 +1086,7 @@ class AgenticProgressRenderer:
                 if tool_name == _TODO_WRITE_TOOL_NAME:
                     params = result_data.get("params") or {}
                     todos = params.get("todos")
-                    if isinstance(todos, list):
+                    if todos is not None and isinstance(todos, list):
                         extra = todos
                         self._live_tasks = todos
 

--- a/holmes/plugins/toolsets/investigator/core_investigation.py
+++ b/holmes/plugins/toolsets/investigator/core_investigation.py
@@ -1,9 +1,9 @@
+import json
 import logging
 import os
 from typing import Any, Dict
-from uuid import uuid4
 
-display_logger = logging.getLogger("holmes.display.core_investigation")
+from pydantic import ValidationError
 
 from holmes.core.todo_tasks_formatter import format_tasks
 from holmes.core.tools import (
@@ -15,22 +15,31 @@ from holmes.core.tools import (
     Toolset,
     ToolsetTag,
 )
-from holmes.plugins.toolsets.investigator.model import Task, TaskStatus
+from holmes.plugins.toolsets.investigator.model import Task
+
+display_logger = logging.getLogger("holmes.display.core_investigation")
 
 TODO_WRITE_TOOL_NAME = "TodoWrite"
 
 
 def parse_tasks(todos_data: Any) -> list[Task]:
-    tasks = []
+    if isinstance(todos_data, str):
+        try:
+            todos_data = json.loads(todos_data)
+        except (json.JSONDecodeError, ValueError):
+            todos_data = [todos_data]
 
-    for todo_item in todos_data:
-        if isinstance(todo_item, dict):
-            task = Task(
-                id=todo_item.get("id", str(uuid4())),
-                content=todo_item.get("content", ""),
-                status=TaskStatus(todo_item.get("status", "pending")),
-            )
-            tasks.append(task)
+    if not isinstance(todos_data, list):
+        todos_data = [todos_data] if todos_data else []
+
+    tasks = []
+    for item in todos_data:
+        if item:
+            try:
+                tasks.append(Task.model_validate(item))
+            except ValidationError:
+                display_logger.debug("Skipping invalid todo item")
+                continue
 
     return tasks
 
@@ -113,6 +122,8 @@ class TodoWriteTool(Tool):
                 response_data += formatted_tasks
             else:
                 response_data += "No tasks currently in the investigation plan."
+
+            params["todos"] = [t.to_dict() for t in tasks]
 
             return StructuredToolResult(
                 status=StructuredToolResultStatus.SUCCESS,

--- a/holmes/plugins/toolsets/investigator/model.py
+++ b/holmes/plugins/toolsets/investigator/model.py
@@ -1,7 +1,8 @@
 from enum import Enum
+from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class TaskStatus(str, Enum):
@@ -15,3 +16,30 @@ class Task(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     content: str
     status: TaskStatus = TaskStatus.PENDING
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_input(cls, data: Any) -> Any:
+        # Some LLMs return tasks as raw strings instead of structured objects;
+        # coerce to dict format to preserve task content in the expected model structure.
+        if isinstance(data, str):
+            return {"content": data}
+
+        # LLMs may produce unsupported or malformed status strings;
+        # fallback to pending to avoid validation failures while preserving the task.
+        if isinstance(data, dict):
+            status = data.get("status")
+            try:
+                TaskStatus(status)
+            except (ValueError, TypeError):
+                data = {**data, "status": TaskStatus.PENDING.value}
+            return data
+
+        return data
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "content": self.content,
+            "status": self.status.value,
+        }

--- a/tests/core/test_todo_write_tool.py
+++ b/tests/core/test_todo_write_tool.py
@@ -1,6 +1,9 @@
 from holmes.core.tools import StructuredToolResultStatus
-from holmes.plugins.toolsets.investigator.core_investigation import TodoWriteTool
-from holmes.plugins.toolsets.investigator.model import TaskStatus
+from holmes.plugins.toolsets.investigator.core_investigation import (
+    TodoWriteTool,
+    parse_tasks,
+)
+from holmes.plugins.toolsets.investigator.model import Task, TaskStatus
 from tests.conftest import create_mock_tool_invoke_context
 
 
@@ -66,8 +69,22 @@ class TestTodoWriteTool:
         # Should include pretty printed TodoList
         assert "Test task" in result.data
 
+    def test_todo_write_tool_with_string_tasks(self):
+        """Test TodoWriteTool handles string task items gracefully."""
+        tool = TodoWriteTool()
+        params = {"todos": ["Check pod status", "Analyze logs"]}
+
+        result = tool._invoke(params, context=create_mock_tool_invoke_context())
+
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert "2 tasks" in result.data
+        assert "Check pod status" in result.data
+        assert isinstance(result.params["todos"], list)
+        assert result.params["todos"][0]["content"] == "Check pod status"
+        assert result.params["todos"][0]["status"] == "pending"
+
     def test_todo_write_tool_invalid_enum_values(self):
-        """Test TodoWriteTool handles invalid enum values gracefully."""
+        """Test TodoWriteTool handles invalid enum values gracefully by sanitizing to pending."""
         tool = TodoWriteTool()
         params = {
             "todos": [
@@ -81,9 +98,11 @@ class TestTodoWriteTool:
 
         result = tool._invoke(params, context=create_mock_tool_invoke_context())
 
-        # Should handle gracefully and return error
-        assert result.status == StructuredToolResultStatus.ERROR
-        assert "Failed to process tasks" in result.error
+        # Should handle gracefully by sanitizing invalid status to pending
+        assert result.status == StructuredToolResultStatus.SUCCESS
+        assert "1 tasks" in result.data
+        assert result.params["todos"][0]["status"] == "pending"
+        assert result.params["todos"][0]["content"] == "Test task"
 
     def test_get_parameterized_one_liner(self):
         """Test the parameterized one-liner description."""
@@ -125,3 +144,93 @@ class TestTodoWriteTool:
 
         # Check required fields
         assert "todos" in params["required"]
+
+
+class TestTaskModel:
+    def test_task_model_string_coercion(self):
+        """Test that Task.model_validate with a string coerces to Task with content and pending status."""
+        task = Task.model_validate("Check pod status")
+        assert task.content == "Check pod status"
+        assert task.status == TaskStatus.PENDING
+        assert isinstance(task.id, str)
+        assert len(task.id) > 0
+
+    def test_task_model_invalid_status_sanitization(self):
+        """Test that Task.model_validate with an unknown or malformed status sanitizes to pending status."""
+        for invalid_status in ["unknown_value", None, "", ["pending"]]:
+            task = Task.model_validate({"content": "foo", "status": invalid_status})
+            assert task.content == "foo"
+            assert task.status == TaskStatus.PENDING
+            assert isinstance(task.id, str)
+
+    def test_task_model_to_dict(self):
+        """Test that Task.to_dict returns a dict with string status."""
+        task = Task.model_validate(
+            {"id": "custom-id", "content": "foo", "status": "completed"}
+        )
+        task_dict = task.to_dict()
+        assert task_dict == {
+            "id": "custom-id",
+            "content": "foo",
+            "status": "completed",
+        }
+        assert isinstance(task_dict["status"], str)
+
+
+class TestParseTasks:
+    def test_parse_tasks_with_json_string_list(self):
+        """Test parse_tasks with a JSON string of task strings."""
+        tasks = parse_tasks('["Check pods", "View logs"]')
+        assert len(tasks) == 2
+        assert tasks[0].content == "Check pods"
+        assert tasks[0].status == TaskStatus.PENDING
+        assert tasks[1].content == "View logs"
+        assert tasks[1].status == TaskStatus.PENDING
+
+    def test_parse_tasks_with_json_object_list(self):
+        """Test parse_tasks with a JSON string of task objects."""
+        tasks = parse_tasks(
+            '[{"id": "t1", "content": "Check pods", "status": "in_progress"}]'
+        )
+        assert len(tasks) == 1
+        assert tasks[0].id == "t1"
+        assert tasks[0].content == "Check pods"
+        assert tasks[0].status == TaskStatus.IN_PROGRESS
+
+    def test_parse_tasks_with_json_singleton_object(self):
+        """Test parse_tasks with a JSON string of a single task object."""
+        tasks = parse_tasks('{"content": "Check pods", "status": "in_progress"}')
+        assert len(tasks) == 1
+        assert tasks[0].content == "Check pods"
+        assert tasks[0].status == TaskStatus.IN_PROGRESS
+
+    def test_parse_tasks_with_plain_string(self):
+        """Test parse_tasks with a plain non-JSON string."""
+        tasks = parse_tasks("Check single pod")
+        assert len(tasks) == 1
+        assert tasks[0].content == "Check single pod"
+        assert tasks[0].status == TaskStatus.PENDING
+
+    def test_parse_tasks_with_dict_list(self):
+        """Test parse_tasks with a Python list of dicts."""
+        data = [
+            {"content": "Task 1", "status": "completed"},
+            {"content": "Task 2", "status": "invalid_status"},
+        ]
+        tasks = parse_tasks(data)
+        assert len(tasks) == 2
+        assert tasks[0].status == TaskStatus.COMPLETED
+        assert tasks[1].status == TaskStatus.PENDING
+
+    def test_parse_tasks_skips_invalid_items(self):
+        """Test parse_tasks gracefully skips unparseable items."""
+        data = [None, "", {"non_task_field": 123}, {"content": "Valid task"}]
+        tasks = parse_tasks(data)
+        assert len(tasks) == 1
+        assert tasks[0].content == "Valid task"
+
+    def test_parse_tasks_empty_inputs(self):
+        """Test parse_tasks with empty or None input."""
+        assert parse_tasks([]) == []
+        assert parse_tasks(None) == []
+        assert parse_tasks("") == []

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -21,11 +21,13 @@ from holmes.interactive import (
     SlashCommands,
     UserFeedback,
     _LiveLogFilter,
+    _build_task_panel,
     _make_live,
     _run_inline_menu,
     handle_feedback_command,
     run_interactive_loop,
 )
+from holmes.plugins.toolsets.investigator.model import Task, TaskStatus
 from holmes.utils.stream import StreamEvents, StreamMessage
 from tests.mocks.toolset_mocks import SampleToolset
 
@@ -98,6 +100,97 @@ class TestAgenticProgressRendererSummary(unittest.TestCase):
 
         panels = self._get_printed_panels(console)
         assert len(panels) >= 2, f"Expected tasks + tools panels, got {len(panels)}"
+
+    def test_live_tasks_with_strings(self):
+        """Test that renderer handles live tasks when LLM returns strings instead of dicts."""
+        console = Mock(spec=Console)
+        renderer = AgenticProgressRenderer(console, tool_number_offset=0)
+        renderer._live_tasks = ["Check pods", "Check logs"]
+        renderer._tool_history.append(("kubectl_get_pods", "get pods in namespace default", "kubernetes", 1.0, 100, False))
+
+        pane = renderer._build_left_pane()
+        assert pane is not None
+
+        renderer.flush()
+        panels = self._get_printed_panels(console)
+        assert len(panels) >= 2
+
+    def test_todo_write_tool_result_with_string_todos(self):
+        """Test that handle_event handles TodoWrite when todos contains strings."""
+        console = Mock(spec=Console)
+        renderer = AgenticProgressRenderer(console, tool_number_offset=0)
+        event = StreamMessage(
+            event=StreamEvents.TOOL_RESULT,
+            data={
+                "tool_name": "TodoWrite",
+                "description": "Update tasks",
+                "result": {
+                    "data": "Investigation plan updated",
+                    "params": {"todos": ["Task 1", "Task 2"]},
+                },
+            },
+        )
+        all_calls = []
+        renderer.handle_event(event, all_calls, [])
+        pane = renderer._build_left_pane()
+        assert pane is not None
+
+    def test_todo_write_empty_todos_clears_tasks(self):
+        """Test that TodoWrite with empty todos clears live tasks and is not added to tool history."""
+        console = Mock(spec=Console)
+        renderer = AgenticProgressRenderer(console, tool_number_offset=0)
+        renderer._live_tasks = [{"content": "Existing task", "status": "pending"}]
+
+        event = StreamMessage(
+            event=StreamEvents.TOOL_RESULT,
+            data={
+                "tool_name": "TodoWrite",
+                "description": "Update tasks",
+                "result": {
+                    "data": "Investigation plan updated with 0 tasks",
+                    "params": {"todos": []},
+                },
+            },
+        )
+        all_calls = []
+        renderer.handle_event(event, all_calls, [])
+
+        assert renderer._live_tasks == []
+        assert len(renderer._tool_history) == 0
+
+    def test_build_task_panel_with_dicts_and_tasks(self):
+        """Test _build_task_panel renders both dicts and Task model instances with correct counts and icons."""
+        tasks = [
+            {"content": "Check pods", "status": "completed"},
+            Task(content="Analyze logs", status=TaskStatus.IN_PROGRESS),
+            Task(content="Check metrics", status=TaskStatus.FAILED),
+            {"content": "Draft report", "status": "pending"},
+        ]
+        panel = _build_task_panel(tasks)
+        assert panel is not None
+        assert "1/4" in str(panel.title)
+        plain_text = panel.renderable.plain
+        assert "Check pods" in plain_text
+        assert "Analyze logs" in plain_text
+        assert "Check metrics" in plain_text
+        assert "Draft report" in plain_text
+
+    def test_live_tasks_with_task_objects(self):
+        """Test that renderer handles live tasks containing Task model instances directly."""
+        console = Mock(spec=Console)
+        renderer = AgenticProgressRenderer(console, tool_number_offset=0)
+        renderer._live_tasks = [
+            Task(content="Task A", status=TaskStatus.COMPLETED),
+            Task(content="Task B", status=TaskStatus.PENDING),
+        ]
+        renderer._tool_history.append(("kubectl_get_pods", "get pods", "kubernetes", 1.0, 100, False))
+
+        pane = renderer._build_left_pane()
+        assert pane is not None
+
+        renderer.flush()
+        panels = self._get_printed_panels(console)
+        assert len(panels) >= 2
 
     def test_flush_no_double_print_after_ai_message(self):
         """Summary should print only once even if AI_MESSAGE already triggered it."""


### PR DESCRIPTION
## Summary
- Coerce string task items into valid `Task` dict structures in `Task._coerce_input`
- Normalize unsupported or malformed status strings to `TaskStatus.PENDING` instead of throwing validation errors
- Support JSON strings (lists and singletons) in `parse_tasks`, skipping invalid items with debug logs
- Handle non-dict items and `Task` model instances safely in `AgenticProgressRenderer` and `_build_task_panel`
- Clear live tasks when `TodoWrite` updates with an empty task list without appending to tool history
- Address CodeRabbit review feedback on variable naming and comment rationales

## Testing
- `poetry run pytest tests/core/test_todo_write_tool.py tests/test_interactive.py --no-cov` (91 passed)
- Unit tests covering string tasks, invalid statuses, singleton JSON objects, and live renderer rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task-list handling for string, object, and dictionary task entries.
  - Invalid task statuses are now safely treated as pending instead of causing errors.
  - Task progress counts and status icons now display correctly for mixed task formats.
  - Empty task updates are handled correctly, including clearing live tasks and related history.
  - Live-update failures no longer interrupt rendering.
- **Tests**
  - Added coverage for task parsing, validation, serialization, rendering, and empty task updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->