### PR TITLE
fix(mcp): support boolean JSON schemas

### DIFF
--- a/holmes/core/openai_formatting.py
+++ b/holmes/core/openai_formatting.py
@@ -69,6 +69,10 @@ def _is_tool_strict_compatible(tool_parameters: dict) -> bool:
 
 
 def type_to_open_ai_schema(param_attributes: Any, strict_mode: bool) -> dict[str, Any]:
+    if param_attributes.boolean_schema is not None:
+        # Keep the return value mutable because callers may add a description.
+        return {} if param_attributes.boolean_schema else {"not": {}}
+
     # Handle union types (anyOf with multiple non-null branches) first.
     if hasattr(param_attributes, "any_of") and param_attributes.any_of:
         branches = [type_to_open_ai_schema(branch, strict_mode) for branch in param_attributes.any_of]

--- a/holmes/core/openai_formatting.py
+++ b/holmes/core/openai_formatting.py
@@ -69,9 +69,9 @@ def _is_tool_strict_compatible(tool_parameters: dict) -> bool:
 
 
 def type_to_open_ai_schema(param_attributes: Any, strict_mode: bool) -> dict[str, Any]:
-    if param_attributes.boolean_schema is not None:
+    if param_attributes.json_schema_override is not None:
         # Keep the return value mutable because callers may add a description.
-        return {} if param_attributes.boolean_schema else {"not": {}}
+        return dict(param_attributes.json_schema_override)
 
     # Handle union types (anyOf with multiple non-null branches) first.
     if hasattr(param_attributes, "any_of") and param_attributes.any_of:

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -217,9 +217,8 @@ class ToolParameter(BaseModel):
     # When set, type_to_open_ai_schema emits {"anyOf": [...]} instead of a
     # single type.  Each entry is a ToolParameter representing one branch.
     any_of: Optional[List["ToolParameter"]] = None
-    # JSON Schema permits boolean schemas: true accepts every value, while
-    # false accepts none. Preserve them instead of assuming every schema is a dict.
-    boolean_schema: Optional[bool] = None
+    # Provider-facing schema for values that cannot be represented by the typed fields.
+    json_schema_override: Optional[Dict[str, Any]] = None
 
     def is_strict_compatible(self) -> bool:
         """Check if this parameter (and all nested parameters) can be used in strict mode.
@@ -228,7 +227,7 @@ class ToolParameter(BaseModel):
         Parameters with dynamic keys (additionalProperties set to a schema dict or True)
         are incompatible with strict mode.
         """
-        if self.boolean_schema is not None:
+        if self.json_schema_override is not None:
             return False
         # If this parameter has additionalProperties with a schema or True, it's not strict-compatible
         if self.additional_properties is not None and self.additional_properties is not False:

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -217,6 +217,9 @@ class ToolParameter(BaseModel):
     # When set, type_to_open_ai_schema emits {"anyOf": [...]} instead of a
     # single type.  Each entry is a ToolParameter representing one branch.
     any_of: Optional[List["ToolParameter"]] = None
+    # JSON Schema permits boolean schemas: true accepts every value, while
+    # false accepts none. Preserve them instead of assuming every schema is a dict.
+    boolean_schema: Optional[bool] = None
 
     def is_strict_compatible(self) -> bool:
         """Check if this parameter (and all nested parameters) can be used in strict mode.
@@ -225,6 +228,8 @@ class ToolParameter(BaseModel):
         Parameters with dynamic keys (additionalProperties set to a schema dict or True)
         are incompatible with strict mode.
         """
+        if self.boolean_schema is not None:
+            return False
         # If this parameter has additionalProperties with a schema or True, it's not strict-compatible
         if self.additional_properties is not None and self.additional_properties is not False:
             return False

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -468,14 +468,7 @@ class RemoteMCPTool(Tool):
             with lock:
                 tools_result = asyncio.run(self.toolset._get_server_tools_with_context(context.request_context))
 
-            real_tools = [
-                RemoteMCPTool.create(
-                    tool,
-                    self.toolset,
-                    is_remote=tool.name.startswith(REMOTE_TOOL_NAME_PREFIX),
-                )
-                for tool in tools_result.tools
-            ]
+            real_tools = self.toolset._create_remote_tools(tools_result.tools)
 
             if real_tools:
                 tool_names = [t.name for t in real_tools]
@@ -665,8 +658,8 @@ class RemoteMCPTool(Tool):
 
     @classmethod
     def _resolve_schema(
-        cls, schema: bool | dict[str, Any], root_schema: dict[str, Any]
-    ) -> bool | dict[str, Any]:
+        cls, schema: Any, root_schema: dict[str, Any]
+    ) -> Any:
         """Resolves $ref and extracts the first non-null type from anyOf/oneOf/allOf."""
         if not isinstance(schema, dict):
             return schema
