### PR TITLE
Add configurable request timeout for New Relic toolset

### DIFF
--- a/docs/data-sources/builtin-toolsets/newrelic.md
+++ b/docs/data-sources/builtin-toolsets/newrelic.md
@@ -125,6 +125,7 @@ config: |
 | `account_id` | (required) | New Relic account ID (numeric, e.g. `1234567`). |
 | `is_eu_datacenter` | `false` | Set `true` for the EU region. Controls both the API endpoint (`api.eu.newrelic.com`) and the URL used in clickable links in Holmes's responses. |
 | `enable_multi_account` | `false` | Enable cross-account queries. When true, Holmes exposes an additional `newrelic_list_organization_accounts` tool and lets individual NRQL queries override the account ID. |
+| `timeout_seconds` | `30` | Request timeout in seconds for New Relic API calls. Increase it if large NRQL queries time out. |
 
 ## Capabilities
 

--- a/holmes/plugins/toolsets/newrelic/new_relic_api.py
+++ b/holmes/plugins/toolsets/newrelic/new_relic_api.py
@@ -1,7 +1,7 @@
 """NewRelic API wrapper for executing NRQL queries via GraphQL."""
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests  # type: ignore
 
@@ -15,13 +15,20 @@ class NewRelicAPI:
     supporting both US and EU datacenters.
     """
 
-    def __init__(self, api_key: str, account_id: str, is_eu_datacenter: bool = False):
+    def __init__(
+        self,
+        api_key: str,
+        account_id: str,
+        is_eu_datacenter: bool = False,
+        timeout_seconds: int = 30,
+    ):
         """Initialize the NewRelic API wrapper.
 
         Args:
             api_key: NewRelic API key
             account_id: NewRelic account ID
             is_eu_datacenter: If True, use EU datacenter URL. Defaults to False (US).
+            timeout_seconds: Default request timeout in seconds for API calls.
         """
         self.api_key = api_key
         # Validate account_id is numeric to prevent injection
@@ -30,6 +37,7 @@ class NewRelicAPI:
         except ValueError:
             raise ValueError(f"Invalid account_id: must be numeric, got '{account_id}'")
         self.is_eu_datacenter = is_eu_datacenter
+        self.timeout_seconds = timeout_seconds
 
     def _get_api_url(self) -> str:
         """Get the appropriate API URL based on datacenter location.
