### PR TITLE
Add tool-choice evals and clarify which cluster the k8s MCP tools reach

### DIFF
--- a/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
+++ b/docs/data-sources/builtin-toolsets/kubernetes-mcp.md
@@ -611,3 +611,12 @@ holmes ask "Show me the resource requests and limits for all deployments in name
 ```bash
 holmes ask "Why is the checkout-api pod not scheduling?"
 ```
+
+## Known Issues
+
+### `configuration_contexts_list` is missing with a single cluster
+
+The tool is registered only when the kubeconfig holds more than one context, so
+a single-cluster setup will not expose it. Add a second context to the
+kubeconfig if you need it. Note that `--disable-multi-cluster` also removes it,
+even when several contexts are present.

--- a/helm/holmes/templates/mcp-servers/kubernetes/_helpers.tpl
+++ b/helm/holmes/templates/mcp-servers/kubernetes/_helpers.tpl
@@ -16,9 +16,26 @@ Use the Kubernetes MCP when investigating:
 - Kubernetes events and cluster-level diagnostics
 - Helm release status and management
 
+## Which Cluster These Tools Reach
+
+These tools reach the clusters in this server's kubeconfig — NOT necessarily the
+cluster Holmes itself runs on. Do not assume the two are the same.
+
+- `configuration_contexts_list` enumerates the reachable clusters. It is
+  registered ONLY when the kubeconfig holds more than one context, so its
+  absence means a single cluster is configured — not that context selection
+  failed. When it is absent, every tool here targets that one cluster; say
+  which cluster you queried only if you can identify it, and never guess a name.
+- When it IS available, call it before other tools and pass an explicit
+  `context` argument, rather than relying on the default.
+- For the LOCAL cluster Holmes runs on, prefer the `bash` toolset.
+- For other clusters in the Robusta FLEET, use the platform's `remote_*` tools
+  with an `agent_name`. Those are a different mechanism from the kubeconfig
+  contexts here; do not confuse a context name with an `agent_name`.
+
 ## Investigation Workflow
 
-1. **Check cluster context**: Use configuration tools to verify which cluster you're connected to
+1. **Check cluster context**: Establish which cluster you are querying (see above)
 2. **List namespaces**: Identify the relevant namespace for the investigation
 3. **Check events**: Look at Kubernetes events for warnings and errors
 4. **Inspect pods**: Get pod status, logs, and resource usage

--- a/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/k8s_mcp_mock.py
+++ b/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/k8s_mcp_mock.py
@@ -1,0 +1,51 @@
+"""Mock kubernetes-mcp-server for the tool-choice evals (290/291/292).
+
+Mirrors the real kubernetes-mcp-server toolset: it is wired to REMOTE clusters
+via kubeconfig contexts, so every tool takes an explicit `context`. Holmes must
+pick these tools only when the question is about another cluster — never for
+the cluster Holmes itself runs on.
+
+Self-contained so the eval needs no live cluster.
+"""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+CONTEXTS = ["eu-prod-1", "us-prod-2"]
+
+_PODS = {
+    "eu-prod-1": [
+        {"name": "checkout-api-7d9f-abc", "namespace": "payments", "status": "CrashLoopBackOff", "restarts": 47},
+        {"name": "ledger-6b8c-def", "namespace": "payments", "status": "Running", "restarts": 0},
+    ],
+    "us-prod-2": [
+        {"name": "search-indexer-5f7a-ghi", "namespace": "search", "status": "Running", "restarts": 1},
+    ],
+}
+
+mcp = FastMCP("kubernetes-mcp-mock")
+
+
+@mcp.tool(name="configuration_contexts_list", description=(
+        "List every Kubernetes cluster context available to this MCP server. "
+        "Call this first to discover which remote clusters can be queried, then "
+        "pass one of the returned names as the `context` argument of any other "
+        "tool. Does NOT cover the cluster Holmes itself runs on."))
+def configuration_contexts_list() -> str:
+    return json.dumps({"contexts": CONTEXTS, "default": CONTEXTS[0]})
+
+
+@mcp.tool(name="pods_list_in_namespace", description=(
+        "List pods in a namespace on a REMOTE Kubernetes cluster. Requires the "
+        "`context` argument naming the target cluster (see "
+        "configuration_contexts_list)."))
+def pods_list_in_namespace(context: str, namespace: str) -> str:
+    if context not in CONTEXTS:
+        return json.dumps({"error": f"unknown context {context!r}; known: {CONTEXTS}"})
+    pods = [p for p in _PODS.get(context, []) if p["namespace"] == namespace]
+    return json.dumps({"context": context, "namespace": namespace, "pods": pods})
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/local_kubectl.sh
+++ b/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/local_kubectl.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Stub kubectl for the tool-choice evals (290/291/292). Stands in for the LOCAL
+# cluster so the eval needs no live cluster: the point is which TOOL Holmes
+# picks, not what the cluster returns.
+echo "NAMESPACE   NAME                        READY   STATUS             RESTARTS   AGE"
+echo "billing     invoice-worker-84cd-x2k9    0/1     CrashLoopBackOff   31         2d"
+echo "billing     invoice-api-5f7b-pp41       1/1     Running            0          9d"

