### PR TITLE
docs: fix GitLab MCP TLS troubleshooting link

### DIFF
--- a/docs/data-sources/builtin-toolsets/gitlab-mcp.md
+++ b/docs/data-sources/builtin-toolsets/gitlab-mcp.md
@@ -335,7 +335,7 @@ curl -H "PRIVATE-TOKEN: <YOUR_GITLAB_PAT>" https://gitlab.com/api/v4/user
 
 ### SSL Certificate Verification Errors
 
-See the [Self-Hosted GitLab](#sslsignedtls-for-self-signed-certificates) section above. Prefer mounting a custom CA over disabling verification.
+See the [SSL/TLS for Self-Signed Certificates](#ssltls-for-self-signed-certificates) section above. Prefer mounting a custom CA over disabling verification.
 
 ### Tool Not Found
 


### PR DESCRIPTION
## Summary

Fix the TLS troubleshooting cross-reference in the GitLab MCP guide.

- Link text: `Self-Hosted GitLab` → `SSL/TLS for Self-Signed Certificates`
- Anchor: non-existent `#sslsignedtls-for-self-signed-certificates` →  `#ssltls-for-self-signed-certificates`

The link now points directly to the matching TLS configuration subsection.

## Validation

- Ran `poetry run mkdocs build` successfully with `PYTHONPATH` set to the repository root.
- Confirmed the GitLab MCP page no longer reports a missing TLS anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the troubleshooting link for SSL certificate verification errors so it points to the relevant self-signed certificate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->