@@ -42,13 +50,14 @@ class NewRelicAPI:
         return "https://api.newrelic.com/graphql"
 
     def _make_request(
-        self, graphql_query: Dict[str, Any], timeout: int = 30
+        self, graphql_query: Dict[str, Any], timeout: Optional[int] = None
     ) -> Dict[str, Any]:
         """Make HTTP POST request to NewRelic GraphQL API.
 
         Args:
             graphql_query: The GraphQL query as a dictionary
-            timeout: Request timeout in seconds
+            timeout: Request timeout in seconds; falls back to the configured
+                timeout_seconds when not given
 
         Returns:
             JSON response from the API
@@ -67,7 +76,7 @@ class NewRelicAPI:
             url,
             headers=headers,
             json=graphql_query,
-            timeout=timeout,
+            timeout=timeout if timeout is not None else self.timeout_seconds,
         )
         response.raise_for_status()
 

--- a/holmes/plugins/toolsets/newrelic/newrelic.py
+++ b/holmes/plugins/toolsets/newrelic/newrelic.py
@@ -254,6 +254,12 @@ class NewrelicConfig(ToolsetConfig):
         title="Multi-Account Mode",
         description="Enable multi-account support for querying across accounts",
     )
+    timeout_seconds: int = Field(
+        default=30,
+        gt=0,
+        title="Request Timeout",
+        description="Request timeout in seconds for New Relic API calls",
+    )
 
 
 class NewRelicToolset(Toolset):
@@ -263,6 +269,7 @@ class NewRelicToolset(Toolset):
     account_id: Optional[str] = None
     is_eu_datacenter: bool = False
     enable_multi_account: bool = False
+    timeout_seconds: int = 30
 
     @property
     def base_url(self) -> str:
@@ -302,6 +309,7 @@ class NewRelicToolset(Toolset):
             api_key=self.api_key,
             account_id=effective_account_id,
             is_eu_datacenter=self.is_eu_datacenter,
+            timeout_seconds=self.timeout_seconds,
         )
 
     def __init__(self):
@@ -327,6 +335,7 @@ class NewRelicToolset(Toolset):
             self.api_key = nr_config.api_key
             self.is_eu_datacenter = nr_config.is_eu_datacenter or False
             self.enable_multi_account = nr_config.enable_multi_account or False
+            self.timeout_seconds = nr_config.timeout_seconds
         except Exception as e:
             logging.exception("Failed to parse New Relic configuration")
             return False, f"Invalid New Relic configuration: {e}"

--- a/tests/plugins/toolsets/newrelic/test_newrelic_timeout.py
+++ b/tests/plugins/toolsets/newrelic/test_newrelic_timeout.py
@@ -1,0 +1,64 @@
+"""Config-driven request timeout for the New Relic toolset.
+
+`timeout_seconds` on the toolset config must reach the actual `requests.post`
+call made by NewRelicAPI, both for the prerequisite health check and for tool
+invocations.
+"""
+
+import re
+
+import pytest
+import responses
+from pydantic import ValidationError
+
+from holmes.plugins.toolsets.newrelic.newrelic import NewrelicConfig, NewRelicToolset
+from tests.conftest import create_mock_tool_invoke_context
+
+GRAPHQL = "https://api.newrelic.com/graphql"
+_NRQL_OK = {"data": {"actor": {"account": {"nrql": {"results": [{"count": 1}]}}}}}
+
+
+def _mock(rsps):
+    rsps.add(responses.POST, re.compile(re.escape(GRAPHQL)), json=_NRQL_OK, status=200)
+
+
+def test_default_timeout_used_on_requests():
+    ts = NewRelicToolset()
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        _mock(rsps)
+        ok, _ = ts.prerequisites_callable({"api_key": "NRAK-1", "account_id": "111"})
+        assert ok is True
+        assert ts.timeout_seconds == 30
+        assert rsps.calls[-1].request.req_kwargs["timeout"] == 30
+
+
+def test_configured_timeout_used_on_requests():
+    ts = NewRelicToolset()
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        _mock(rsps)
+        ok, _ = ts.prerequisites_callable(
+            {"api_key": "NRAK-1", "account_id": "111", "timeout_seconds": 120}
+        )
+        assert ok is True
+        assert ts.timeout_seconds == 120
+        # Prerequisite health-check request already uses the configured timeout
+        assert rsps.calls[-1].request.req_kwargs["timeout"] == 120
+
+        # And so does a routed tool invocation
+        tool = next(t for t in ts.tools if t.name == "newrelic_execute_nrql_query")
+        before = len(rsps.calls)
+        tool.invoke(
+            {
+                "query": "SELECT count(*) FROM Transaction",
+                "description": "count transactions test",
+                "query_type": "Other",
+            },
+            create_mock_tool_invoke_context(),
+        )
+        assert len(rsps.calls) == before + 1
+        assert rsps.calls[-1].request.req_kwargs["timeout"] == 120
+
+
+def test_non_positive_timeout_rejected():
+    with pytest.raises(ValidationError):
+        NewrelicConfig(api_key="NRAK-1", account_id="111", timeout_seconds=0)


### PR DESCRIPTION
## Summary
Adds support for configurable request timeouts in the New Relic toolset, allowing users to override the default 30-second timeout via the `timeout_seconds` configuration parameter.

## Changes
- **NewrelicConfig**: Added `timeout_seconds` field (default: 30, must be > 0) to allow users to configure request timeouts
- **NewRelicToolset**: Added `timeout_seconds` instance variable that gets populated from config during `prerequisites_callable()`
- **NewRelicAPI**: 
  - Added `timeout_seconds` parameter to `__init__()` 
  - Modified `_make_request()` to use configured timeout as fallback when no explicit timeout is provided
  - Updated docstrings to document the new timeout behavior
- **create_api_client()**: Passes `timeout_seconds` when instantiating NewRelicAPI
- **Documentation**: Updated `newrelic.md` to document the new `timeout_seconds` configuration option

## Implementation Details
- The timeout is applied to all HTTP requests made by the NewRelicAPI, including both the prerequisite health check and tool invocations
- Validation ensures `timeout_seconds` must be positive (> 0) using Pydantic's `gt` validator
- The configured timeout is stored on the toolset instance and passed to the API client during initialization
- Comprehensive test coverage validates default timeout behavior, configured timeout usage, and validation of invalid values

https://claude.ai/code/session_01DWvKcDmB4tbpyisWntdhx9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable request timeout for New Relic API calls.
  - The timeout defaults to 30 seconds and can be increased for large NRQL queries.
  - Invalid non-positive timeout values are rejected.

- **Documentation**
  - Updated the New Relic configuration reference with the new `timeout_seconds` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->