### PR TITLE
fix: add configurable tool count preflight

### DIFF
--- a/docs/ai-providers/openai.md
+++ b/docs/ai-providers/openai.md
@@ -103,6 +103,27 @@ Get a paid [OpenAI API key](https://help.openai.com/en/articles/4936850-where-do
         model: "gpt-4.1"  # This refers to the key name in modelList above
     ```
 
+## Tool Count Limits
+
+Some model endpoints reject requests that contain more tool definitions than
+they support. If your endpoint reports a specific limit, configure it on the
+corresponding `modelList` entry:
+
+```yaml
+modelList:
+  gpt-4.1:
+    api_key: "{{ env.OPENAI_API_KEY }}"
+    model: openai/gpt-4.1
+    custom_args:
+      max_tools: 128  # Use the limit reported by your endpoint
+```
+
+Holmes validates the final tools array before sending the request. When the
+configured limit is exceeded, it reports the model, tool count, and limit
+without silently removing tools. Reduce the enabled toolsets or MCP tools to
+continue. If `max_tools` is omitted, Holmes preserves the provider's existing
+behavior.
+
 ## Available Models
 
 Most OpenAI models are supported. For example:

--- a/holmes/core/llm.py
+++ b/holmes/core/llm.py
@@ -365,6 +365,8 @@ class DefaultLLM(LLM):
     api_version: Optional[str]
     args: Dict
     is_robusta_model: bool
+    max_context_size: Optional[int]
+    max_tools: Optional[int]
 
     def __init__(
         self,
@@ -391,7 +393,15 @@ class DefaultLLM(LLM):
         )
 
     def update_custom_args(self):
-        self.max_context_size = self.args.get("custom_args", {}).get("max_context_size")
+        custom_args = self.args.get("custom_args", {})
+        self.max_context_size = custom_args.get("max_context_size")
+        self.max_tools = custom_args.get("max_tools")
+        if self.max_tools is not None and (
+            isinstance(self.max_tools, bool)
+            or not isinstance(self.max_tools, int)
+            or self.max_tools <= 0
+        ):
+            raise ValueError("custom_args.max_tools must be a positive integer")
         self.args.pop("custom_args", None)
 
     def check_llm(
@@ -667,6 +677,14 @@ class DefaultLLM(LLM):
         allowed_openai_params = None
 
         if tools and len(tools) > 0 and tool_choice == "auto":
+            max_tools = getattr(self, "max_tools", None)
+            if max_tools is not None and len(tools) > max_tools:
+                raise ValueError(
+                    f"Model '{self.model}' is configured with max_tools={max_tools}, "
+                    f"but this request includes {len(tools)} tools. Reduce the enabled "
+                    "toolsets or MCP tools, or raise custom_args.max_tools only if the "
+                    "provider supports it. The request was not sent."
+                )
             tools_args["tools"] = tools
             tools_args["tool_choice"] = tool_choice  # type: ignore
 

--- a/tests/core/test_llm_completion_tool_limit.py
+++ b/tests/core/test_llm_completion_tool_limit.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+from holmes.core.llm import DefaultLLM
+
+
+def _tool(index: int) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": f"tool_{index}",
+            "description": "Synthetic tool used to verify the request boundary.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _response() -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-test",
+        choices=[
+            Choices(
+                index=0,
+                message=Message(role="assistant", content="ok", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test-model",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def test_configured_tool_limit_rejects_request_before_litellm_call():
+    with patch.object(DefaultLLM, "check_llm"):
+        llm = DefaultLLM(
+            model="openai/gpt-4.1",
+            args={"custom_args": {"max_tools": 128}},
+        )
+
+    with patch("holmes.core.llm.litellm.completion") as completion:
+        with pytest.raises(ValueError) as exc_info:
+            llm.completion(
+                messages=[{"role": "user", "content": "Investigate the incident"}],
+                tools=[_tool(index) for index in range(129)],
+                tool_choice="auto",
+            )
+
+    message = str(exc_info.value)
+    assert "openai/gpt-4.1" in message
+    assert "129" in message
+    assert "128" in message
+    completion.assert_not_called()
+
+
+def test_configured_tool_limit_must_be_a_positive_integer():
+    with patch.object(DefaultLLM, "check_llm"):
+        with pytest.raises(ValueError, match="max_tools must be a positive integer"):
+            DefaultLLM(
+                model="openai/gpt-4.1",
+                args={"custom_args": {"max_tools": "128"}},
+            )
+
+
+@pytest.mark.parametrize("tool_count", [127, 128])
+def test_request_at_or_below_configured_tool_limit_is_sent(tool_count: int):
+    with patch.object(DefaultLLM, "check_llm"):
+        llm = DefaultLLM(
+            model="openai/gpt-4.1",
+            args={"custom_args": {"max_tools": 128}},
+        )
+
+    tools = [_tool(index) for index in range(tool_count)]
+    with patch("holmes.core.llm.litellm.completion", return_value=_response()) as completion:
+        llm.completion(
+            messages=[{"role": "user", "content": "Investigate the incident"}],
+            tools=tools,
+            tool_choice="auto",
+        )
+
+    assert completion.call_args.kwargs["tools"] == tools
+    assert "max_tools" not in completion.call_args.kwargs
+
+
+def test_request_without_configured_tool_limit_preserves_existing_behavior():
+    with patch.object(DefaultLLM, "check_llm"):
+        llm = DefaultLLM(model="custom/provider-model")
+
+    tools = [_tool(index) for index in range(129)]
+    with patch("holmes.core.llm.litellm.completion", return_value=_response()) as completion:
+        llm.completion(
+            messages=[{"role": "user", "content": "Investigate the incident"}],
+            tools=tools,
+            tool_choice="auto",
+        )
+
+    assert completion.call_args.kwargs["tools"] == tools


### PR DESCRIPTION
## Problem

OpenAI-compatible endpoints can reject a completion after Holmes has assembled more tool definitions than the endpoint supports. The resulting provider error happens only after an outbound request and does not tell operators which Holmes configuration to change.

Related to #1050.

## Solution

Add an optional per-model `custom_args.max_tools` capability:

```yaml
modelList:
  gpt-4.1:
    api_key: "{{ env.OPENAI_API_KEY }}"
    model: openai/gpt-4.1
    custom_args:
      max_tools: 128
```

When the final tool array exceeds the configured limit, `DefaultLLM.completion()` now fails before calling LiteLLM. The error includes the model, actual tool count, configured limit, and remediation guidance.

The limit is deliberately opt-in rather than inferred from an `openai/` model prefix: OpenAI-compatible endpoints and model capabilities can differ. Existing behavior is unchanged when `max_tools` is omitted.

## Behavior

- Reject invalid limits at configuration time; `max_tools` must be a positive integer.
- Allow requests at or below the configured boundary.
- Fail before the outbound completion call when the boundary is exceeded.
- Never silently truncate tools.
- Do not forward this Holmes-only setting to LiteLLM.

## Tests

- Added regression coverage for a 129-tool request with a limit of 128 and verified that `litellm.completion()` is not called.
- Covered invalid configuration, 127/128 boundary values, and unchanged behavior without a configured limit.
- Targeted completion, model configuration, and agent-loop suites pass locally (100 tests total).

The broad non-LLM suite was also attempted on Windows/WSL; unrelated environment-dependent tests require Unix permission/symlink semantics, optional dependencies, or external services, so this PR does not claim a full-suite pass in that environment.

## Non-goals

This PR does not select, rank, or dynamically load tools. A provider-neutral router can be designed separately without coupling this safety boundary to a larger behavioral change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring per-model tool limits through provider settings.
  - Requests exceeding the configured limit are rejected before being sent, with an error identifying the model, tool count, and limit.
  - Existing behavior is preserved when no limit is configured.

- **Documentation**
  - Added OpenAI configuration guidance for setting model-specific tool limits.

- **Tests**
  - Added coverage for validation, accepted limits, rejected requests, and unchanged behavior without a configured limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->