@@ -687,7 +680,12 @@ class RemoteMCPTool(Tool):
                 # Recursively resolve the matched definition in case it contains more refs/anyOf
                 resolved_schema = dict(schema)
                 resolved_schema.pop("$ref")
-                resolved_schema.update(cls._resolve_schema(resolved, root_schema))
+                resolved = cls._resolve_schema(resolved, root_schema)
+                if resolved is True:
+                    return resolved_schema or True
+                if not isinstance(resolved, dict):
+                    return resolved
+                resolved_schema.update(resolved)
                 return resolved_schema
 
         # 2. Handle anyOf / oneOf / allOf for nullable or union types
@@ -755,7 +753,7 @@ class RemoteMCPTool(Tool):
     @classmethod
     def _parse_tool_parameter(
         cls,
-        schema: bool | dict[str, Any],
+        schema: Any,
         root_schema: dict[str, Any],
         required: bool = True,
     ) -> ToolParameter:
@@ -768,6 +766,11 @@ class RemoteMCPTool(Tool):
         schema = cls._resolve_schema(schema, root_schema)
         if isinstance(schema, bool):
             return ToolParameter(required=required, boolean_schema=schema)
+        if not isinstance(schema, dict):
+            raise ValueError(
+                "Invalid JSON Schema node: expected an object or boolean, "
+                f"got {type(schema).__name__}"
+            )
 
         # If _resolve_schema preserved a multi-branch anyOf, parse each branch
         # into a ToolParameter and store on the any_of field.
@@ -934,18 +937,33 @@ class RemoteMCPToolset(Toolset):
             return None
         return self._mcp_config.oauth.model_dump(exclude_none=True)
 
+    def _create_remote_tools(self, tools: List[MCP_Tool]) -> List["RemoteMCPTool"]:
+        parsed_tools = []
+        for tool in tools:
+            try:
+                parsed_tools.append(
+                    RemoteMCPTool.create(
+                        tool,
+                        self,
+                        is_remote=tool.name.startswith(REMOTE_TOOL_NAME_PREFIX),
+                    )
+                )
+            except Exception as e:
+                logger.warning(
+                    "Skipping invalid MCP tool %s from %s: %s",
+                    tool.name,
+                    self.name,
+                    _extract_root_error_message(e),
+                )
+        return parsed_tools
+
     def _load_remote_tools(self, request_context: Optional[Dict[str, Any]] = None) -> List["RemoteMCPTool"]:
         """Load tools from the MCP server and return as RemoteMCPTool instances."""
         if request_context:
             tools_result = asyncio.run(self._get_server_tools_with_context(request_context))
         else:
             tools_result = asyncio.run(self._get_server_tools())
-        return [
-            RemoteMCPTool.create(
-                tool, self, is_remote=tool.name.startswith(REMOTE_TOOL_NAME_PREFIX)
-            )
-            for tool in tools_result.tools
-        ]
+        return self._create_remote_tools(tools_result.tools)
 
     def _render_headers(
         self, request_context: Optional[Dict[str, Any]] = None

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -665,8 +665,8 @@ class RemoteMCPTool(Tool):
 
     @classmethod
     def _resolve_schema(
-        cls, schema: dict[str, Any], root_schema: dict[str, Any]
-    ) -> dict[str, Any]:
+        cls, schema: bool | dict[str, Any], root_schema: dict[str, Any]
+    ) -> bool | dict[str, Any]:
         """Resolves $ref and extracts the first non-null type from anyOf/oneOf/allOf."""
         if not isinstance(schema, dict):
             return schema
@@ -754,7 +754,10 @@ class RemoteMCPTool(Tool):
 
     @classmethod
     def _parse_tool_parameter(
-        cls, schema: dict[str, Any], root_schema: dict[str, Any], required: bool = True
+        cls,
+        schema: bool | dict[str, Any],
+        root_schema: dict[str, Any],
+        required: bool = True,
     ) -> ToolParameter:
         """Recursively parse a JSON Schema property into a ToolParameter.
 
@@ -763,6 +766,8 @@ class RemoteMCPTool(Tool):
         complex parameter types (arrays, objects).
         """
         schema = cls._resolve_schema(schema, root_schema)
+        if isinstance(schema, bool):
+            return ToolParameter(required=required, boolean_schema=schema)
 
         # If _resolve_schema preserved a multi-branch anyOf, parse each branch
         # into a ToolParameter and store on the any_of field.