--- a/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/platform_mcp_mock.py
+++ b/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/platform_mcp_mock.py
@@ -1,0 +1,49 @@
+"""Mock Robusta platform MCP for the tool-choice evals (290/291/292).
+
+Mirrors relay's platform-mcp: `remote_*` tools that the PLATFORM dispatches to
+another Holmes instance in the fleet, selected by `agent_name`. Distinct from
+the kubernetes MCP server, which talks to remote clusters directly over
+kubeconfig contexts. Holmes must pick these only for fleet-wide questions.
+"""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+AGENTS = ["eu-prod-1", "us-prod-2", "ap-staging-3"]
+
+mcp = FastMCP("platform-mcp-mock")
+
+
+@mcp.tool(name="list_available_clusters", description=(
+        "List every cluster in the Robusta fleet that this account can reach, "
+        "along with whether each is currently connected. Returns the "
+        "`agent_name` values accepted by the remote_* tools."))
+def list_available_clusters() -> str:
+    return json.dumps({
+        "clusters": [
+            {"agent_name": "eu-prod-1", "connected": True},
+            {"agent_name": "us-prod-2", "connected": True},
+            {"agent_name": "ap-staging-3", "connected": False},
+        ]
+    })
+
+
+@mcp.tool(name="remote_kubernetes_tabular_query", description=(
+        "Run a read-only Kubernetes query on ANOTHER cluster in the Robusta "
+        "fleet, routed through the platform. Requires `agent_name` naming the "
+        "target cluster (see list_available_clusters)."))
+def remote_kubernetes_tabular_query(agent_name: str, query: str) -> str:
+    if agent_name not in AGENTS:
+        return json.dumps({"error": f"unknown agent_name {agent_name!r}; known: {AGENTS}"})
+    if agent_name == "ap-staging-3":
+        return json.dumps({"error": "cluster ap-staging-3 is not connected"})
+    return json.dumps({
+        "agent_name": agent_name,
+        "query": query,
+        "rows": [{"namespace": "payments", "deployment": "checkout-api", "ready": "2/3"}],
+    })
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/test_case.yaml
@@ -1,0 +1,25 @@
+user_prompt: "Why is invoice-worker crashlooping in the billing namespace on this cluster?"
+
+description: |
+  Tool-choice eval 1/3 (local cluster -> bash).
+
+  All three tool sources are enabled: bash (local cluster), the kubernetes MCP
+  server (remote clusters via kubeconfig contexts) and the platform MCP
+  (the fleet via remote_*). The question is about the cluster Holmes RUNS ON,
+  so it must use bash and must NOT reach for either remote path.
+
+# Fails deterministically if Holmes routes a local question to a remote tool.
+forbidden_tools:
+  - "pods_list_in_namespace"
+  - "configuration_contexts_list"
+  - "remote_kubernetes_tabular_query"
+  - "list_available_clusters"
+
+expected_output:
+  - Identifies invoice-worker-84cd-x2k9 in the billing namespace as CrashLoopBackOff
+  - Answers using the local cluster, without querying another cluster or the fleet
+
+include_tool_calls: true
+tags:
+  - kubernetes
+  - question-answer

--- a/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/toolsets.yaml
@@ -1,0 +1,37 @@
+# Shared by the tool-choice evals (290/291/292): all three tool sources are
+# enabled in every case, so each eval proves Holmes DISCRIMINATES between them
+# rather than just using the only thing available.
+#
+#   bash                  -> the LOCAL cluster Holmes runs on
+#   kubernetes MCP        -> REMOTE clusters, via kubeconfig contexts
+#   platform MCP          -> the Robusta FLEET, via remote_* + agent_name
+toolsets:
+  bash:
+    enabled: true
+    config:
+      allow:
+        - "tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/local_kubectl.sh"
+      deny: []
+  kubernetes/core: { enabled: false }
+  kubernetes/logs: { enabled: false }
+  kubernetes/live-metrics: { enabled: false }
+  helm/core: { enabled: false }
+  core_investigation: { enabled: false }
+  internet: { enabled: false }
+  skills: { enabled: false }
+  robusta: { enabled: false }
+  connectivity_check: { enabled: false }
+
+mcp_servers:
+  kubernetes:
+    enabled: true
+    config:
+      mode: stdio
+      command: python
+      args: ["tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/k8s_mcp_mock.py"]
+  robusta_platform:
+    enabled: true
+    config:
+      mode: stdio
+      command: python
+      args: ["tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/platform_mcp_mock.py"]

--- a/tests/llm/fixtures/test_ask_holmes/291_tool_choice_remote_cluster_k8s_mcp/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/291_tool_choice_remote_cluster_k8s_mcp/test_case.yaml
@@ -1,0 +1,25 @@
+user_prompt: "Are there any crashlooping pods in the payments namespace on the eu-prod-1 cluster?"
+
+description: |
+  Tool-choice eval 2/3 (remote cluster -> kubernetes MCP).
+
+  Same three tool sources as 290. The question names ANOTHER cluster, which the
+  kubernetes MCP server reaches over kubeconfig contexts. Holmes must use those
+  tools (discovering the context first if needed) and must NOT run bash against
+  its own cluster, nor route through the platform's remote_* fleet tools.
+
+# Fails deterministically if Holmes answers a remote question from the local
+# cluster, or confuses the kubeconfig path with the platform fleet path.
+forbidden_tools:
+  - "bash"
+  - "remote_kubernetes_tabular_query"
+  - "list_available_clusters"
+
+expected_output:
+  - Reports checkout-api-7d9f-abc in the payments namespace as CrashLoopBackOff
+  - Queries the eu-prod-1 cluster explicitly rather than the local one
+
+include_tool_calls: true
+tags:
+  - kubernetes
+  - question-answer

--- a/tests/llm/fixtures/test_ask_holmes/291_tool_choice_remote_cluster_k8s_mcp/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/291_tool_choice_remote_cluster_k8s_mcp/toolsets.yaml
@@ -1,0 +1,37 @@
+# Shared by the tool-choice evals (290/291/292): all three tool sources are
+# enabled in every case, so each eval proves Holmes DISCRIMINATES between them
+# rather than just using the only thing available.
+#
+#   bash                  -> the LOCAL cluster Holmes runs on
+#   kubernetes MCP        -> REMOTE clusters, via kubeconfig contexts
+#   platform MCP          -> the Robusta FLEET, via remote_* + agent_name
+toolsets:
+  bash:
+    enabled: true
+    config:
+      allow:
+        - "tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/local_kubectl.sh"
+      deny: []
+  kubernetes/core: { enabled: false }
+  kubernetes/logs: { enabled: false }
+  kubernetes/live-metrics: { enabled: false }
+  helm/core: { enabled: false }
+  core_investigation: { enabled: false }
+  internet: { enabled: false }
+  skills: { enabled: false }
+  robusta: { enabled: false }
+  connectivity_check: { enabled: false }
+
+mcp_servers:
+  kubernetes:
+    enabled: true
+    config:
+      mode: stdio
+      command: python
+      args: ["tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/k8s_mcp_mock.py"]
+  robusta_platform:
+    enabled: true
+    config:
+      mode: stdio
+      command: python
+      args: ["tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/platform_mcp_mock.py"]