--- a/holmes/plugins/toolsets/mcp/toolset_mcp.py
+++ b/holmes/plugins/toolsets/mcp/toolset_mcp.py
@@ -765,7 +765,10 @@ class RemoteMCPTool(Tool):
         """
         schema = cls._resolve_schema(schema, root_schema)
         if isinstance(schema, bool):
-            return ToolParameter(required=required, boolean_schema=schema)
+            return ToolParameter(
+                required=required,
+                json_schema_override={} if schema else {"not": {}},
+            )
         if not isinstance(schema, dict):
             raise ValueError(
                 "Invalid JSON Schema node: expected an object or boolean, "

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -676,8 +676,8 @@ class TestMCPSchemaPreservation:
 
         tool = RemoteMCPTool.create(mcp_tool, mock_toolset)
 
-        assert tool.parameters["value"].boolean_schema is True
-        assert tool.parameters["impossible"].boolean_schema is False
+        assert tool.parameters["value"].json_schema_override == {}
+        assert tool.parameters["impossible"].json_schema_override == {"not": {}}
         openai_format = tool.get_openai_format()
         assert "strict" not in openai_format["function"]
         assert openai_format["function"]["parameters"]["required"] == ["value"]

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -686,6 +686,48 @@ class TestMCPSchemaPreservation:
             "impossible": {"not": {}},
         }
 
+        malformed_tool = Tool(
+            name="malformed_tool",
+            inputSchema={"type": "object", "properties": {"value": "string"}},
+            description="Tool with an invalid property schema",
+            annotations=None,
+        )
+        with pytest.raises(
+            ValueError, match="expected an object or boolean, got str"
+        ):
+            RemoteMCPTool.create(malformed_tool, mock_toolset)
+
+        parsed_tools = mock_toolset._create_remote_tools([mcp_tool, malformed_tool])
+
+        assert [parsed_tool.name for parsed_tool in parsed_tools] == ["query_tool"]
+
+        referenced_tool = Tool(
+            name="referenced_tool",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "free": {"$ref": "#/$defs/free"},
+                    "integer": {"$ref": "#/$defs/free", "type": "integer"},
+                    "impossible": {
+                        "$ref": "#/$defs/impossible",
+                        "type": "integer",
+                    },
+                },
+                "$defs": {"free": True, "impossible": False},
+            },
+            description="Tool with boolean schema references",
+            annotations=None,
+        )
+
+        referenced_format = RemoteMCPTool.create(
+            referenced_tool, mock_toolset
+        ).get_openai_format()
+        assert referenced_format["function"]["parameters"]["properties"] == {
+            "free": {},
+            "integer": {"type": "integer"},
+            "impossible": {"not": {}},
+        }
+
     @pytest.mark.usefixtures("suppress_migration_warnings")
     def test_additional_properties_anyof_preserved(self) -> None:
         """Test that additionalProperties with anyOf is not flattened.

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -657,6 +657,36 @@ class TestMCPSchemaPreservation:
     """Tests for preserving JSON Schema features from MCP tool schemas."""
 
     @pytest.mark.usefixtures("suppress_migration_warnings")
+    def test_boolean_property_schemas_preserved(self) -> None:
+        mcp_tool = Tool(
+            name="query_tool",
+            inputSchema={
+                "type": "object",
+                "properties": {"value": True, "impossible": False},
+                "required": ["value"],
+            },
+            description="Query with an unconstrained filter value",
+            annotations=None,
+        )
+        mock_toolset = RemoteMCPToolset(
+            name="test_toolset",
+            description="Test toolset",
+            config={"url": "http://localhost:1234"},
+        )
+
+        tool = RemoteMCPTool.create(mcp_tool, mock_toolset)
+
+        assert tool.parameters["value"].boolean_schema is True
+        assert tool.parameters["impossible"].boolean_schema is False
+        openai_format = tool.get_openai_format()
+        assert "strict" not in openai_format["function"]
+        assert openai_format["function"]["parameters"]["required"] == ["value"]
+        assert openai_format["function"]["parameters"]["properties"] == {
+            "value": {},
+            "impossible": {"not": {}},
+        }
+
+    @pytest.mark.usefixtures("suppress_migration_warnings")
     def test_additional_properties_anyof_preserved(self) -> None:
         """Test that additionalProperties with anyOf is not flattened.
 


### PR DESCRIPTION
Honeycomb’s hosted MCP server can advertise legal boolean JSON Schema nodes, which currently crash `RemoteMCPTool` while loading tool definitions. This preserves those schemas through tool formatting (`true` as `{}` and `false` as `{"not": {}}`), retains sibling constraints on boolean references, and disables strict mode for affected tools. Other malformed schema shapes now produce a precise validation error and only skip the offending tool instead of disabling every valid tool from that MCP server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved compatibility with MCP tools using complex, boolean, and referenced JSON Schemas.
  - Preserves provider-specific parameter schema details for more accurate tool definitions.
  - Applies consistent tool loading behavior after OAuth authentication.

- **Bug Fixes**
  - Invalid MCP tools are now skipped instead of preventing other valid tools from loading.
  - Unsupported or malformed schemas produce clearer validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->