--- a/tests/llm/fixtures/test_ask_holmes/292_tool_choice_fleet_platform_mcp/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/292_tool_choice_fleet_platform_mcp/test_case.yaml
@@ -1,0 +1,25 @@
+user_prompt: "Which clusters in our fleet are currently connected to Robusta?"
+
+description: |
+  Tool-choice eval 3/3 (fleet -> platform MCP).
+
+  Same three tool sources as 290. The question is about the Robusta FLEET, which
+  only the platform MCP can answer — the kubernetes MCP server knows kubeconfig
+  contexts but nothing about platform connectivity, and bash sees only the local
+  cluster. Holmes must call list_available_clusters.
+
+# Fails deterministically if Holmes mistakes fleet membership for a kubeconfig
+# context listing, or tries to answer locally.
+forbidden_tools:
+  - "bash"
+  - "configuration_contexts_list"
+  - "pods_list_in_namespace"
+
+expected_output:
+  - Reports eu-prod-1 and us-prod-2 as connected
+  - Reports ap-staging-3 as not connected
+  - Answers from the Robusta fleet rather than kubeconfig contexts
+
+include_tool_calls: true
+tags:
+  - question-answer

--- a/tests/llm/fixtures/test_ask_holmes/292_tool_choice_fleet_platform_mcp/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/292_tool_choice_fleet_platform_mcp/toolsets.yaml
@@ -1,0 +1,37 @@
+# Shared by the tool-choice evals (290/291/292): all three tool sources are
+# enabled in every case, so each eval proves Holmes DISCRIMINATES between them
+# rather than just using the only thing available.
+#
+#   bash                  -> the LOCAL cluster Holmes runs on
+#   kubernetes MCP        -> REMOTE clusters, via kubeconfig contexts
+#   platform MCP          -> the Robusta FLEET, via remote_* + agent_name
+toolsets:
+  bash:
+    enabled: true
+    config:
+      allow:
+        - "tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/local_kubectl.sh"
+      deny: []
+  kubernetes/core: { enabled: false }
+  kubernetes/logs: { enabled: false }
+  kubernetes/live-metrics: { enabled: false }
+  helm/core: { enabled: false }
+  core_investigation: { enabled: false }
+  internet: { enabled: false }
+  skills: { enabled: false }
+  robusta: { enabled: false }
+  connectivity_check: { enabled: false }
+
+mcp_servers:
+  kubernetes:
+    enabled: true
+    config:
+      mode: stdio
+      command: python
+      args: ["tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/k8s_mcp_mock.py"]
+  robusta_platform:
+    enabled: true
+    config:
+      mode: stdio
+      command: python
+      args: ["tests/llm/fixtures/test_ask_holmes/290_tool_choice_local_cluster_bash/platform_mcp_mock.py"]


### PR DESCRIPTION
## Problem

Holmes conflates three different ways of reaching a cluster:

| Tool source | Reaches | Selected by |
|---|---|---|
| `bash` | the LOCAL cluster Holmes runs on | — |
| kubernetes MCP | REMOTE clusters | kubeconfig `context` |
| platform MCP | the Robusta FLEET | `agent_name` |

It also cannot tell which cluster it is operating on when only one is configured, because `configuration_contexts_list` is registered only when the kubeconfig holds more than one context — so its absence reads as a failed lookup rather than "there is exactly one cluster".

## Changes

### 1. Clearer built-in instructions (`llmInstructions`)

Adds a "Which Cluster These Tools Reach" section stating that these tools reach the kubeconfig's clusters rather than necessarily the local one; that the absence of `configuration_contexts_list` means a single cluster is configured — not a failed lookup, and not a licence to guess a cluster name; and when to prefer `bash` or the platform's `remote_*` tools instead. A user-supplied `llmInstructions` still overrides it (verified via `helm template`).

### 2. Three tool-choice evals

- **290** local cluster → `bash`
- **291** remote cluster → kubernetes MCP
- **292** fleet → platform MCP

All three enable **all three tool sources in every case**, so each eval proves Holmes *discriminates* rather than just using the only thing wired up. Each forbids the other two via `forbidden_tools`, so picking the wrong source fails deterministically instead of being LLM-judged.

Mocks are stdio MCP stubs (`k8s_mcp_mock.py`, `platform_mcp_mock.py`) plus a stub script behind the bash allow-list, so none of the three needs a live cluster. Both stubs were probed directly and expose the expected tools; all three cases collect under pytest.

### 3. Known Issues doc note

`configuration_contexts_list` is missing with a single cluster. Verified empirically against the running image: two contexts expose 14 tools including it, one context exposes 13 without it. `--disable-multi-cluster` removes it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining which clusters Kubernetes tools access and how to select the intended cluster context.
  * Clarified that the configured kubeconfig may differ from the cluster running Holmes.
  * Documented when context-listing tools are available and how multi-cluster settings affect them.
  * Added recommendations for using local-cluster tools and remote fleet tools appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->